### PR TITLE
fix: correct ConfigMerger merge rules for booleans and arrays

### DIFF
--- a/specs/013-fix-merge-rules/data-model.md
+++ b/specs/013-fix-merge-rules/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: Fix Config Merge Rules
+
+**Branch**: `013-fix-merge-rules` | **Date**: 2026-02-22
+
+## Entities
+
+### DevContainerConfig (existing, unchanged)
+
+The primary configuration structure. No fields are added or removed. The merge *behavior* changes for specific field categories.
+
+**Relevant fields by merge category:**
+
+| Field | Type | Current Merge | Target Merge |
+|-------|------|---------------|--------------|
+| `privileged` | `Option<bool>` | `Option::or()` (last-wins) | Boolean OR |
+| `init` | `Option<bool>` | `Option::or()` (last-wins) | Boolean OR |
+| `mounts` | `Vec<serde_json::Value>` | Replace if overlay non-empty | Union with dedup |
+| `forward_ports` | `Vec<PortSpec>` | Replace if overlay non-empty | Union with dedup |
+
+**Unchanged merge categories (FR-007):**
+
+| Category | Fields | Merge Behavior |
+|----------|--------|---------------|
+| Scalar (last-wins) | `name`, `image`, `dockerfile`, `build`, `workspace_folder`, `workspace_mount`, `app_port`, `shutdown_action`, `override_command`, `container_user`, `remote_user`, `update_remote_user_uid`, `host_requirements`, `other_ports_attributes` | `overlay.or(base)` |
+| Map (key merge) | `container_env`, `remote_env`, `ports_attributes` | Deep merge, overlay wins per key |
+| Object (deep merge) | `features`, `customizations` | Recursive JSON object merge |
+| Concat arrays | `run_args`, `cap_add`, `security_opt` | `concat_string_arrays()` |
+| Lifecycle (last-wins) | `on_create_command`, `post_create_command`, `post_start_command`, `post_attach_command`, `initialize_command`, `update_content_command` | `overlay.or(base)` |
+
+### PortSpec (existing, unchanged)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PortSpec {
+    Number(u16),
+    String(String),
+}
+```
+
+Already derives `PartialEq`. `PortSpec::Number(3000)` and `PortSpec::String("3000:3000")` are distinct values per the spec.
+
+## New Functions
+
+### `merge_bool_or(base: Option<bool>, overlay: Option<bool>) -> Option<bool>`
+
+Truth table:
+
+| Base | Overlay | Result |
+|------|---------|--------|
+| `None` | `None` | `None` |
+| `None` | `Some(true)` | `Some(true)` |
+| `None` | `Some(false)` | `Some(false)` |
+| `Some(true)` | `None` | `Some(true)` |
+| `Some(true)` | `Some(true)` | `Some(true)` |
+| `Some(true)` | `Some(false)` | `Some(true)` |
+| `Some(false)` | `None` | `Some(false)` |
+| `Some(false)` | `Some(true)` | `Some(true)` |
+| `Some(false)` | `Some(false)` | `Some(false)` |
+
+### `union_json_arrays(base: &[serde_json::Value], overlay: &[serde_json::Value]) -> Vec<serde_json::Value>`
+
+Algorithm:
+1. Start with `result = base.to_vec()`
+2. For each entry in overlay: if `!result.contains(&entry)`, append it
+3. Return result
+
+### `union_port_arrays(base: &[PortSpec], overlay: &[PortSpec]) -> Vec<PortSpec>`
+
+Algorithm:
+1. Start with `result = base.to_vec()`
+2. For each entry in overlay: if `!result.contains(&entry)`, append it
+3. Return result
+
+## State Transitions
+
+N/A — this is a stateless merge operation with no lifecycle transitions.
+
+## Validation Rules
+
+- Boolean OR preserves `None` when both inputs are `None` (FR-006)
+- Union preserves base ordering, appends new overlay entries (FR-002, FR-003)
+- Deduplication is by value equality, not by semantic equivalence (FR-004, FR-005)

--- a/specs/013-fix-merge-rules/plan.md
+++ b/specs/013-fix-merge-rules/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: Fix Config Merge Rules
+
+**Branch**: `013-fix-merge-rules` | **Date**: 2026-02-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/013-fix-merge-rules/spec.md`
+
+## Summary
+
+Fix two categories of property merge bugs in `ConfigMerger::merge_two_configs()` to match the upstream containers.dev specification:
+1. **Boolean properties** (`privileged`, `init`): Change from last-wins (`Option::or()`) to OR semantics (true if either source is true).
+2. **Array properties** (`mounts`, `forwardPorts`): Change from replace-if-non-empty to union with deduplication.
+
+The fix is surgical — three new private helper functions added to `ConfigMerger`, four lines changed in `merge_two_configs()`, comprehensive tests added. No new dependencies.
+
+## Technical Context
+
+**Language/Version**: Rust 1.70+ (Edition 2021)
+**Primary Dependencies**: `serde_json` (Value PartialEq for mount dedup), `clap`, `tracing`
+**Storage**: N/A
+**Testing**: `cargo-nextest` via `make test-nextest-fast`
+**Target Platform**: Linux (Docker/Podman host)
+**Project Type**: CLI (Rust workspace: `crates/core` library + `crates/deacon` binary)
+**Performance Goals**: N/A — merge operates on small arrays (< 20 entries), O(n²) dedup is negligible
+**Constraints**: Must not break any existing merge behavior (FR-007)
+**Scale/Scope**: Single file change (`crates/core/src/config.rs`), ~50 lines implementation + ~200 lines tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Parity | **PASS** | Fix aligns merge behavior with upstream containers.dev spec (boolean OR, array union) |
+| II. Consumer-Only Scope | **PASS** | Config merging is core consumer functionality used by `up`, `read-configuration`, `build` |
+| III. Keep Build Green | **PASS** | All existing tests must continue to pass; new tests added for fixed behavior |
+| IV. No Silent Fallbacks | **PASS** | Fix removes a silent fallback (booleans silently losing `true`, arrays silently dropping entries) |
+| V. Idiomatic Rust | **PASS** | Helper functions use `Option<bool>` pattern matching; no unsafe, no unwrap |
+| VI. Observability | **N/A** | Internal merge logic, no output format changes |
+| VII. Testing Completeness | **PASS** | All spec acceptance scenarios will have corresponding unit tests |
+| VIII. Subcommand Consistency | **PASS** | Fix is in shared `ConfigMerger` used by all subcommands — no per-command changes needed |
+| IX. Executable Examples | **N/A** | No example changes required for internal merge fix |
+
+**Post-Design Re-check**: All gates still pass. No new dependencies, no new modules, no architecture changes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-fix-merge-rules/
+├── plan.md              # This file
+├── research.md          # Phase 0: decisions and rationale
+├── data-model.md        # Phase 1: merge truth tables and algorithms
+├── quickstart.md        # Phase 1: verification guide
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+crates/core/src/
+└── config.rs            # ConfigMerger::merge_two_configs() — the only file modified
+                         # New helpers: merge_bool_or(), union_json_arrays(), union_port_arrays()
+                         # New tests in mod tests block
+```
+
+**Structure Decision**: Single file modification in existing `crates/core/src/config.rs`. The `ConfigMerger` impl block already contains all merge helpers — new helpers follow the same pattern (`concat_string_arrays`, `merge_string_maps`, etc.).
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.
+
+## Implementation Approach
+
+### Step 1: Add Helper Functions
+
+Add three private helper functions to the `ConfigMerger` impl block:
+
+1. **`merge_bool_or(base: Option<bool>, overlay: Option<bool>) -> Option<bool>`**
+   - Pattern match on `(base, overlay)`:
+     - `(None, None)` → `None`
+     - `(Some(true), _) | (_, Some(true))` → `Some(true)`
+     - `(Some(false), Some(false))` → `Some(false)`
+     - `(Some(v), None) | (None, Some(v))` → `Some(v)`
+
+2. **`union_json_arrays(base: &[serde_json::Value], overlay: &[serde_json::Value]) -> Vec<serde_json::Value>`**
+   - Start with base clone, append overlay entries not in base (using `serde_json::Value::eq`)
+
+3. **`union_port_arrays(base: &[PortSpec], overlay: &[PortSpec]) -> Vec<PortSpec>`**
+   - Start with base clone, append overlay entries not in base (using `PortSpec::eq`)
+
+### Step 2: Update merge_two_configs
+
+Replace four field assignments in `merge_two_configs()`:
+
+```rust
+// Before (boolean last-wins):
+privileged: overlay.privileged.or(base.privileged),
+init: overlay.init.or(base.init),
+
+// After (boolean OR):
+privileged: Self::merge_bool_or(base.privileged, overlay.privileged),
+init: Self::merge_bool_or(base.init, overlay.init),
+
+// Before (array replace):
+mounts: if overlay.mounts.is_empty() { base.mounts.clone() } else { overlay.mounts.clone() },
+forward_ports: if overlay.forward_ports.is_empty() { base.forward_ports.clone() } else { overlay.forward_ports.clone() },
+
+// After (array union):
+mounts: Self::union_json_arrays(&base.mounts, &overlay.mounts),
+forward_ports: Self::union_port_arrays(&base.forward_ports, &overlay.forward_ports),
+```
+
+### Step 3: Add Tests
+
+Unit tests covering all spec acceptance scenarios:
+
+**Boolean OR tests** (FR-001, FR-006, FR-008):
+- `test_merge_bool_or_both_none` → `None`
+- `test_merge_bool_or_true_false` → `Some(true)`
+- `test_merge_bool_or_false_true` → `Some(true)`
+- `test_merge_bool_or_true_none` → `Some(true)`
+- `test_merge_bool_or_none_true` → `Some(true)`
+- `test_merge_bool_or_false_false` → `Some(false)`
+- `test_merge_bool_or_none_false` → `Some(false)`
+- `test_merge_bool_or_false_none` → `Some(false)`
+- `test_merge_privileged_or_semantics` — integration via `merge_two_configs`
+- `test_merge_init_or_semantics` — integration via `merge_two_configs`
+
+**Array union tests** (FR-002, FR-003, FR-004, FR-005):
+- `test_merge_mounts_union_disjoint` → all entries preserved
+- `test_merge_mounts_union_with_duplicates` → dedup by JSON equality
+- `test_merge_mounts_union_base_empty` → overlay entries
+- `test_merge_mounts_union_overlay_empty` → base entries
+- `test_merge_mounts_union_both_empty` → empty
+- `test_merge_forward_ports_union_disjoint` → all entries preserved
+- `test_merge_forward_ports_union_with_duplicates` → dedup by PortSpec equality
+- `test_merge_forward_ports_union_mixed_types` → Number and String kept distinct
+
+**Chain merge tests** (FR-008):
+- `test_merge_chain_bool_or` — three configs, boolean OR across chain
+- `test_merge_chain_array_union` — three configs, array union across chain
+
+**Regression test** (FR-007):
+- `test_merge_other_categories_unchanged` — verify scalars, maps, concat arrays unchanged
+
+### Step 4: Verify
+
+```bash
+cargo fmt --all && cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+make test-nextest-fast
+```
+
+## Pre-Implementation Checklist
+
+1. **Spec Review**: Read complete upstream merge rules at containers.dev/implementors/spec/ ✓
+2. **Scope Check**: Config merging is consumer functionality (Principle II) ✓
+3. **Data Model Alignment**: No struct changes, only merge behavior ✓
+4. **Algorithm Alignment**: Boolean OR and array union match upstream spec exactly ✓
+5. **Input Validation**: N/A — inputs are already-parsed DevContainerConfig objects ✓
+6. **Configuration Resolution**: N/A — merge operates on already-resolved configs ✓
+7. **Output Contracts**: No output format changes ✓
+8. **Testing Coverage**: All 8 FR acceptance scenarios have corresponding tests ✓
+9. **Infrastructure Reuse**: Uses existing `ConfigMerger` impl block and test patterns ✓
+10. **Nextest Configuration**: New tests are unit tests in config.rs — no new nextest group config needed ✓

--- a/specs/013-fix-merge-rules/quickstart.md
+++ b/specs/013-fix-merge-rules/quickstart.md
@@ -1,0 +1,50 @@
+# Quickstart: Fix Config Merge Rules
+
+**Branch**: `013-fix-merge-rules` | **Date**: 2026-02-22
+
+## What Changed
+
+Fixed two categories of property merge bugs in `ConfigMerger::merge_two_configs()`:
+
+1. **Boolean OR**: `privileged` and `init` now use OR semantics — if any source sets `true`, the result is `true`.
+2. **Array Union**: `mounts` and `forwardPorts` now use union with deduplication — entries from all sources are preserved.
+
+## Files Modified
+
+- `crates/core/src/config.rs` — `merge_two_configs()`, plus three new helpers: `merge_bool_or()`, `union_json_arrays()`, `union_port_arrays()`
+
+## How to Verify
+
+```bash
+# Run all tests
+make test-nextest-fast
+
+# Run specific merge tests
+cargo nextest run test_merge_bool_or
+cargo nextest run test_merge_mounts_union
+cargo nextest run test_merge_forward_ports_union
+cargo nextest run test_merge_chain
+```
+
+## Before/After
+
+### Boolean merge (privileged)
+
+```
+Before: base=Some(true), overlay=Some(false) → Some(false)  [WRONG]
+After:  base=Some(true), overlay=Some(false) → Some(true)   [CORRECT]
+```
+
+### Array merge (mounts)
+
+```
+Before: base=[A, B], overlay=[C, D] → [C, D]         [WRONG - base lost]
+After:  base=[A, B], overlay=[C, D] → [A, B, C, D]   [CORRECT - union]
+```
+
+### Array merge (forwardPorts)
+
+```
+Before: base=[3000], overlay=[8080] → [8080]         [WRONG - base lost]
+After:  base=[3000], overlay=[8080] → [3000, 8080]   [CORRECT - union]
+```

--- a/specs/013-fix-merge-rules/research.md
+++ b/specs/013-fix-merge-rules/research.md
@@ -1,0 +1,61 @@
+# Research: Fix Config Merge Rules
+
+**Branch**: `013-fix-merge-rules` | **Date**: 2026-02-22
+
+## Decision 1: Upstream Spec Merge Semantics Confirmed
+
+**Decision**: Implement boolean OR for `privileged`/`init` and array union for `mounts`/`forwardPorts` per upstream containers.dev spec.
+
+**Rationale**: The upstream [containers.dev implementors spec](https://containers.dev/implementors/spec/) explicitly defines:
+- `privileged`, `init`: "true if at least one is true, false otherwise"
+- `forwardPorts`: "Union of all ports without duplicates. Last one wins (when mapping changes)."
+- `mounts`: "Collected list of all mountpoints. Conflicts: Last source wins."
+
+**Alternatives considered**:
+- Keep last-wins for booleans: Rejected — violates spec, causes Features requiring `privileged: true` to silently lose that capability.
+- Use replace for arrays: Rejected — violates spec, causes Features adding mounts/ports to silently destroy user entries.
+
+## Decision 2: Fix Scope Limited to ConfigMerger::merge_two_configs
+
+**Decision**: Only modify `ConfigMerger::merge_two_configs()` in `crates/core/src/config.rs`. Do not modify `mount::merge_mounts()` in `mount.rs`.
+
+**Rationale**: These operate at different merge levels:
+- `merge_two_configs()`: Merges two `DevContainerConfig` objects (extends chains, Feature metadata overlay). This is where the bug lives — booleans use `Option::or()` (last-wins) and arrays use replace-if-non-empty.
+- `mount::merge_mounts()`: Merges config mounts with resolved Feature mounts by target path. This is a higher-level deduplication with different semantics (target-path-based, config overrides features). This function is correct for its purpose.
+
+**Alternatives considered**:
+- Modify both merge functions: Rejected — `merge_mounts` operates on a different abstraction level with intentionally different deduplication (by target path vs by JSON representation). Changing it would break Feature mount precedence.
+
+## Decision 3: Boolean OR Implementation Strategy
+
+**Decision**: Replace `overlay.privileged.or(base.privileged)` with a dedicated `merge_bool_or()` helper that implements: `Some(true)` if either is `Some(true)`, `Some(false)` if both are `Some(false)`, `None` if both are `None`, and pass-through for mixed `Some`/`None`.
+
+**Rationale**: `Option::or()` returns the first `Some` value, meaning `Some(false).or(Some(true))` returns `Some(false)` — this is last-wins, not OR. The correct behavior is: if any source says `true`, the result is `true`.
+
+**Alternatives considered**:
+- Use `Option::max()` since `true > false`: This works for the `Some` cases but doesn't handle `None` correctly — `None.max(Some(false))` returns `Some(false)`, which is correct, but it's less readable and the intent is obscured. A named helper is clearer.
+- Inline the logic: Rejected — used for two properties (`privileged`, `init`), DRY is appropriate.
+
+## Decision 4: Array Union Implementation Strategy
+
+**Decision**: Implement union as: start with base entries, then append overlay entries not already present. For mounts, compare using `serde_json::Value` equality (which compares full JSON structure). For forwardPorts, compare using `PortSpec::PartialEq` (already derived).
+
+**Rationale**:
+- `serde_json::Value` implements `PartialEq` with structural comparison, so two identical JSON objects/strings compare equal regardless of internal representation details.
+- `PortSpec` already derives `PartialEq`, so `PortSpec::Number(3000) != PortSpec::String("3000:3000")` — they are different variants representing different things.
+- Base-first ordering matches the spec: "the devcontainer.json is considered last" means user config entries appear first, Feature entries are appended.
+
+**Alternatives considered**:
+- Use `HashSet` for deduplication: Rejected — `serde_json::Value` doesn't implement `Hash`, and order preservation is required.
+- Use `IndexSet` from `indexmap`: Rejected — again, `serde_json::Value` doesn't implement `Hash`. The `Vec::contains()` approach is O(n²) but mount/port arrays are always small (typically < 20 entries), so this is negligible.
+- Serialize mounts to strings for comparison: Rejected — the spec edge case explicitly states string-form and object-form mounts are treated as distinct. JSON structural equality handles this correctly.
+
+## Decision 5: No New Dependencies Required
+
+**Decision**: No new crate dependencies needed.
+
+**Rationale**: All required functionality exists:
+- `serde_json::Value` already implements `PartialEq` for mount comparison
+- `PortSpec` already derives `PartialEq` for port comparison
+- `Vec::contains()` provides adequate deduplication for small arrays
+- No `Hash` trait implementations needed since we don't use set data structures

--- a/specs/013-fix-merge-rules/tasks.md
+++ b/specs/013-fix-merge-rules/tasks.md
@@ -1,0 +1,224 @@
+# Tasks: Fix Config Merge Rules
+
+**Input**: Design documents from `/specs/013-fix-merge-rules/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included — spec.md defines acceptance scenarios and plan.md specifies comprehensive test coverage.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Rust workspace**: `crates/core/src/` (library), `crates/deacon/src/` (binary)
+- All changes for this feature are in `crates/core/src/config.rs`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — this is a surgical bugfix in an existing codebase.
+
+- [X] T001 Read and understand current `merge_two_configs()` implementation at `crates/core/src/config.rs:1053` including the existing helper pattern (`concat_string_arrays`, `merge_string_maps`, `merge_json_objects`)
+
+---
+
+## Phase 2: Foundational (Helper Functions)
+
+**Purpose**: Add three private helper functions to the `ConfigMerger` impl block in `crates/core/src/config.rs`. These helpers are shared prerequisites for all user stories.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 Implement `merge_bool_or(base: Option<bool>, overlay: Option<bool>) -> Option<bool>` helper in `crates/core/src/config.rs` using pattern matching per data-model.md truth table: `Some(true)` if either is `Some(true)`, `Some(false)` if both `Some(false)`, `None` if both `None`, pass-through for mixed `Some`/`None`
+- [X] T003 Implement `union_json_arrays(base: &[serde_json::Value], overlay: &[serde_json::Value]) -> Vec<serde_json::Value>` helper in `crates/core/src/config.rs` — start with base clone, append overlay entries not already present using `serde_json::Value` structural equality
+- [X] T004 Implement `union_port_arrays(base: &[PortSpec], overlay: &[PortSpec]) -> Vec<PortSpec>` helper in `crates/core/src/config.rs` — start with base clone, append overlay entries not already present using derived `PartialEq`
+
+**Checkpoint**: All three helpers compiled and ready. Run `cargo fmt --all && cargo clippy --all-targets -- -D warnings` to verify.
+
+---
+
+## Phase 3: User Story 1 — Feature requiring privileged mode merges correctly (Priority: P1) MVP
+
+**Goal**: `privileged` boolean uses OR semantics in `merge_two_configs()` — if any source sets `true`, the merged result is `true`.
+
+**Independent Test**: Merge two configs where base has `privileged: true` and overlay has `privileged: false`, verify merged result is `true`.
+
+### Tests for User Story 1
+
+- [X] T005 [US1] Add unit test `test_merge_bool_or_both_none` in `crates/core/src/config.rs` — verify `merge_bool_or(None, None)` returns `None` (FR-006)
+- [X] T006 [US1] Add unit test `test_merge_bool_or_true_false` in `crates/core/src/config.rs` — verify `merge_bool_or(Some(true), Some(false))` returns `Some(true)` (FR-001)
+- [X] T007 [US1] Add unit test `test_merge_bool_or_false_true` in `crates/core/src/config.rs` — verify `merge_bool_or(Some(false), Some(true))` returns `Some(true)` (FR-001)
+- [X] T008 [US1] Add unit test `test_merge_bool_or_true_none` in `crates/core/src/config.rs` — verify `merge_bool_or(Some(true), None)` returns `Some(true)`
+- [X] T009 [US1] Add unit test `test_merge_bool_or_none_true` in `crates/core/src/config.rs` — verify `merge_bool_or(None, Some(true))` returns `Some(true)`
+- [X] T010 [US1] Add unit test `test_merge_bool_or_false_false` in `crates/core/src/config.rs` — verify `merge_bool_or(Some(false), Some(false))` returns `Some(false)`
+- [X] T011 [US1] Add unit test `test_merge_bool_or_none_false` in `crates/core/src/config.rs` — verify `merge_bool_or(None, Some(false))` returns `Some(false)`
+- [X] T012 [US1] Add unit test `test_merge_bool_or_false_none` in `crates/core/src/config.rs` — verify `merge_bool_or(Some(false), None)` returns `Some(false)`
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Update `privileged` field assignment in `merge_two_configs()` at `crates/core/src/config.rs:1179` — replace `overlay.privileged.or(base.privileged)` with `Self::merge_bool_or(base.privileged, overlay.privileged)`
+- [X] T014 [US1] Add integration test `test_merge_privileged_or_semantics` in `crates/core/src/config.rs` — test via `merge_two_configs` with base `privileged: true` + overlay `privileged: false`, verify merged result is `Some(true)` per spec acceptance scenario 1
+
+**Checkpoint**: `privileged` OR merge works. Run `cargo nextest run test_merge_bool_or && cargo nextest run test_merge_privileged`.
+
+---
+
+## Phase 4: User Story 2 — Feature adding mounts preserves existing mounts (Priority: P1)
+
+**Goal**: `mounts` array uses union with deduplication — entries from all sources are preserved, duplicates removed by JSON structural equality.
+
+**Independent Test**: Merge two configs with distinct mounts `[A, B]` and `[C, D]`, verify result is `[A, B, C, D]`.
+
+### Tests for User Story 2
+
+- [X] T015 [US2] Add unit test `test_merge_mounts_union_disjoint` in `crates/core/src/config.rs` — base `[A, B]`, overlay `[C, D]`, verify result `[A, B, C, D]` (FR-002)
+- [X] T016 [US2] Add unit test `test_merge_mounts_union_with_duplicates` in `crates/core/src/config.rs` — base `[A, B]`, overlay `[B, C]`, verify result `[A, B, C]` with B not duplicated (FR-004)
+- [X] T017 [US2] Add unit test `test_merge_mounts_union_base_empty` in `crates/core/src/config.rs` — base `[]`, overlay `[A]`, verify result `[A]`
+- [X] T018 [US2] Add unit test `test_merge_mounts_union_overlay_empty` in `crates/core/src/config.rs` — base `[A]`, overlay `[]`, verify result `[A]`
+- [X] T019 [US2] Add unit test `test_merge_mounts_union_both_empty` in `crates/core/src/config.rs` — both `[]`, verify result `[]`
+
+### Implementation for User Story 2
+
+- [X] T020 [US2] Update `mounts` field assignment in `merge_two_configs()` at `crates/core/src/config.rs:1107-1111` — replace `if overlay.mounts.is_empty() { base.mounts.clone() } else { overlay.mounts.clone() }` with `Self::union_json_arrays(&base.mounts, &overlay.mounts)`
+
+**Checkpoint**: `mounts` union works. Run `cargo nextest run test_merge_mounts`.
+
+---
+
+## Phase 5: User Story 3 — Feature adding forwarded ports preserves existing ports (Priority: P1)
+
+**Goal**: `forwardPorts` array uses union with deduplication — all unique ports from both configs preserved, duplicates removed by `PortSpec::PartialEq`.
+
+**Independent Test**: Merge two configs with `forwardPorts: [3000, 8080]` and `forwardPorts: [5432, 6379]`, verify result is `[3000, 8080, 5432, 6379]`.
+
+### Tests for User Story 3
+
+- [X] T021 [US3] Add unit test `test_merge_forward_ports_union_disjoint` in `crates/core/src/config.rs` — base `[3000, 8080]`, overlay `[5432, 6379]`, verify result `[3000, 8080, 5432, 6379]` (FR-003)
+- [X] T022 [US3] Add unit test `test_merge_forward_ports_union_with_duplicates` in `crates/core/src/config.rs` — base `[3000, 8080]`, overlay `[8080, 5432]`, verify result `[3000, 8080, 5432]` with 8080 not duplicated (FR-005)
+- [X] T023 [US3] Add unit test `test_merge_forward_ports_union_mixed_types` in `crates/core/src/config.rs` — base `[Number(3000)]`, overlay `[String("3000:3000")]`, verify both kept as distinct entries per edge case spec
+
+### Implementation for User Story 3
+
+- [X] T024 [US3] Update `forward_ports` field assignment in `merge_two_configs()` at `crates/core/src/config.rs:1112-1115` — replace `if overlay.forward_ports.is_empty() { base.forward_ports.clone() } else { overlay.forward_ports.clone() }` with `Self::union_port_arrays(&base.forward_ports, &overlay.forward_ports)`
+
+**Checkpoint**: `forwardPorts` union works. Run `cargo nextest run test_merge_forward_ports`.
+
+---
+
+## Phase 6: User Story 4 — Init boolean merges with OR semantics (Priority: P2)
+
+**Goal**: `init` property follows the same boolean OR merge rules as `privileged` — if any source sets `init: true`, the merged result is `true`.
+
+**Independent Test**: Merge two configs where one has `init: true` and the other has `init: false`, verify merged result is `true`.
+
+### Tests for User Story 4
+
+- [X] T025 [US4] Add integration test `test_merge_init_or_semantics` in `crates/core/src/config.rs` — test via `merge_two_configs` with base `init: true` + overlay `init: false`, verify merged result is `Some(true)` (FR-001)
+
+### Implementation for User Story 4
+
+- [X] T026 [US4] Update `init` field assignment in `merge_two_configs()` at `crates/core/src/config.rs:1180` — replace `overlay.init.or(base.init)` with `Self::merge_bool_or(base.init, overlay.init)`
+
+**Checkpoint**: `init` OR merge works. Run `cargo nextest run test_merge_init`.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Chain merge tests, regression guard, and full validation across all stories.
+
+- [X] T027 Add chain merge test `test_merge_chain_bool_or` in `crates/core/src/config.rs` — merge three configs where config1 has `privileged: false`, config2 has `privileged: true`, config3 has `privileged: false`, verify final result is `Some(true)` (FR-008)
+- [X] T028 Add chain merge test `test_merge_chain_array_union` in `crates/core/src/config.rs` — merge three configs with distinct mounts `[A]`, `[B]`, `[C]`, verify final result is `[A, B, C]` (FR-008)
+- [X] T029 Add regression test `test_merge_other_categories_unchanged` in `crates/core/src/config.rs` — verify scalars use last-wins, maps use key-merge, concat arrays use concatenation — all unchanged by this fix (FR-007)
+- [X] T030 Run full verification: `cargo fmt --all && cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && make test-nextest-fast` (SC-004, SC-005)
+- [X] T031 Run quickstart.md validation scenarios per `specs/013-fix-merge-rules/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — read-only orientation
+- **Foundational (Phase 2)**: Depends on Phase 1 — adds helper functions that all stories use
+- **US1 (Phase 3)**: Depends on Phase 2 (needs `merge_bool_or` helper)
+- **US2 (Phase 4)**: Depends on Phase 2 (needs `union_json_arrays` helper)
+- **US3 (Phase 5)**: Depends on Phase 2 (needs `union_port_arrays` helper)
+- **US4 (Phase 6)**: Depends on Phase 2 (needs `merge_bool_or` helper — same as US1)
+- **Polish (Phase 7)**: Depends on all user story phases (3–6) being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational — no dependency on other stories
+- **User Story 2 (P1)**: Can start after Foundational — no dependency on other stories
+- **User Story 3 (P1)**: Can start after Foundational — no dependency on other stories
+- **User Story 4 (P2)**: Can start after Foundational — no dependency on other stories
+
+**Note**: While stories are logically independent, all changes are in the same file (`crates/core/src/config.rs`), so parallel execution requires careful merge coordination. Sequential execution in priority order (US1 → US2 → US3 → US4) is recommended for a single implementer.
+
+### Within Each User Story
+
+- Tests written first, verified to compile (they will fail until implementation)
+- Implementation updates the merge line in `merge_two_configs()`
+- Tests re-run and verified passing
+- Checkpoint verification before moving to next story
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# All three helpers can be written together (same file, adjacent location):
+Task: "Implement merge_bool_or helper in crates/core/src/config.rs"
+Task: "Implement union_json_arrays helper in crates/core/src/config.rs"
+Task: "Implement union_port_arrays helper in crates/core/src/config.rs"
+```
+
+## Parallel Example: User Stories (with merge coordination)
+
+```bash
+# After Foundational phase, stories are logically parallelizable:
+Agent A: "US1 — privileged boolean OR (Phase 3)"
+Agent B: "US2 — mounts array union (Phase 4)"
+# Note: Requires file-level merge coordination since both touch config.rs
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Read existing code
+2. Complete Phase 2: Add all three helper functions
+3. Complete Phase 3: US1 — privileged boolean OR with tests
+4. **STOP and VALIDATE**: Run `cargo nextest run test_merge_bool_or && cargo nextest run test_merge_privileged`
+5. Verify the critical `base=true, overlay=false → true` case passes
+
+### Incremental Delivery
+
+1. Phase 2 (Foundational) → All helpers ready
+2. Phase 3 (US1: privileged OR) → Test independently → Core bug fixed
+3. Phase 4 (US2: mounts union) → Test independently → Mount preservation fixed
+4. Phase 5 (US3: forwardPorts union) → Test independently → Port preservation fixed
+5. Phase 6 (US4: init OR) → Test independently → Full boolean OR coverage
+6. Phase 7 (Polish) → Chain tests, regression guard, full validation
+
+### Suggested MVP Scope
+
+**US1 + US4 together** (both use `merge_bool_or`, ~10 min) — fixes all boolean merge bugs. Then US2 + US3 (both use array union, ~10 min) — fixes all array merge bugs.
+
+---
+
+## Notes
+
+- All 31 tasks operate on a single file: `crates/core/src/config.rs`
+- No new dependencies required (research.md Decision 5)
+- `mount::merge_mounts()` in `mount.rs` is NOT modified (research.md Decision 2)
+- Existing merge behavior for other categories is explicitly regression-tested (FR-007)
+- Implementation is ~50 lines code + ~200 lines tests per plan.md estimate


### PR DESCRIPTION
## Summary

Fix two categories of spec-compliance bugs in `ConfigMerger::merge_two_configs()` to match the upstream [containers.dev implementors spec](https://containers.dev/implementors/spec/):

- **Boolean OR semantics** for `privileged` and `init`: previously used `Option::or()` (last-wins); now uses OR semantics — result is `true` if _any_ source sets `true`. Fixes Features requiring privileged access from silently losing that capability during merge.
- **Array union** for `mounts` and `forwardPorts`: previously replaced the base array with the overlay when non-empty; now unions both with deduplication — all unique entries from all sources are preserved. Fixes Features that add mounts/ports from silently dropping the user's own entries.

## Changes

- Replace duplicate `union_json_arrays` + `union_port_arrays` with generic `union_arrays<T: Clone + PartialEq>`
- Simplify `merge_bool_or` to a concise 2-arm match
- Derive `Eq` for `PortSpec` (zero-cost type hygiene)
- Add clarifying comment on `run_services` (Compose-specific, confirmed not in upstream merge spec)
- Add 5 missing tests: `true+true` truth-table row, string-vs-object mount edge case, `forwardPorts` overlay-empty scenario, `init` both-None integration test, `forwardPorts` 3-config chain merge (FR-008)

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `make test-nextest-fast` — 1784 tests passed, 0 failures
- [x] All 5 new tests pass (verified individually)
- [x] Regression test `test_merge_other_categories_unchanged` guards all unmodified merge categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)