### PR TITLE
docs: update README for consumer-only scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,7 @@ RUST_LOG=debug cargo run -- up --container-data-folder /tmp/cache
 ## Active Technologies
 - Rust 1.70+ (Edition 2021) + clap, serde, tokio, reqwest (rustls TLS), tracing (009-complete-feature-support)
 - N/A (devcontainer.json configuration files) (009-complete-feature-support)
+- N/A (Markdown documentation only) (011-update-readme-scope)
 
 ## Recent Changes
 - 009-complete-feature-support: Added Rust 1.70+ (Edition 2021) + clap, serde, tokio, reqwest (rustls TLS), tracing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # deacon
 
-A fast, Rust-based [Dev Containers](https://containers.dev) CLI.
+**The DevContainer CLI, minus the parts you don't use.**
+
+A fast, focused Rust CLI for developers who use [dev containers](https://containers.dev) and CI pipelines — not for feature authors.
 
 <!-- Badges -->
 <p>
@@ -80,6 +82,19 @@ Verify installation:
 ```bash
 deacon --version
 ```
+
+## Shipped Commands
+
+| Command | Description |
+|---------|-------------|
+| `up` | Create and start a dev container |
+| `down` | Stop and remove a dev container |
+| `exec` | Execute a command in a running container |
+| `build` | Build a dev container image |
+| `read-configuration` | Resolve and output devcontainer.json |
+| `run-user-commands` | Run lifecycle commands in a container |
+| `templates apply` | Scaffold a project from a template |
+| `doctor` | Check system prerequisites and configuration |
 
 ## In Progress
 
@@ -435,10 +450,10 @@ For comprehensive troubleshooting, classification workflows, and remediation ste
 
 ## Roadmap
 
-This CLI implements the DevContainer specification domains below and continues to expand coverage:
+Deacon focuses on consuming dev containers — building, running, and managing them — rather than authoring reusable features or publishing to registries. Coverage continues to expand across these specification domains:
 
 - Configuration resolution and parsing (`devcontainer.json`)
-- Feature system for reusable development environment components
+- Feature consumption: installing and resolving community features during container builds
 - Template system for scaffolding new projects
 - Container lifecycle management
 - Docker/OCI integration

--- a/specs/011-update-readme-scope/checklists/requirements.md
+++ b/specs/011-update-readme-scope/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Update README for Consumer-Only Scope
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec correctly focuses on WHAT content changes are needed (positioning, command list, table cleanup) without prescribing HOW to edit the file.
+- No [NEEDS CLARIFICATION] markers were needed — the user's feature description was comprehensive and unambiguous.

--- a/specs/011-update-readme-scope/plan.md
+++ b/specs/011-update-readme-scope/plan.md
@@ -1,0 +1,100 @@
+# Implementation Plan: Update README for Consumer-Only Scope
+
+**Branch**: `011-update-readme-scope` | **Date**: 2026-02-20 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/011-update-readme-scope/spec.md`
+
+## Summary
+
+Update `README.md` to reflect Deacon's consumer-only positioning after the removal of feature-authoring commands (features test, info, plan, package, publish). The update replaces the project tagline, clarifies the feature list to match shipped commands (up, down, exec, build, read-configuration, run-user-commands, templates apply, doctor), cleans the "In Progress" table, and adjusts the Roadmap section — all while preserving existing badges, CI links, installation instructions, structure, and tone.
+
+## Technical Context
+
+**Language/Version**: N/A (Markdown documentation only)
+**Primary Dependencies**: N/A
+**Storage**: N/A
+**Testing**: Manual review + existing test suite pass-through (`make test-nextest-fast`)
+**Target Platform**: GitHub README.md rendering
+**Project Type**: Single project (documentation change only)
+**Performance Goals**: N/A
+**Constraints**: Must preserve all badge URLs, CI references, installation instructions byte-identical
+**Scale/Scope**: Single file (README.md), ~510 lines
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Parity | PASS | No CLI behavior changes; documentation aligns with post-010 codebase state |
+| II. Keep the Build Green | PASS | Run `make test-nextest-fast` after changes to verify no regressions |
+| III. No Silent Fallbacks | N/A | No code changes |
+| IV. Idiomatic Safe Rust | N/A | No code changes |
+| V. Observability/Output | N/A | No output contract changes |
+| VI. Testing Completeness | PASS | No new tests needed; verify existing pass |
+| VII. Subcommand Consistency | N/A | No subcommand changes |
+| VIII. Executable Examples | PASS | Examples section references feature *consumption*, remains valid |
+
+All gates pass. No violations to justify.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-update-readme-scope/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── spec.md              # Feature specification
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+README.md                # Only file modified by this feature
+```
+
+**Structure Decision**: This is a documentation-only feature. No source code files are created or modified beyond the root `README.md`.
+
+## Implementation Approach
+
+### Change 1: Update Project Tagline (Line 3)
+
+**Current**: `A fast, Rust-based [Dev Containers](https://containers.dev) CLI.`
+
+**Updated**: Replace with consumer-only positioning including the tagline "The DevContainer CLI, minus the parts you don't use." and a brief description of Deacon as a fast, focused Rust CLI for developers who use dev containers and CI pipelines — not for feature authors.
+
+**Scope**: Lines 1-3 of README.md. Badges block (lines 5-16) MUST remain untouched.
+
+### Change 2: Review "In Progress" Table (Lines 84-97)
+
+**Current table rows**:
+1. Docker Compose profiles — consumer, KEEP
+2. Features installation during `up` — consumer, KEEP
+3. Dotfiles (container-side) — consumer, KEEP
+4. `--expect-existing-container` — consumer, KEEP
+5. Port forwarding — consumer, KEEP
+6. Podman runtime — consumer, KEEP
+
+**Result**: No feature-authoring rows exist. Table is already clean. No changes needed.
+
+### Change 3: Update Roadmap Section (Lines 436-447)
+
+**Current**: "Feature system for reusable development environment components" — ambiguous, could be read as authoring.
+
+**Updated**: Clarify to indicate feature *consumption* (installing and resolving features during container builds), not authoring. Also remove or adjust any wording that implies Deacon covers the full specification (it covers the consumer surface).
+
+### Change 4: Verify Examples Section (Lines 99-108)
+
+**Current**: References "Feature System: dependencies, parallelism, caching, and lockfile support" — this describes feature *consumption* during `up`/`build`, which is accurate.
+
+**Result**: No changes needed. The examples describe consumer workflows.
+
+### Change 5: Verify No Other Stale References
+
+Scan the entire README for any remaining references to feature authoring commands or positioning that conflicts with consumer-only scope. The `grep` for `feature.*(test|info|plan|package|publish|author)` found only the generic word "features" in the "In Progress" table context (consumer usage).
+
+## Complexity Tracking
+
+No constitution violations to justify. This is a minimal-scope documentation update.

--- a/specs/011-update-readme-scope/research.md
+++ b/specs/011-update-readme-scope/research.md
@@ -1,0 +1,61 @@
+# Research: Update README for Consumer-Only Scope
+
+**Branch**: `011-update-readme-scope`
+**Date**: 2026-02-20
+
+## Research Summary
+
+This feature is a documentation-only update to `README.md`. Research focused on identifying exactly which sections need changes and verifying no feature-authoring references exist in the current README.
+
+## Decision 1: Scope of Tagline Change
+
+**Decision**: Replace only line 3 (project description) with the new consumer-only positioning. Do not modify the `# deacon` heading or badge block.
+
+**Rationale**: The user's spec requires the positioning "The DevContainer CLI, minus the parts you don't use." to be visible within the first 3 lines. Line 3 is the natural location for a project tagline. The heading and badges are stable infrastructure that must not change.
+
+**Alternatives considered**:
+- Adding a separate "About" section below badges — rejected because it pushes the positioning down and fails SC-002 (positioning visible in first 3 lines).
+- Adding a subtitle under the heading — rejected because it changes the README structure unnecessarily.
+
+## Decision 2: "In Progress" Table — No Feature-Authoring Rows Exist
+
+**Decision**: No changes needed to the "In Progress" table.
+
+**Rationale**: Reviewed all 6 rows in the current table:
+1. Docker Compose profiles — consumer capability
+2. Features installation during `up` — consumer capability (installing features, not authoring)
+3. Dotfiles (container-side) — consumer capability
+4. `--expect-existing-container` — consumer capability
+5. Port forwarding — consumer capability
+6. Podman runtime — consumer capability
+
+None reference feature authoring. The table is already clean.
+
+**Alternatives considered**: None needed.
+
+## Decision 3: Roadmap Section Wording
+
+**Decision**: Update "Feature system for reusable development environment components" to clarify it refers to feature consumption (installing community features into dev containers), not authoring. Also update the introductory sentence to reflect consumer-only scope.
+
+**Rationale**: The current wording is ambiguous — "Feature system" could imply Deacon provides tools for creating features. Since Deacon has explicitly removed all authoring commands, the Roadmap should be unambiguous about consumer scope.
+
+**Alternatives considered**:
+- Removing the "Feature system" bullet entirely — rejected because feature consumption (installation during up/build) is a real shipped capability.
+- Leaving the wording as-is — rejected because it contradicts the consumer-only positioning.
+
+## Decision 4: Examples Section — No Changes Needed
+
+**Decision**: Leave the Examples section unchanged.
+
+**Rationale**: The examples reference "Feature System: dependencies, parallelism, caching, and lockfile support" which describes consumer-side behavior (how features are installed, resolved, and cached during `up`/`build`). This is accurate for a consumer-only tool.
+
+**Alternatives considered**:
+- Renaming to "Feature Installation" — rejected as unnecessary granularity; the current wording is accurate in context.
+
+## Decision 5: MVP-ROADMAP.md Link Validity
+
+**Decision**: Keep the link to `docs/MVP-ROADMAP.md` unchanged.
+
+**Rationale**: The MVP-ROADMAP.md covers `up` and `exec` commands — purely consumer-side. No feature-authoring content exists in that document. The link remains valid and relevant.
+
+**Alternatives considered**: None needed.

--- a/specs/011-update-readme-scope/spec.md
+++ b/specs/011-update-readme-scope/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Update README for Consumer-Only Scope
+
+**Feature Branch**: `011-update-readme-scope`
+**Created**: 2026-02-20
+**Status**: Draft
+**Input**: User description: "Update Deacon's README to reflect its new consumer-only scope after removing feature-authoring commands."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - New Visitor Understands Deacon's Purpose (Priority: P1)
+
+A developer visits the Deacon GitHub repository for the first time and reads the README. They immediately understand that Deacon is a focused, consumer-oriented DevContainer CLI for developers who use dev containers and CI pipelines — not a tool for feature authors.
+
+**Why this priority**: The README is the project's front door. If the positioning is wrong or stale, every new visitor gets a misleading impression of what Deacon does.
+
+**Independent Test**: Can be tested by reading the README top-to-bottom and verifying the positioning statement, feature list, and "In Progress" table all consistently reflect a consumer-only tool.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor opens the README, **When** they read the project description, **Then** they see positioning that communicates Deacon is "The DevContainer CLI, minus the parts you don't use" — a fast, focused Rust CLI for developers who use dev containers and CI pipelines, not for feature authors.
+2. **Given** a visitor reads the README, **When** they look for feature-authoring capabilities (features test, info, plan, package, publish), **Then** they find no references to these commands anywhere in the document.
+
+---
+
+### User Story 2 - Existing User Sees Accurate Command List (Priority: P1)
+
+A developer already using Deacon checks the README to see what commands are available. The feature list accurately reflects the shipped commands: up, down, exec, build, read-configuration, run-user-commands, templates apply, and doctor.
+
+**Why this priority**: An inaccurate command list erodes trust and causes confusion. Users need to know exactly what the tool ships.
+
+**Independent Test**: Can be tested by comparing the README's listed commands against the actual CLI output (`deacon --help`) and verifying parity.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user reads the README, **When** they look at the feature/command list, **Then** they see exactly: up, down, exec, build, read-configuration, run-user-commands, templates apply, and doctor.
+2. **Given** a user reads the README, **When** they search for any feature-authoring commands (features test, features info, features plan, features package, features publish), **Then** they find zero references.
+
+---
+
+### User Story 3 - CI/Automation User Sees Current Status (Priority: P2)
+
+A DevOps engineer evaluating Deacon for CI pipeline integration reads the "In Progress" table to understand what's stable and what's coming. The table contains no rows referencing feature-authoring capabilities and accurately reflects the current development status.
+
+**Why this priority**: The "In Progress" table sets expectations for what works today vs. what's coming. Stale rows referencing removed capabilities mislead evaluators.
+
+**Independent Test**: Can be tested by reviewing the "In Progress" table and verifying every listed item corresponds to an actual planned capability (not a removed one).
+
+**Acceptance Scenarios**:
+
+1. **Given** an engineer reads the "In Progress" table, **When** they review each row, **Then** no row references feature-authoring commands or capabilities.
+2. **Given** an engineer reads the "In Progress" table, **When** they check the listed items, **Then** each item accurately reflects current development status.
+
+---
+
+### User Story 4 - No Broken Links or Stale References (Priority: P2)
+
+Any visitor navigating the README finds that all badges, CI links, installation instructions, and internal references remain intact and functional after the update.
+
+**Why this priority**: Broken links and stale references signal an unmaintained project and frustrate users trying to install or evaluate the tool.
+
+**Independent Test**: Can be tested by verifying all links in the README resolve correctly and that badge URLs, CI references, and installation instructions are unchanged from the pre-update version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor reads the updated README, **When** they click any badge or link, **Then** all links resolve correctly.
+2. **Given** a visitor follows the installation instructions, **When** they compare against the previous version, **Then** all installation content (URLs, commands, environment variables) is identical.
+
+---
+
+### Edge Cases
+
+- What happens if the Roadmap section references feature authoring indirectly (e.g., "Feature system for reusable development environment components")? Update to clarify this refers to feature *consumption* (installing features into dev containers), not authoring.
+- What happens if examples references mention feature-authoring workflows? Verify examples content describes feature consumption, not authoring, and update references if needed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: README MUST include the positioning statement: "The DevContainer CLI, minus the parts you don't use." with supporting text describing Deacon as a fast, focused Rust CLI for developers who use dev containers and CI pipelines — not for feature authors.
+- **FR-002**: README MUST list exactly these shipped commands: up, down, exec, build, read-configuration, run-user-commands, templates apply, and doctor.
+- **FR-003**: README MUST NOT contain any references to feature-authoring commands: features test, features info, features plan, features package, features publish.
+- **FR-004**: The "In Progress" table MUST NOT contain any rows related to feature-authoring capabilities.
+- **FR-005**: All existing badge URLs, CI references, and installation instructions MUST remain unchanged.
+- **FR-006**: The Roadmap section MUST accurately reflect consumer-only scope (feature consumption, not authoring).
+- **FR-007**: README MUST preserve its existing structure, tone, and formatting conventions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of README command references match the actual shipped command set (up, down, exec, build, read-configuration, run-user-commands, templates apply, doctor) with zero references to removed feature-authoring commands.
+- **SC-002**: A reader can determine Deacon's consumer-only positioning within the first 3 lines of the README.
+- **SC-003**: Zero broken links or stale references exist in the updated README.
+- **SC-004**: All badge URLs, CI links, and installation instructions are byte-identical to the pre-update version.
+- **SC-005**: The "In Progress" table contains zero rows referencing feature-authoring capabilities.
+
+## Assumptions
+
+- The feature-authoring commands (features test, info, plan, package, publish) have already been fully removed from the codebase in a prior change (branch 010-remove-feature-authoring).
+- The existing README structure (sections, ordering, formatting) is considered good and should be preserved.
+- "Consumer-only scope" means Deacon still installs/resolves features as part of `up` and `build` commands — it just doesn't provide tools for *authoring* features.
+- The Examples section references to the Feature System are about feature *consumption* (installing features into containers) and remain valid.

--- a/specs/011-update-readme-scope/tasks.md
+++ b/specs/011-update-readme-scope/tasks.md
@@ -1,0 +1,145 @@
+# Tasks: Update README for Consumer-Only Scope
+
+**Input**: Design documents from `/specs/011-update-readme-scope/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md
+
+**Tests**: No test tasks included — this is a documentation-only change. Existing test suite (`make test-nextest-fast`) validates no regressions.
+
+**Organization**: Tasks are grouped by user story. All tasks operate on a single file (`README.md`), so parallelism is limited.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational
+
+**Purpose**: Read current state and establish baseline
+
+- [x] T001 Read current README.md and identify all sections requiring changes per plan.md (sections: tagline line 3, Roadmap lines 436-447)
+
+**Checkpoint**: Current README state understood, change targets identified
+
+---
+
+## Phase 2: User Story 1 — New Visitor Understands Deacon's Purpose (Priority: P1) MVP
+
+**Goal**: A first-time visitor immediately understands Deacon is a consumer-only DevContainer CLI.
+
+**Independent Test**: Read the first 3 lines of README.md and verify the positioning "The DevContainer CLI, minus the parts you don't use" is present with supporting text about being for developers who use dev containers and CI pipelines, not feature authors.
+
+### Implementation for User Story 1
+
+- [x] T002 [US1] Replace project tagline on line 3 of README.md — change `A fast, Rust-based [Dev Containers](https://containers.dev) CLI.` to consumer-only positioning per FR-001: include "The DevContainer CLI, minus the parts you don't use." and describe Deacon as a fast, focused Rust CLI for developers who use dev containers and CI pipelines, not for feature authors. Do NOT modify the `# deacon` heading (line 1) or badge block (lines 5-16).
+- [x] T003 [US1] Update Roadmap section in README.md (lines 436-447) — change "Feature system for reusable development environment components" to clarify feature *consumption* (installing and resolving community features during container builds). Update the introductory sentence to reflect consumer-only scope per FR-006 and research.md Decision 3.
+- [x] T004 [US1] Scan entire README.md for any remaining references to feature-authoring commands (features test, features info, features plan, features package, features publish) per FR-003. Remove or reword any found. Grep for patterns: `features test`, `features info`, `features plan`, `features package`, `features publish`, `feature author`.
+
+**Checkpoint**: Positioning is consumer-only, Roadmap is clarified, no authoring references remain.
+
+---
+
+## Phase 3: User Story 2 — Existing User Sees Accurate Command List (Priority: P1)
+
+**Goal**: The README lists exactly the shipped commands: up, down, exec, build, read-configuration, run-user-commands, templates apply, and doctor.
+
+**Independent Test**: Search README.md for the command list and verify it matches the eight shipped commands exactly. Verify zero references to removed commands.
+
+### Implementation for User Story 2
+
+- [x] T005 [US2] Verify or add an explicit shipped command list in README.md per FR-002 listing exactly: up, down, exec, build, read-configuration, run-user-commands, templates apply, and doctor. If no explicit list exists, add one in an appropriate location (e.g., after Quick Start or as part of the updated positioning). Ensure the list reflects consumer-only surface.
+
+**Checkpoint**: Command list is accurate and complete.
+
+---
+
+## Phase 4: User Story 3 — CI/Automation User Sees Current Status (Priority: P2)
+
+**Goal**: The "In Progress" table contains no feature-authoring rows and accurately reflects current development status.
+
+**Independent Test**: Read the "In Progress" table (lines 84-97) and verify every row describes a consumer capability.
+
+### Implementation for User Story 3
+
+- [x] T006 [US3] Verify "In Progress" table in README.md (lines 84-97) contains no feature-authoring rows per FR-004. Per research.md Decision 2, all 6 current rows are consumer capabilities (Docker Compose profiles, Features installation during up, Dotfiles, --expect-existing-container, Port forwarding, Podman runtime). Confirm no changes needed and document verification.
+
+**Checkpoint**: "In Progress" table verified clean.
+
+---
+
+## Phase 5: User Story 4 — No Broken Links or Stale References (Priority: P2)
+
+**Goal**: All badges, CI links, installation instructions, and internal references remain intact after the update.
+
+**Independent Test**: Diff the badge block (lines 5-16), Install section (lines 18-64), and CI section (lines 474-490) against the original to verify byte-identical preservation.
+
+### Implementation for User Story 4
+
+- [x] T007 [US4] Verify all badge URLs (lines 5-16), installation instructions (lines 18-64), and CI references (lines 474-490) in README.md are unchanged from before any edits per FR-005. Compare against original content to confirm byte-identical preservation.
+- [x] T008 [US4] Verify the link to `docs/MVP-ROADMAP.md` (line 97) still resolves to an existing file per research.md Decision 5. Verify the Examples section references (lines 99-108) remain accurate per research.md Decision 4.
+
+**Checkpoint**: All links valid, all preserved sections unchanged.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all user stories
+
+- [x] T009 Run `make test-nextest-fast` to verify no regressions from documentation changes in README.md
+- [x] T010 Final full-document review of README.md: verify structure, tone, and formatting conventions preserved per FR-007. Verify SC-001 through SC-005 all pass. Confirm consumer-only positioning, accurate command list, clean In Progress table, valid links, and no stale references.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 1)**: No dependencies — start immediately
+- **US1 (Phase 2)**: Depends on Phase 1 — core positioning change
+- **US2 (Phase 3)**: Depends on Phase 2 (positioning informs where command list goes)
+- **US3 (Phase 4)**: Depends on Phase 1 — verification only, can run after T001
+- **US4 (Phase 5)**: Depends on Phase 2 and Phase 3 (must verify after all edits)
+- **Polish (Phase 6)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after T001 — no dependencies on other stories
+- **User Story 2 (P1)**: Can start after US1 edits (T002-T004) since command list placement may depend on updated positioning
+- **User Story 3 (P2)**: Can start after T001 — independent verification, no dependencies on US1/US2
+- **User Story 4 (P2)**: Must run after all edits (T002-T006) to verify nothing was broken
+
+### Parallel Opportunities
+
+- T006 (US3 verification) can run in parallel with T002-T005 (US1/US2 edits) since it only reads the "In Progress" table which is not being modified
+- T007 and T008 (US4 verification) must wait until all edits are complete
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete T001: Read and understand current README
+2. Complete T002-T004: Update positioning, Roadmap, remove authoring references
+3. **STOP and VALIDATE**: Read first 3 lines — positioning is clear
+
+### Incremental Delivery
+
+1. T001 → Baseline established
+2. T002-T004 (US1) → Positioning updated → Validate
+3. T005 (US2) → Command list accurate → Validate
+4. T006 (US3) → In Progress table verified → Validate
+5. T007-T008 (US4) → Links and preservation verified → Validate
+6. T009-T010 → Full validation and test suite pass
+
+---
+
+## Notes
+
+- All tasks operate on a single file (`README.md`) so true file-level parallelism is minimal
+- US3 (Phase 4) is verification-only — the "In Progress" table is already clean per research
+- US4 (Phase 5) is verification-only — ensures edits in US1/US2 didn't break preserved sections
+- T009 runs the existing test suite as a regression check, not to test new code


### PR DESCRIPTION
## Summary
- Replaced project tagline with consumer-only positioning: "The DevContainer CLI, minus the parts you don't use."
- Added explicit "Shipped Commands" table listing all 8 shipped commands (up, down, exec, build, read-configuration, run-user-commands, templates apply, doctor)
- Updated Roadmap section to clarify feature consumption vs authoring scope

## Test plan
- [x] Verified consumer-only positioning visible in first 3 lines
- [x] Scanned for zero remaining feature-authoring references
- [x] Verified In Progress table contains only consumer capabilities
- [x] Confirmed badges, install, and CI sections unchanged (byte-identical)
- [x] Verified docs/MVP-ROADMAP.md link resolves
- [x] `make test-nextest-fast` passes (1755/1755 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)