### PR TITLE
refactor: lifecycle code deduplication + named config search spec (014)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -87,7 +87,9 @@
       "Bash(export:*)",
       "Bash(head:*)",
       "Bash(fish:*)",
-      "Bash(brew list rust)"
+      "Bash(brew list rust)",
+      "Bash(mdfind:*)",
+      "WebFetch(domain:rust-lang.github.io)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,8 @@ RUST_LOG=debug cargo run -- up --container-data-folder /tmp/cache
 - N/A (devcontainer.json configuration files) (009-complete-feature-support)
 - N/A (Markdown documentation only) (011-update-readme-scope)
 - Rust 1.70+ (Edition 2021) + okio (async runtime, JoinSet for parallel), serde/serde_json (JSON parsing), indexmap (ordered maps for object format), clap (CLI), tracing (logging) (012-fix-lifecycle-formats)
+- Rust 1.70+ (Edition 2021) + serde, tracing, thiserror, clap (existing — no new dependencies) (014-named-config-search)
+- N/A (filesystem-only config discovery) (014-named-config-search)
 
 ## Recent Changes
 - 009-complete-feature-support: Added Rust 1.70+ (Edition 2021) + clap, serde, tokio, reqwest (rustls TLS), tracing

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -30,6 +30,11 @@ pub enum ConfigError {
     #[error("Failed to read configuration file")]
     Io(#[from] std::io::Error),
 
+    /// Multiple configuration files found — user must select one
+    #[error("Multiple devcontainer configurations found. Use --config to specify one:\n{}",
+        paths.iter().map(|p| format!("  {}", p)).collect::<Vec<_>>().join("\n"))]
+    MultipleConfigs { paths: Vec<String> },
+
     /// Configuration file not found
     #[error("Configuration file not found: {path}")]
     NotFound { path: String },
@@ -288,6 +293,17 @@ mod tests {
         assert_eq!(
             format!("{}", error),
             "Configuration file not found: /path/to/file"
+        );
+
+        let error = ConfigError::MultipleConfigs {
+            paths: vec![
+                ".devcontainer/node/devcontainer.json".to_string(),
+                ".devcontainer/python/devcontainer.json".to_string(),
+            ],
+        };
+        assert_eq!(
+            format!("{}", error),
+            "Multiple devcontainer configurations found. Use --config to specify one:\n  .devcontainer/node/devcontainer.json\n  .devcontainer/python/devcontainer.json"
         );
     }
 

--- a/crates/core/tests/common/mod.rs
+++ b/crates/core/tests/common/mod.rs
@@ -1,0 +1,18 @@
+//! Shared test helpers for core integration tests.
+
+use deacon_core::container_lifecycle::{
+    AggregatedLifecycleCommand, LifecycleCommandList, LifecycleCommandSource, LifecycleCommandValue,
+};
+
+/// Helper to create a LifecycleCommandList from shell command strings
+pub fn make_shell_command_list(cmds: &[&str]) -> LifecycleCommandList {
+    LifecycleCommandList {
+        commands: cmds
+            .iter()
+            .map(|cmd| AggregatedLifecycleCommand {
+                command: LifecycleCommandValue::Shell(cmd.to_string()),
+                source: LifecycleCommandSource::Config,
+            })
+            .collect(),
+    }
+}

--- a/crates/core/tests/integration_mock_runtime.rs
+++ b/crates/core/tests/integration_mock_runtime.rs
@@ -3,13 +3,13 @@
 //! These tests use the MockDocker runtime to validate exec and lifecycle command execution
 //! without requiring a real Docker daemon, enabling comprehensive testing in CI environments.
 
+mod common;
+
 use anyhow::Result;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_docker, AggregatedLifecycleCommand,
-    ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandList,
-    LifecycleCommandSource, LifecycleCommandValue,
+    execute_container_lifecycle_with_docker, ContainerLifecycleCommands, ContainerLifecycleConfig,
 };
 use deacon_core::docker::mock::{MockContainer, MockDocker, MockDockerConfig, MockExecResponse};
 use deacon_core::docker::{Docker, ExecConfig};
@@ -17,19 +17,6 @@ use deacon_core::variable::SubstitutionContext;
 use std::collections::HashMap;
 use std::time::Duration;
 use tempfile::TempDir;
-
-/// Helper to create a LifecycleCommandList from shell command strings
-fn make_shell_command_list(cmds: &[&str]) -> LifecycleCommandList {
-    LifecycleCommandList {
-        commands: cmds
-            .iter()
-            .map(|cmd| AggregatedLifecycleCommand {
-                command: LifecycleCommandValue::Shell(cmd.to_string()),
-                source: LifecycleCommandSource::Config,
-            })
-            .collect(),
-    }
-}
 
 /// Test helper to create a basic dev container config
 fn create_test_config() -> DevContainerConfig {
@@ -361,10 +348,14 @@ async fn test_lifecycle_execution_with_mock_docker() -> Result<()> {
 
     // Create lifecycle commands
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["npm install"]))
-        .with_post_create(make_shell_command_list(&["npm run build"]))
-        .with_post_start(make_shell_command_list(&["echo 'container started'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'container attached'"]));
+        .with_on_create(common::make_shell_command_list(&["npm install"]))
+        .with_post_create(common::make_shell_command_list(&["npm run build"]))
+        .with_post_start(common::make_shell_command_list(&[
+            "echo 'container started'",
+        ]))
+        .with_post_attach(common::make_shell_command_list(&[
+            "echo 'container attached'",
+        ]));
 
     // Create substitution context
     let temp_dir = TempDir::new()?;
@@ -455,10 +446,10 @@ async fn test_lifecycle_execution_with_skip_flags() -> Result<()> {
 
     // Create lifecycle commands
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'on create'"]))
-        .with_post_create(make_shell_command_list(&["echo 'post create'"]))
-        .with_post_start(make_shell_command_list(&["echo 'post start'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'post attach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'on create'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'post create'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'post start'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'post attach'"]));
 
     // Create substitution context
     let temp_dir = TempDir::new()?;
@@ -522,8 +513,8 @@ async fn test_lifecycle_execution_with_command_failure() -> Result<()> {
 
     // Create lifecycle commands with a failing command
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'success'"]))
-        .with_post_create(make_shell_command_list(&["failing-command"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'success'"]))
+        .with_post_create(common::make_shell_command_list(&["failing-command"]));
 
     // Create substitution context
     let temp_dir = TempDir::new()?;
@@ -628,10 +619,10 @@ async fn test_non_blocking_command_skip_behavior() -> Result<()> {
 
     // Create lifecycle commands
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Create substitution context
     let temp_dir = TempDir::new()?;

--- a/crates/core/tests/integration_non_blocking_lifecycle.rs
+++ b/crates/core/tests/integration_non_blocking_lifecycle.rs
@@ -1,28 +1,16 @@
 //! Test to demonstrate non-blocking lifecycle phases
 
+mod common;
+
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_docker, AggregatedLifecycleCommand,
-    ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandList,
-    LifecycleCommandSource, LifecycleCommandValue,
+    execute_container_lifecycle_with_docker, ContainerLifecycleCommands, ContainerLifecycleConfig,
+    LifecycleCommandValue,
 };
 use deacon_core::docker::mock::{MockDocker, MockDockerConfig, MockExecResponse};
 use deacon_core::variable::SubstitutionContext;
 use std::collections::HashMap;
 use std::time::Duration;
 use tempfile::TempDir;
-
-/// Helper to create a LifecycleCommandList from shell command strings
-fn make_shell_command_list(cmds: &[&str]) -> LifecycleCommandList {
-    LifecycleCommandList {
-        commands: cmds
-            .iter()
-            .map(|cmd| AggregatedLifecycleCommand {
-                command: LifecycleCommandValue::Shell(cmd.to_string()),
-                source: LifecycleCommandSource::Config,
-            })
-            .collect(),
-    }
-}
 
 #[tokio::test]
 async fn test_non_blocking_phases_are_deferred() {
@@ -62,10 +50,10 @@ async fn test_non_blocking_phases_are_deferred() {
 
     // Create lifecycle commands with all phases
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(
@@ -168,10 +156,10 @@ async fn test_skip_non_blocking_commands_behavior() {
 
     // Create lifecycle commands with all phases
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(
@@ -241,10 +229,10 @@ async fn test_non_blocking_phases_sync_execution() {
 
     // Create lifecycle commands with all phases
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(
@@ -364,10 +352,10 @@ async fn test_non_blocking_phase_command_failures_are_handled() {
 
     // Create lifecycle commands with all phases
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(
@@ -482,9 +470,9 @@ async fn test_non_blocking_phase_timeout_handling() {
 
     // Create lifecycle commands
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(
@@ -558,10 +546,10 @@ async fn test_non_blocking_phases_with_progress_streaming() {
 
     // Create lifecycle commands with non-blocking phases
     let commands = ContainerLifecycleCommands::new()
-        .with_on_create(make_shell_command_list(&["echo 'onCreate'"]))
-        .with_post_create(make_shell_command_list(&["echo 'postCreate'"]))
-        .with_post_start(make_shell_command_list(&["echo 'postStart'"]))
-        .with_post_attach(make_shell_command_list(&["echo 'postAttach'"]));
+        .with_on_create(common::make_shell_command_list(&["echo 'onCreate'"]))
+        .with_post_create(common::make_shell_command_list(&["echo 'postCreate'"]))
+        .with_post_start(common::make_shell_command_list(&["echo 'postStart'"]))
+        .with_post_attach(common::make_shell_command_list(&["echo 'postAttach'"]));
 
     // Execute lifecycle commands
     let result = execute_container_lifecycle_with_docker(

--- a/crates/core/tests/integration_worktree.rs
+++ b/crates/core/tests/integration_worktree.rs
@@ -1,6 +1,6 @@
 //! Integration tests for Git worktree support in workspace resolution
 
-use deacon_core::config::{ConfigLoader, DevContainerConfig};
+use deacon_core::config::{ConfigLoader, DevContainerConfig, DiscoveryResult};
 use deacon_core::container::ContainerIdentity;
 use deacon_core::observability::workspace_id;
 use deacon_core::workspace::resolve_workspace_root;
@@ -219,8 +219,7 @@ fn test_config_discovery_in_worktree() {
 
     // Discover config should find it in the worktree
     let discovered = ConfigLoader::discover_config(&worktree_path).unwrap();
-    assert!(discovered.exists());
-    assert_eq!(discovered.path(), &config_path);
+    assert_eq!(discovered, DiscoveryResult::Single(config_path));
 }
 
 #[test]

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -454,14 +454,8 @@ pub async fn execute_build(args: BuildArgs) -> Result<()> {
     debug!("Build args: {:?}", args);
 
     // Initialize progress tracking
-    let emit_progress_event = |event: deacon_core::progress::ProgressEvent| -> Result<()> {
-        if let Ok(mut tracker_guard) = args.progress_tracker.lock() {
-            if let Some(ref mut tracker) = tracker_guard.as_mut() {
-                tracker.emit_event(event)?;
-            }
-        }
-        Ok(())
-    };
+    let emit_progress_event =
+        crate::commands::shared::progress::make_progress_callback(&args.progress_tracker);
 
     // Parse and validate labels from key=value format
     let parsed_labels: Result<Vec<(String, String)>> = args

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod config_loader;
 pub mod env_user;
+pub mod progress;
 pub mod remote_env;
 pub mod terminal;
 pub mod workspace;

--- a/crates/deacon/src/commands/shared/progress.rs
+++ b/crates/deacon/src/commands/shared/progress.rs
@@ -1,0 +1,28 @@
+//! Shared progress callback helpers for command implementations.
+
+use anyhow::Result;
+use deacon_core::progress::{ProgressEvent, ProgressTracker};
+use std::sync::{Arc, Mutex};
+use tracing::warn;
+
+/// Create a progress event callback that emits events through the shared progress tracker.
+///
+/// Returns a closure suitable for passing to lifecycle execution functions as a progress callback.
+/// Standardizes on the explicit `match` + `warn!` pattern for mutex poisoning (no silent fallback).
+pub fn make_progress_callback(
+    tracker: &Arc<Mutex<Option<ProgressTracker>>>,
+) -> impl Fn(ProgressEvent) -> Result<()> + '_ {
+    move |event: ProgressEvent| -> Result<()> {
+        match tracker.lock() {
+            Ok(mut tracker_guard) => {
+                if let Some(ref mut tracker) = tracker_guard.as_mut() {
+                    tracker.emit_event(event)?;
+                }
+            }
+            Err(e) => {
+                warn!("Progress tracker mutex poisoned: {}", e);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -143,14 +143,8 @@ pub(crate) async fn execute_container_up(
     }
 
     // Initialize progress tracking
-    let emit_progress_event = |event: deacon_core::progress::ProgressEvent| -> Result<()> {
-        if let Ok(mut tracker_guard) = args.progress_tracker.lock() {
-            if let Some(ref mut tracker) = tracker_guard.as_mut() {
-                tracker.emit_event(event)?;
-            }
-        }
-        Ok(())
-    };
+    let emit_progress_event =
+        crate::commands::shared::progress::make_progress_callback(&args.progress_tracker);
 
     // Create container identity for deterministic naming and labels
     let identity = ContainerIdentity::new_with_custom_name(

--- a/crates/deacon/src/commands/up/result.rs
+++ b/crates/deacon/src/commands/up/result.rs
@@ -322,6 +322,17 @@ impl UpResult {
                         "Feature not implemented".to_string(),
                         format!("Feature '{}' is not yet implemented", feature),
                     ),
+                    ConfigError::MultipleConfigs { paths } => UpResult::error(
+                        "Multiple devcontainer configurations found".to_string(),
+                        format!(
+                            "Use --config to specify one:\n{}",
+                            paths
+                                .iter()
+                                .map(|p| format!("  {}", p))
+                                .collect::<Vec<_>>()
+                                .join("\n")
+                        ),
+                    ),
                     ConfigError::Io(io_err) => UpResult::error(
                         "Failed to read configuration file".to_string(),
                         format!("{}", io_err),

--- a/specs/012-fix-lifecycle-formats/data-model.md
+++ b/specs/012-fix-lifecycle-formats/data-model.md
@@ -99,6 +99,10 @@ pub struct ParallelCommandResult {
     pub duration: std::time::Duration,
     /// Whether the command succeeded
     pub success: bool,
+    /// Captured standard output from the command
+    pub stdout: String,
+    /// Captured standard error from the command
+    pub stderr: String,
 }
 ```
 

--- a/specs/012-fix-lifecycle-formats/tasks.md
+++ b/specs/012-fix-lifecycle-formats/tasks.md
@@ -128,6 +128,18 @@
 
 ---
 
+## Deferred Work
+
+- [ ] T031 [Deferral] Aggregate feature lifecycle commands in run-user-commands per research.md
+  - **Rationale**: Requires resolved features from image metadata (container labels); only user config commands are collected currently
+  - **Acceptance**: `run-user-commands` includes feature-contributed lifecycle commands matching `up` behavior
+
+- [ ] T032 [Deferral] Line-prefix parallel command output to terminal in real-time
+  - **Rationale**: Current implementation captures stdout/stderr in CommandResult but does not prefix [key] to terminal output stream during execution
+  - **Acceptance**: Parallel commands show `[key]` prefix on each output line in real-time terminal output
+
+---
+
 ## Dependencies & Execution Order
 
 ### Phase Dependencies

--- a/specs/014-named-config-search/checklists/requirements.md
+++ b/specs/014-named-config-search/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Named Config Folder Search
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumption: multi-config disambiguation uses error-with-listing approach (matching reference CLI philosophy where subfolder configs require explicit selection). This was informed by researching the devcontainers/cli reference implementation and the containers.dev spec.
+- The spec intentionally avoids dictating sort order for listed configs in the error message — that is an implementation detail.

--- a/specs/014-named-config-search/contracts/config-discovery.md
+++ b/specs/014-named-config-search/contracts/config-discovery.md
@@ -1,0 +1,109 @@
+# Contract: Config Discovery
+
+**Feature**: 014-named-config-search
+**Date**: 2026-02-22
+
+## Interface: `ConfigLoader::discover_config`
+
+### Signature
+
+```rust
+pub fn discover_config(workspace: &Path) -> Result<DiscoveryResult>
+```
+
+### Preconditions
+
+- `workspace` is a path to an existing directory
+- If `workspace` does not exist, returns `Err(ConfigError::NotFound)`
+
+### Postconditions
+
+Returns one of three variants:
+
+| Variant | Condition | Payload |
+|---------|-----------|---------|
+| `DiscoveryResult::Single(path)` | Exactly one config file found across all 3 priority levels | Absolute path to the config file; file exists |
+| `DiscoveryResult::Multiple(paths)` | Multiple named configs found at priority 3 (no higher-priority match) | Vec of absolute paths, sorted alphabetically by subdirectory name, length >= 2 |
+| `DiscoveryResult::None(default)` | No config file found at any level | Default path (`.devcontainer/devcontainer.json`); file does NOT exist |
+
+### Search Algorithm
+
+```
+1. Check priority 1: .devcontainer/devcontainer.json, then .devcontainer/devcontainer.jsonc
+   → If found: return Single(path)
+
+2. Check priority 2: .devcontainer.json, then .devcontainer.jsonc
+   → If found: return Single(path)
+
+3. Enumerate priority 3: for each direct subdirectory of .devcontainer/ (sorted alphabetically):
+   a. Check for devcontainer.json in subdirectory
+   b. If not found, check for devcontainer.jsonc in subdirectory
+   c. If either found, add to candidates list
+
+4. If candidates.len() == 1: return Single(candidates[0])
+5. If candidates.len() > 1: return Multiple(candidates)
+6. return None(default_path)
+```
+
+### Error Cases
+
+| Error | Condition |
+|-------|-----------|
+| `ConfigError::NotFound { path }` | Workspace directory does not exist |
+| `ConfigError::Io(e)` | Filesystem error during `read_dir` or `file_type` |
+
+### Tracing
+
+- Span: `config.discover` (existing)
+- Debug logs for each search step
+- Info log when named config enumeration produces results
+
+---
+
+## Interface: `load_config` (shared CLI helper)
+
+### Signature
+
+```rust
+pub fn load_config(args: ConfigLoadArgs<'_>) -> Result<ConfigLoadResult>
+```
+
+### Behavior Change
+
+When `args.config_path` is `None` (no explicit `--config`):
+- Calls `ConfigLoader::discover_config()`
+- On `DiscoveryResult::Single(path)` → proceeds with loading (existing behavior)
+- On `DiscoveryResult::Multiple(paths)` → returns `Err(ConfigError::MultipleConfigs { paths })`
+- On `DiscoveryResult::None(default)` → falls back to override or returns `NotFound` (existing behavior)
+
+When `args.config_path` is `Some(path)`:
+- Uses that path directly (existing behavior, unchanged)
+
+---
+
+## Interface: `down` command discovery
+
+### Behavior Change
+
+The `down` command calls `discover_config()` directly. Updated handling:
+- `DiscoveryResult::Single(path)` → load config (existing behavior)
+- `DiscoveryResult::Multiple(paths)` → return `Err(ConfigError::MultipleConfigs { paths })`
+- `DiscoveryResult::None(_)` → fall back to auto-discovery from state (existing behavior)
+
+---
+
+## Error Message Contract
+
+### MultipleConfigs Error Format
+
+```
+Multiple devcontainer configurations found. Use --config to specify one:
+  .devcontainer/node/devcontainer.json
+  .devcontainer/python/devcontainer.json
+  .devcontainer/rust/devcontainer.json
+```
+
+- Paths are relative to the workspace folder
+- Sorted alphabetically by subdirectory name
+- Each path on its own line, indented with two spaces
+- Header line instructs user to use `--config`

--- a/specs/014-named-config-search/data-model.md
+++ b/specs/014-named-config-search/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Named Config Folder Search
+
+**Feature**: 014-named-config-search
+**Date**: 2026-02-22
+
+## Entities
+
+### DiscoveryResult (NEW)
+
+Replaces the current `ConfigLocation` return type from `ConfigLoader::discover_config()`.
+
+```rust
+/// Result of devcontainer configuration discovery.
+///
+/// Represents the three possible outcomes when searching for
+/// devcontainer.json across the three priority locations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiscoveryResult {
+    /// Exactly one configuration file was found.
+    /// Contains the path to the discovered config file.
+    Single(PathBuf),
+
+    /// Multiple configuration files were found at the named config level.
+    /// Contains all discovered paths, sorted alphabetically by subdirectory name.
+    /// The caller should present these to the user and require explicit selection.
+    Multiple(Vec<PathBuf>),
+
+    /// No configuration file was found at any search location.
+    /// Contains the default/preferred path for error messaging.
+    None(PathBuf),
+}
+```
+
+**Fields**:
+| Variant | Payload | Description |
+|---------|---------|-------------|
+| `Single` | `PathBuf` | Path to the one discovered config file |
+| `Multiple` | `Vec<PathBuf>` | All discovered config paths, sorted alphabetically |
+| `None` | `PathBuf` | Default path (`.devcontainer/devcontainer.json`) for error context |
+
+**Invariants**:
+- `Multiple` always contains 2+ paths
+- `Multiple` paths are sorted alphabetically by parent directory name
+- `Single` path always exists on disk at time of construction
+- `None` default path does NOT exist on disk
+
+### ConfigError::MultipleConfigs (NEW)
+
+New error variant added to the existing `ConfigError` enum.
+
+```rust
+/// Multiple configuration files found — user must select one
+#[error("Multiple devcontainer configurations found. Use --config to specify one:\n{}",
+    paths.iter().map(|p| format!("  {}", p)).collect::<Vec<_>>().join("\n"))]
+MultipleConfigs { paths: Vec<String> },
+```
+
+**Fields**:
+| Field | Type | Description |
+|-------|------|-------------|
+| `paths` | `Vec<String>` | Display-formatted paths to all discovered configs |
+
+### ConfigLocation (EXISTING — unchanged)
+
+The existing `ConfigLocation` struct is kept for backward compatibility in any internal usage but is no longer the return type of `discover_config()`.
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfigLocation {
+    pub path: PathBuf,
+    pub exists: bool,
+}
+```
+
+## State Transitions
+
+Config discovery is stateless — it reads the filesystem and produces a `DiscoveryResult`. No state transitions apply.
+
+## Validation Rules
+
+| Rule | Source | Enforcement Point |
+|------|--------|-------------------|
+| Priority order: dir > root > named | FR-001 | `discover_config()` |
+| Short-circuit on priority 1 or 2 match | FR-009 | `discover_config()` |
+| One level deep only | FR-005 | `enumerate_named_configs()` |
+| Alphabetical sort by subdirectory name | FR-005 | `enumerate_named_configs()` |
+| Skip subdirs without config file | FR-006 | `enumerate_named_configs()` |
+| Check both `.json` and `.jsonc` | FR-006, D2 | all search levels |
+| Prefer `.json` over `.jsonc` in same dir | D3 | `check_config_in_dir()` |
+| `--config` bypasses all discovery | FR-004 | `load_config()` (CLI layer) |
+| Multiple configs → error with listing | FR-003, FR-008 | `load_config()` + `down` command |
+
+## Relationships
+
+```
+ConfigLoadArgs --[config_path: Some]-->  bypass discovery
+ConfigLoadArgs --[config_path: None]-->  ConfigLoader::discover_config()
+                                              |
+                                         DiscoveryResult
+                                        /      |       \
+                                   Single   Multiple   None
+                                      |        |         |
+                                  load_with_  error    fallback/
+                                  extends()  listing   not_found
+```

--- a/specs/014-named-config-search/plan.md
+++ b/specs/014-named-config-search/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: Named Config Folder Search
+
+**Branch**: `014-named-config-search` | **Date**: 2026-02-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/014-named-config-search/spec.md`
+
+## Summary
+
+Add support for the third devcontainer.json search location: named config folders inside `.devcontainer/`. When no config exists at the two existing priority locations (`.devcontainer/devcontainer.json`, `.devcontainer.json`), the tool enumerates direct subdirectories of `.devcontainer/` looking for `devcontainer.json`/`devcontainer.jsonc`. If exactly one is found, it is used automatically. If multiple are found, an error lists them and requires `--config` selection. This is implemented by extending `ConfigLoader::discover_config()` in core with a new `DiscoveryResult` type, then adapting the two call sites (shared `load_config()` and `down` command) to handle the multiple-configs case.
+
+## Technical Context
+
+**Language/Version**: Rust 1.70+ (Edition 2021)
+**Primary Dependencies**: serde, tracing, thiserror, clap (existing — no new dependencies)
+**Storage**: N/A (filesystem-only config discovery)
+**Testing**: cargo-nextest (`make test-nextest-fast` for iteration, `make test-nextest` before PR)
+**Target Platform**: Linux (primary), macOS, Windows (cross-platform path handling)
+**Project Type**: CLI tool (core library + binary crate)
+**Performance Goals**: Config discovery completes in <10ms for typical workspace layouts
+**Constraints**: Must be backward-compatible with existing two-location search; alphabetical sort for deterministic multi-platform behavior
+**Scale/Scope**: ~3 files modified in core + CLI, ~200 lines of new code, ~15 new unit tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Parity | PASS | Implements the third search location per upstream containers.dev spec. Priority order and one-level-deep enumeration match spec exactly. |
+| II. Consumer-Only Scope | PASS | Config discovery is consumer functionality (finding configs to use containers). |
+| III. Keep the Build Green | PASS | Will run `cargo fmt`, `cargo clippy`, `make test-nextest-fast` after every change. |
+| IV. No Silent Fallbacks | PASS | Multiple configs produce a clear error listing paths; no silent selection. |
+| V. Idiomatic, Safe Rust | PASS | Uses `std::fs::read_dir` for enumeration, `Result` propagation, `thiserror` for new error variant. |
+| VI. Observability | PASS | Tracing spans/debug logs for discovery steps. No output contract changes. |
+| VII. Testing Completeness | PASS | Unit tests for all discovery scenarios; integration tests via shared loader. |
+| VIII. Shared Abstractions | PASS | Extends existing `ConfigLoader::discover_config()` — all 6 commands benefit through shared `load_config()`. `down` command's custom call site also updated. |
+| IX. Examples | N/A | No example changes needed — this is internal discovery logic. |
+
+**Pre-Implementation Validation**:
+1. Spec review: FR-001 through FR-009 mapped to implementation
+2. Scope check: Consumer command (config discovery)
+3. Data model: New `DiscoveryResult` enum replaces `ConfigLocation` return
+4. Algorithm: Three-tier search with short-circuit, alphabetical enumeration
+5. Input validation: `--config` bypass, filename validation unchanged
+6. Config resolution: Discovery feeds into existing `load_with_extends` chain
+7. Output contracts: No JSON schema changes
+8. Testing: 15+ new tests covering all acceptance scenarios and edge cases
+9. Infrastructure reuse: `ConfigLoader`, `ConfigError`, shared `load_config()`
+10. Nextest config: New tests are unit tests — no new test group needed
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-named-config-search/
+├── plan.md              # This file
+├── research.md          # Phase 0: design decisions
+├── data-model.md        # Phase 1: data structures
+├── quickstart.md        # Phase 1: implementation guide
+├── contracts/           # Phase 1: interface contracts
+│   └── config-discovery.md  # Discovery function contract
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── core/src/
+│   ├── config.rs         # ConfigLoader::discover_config() — MODIFY
+│   │                     # Add DiscoveryResult enum, enumerate_named_configs()
+│   └── errors.rs         # ConfigError — MODIFY (add MultipleConfigs variant)
+└── deacon/src/commands/
+    ├── shared/
+    │   └── config_loader.rs  # load_config() — MODIFY (handle DiscoveryResult)
+    └── down.rs               # Custom discovery call — MODIFY (handle DiscoveryResult)
+```
+
+**Structure Decision**: Existing Rust workspace structure. Changes are localized to 4 files in the existing module hierarchy. No new modules or crates needed.
+
+## Complexity Tracking
+
+> No constitution violations — no entries needed.

--- a/specs/014-named-config-search/quickstart.md
+++ b/specs/014-named-config-search/quickstart.md
@@ -1,0 +1,160 @@
+# Quickstart: Named Config Folder Search
+
+**Feature**: 014-named-config-search
+**Date**: 2026-02-22
+
+## Overview
+
+This feature extends `ConfigLoader::discover_config()` to search for devcontainer.json files inside named subdirectories of `.devcontainer/`. The change is localized to 4 files and follows the existing shared discovery pattern.
+
+## Implementation Order
+
+### Step 1: Add `ConfigError::MultipleConfigs` variant
+
+**File**: `crates/core/src/errors.rs`
+
+Add to `ConfigError` enum:
+```rust
+/// Multiple configuration files found — user must select one
+#[error("Multiple devcontainer configurations found. Use --config to specify one:\n{}", paths.join("\n"))]
+MultipleConfigs { paths: Vec<String> },
+```
+
+Update existing error display test to cover the new variant.
+
+### Step 2: Add `DiscoveryResult` enum and update `discover_config()`
+
+**File**: `crates/core/src/config.rs`
+
+1. Add `DiscoveryResult` enum near `ConfigLocation` (around line 204)
+2. Add helper `fn check_config_file(dir: &Path) -> Option<PathBuf>` that checks for `devcontainer.json` then `devcontainer.jsonc` in a directory
+3. Add helper `fn enumerate_named_configs(devcontainer_dir: &Path) -> Result<Vec<PathBuf>>` that enumerates and sorts subdirectories
+4. Update `discover_config()` to return `DiscoveryResult` instead of `ConfigLocation`
+5. Update existing unit tests, add new tests
+
+**Key logic in `discover_config()`**:
+```rust
+// Priority 1: .devcontainer/devcontainer.json(c)
+if let Some(path) = check_config_file(&workspace.join(".devcontainer")) {
+    return Ok(DiscoveryResult::Single(path));
+}
+
+// Priority 2: root .devcontainer.json(c)
+for ext in &["json", "jsonc"] {
+    let path = workspace.join(format!(".devcontainer.{ext}"));
+    if path.exists() {
+        return Ok(DiscoveryResult::Single(path));
+    }
+}
+
+// Priority 3: named config folders
+let devcontainer_dir = workspace.join(".devcontainer");
+if devcontainer_dir.is_dir() {
+    let named = enumerate_named_configs(&devcontainer_dir)?;
+    match named.len() {
+        0 => {},
+        1 => return Ok(DiscoveryResult::Single(named.into_iter().next().unwrap())),
+        _ => return Ok(DiscoveryResult::Multiple(named)),
+    }
+}
+
+Ok(DiscoveryResult::None(
+    workspace.join(".devcontainer").join("devcontainer.json")
+))
+```
+
+### Step 3: Update shared `load_config()` helper
+
+**File**: `crates/deacon/src/commands/shared/config_loader.rs`
+
+Update the `else` branch (when `args.config_path` is `None`) to match on `DiscoveryResult`:
+```rust
+} else {
+    match ConfigLoader::discover_config(&workspace_folder)? {
+        DiscoveryResult::Single(path) => path,
+        DiscoveryResult::Multiple(paths) => {
+            let display_paths: Vec<String> = paths.iter()
+                .map(|p| p.strip_prefix(&workspace_folder)
+                    .unwrap_or(p)
+                    .display()
+                    .to_string())
+                .map(|p| format!("  {p}"))
+                .collect();
+            return Err(DeaconError::Config(ConfigError::MultipleConfigs {
+                paths: display_paths,
+            }));
+        }
+        DiscoveryResult::None(default) => default,
+    }
+};
+```
+
+Update existing tests, add test for multiple configs error.
+
+### Step 4: Update `down` command
+
+**File**: `crates/deacon/src/commands/down.rs`
+
+Update the `discover_config()` call to match on `DiscoveryResult`:
+```rust
+let config_result = if let Some(config_path) = args.config_path.as_ref() {
+    ConfigLoader::load_from_path(config_path)
+} else {
+    match ConfigLoader::discover_config(workspace_folder)? {
+        DiscoveryResult::Single(path) => ConfigLoader::load_from_path(&path),
+        DiscoveryResult::Multiple(paths) => {
+            let display_paths = paths.iter()
+                .map(|p| format!("  {}", p.strip_prefix(workspace_folder).unwrap_or(p).display()))
+                .collect();
+            return Err(anyhow::anyhow!(DeaconError::Config(
+                ConfigError::MultipleConfigs { paths: display_paths }
+            )));
+        }
+        DiscoveryResult::None(_) => {
+            debug!("No configuration found, attempting auto-discovery from state");
+            return execute_down_with_auto_discovery(workspace_folder, &args).await;
+        }
+    }
+};
+```
+
+### Step 5: Write comprehensive tests
+
+Add unit tests in `crates/core/src/config.rs`:
+- Single named config auto-discovery
+- Multiple named configs returns `Multiple`
+- Priority 1 short-circuits over named configs
+- Priority 2 short-circuits over named configs
+- Subdirectories without config files are skipped
+- Non-directory entries are ignored
+- `.jsonc` files are discovered
+- `.json` preferred over `.jsonc` in same directory
+- Empty `.devcontainer/` directory
+- Alphabetical ordering of results
+- Deeply nested subdirectories are NOT found
+
+Add integration tests in shared `config_loader.rs`:
+- Multiple configs error via `load_config()`
+- Single named config works end-to-end
+
+## Build Verification
+
+After each step:
+```bash
+cargo fmt --all && cargo clippy --all-targets -- -D warnings
+make test-nextest-fast
+```
+
+Before PR:
+```bash
+make test-nextest
+```
+
+## Key Files Reference
+
+| File | Change Type | Scope |
+|------|-------------|-------|
+| `crates/core/src/errors.rs` | Add variant | `MultipleConfigs` to `ConfigError` |
+| `crates/core/src/config.rs` | Major change | `DiscoveryResult`, `discover_config()`, helpers, tests |
+| `crates/deacon/src/commands/shared/config_loader.rs` | Moderate change | Handle `DiscoveryResult` in `load_config()` |
+| `crates/deacon/src/commands/down.rs` | Moderate change | Handle `DiscoveryResult` in custom discovery |

--- a/specs/014-named-config-search/research.md
+++ b/specs/014-named-config-search/research.md
@@ -1,0 +1,98 @@
+# Research: Named Config Folder Search
+
+**Feature**: 014-named-config-search
+**Date**: 2026-02-22
+
+## Research Tasks
+
+### RT-1: Upstream Spec Config Search Algorithm
+
+**Question**: What is the exact algorithm for the three config search locations?
+
+**Findings**: The upstream containers.dev spec (https://containers.dev/implementors/spec/) defines three search locations in priority order:
+1. `.devcontainer/devcontainer.json` (highest priority)
+2. `.devcontainer.json` (root level)
+3. `.devcontainer/<folder>/devcontainer.json` for each direct child subdirectory of `.devcontainer/`
+
+The spec notes: "It is valid that these files may exist in more than one location, so consider providing a mechanism for users to select one when appropriate."
+
+Priority levels 1 and 2 short-circuit: if found, no subdirectory enumeration occurs. When multiple configs are found at level 3, the implementation should provide a selection mechanism (in our case: error with listing + `--config` flag).
+
+### RT-2: Current Implementation Architecture
+
+**Question**: How is config discovery currently structured?
+
+**Findings**:
+- `ConfigLoader::discover_config(workspace: &Path) -> Result<ConfigLocation>` in `crates/core/src/config.rs:1382-1416`
+- Returns `ConfigLocation { path, exists }` — a single path with existence flag
+- Two call sites:
+  1. Shared `load_config()` in `crates/deacon/src/commands/shared/config_loader.rs:70` — used by 5 of 6 commands
+  2. `down` command in `crates/deacon/src/commands/down.rs:62` — has custom fallback to auto-discovery from state
+- Current behavior when no config found: returns the first search path (`.devcontainer/devcontainer.json`) with `exists: false`, which downstream code handles via fallback or `NotFound` error
+
+### RT-3: Return Type Design for Multiple Configs
+
+**Question**: Should `discover_config()` return a single path, multiple paths, or an enum?
+
+**Findings**: The current `ConfigLocation` type cannot represent the "multiple configs found" case. Three options considered:
+
+1. **Return `Vec<ConfigLocation>`**: Callers must check length. Loses the semantic distinction between "not found" and "ambiguous".
+2. **Return new `DiscoveryResult` enum**: Explicitly models all three outcomes (single found, multiple found, none found). Best for type safety.
+3. **Return error on multiple**: Put the error inside `discover_config()`. Works but moves policy into core where it may not belong.
+
+**Decision**: Option 2 — new `DiscoveryResult` enum. This keeps core logic pure (discovery reports what it found) and lets callers (CLI layer) decide how to present the error. The enum variants clearly encode the three outcomes and carry the relevant paths.
+
+### RT-4: File Extension Handling
+
+**Question**: Should named config search check for both `.json` and `.jsonc`?
+
+**Findings**: The spec and existing code both support JSONC (JSON with comments) via the `json5` parser. The existing search paths only check `devcontainer.json` (not `.jsonc`), but the shared `load_config()` validates that `--config` paths can be either `devcontainer.json` or `devcontainer.jsonc`. For consistency, named config enumeration should check for both `devcontainer.json` and `devcontainer.jsonc` in each subdirectory. If both exist in the same subdirectory, that subdirectory contributes one config (prefer `.json` over `.jsonc`).
+
+**Decision**: Check both `devcontainer.json` and `devcontainer.jsonc` in each subdirectory. Within a single subdirectory, prefer `devcontainer.json` if both exist (consistent with `.json` being the primary extension).
+
+Note: The existing priority-1 and priority-2 search locations also only check `.json`. Adding `.jsonc` support to those locations is a separate enhancement — this feature only adds `.jsonc` checking to the new named config search (priority 3) per FR-006. However, for consistency across the full discovery function, we should also check `.jsonc` at priority levels 1 and 2 in the same change. This avoids a situation where `.devcontainer/devcontainer.jsonc` exists but is not found while `.devcontainer/python/devcontainer.jsonc` is found.
+
+**Revised Decision**: Check both `.json` and `.jsonc` at ALL three priority levels. Within each level, prefer `.json` if both exist. This is the most consistent behavior and aligns with the spec's intent that `.jsonc` is a valid config filename everywhere.
+
+### RT-5: Error Message Format for Multiple Configs
+
+**Question**: What should the error message look like when multiple named configs are found?
+
+**Findings**: The upstream reference CLI (`@devcontainers/cli`) produces an error listing available configs. For Deacon, the error should be clear and actionable.
+
+**Decision**: Use `ConfigError::MultipleConfigs` with a formatted message:
+```
+Multiple devcontainer configurations found. Use --config to specify one:
+  .devcontainer/node/devcontainer.json
+  .devcontainer/python/devcontainer.json
+  .devcontainer/rust/devcontainer.json
+```
+Paths are listed alphabetically (sorted by subdirectory name per FR-005) and displayed relative to the workspace folder for readability.
+
+### RT-6: Symlink and Special Character Handling
+
+**Question**: How should symlinked directories and special characters in directory names be handled?
+
+**Findings**: The spec says only direct subdirectories are searched, one level deep. `std::fs::read_dir()` follows symlinks by default on all platforms (it reads directory entries, and accessing metadata/existence of a symlink target is standard OS behavior). Special characters in directory names are handled naturally by `PathBuf` and the OS filesystem layer.
+
+**Decision**: No special handling needed. Use standard `std::fs::read_dir()` and `PathBuf` operations. Symlinks are followed naturally. Unicode/special characters work via OS path handling. Only filter for entries that are directories (via `entry.file_type()?.is_dir()`).
+
+### RT-7: Down Command Integration
+
+**Question**: How should the `down` command's custom config handling adapt?
+
+**Findings**: The `down` command calls `ConfigLoader::discover_config()` directly (not through `load_config()`), then has custom fallback logic: if no config found, it tries auto-discovery from saved state. With the new `DiscoveryResult`, `down` needs to handle the `Multiple` case as an error (same as other commands) and the `Single`/`None` cases as before.
+
+**Decision**: Update `down` to match on `DiscoveryResult`. The `Multiple` case produces the same `MultipleConfigs` error. The `None` case preserves the existing auto-discovery-from-state fallback. This keeps `down`'s special behavior intact while adding multi-config awareness.
+
+## Decisions Summary
+
+| # | Decision | Rationale | Alternatives Rejected |
+|---|----------|-----------|----------------------|
+| D1 | New `DiscoveryResult` enum with `Single`, `Multiple`, `None` variants | Type-safe representation of all outcomes; keeps policy in CLI layer | Vec return (loses semantics), error-on-multiple (policy in core) |
+| D2 | Check `.json` and `.jsonc` at all three priority levels | Consistency across discovery; prevents inconsistent behavior | Only add to priority 3 (inconsistent with spec intent) |
+| D3 | Prefer `.json` over `.jsonc` when both exist in same location | `.json` is the primary/canonical extension | Error on both (too strict), use `.jsonc` first (unusual precedence) |
+| D4 | Alphabetical sort of subdirectories by name | Deterministic cross-platform behavior per FR-005 | No sort (platform-dependent), sort by mtime (non-deterministic) |
+| D5 | `ConfigError::MultipleConfigs` error variant with path list | Clear, actionable error message per FR-008 | Reuse `Validation` (loses specificity), return first (violates spec) |
+| D6 | Standard `read_dir` for symlinks/special chars | OS handles naturally; no special code needed | Manual symlink detection (unnecessary complexity) |
+| D7 | `down` command updated to match on `DiscoveryResult` | Preserves existing auto-discovery fallback while adding multi-config awareness | Force `down` through shared `load_config()` (loses state fallback) |

--- a/specs/014-named-config-search/spec.md
+++ b/specs/014-named-config-search/spec.md
@@ -88,11 +88,19 @@ A developer explicitly specifies a config path with `--config` to select a parti
 - **FR-002**: When exactly one config file is found across all three search locations, the tool MUST use it automatically without requiring `--config`.
 - **FR-003**: When multiple named config files are found at priority level 3 (and no higher-priority config exists), the tool MUST return an error listing all discovered configs and instructing the user to specify `--config`.
 - **FR-004**: When `--config` is specified, the tool MUST use that exact path, bypassing all automatic discovery logic.
-- **FR-005**: Subdirectory enumeration MUST be limited to one level deep under `.devcontainer/` — only direct child directories are checked.
-- **FR-006**: Subdirectories that do not contain a `devcontainer.json` file MUST be silently skipped during enumeration.
-- **FR-007**: The expanded search MUST apply to all commands that consume config: `up`, `exec`, `build`, `read-configuration`, and `run-user-commands`.
+- **FR-005**: Subdirectory enumeration MUST be limited to one level deep under `.devcontainer/` — only direct child directories are checked. Results MUST be sorted alphabetically by directory name for deterministic behavior across platforms.
+- **FR-006**: Subdirectories that do not contain a `devcontainer.json` or `devcontainer.jsonc` file MUST be silently skipped during enumeration. Both filename variants are valid config files, consistent with the existing search locations.
+- **FR-007**: The expanded search MUST apply to all commands that consume config: `up`, `down`, `exec`, `build`, `read-configuration`, and `run-user-commands`.
 - **FR-008**: The error message for multiple named configs MUST list all discovered config file paths so the user can choose.
 - **FR-009**: Priority levels 1 and 2 (`.devcontainer/devcontainer.json` and `.devcontainer.json`) MUST short-circuit the search — if found, no subdirectory enumeration occurs.
+
+## Clarifications
+
+### Session 2026-02-22
+
+- Q: Should `down` be included in FR-007 scope alongside the other config-consuming commands? → A: Yes, add `down` to FR-007 (6 commands total)
+- Q: Should named config subfolder enumeration be sorted alphabetically for determinism? → A: Yes, sort alphabetically
+- Q: Should named subfolder search check for `devcontainer.jsonc` in addition to `devcontainer.json`? → A: Yes, check both for consistency with existing discovery
 
 ## Success Criteria *(mandatory)*
 
@@ -101,5 +109,5 @@ A developer explicitly specifies a config path with `--config` to select a parti
 - **SC-001**: Developers with a single named config folder can run all supported commands without specifying `--config`, with zero additional steps compared to the standard `.devcontainer/devcontainer.json` layout.
 - **SC-002**: Existing projects using `.devcontainer/devcontainer.json` or `.devcontainer.json` experience no change in behavior (full backward compatibility).
 - **SC-003**: Developers with multiple named configs receive a clear, actionable error message that lists all available configs within one command invocation.
-- **SC-004**: All five config-consuming commands (`up`, `exec`, `build`, `read-configuration`, `run-user-commands`) correctly resolve named configs through the shared discovery logic.
+- **SC-004**: All six config-consuming commands (`up`, `down`, `exec`, `build`, `read-configuration`, `run-user-commands`) correctly resolve named configs through the shared discovery logic.
 - **SC-005**: The tool passes all existing tests with no regressions and includes new tests covering named config discovery, multi-config error handling, and `--config` override scenarios.

--- a/specs/014-named-config-search/spec.md
+++ b/specs/014-named-config-search/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Named Config Folder Search
+
+**Feature Branch**: `014-named-config-search`
+**Created**: 2026-02-21
+**Status**: Draft
+**Input**: User description: "Add support for the third devcontainer.json search location: named config folders inside `.devcontainer/`"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Single Named Config Discovery (Priority: P1)
+
+A developer working in a monorepo has a single named configuration at `.devcontainer/python/devcontainer.json` (with no config at `.devcontainer/devcontainer.json` or `.devcontainer.json`). When they run `deacon up` without specifying `--config`, the tool automatically discovers and uses the named config.
+
+**Why this priority**: This is the core capability — without automatic discovery of named configs, the feature has no value. Most monorepo users start with a single named config before adding more.
+
+**Independent Test**: Can be fully tested by creating a workspace with only `.devcontainer/python/devcontainer.json` and running config discovery. Delivers value by enabling named config projects to work without explicit `--config` flags.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with only `.devcontainer/myconfig/devcontainer.json`, **When** the user runs `deacon up` (or any config-consuming command) without `--config`, **Then** the tool discovers and uses that named config automatically.
+2. **Given** a workspace with `.devcontainer/myconfig/devcontainer.json`, **When** the user runs `deacon read-configuration`, **Then** the output reflects the config from the named subfolder and includes the correct `configFilePath`.
+3. **Given** a workspace with no config files at any of the three search locations, **When** the user runs `deacon up`, **Then** the tool reports a clear "no configuration found" error.
+
+---
+
+### User Story 2 - Existing Search Locations Still Work (Priority: P1)
+
+A developer with an existing project that uses `.devcontainer/devcontainer.json` or `.devcontainer.json` continues to have their configuration discovered automatically, with no change in behavior.
+
+**Why this priority**: Regression protection is equally critical to new functionality. Breaking existing users would be unacceptable.
+
+**Independent Test**: Can be tested by running config discovery against workspaces that use the two existing search locations and verifying identical behavior to the current implementation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with `.devcontainer/devcontainer.json`, **When** the user runs config discovery, **Then** that file is found (same as today).
+2. **Given** a workspace with only `.devcontainer.json` at the root, **When** the user runs config discovery, **Then** that file is found (same as today).
+3. **Given** a workspace with both `.devcontainer/devcontainer.json` and `.devcontainer/python/devcontainer.json`, **When** the user runs config discovery without `--config`, **Then** `.devcontainer/devcontainer.json` wins (higher priority per spec).
+
+---
+
+### User Story 3 - Multiple Named Configs Require Explicit Selection (Priority: P2)
+
+A monorepo developer has multiple named configurations (e.g., `python/`, `node/`, `rust/` under `.devcontainer/`). When they run a command without specifying which config to use, the tool reports an error listing the available configs and asks them to select one with `--config`.
+
+**Why this priority**: This is the multi-config disambiguation path. It's important for the full monorepo experience but less common than the single-config case.
+
+**Independent Test**: Can be tested by creating a workspace with multiple named config folders and verifying the error message lists all available configs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with `.devcontainer/python/devcontainer.json` and `.devcontainer/node/devcontainer.json` (and no higher-priority configs), **When** the user runs `deacon up` without `--config`, **Then** the tool returns an error listing both available configs and instructing the user to specify `--config`.
+2. **Given** the same multi-config workspace, **When** the user runs `deacon up --config .devcontainer/python/devcontainer.json`, **Then** the tool uses the specified config without error.
+
+---
+
+### User Story 4 - Explicit Config Path Override (Priority: P2)
+
+A developer explicitly specifies a config path with `--config` to select a particular named configuration, bypassing automatic discovery entirely.
+
+**Why this priority**: Explicit selection is the escape hatch for ambiguous cases and automation/CI pipelines that need deterministic config selection.
+
+**Independent Test**: Can be tested by providing `--config` pointing to a specific named config and verifying it is used regardless of what other configs exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with multiple named configs, **When** the user runs `deacon up --config .devcontainer/rust/devcontainer.json`, **Then** the tool uses exactly that config file.
+2. **Given** a workspace with `.devcontainer/devcontainer.json` (higher priority) and `.devcontainer/python/devcontainer.json`, **When** the user runs `deacon up --config .devcontainer/python/devcontainer.json`, **Then** the explicitly specified named config is used, not the higher-priority default.
+3. **Given** `--config` points to a non-existent file, **When** the user runs any command, **Then** the tool returns a clear error indicating the specified config file was not found.
+
+---
+
+### Edge Cases
+
+- What happens when `.devcontainer/` contains subdirectories that do NOT have a `devcontainer.json`? They are silently ignored during enumeration.
+- What happens when `.devcontainer/` contains files (not directories) alongside subdirectories? Only directories are enumerated; files are ignored.
+- What happens when a subdirectory name contains special characters (spaces, unicode)? The tool handles any valid directory name the OS supports.
+- What happens when `.devcontainer/` itself does not exist? The tool falls back to checking `.devcontainer.json` at root (existing behavior), then reports no config found.
+- What happens when a subdirectory contains a `devcontainer.json` that is invalid JSON? Discovery finds the file successfully; the parse error surfaces later during config loading, not during search.
+- What happens with nested subdirectories (e.g., `.devcontainer/a/b/devcontainer.json`)? Only one level deep is searched per the spec. Deeper nesting is not discovered.
+- What happens with symlinked subdirectories under `.devcontainer/`? They are followed if the OS resolves them (standard filesystem behavior).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The config search MUST check three locations in this priority order: (1) `.devcontainer/devcontainer.json`, (2) `.devcontainer.json`, (3) `.devcontainer/<subfolder>/devcontainer.json` for each direct subdirectory of `.devcontainer/`.
+- **FR-002**: When exactly one config file is found across all three search locations, the tool MUST use it automatically without requiring `--config`.
+- **FR-003**: When multiple named config files are found at priority level 3 (and no higher-priority config exists), the tool MUST return an error listing all discovered configs and instructing the user to specify `--config`.
+- **FR-004**: When `--config` is specified, the tool MUST use that exact path, bypassing all automatic discovery logic.
+- **FR-005**: Subdirectory enumeration MUST be limited to one level deep under `.devcontainer/` — only direct child directories are checked.
+- **FR-006**: Subdirectories that do not contain a `devcontainer.json` file MUST be silently skipped during enumeration.
+- **FR-007**: The expanded search MUST apply to all commands that consume config: `up`, `exec`, `build`, `read-configuration`, and `run-user-commands`.
+- **FR-008**: The error message for multiple named configs MUST list all discovered config file paths so the user can choose.
+- **FR-009**: Priority levels 1 and 2 (`.devcontainer/devcontainer.json` and `.devcontainer.json`) MUST short-circuit the search — if found, no subdirectory enumeration occurs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers with a single named config folder can run all supported commands without specifying `--config`, with zero additional steps compared to the standard `.devcontainer/devcontainer.json` layout.
+- **SC-002**: Existing projects using `.devcontainer/devcontainer.json` or `.devcontainer.json` experience no change in behavior (full backward compatibility).
+- **SC-003**: Developers with multiple named configs receive a clear, actionable error message that lists all available configs within one command invocation.
+- **SC-004**: All five config-consuming commands (`up`, `exec`, `build`, `read-configuration`, `run-user-commands`) correctly resolve named configs through the shared discovery logic.
+- **SC-005**: The tool passes all existing tests with no regressions and includes new tests covering named config discovery, multi-config error handling, and `--config` override scenarios.

--- a/specs/014-named-config-search/tasks.md
+++ b/specs/014-named-config-search/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Named Config Folder Search
+
+**Input**: Design documents from `/specs/014-named-config-search/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/config-discovery.md
+
+**Tests**: Included — the plan specifies ~15 new unit tests and existing tests require updating for the new return type.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing. US1 and US2 (both P1) share an implementation phase because the same `discover_config()` rewrite serves both.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No setup needed — existing Rust workspace, no new dependencies per plan.md.
+
+*(No tasks — project structure and dependencies already exist.)*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: New data types and helpers that ALL user stories depend on. These are pure additions with no behavior changes to existing code.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T001 Add `ConfigError::MultipleConfigs { paths: Vec<String> }` error variant to `ConfigError` enum in `crates/core/src/errors.rs`. Use `#[error]` format per data-model.md: `"Multiple devcontainer configurations found. Use --config to specify one:\n{}"` with paths joined by newlines. Add a display test in the existing `test_config_error_display` test.
+- [ ] T002 [P] Add `DiscoveryResult` enum (`Single(PathBuf)`, `Multiple(Vec<PathBuf>)`, `None(PathBuf)`) to `crates/core/src/config.rs` near the existing `ConfigLocation` struct (around line 204). Derive `Debug, Clone, PartialEq`. Add doc comments per data-model.md invariants.
+- [ ] T003 [P] Add `fn check_config_file(dir: &Path) -> Option<PathBuf>` helper to `crates/core/src/config.rs` that checks for `devcontainer.json` then `devcontainer.jsonc` in a directory, returning the first found path. Per research.md D3: prefer `.json` over `.jsonc` when both exist.
+- [ ] T004 Add `fn enumerate_named_configs(devcontainer_dir: &Path) -> Result<Vec<PathBuf>>` helper to `crates/core/src/config.rs`. Reads direct child directories of `.devcontainer/` using `std::fs::read_dir`, filters for directories only, checks each with `check_config_file()`, sorts results alphabetically by subdirectory name per FR-005/D4. Skips subdirs without config files per FR-006.
+
+**Checkpoint**: Foundation ready — new types and helpers compiled, no existing behavior changed yet.
+
+---
+
+## Phase 3: User Story 1 + User Story 2 — Single Named Config Discovery & Backward Compatibility (Priority: P1) MVP
+
+**Goal**: Rewrite `discover_config()` to search all three priority locations and return `DiscoveryResult`. Existing search locations continue to work identically (US2), and new named config folders are discovered (US1).
+
+**Independent Test**: Create temp workspaces with various config layouts and verify `discover_config()` returns the correct `DiscoveryResult` variant for each.
+
+### Implementation for US1 + US2
+
+- [ ] T005 [US1] [US2] Rewrite `ConfigLoader::discover_config()` in `crates/core/src/config.rs:1382` to return `DiscoveryResult` instead of `ConfigLocation`. Implement three-tier search per contracts/config-discovery.md: (1) check `.devcontainer/` with `check_config_file()`, (2) check root `.devcontainer.json` then `.devcontainer.jsonc`, (3) enumerate named configs. Short-circuit on priority 1/2 match per FR-009. Update the function's doc comment and doctest to reflect the new return type.
+- [ ] T006 [US1] [US2] Update the 5 existing `discover_config` unit tests in `crates/core/src/config.rs` (`test_discover_config_devcontainer_dir`, `test_discover_config_root_file`, `test_discover_config_preference_order`, `test_discover_config_no_file_exists`, `test_discover_config_workspace_not_exists`) to assert against `DiscoveryResult` variants instead of `ConfigLocation`.
+- [ ] T007 [P] [US1] Add unit test `test_discover_config_single_named_config` in `crates/core/src/config.rs`: workspace with only `.devcontainer/python/devcontainer.json` → returns `DiscoveryResult::Single` pointing to that file.
+- [ ] T008 [P] [US1] Add unit tests for `.jsonc` support in `crates/core/src/config.rs`: (a) `test_discover_config_jsonc_priority1` — `.devcontainer/devcontainer.jsonc` found at priority 1, (b) `test_discover_config_json_preferred_over_jsonc` — when both `.json` and `.jsonc` exist in same dir, `.json` wins, (c) `test_discover_config_jsonc_named` — named config with only `.jsonc` is discovered. Per research.md D2/D3.
+- [ ] T009 [P] [US2] Add unit tests for short-circuit behavior in `crates/core/src/config.rs`: (a) `test_discover_config_priority1_overrides_named` — `.devcontainer/devcontainer.json` exists alongside `.devcontainer/python/devcontainer.json` → returns priority 1 path, (b) `test_discover_config_priority2_overrides_named` — `.devcontainer.json` exists alongside named configs → returns priority 2 path. Per FR-009.
+- [ ] T010 [P] [US1] Add unit tests for edge cases in `crates/core/src/config.rs`: (a) `test_discover_config_skip_non_dir_entries` — files in `.devcontainer/` alongside named subdirs are ignored, (b) `test_discover_config_deep_nesting_ignored` — `.devcontainer/a/b/devcontainer.json` NOT found (one level only per FR-005), (c) `test_discover_config_empty_devcontainer_dir` — `.devcontainer/` exists but has no subdirs with configs → returns `None`, (d) `test_discover_config_subdir_without_config_skipped` — subdir exists but has no devcontainer.json → skipped per FR-006.
+
+**Checkpoint**: `discover_config()` now supports all three search locations. Existing behavior preserved (US2). Single named configs auto-discovered (US1). All unit tests pass.
+
+---
+
+## Phase 4: User Story 3 — Multiple Named Configs Require Explicit Selection (Priority: P2)
+
+**Goal**: All 4 call sites that invoke `discover_config()` handle `DiscoveryResult::Multiple` by returning a clear error listing available configs.
+
+**Independent Test**: Create a workspace with `.devcontainer/python/devcontainer.json` and `.devcontainer/node/devcontainer.json`, invoke each call site without `--config`, verify `MultipleConfigs` error with both paths listed.
+
+### Implementation for US3
+
+- [ ] T011 [US3] Update shared `load_config()` in `crates/deacon/src/commands/shared/config_loader.rs:69-73` to match on `DiscoveryResult` instead of calling `.path().to_path_buf()`. Handle `Single` → use path, `Multiple` → return `ConfigError::MultipleConfigs` with workspace-relative display paths, `None` → existing fallback behavior. Import `DiscoveryResult` from core.
+- [ ] T012 [P] [US3] Update `down` command in `crates/deacon/src/commands/down.rs:62-68` to match on `DiscoveryResult`. Handle `Single` → load from path, `Multiple` → return `ConfigError::MultipleConfigs`, `None` → preserve existing auto-discovery-from-state fallback per research.md D7.
+- [ ] T013 [P] [US3] Update `read-configuration` command in `crates/deacon/src/commands/config.rs:144-150` to match on `DiscoveryResult`. Handle `Single` → load from path (existing), `Multiple` → return `ConfigError::MultipleConfigs`, `None` → return `ConfigError::NotFound` (existing).
+- [ ] T014 [P] [US3] Update `outdated` command's `resolve_config_path()` in `crates/deacon/src/commands/outdated.rs:414-420` to match on `DiscoveryResult`. Handle `Single` → return location, `Multiple` → return `ConfigError::MultipleConfigs`, `None` → existing error behavior. Update return type from `ConfigLocation` to accommodate `DiscoveryResult`.
+- [ ] T015 [US3] Add unit tests for multiple configs in `crates/core/src/config.rs`: (a) `test_discover_config_multiple_named_configs` — two+ named subdirs with configs → returns `DiscoveryResult::Multiple` with all paths, (b) `test_discover_config_multiple_sorted_alphabetically` — verify paths in `Multiple` are sorted by subdirectory name per FR-005, (c) `test_multiple_configs_error_display` — verify `ConfigError::MultipleConfigs` error message format matches contracts/config-discovery.md (each path on its own line, indented with two spaces).
+
+**Checkpoint**: All 4 call sites (shared load_config, down, read-configuration, outdated) handle the multiple-configs case with a clear, actionable error.
+
+---
+
+## Phase 5: User Story 4 — Explicit Config Path Override (Priority: P2)
+
+**Goal**: Verify `--config` flag bypasses all auto-discovery, working correctly with the new `DiscoveryResult` return type.
+
+**Independent Test**: Provide `--config .devcontainer/rust/devcontainer.json` to a workspace with multiple named configs and verify it uses the specified config without error.
+
+### Implementation for US4
+
+- [ ] T016 [US4] Add unit tests for `--config` bypass in `crates/deacon/src/commands/shared/config_loader.rs` (existing test module): (a) verify `--config` path is used directly when provided, skipping `discover_config()` entirely, (b) verify `--config` to a specific named config works even when multiple named configs exist, (c) verify `--config` to non-existent file returns appropriate error. These tests validate FR-004 — no code change needed since the bypass already exists in the `if let Some(path)` branch.
+
+**Checkpoint**: `--config` override works correctly with no regressions. US4 acceptance scenarios validated.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration test updates, full validation, and cleanup.
+
+- [ ] T017 Update integration tests that use `discover_config()` or `ConfigLocation` in `crates/core/tests/integration_variable_substitution.rs` (lines 14, 151) and `crates/core/tests/integration_worktree.rs` (line 192) to work with new `DiscoveryResult` return type. Update assertions from `ConfigLocation` field access to `DiscoveryResult` pattern matching.
+- [ ] T018 [P] Add tracing debug/info logs for named config discovery steps in `crates/core/src/config.rs`: info-level log when named config enumeration finds configs, debug-level logs for each subdirectory examined. Per spec contracts/config-discovery.md tracing requirements.
+- [ ] T019 Run `cargo fmt --all && cargo clippy --all-targets -- -D warnings && make test-nextest-fast` to verify zero warnings, correct formatting, and all tests pass.
+- [ ] T020 Run `make test-nextest` for full validation before PR — ensure no regressions in docker, smoke, or integration test suites.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — can start immediately. BLOCKS all user stories.
+- **US1 + US2 (Phase 3)**: Depends on Phase 2 completion (needs DiscoveryResult, check_config_file, enumerate_named_configs)
+- **US3 (Phase 4)**: Depends on Phase 3 completion (needs discover_config() returning DiscoveryResult)
+- **US4 (Phase 5)**: Depends on Phase 4 completion (tests validate --config bypass works with updated call sites)
+- **Polish (Phase 6)**: Depends on all user story phases complete
+
+### User Story Dependencies
+
+- **US1 + US2 (P1)**: Can start after Foundational (Phase 2) — core implementation
+- **US3 (P2)**: Depends on US1+US2 — caller updates require the new return type to exist
+- **US4 (P2)**: Depends on US3 — tests need updated call sites to verify override works end-to-end
+
+### Within Each Phase
+
+- Foundational: T001, T002, T003 can run in parallel; T004 depends on T003
+- US1+US2: T005 first (rewrites function), then T006 (updates existing tests), then T007-T010 in parallel (new tests)
+- US3: T011 first, then T012-T014 in parallel, then T015 (tests)
+- US4: T016 standalone
+- Polish: T017, T018 in parallel, then T019, then T020
+
+### Critical Path
+
+```
+T001 ──┐
+T002 ──┤
+T003 ──┼──→ T004 ──→ T005 ──→ T006 ──→ T011 ──→ T015 ──→ T016 ──→ T017 ──→ T019 ──→ T020
+       │                  ├──→ T007    ├──→ T012            ├──→ T018
+       │                  ├──→ T008    ├──→ T013
+       │                  ├──→ T009    └──→ T014
+       │                  └──→ T010
+```
+
+### Parallel Opportunities
+
+**Phase 2** (3 parallel): T001, T002, T003 can run simultaneously (different sections of different files)
+
+**Phase 3** (4 parallel): T007, T008, T009, T010 are independent test additions after T005/T006
+
+**Phase 4** (3 parallel): T012, T013, T014 update different command files independently after T011
+
+**Phase 6** (2 parallel): T017, T018 touch different files
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```
+# These three tasks touch independent code sections:
+Task T001: "Add MultipleConfigs variant in crates/core/src/errors.rs"
+Task T002: "Add DiscoveryResult enum in crates/core/src/config.rs"
+Task T003: "Add check_config_file() helper in crates/core/src/config.rs"
+# Then sequentially:
+Task T004: "Add enumerate_named_configs() helper (uses check_config_file from T003)"
+```
+
+## Parallel Example: Phase 4 (US3 — Caller Updates)
+
+```
+# After T011 (shared load_config), these three are independent files:
+Task T012: "Update down.rs"
+Task T013: "Update config.rs (read-configuration)"
+Task T014: "Update outdated.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 Only)
+
+1. Complete Phase 2: Foundational types and helpers
+2. Complete Phase 3: Rewrite discover_config() + all tests
+3. **STOP and VALIDATE**: `make test-nextest-fast` — single named config works, existing behavior preserved
+4. At this point, named config discovery works but callers haven't been updated for `Multiple` case
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready
+2. Phase 3 (US1 + US2) → Core discovery works → `make test-nextest-fast` (MVP!)
+3. Phase 4 (US3) → All callers handle multiple configs → `make test-nextest-fast`
+4. Phase 5 (US4) → Override validated → `make test-nextest-fast`
+5. Phase 6 → Polish, integration tests, full validation → `make test-nextest`
+
+### Call Site Coverage (FR-007)
+
+The 4 `discover_config()` call sites cover all commands specified in FR-007:
+- **shared `load_config()`** → `up`, `exec`, `build`, `run-user-commands`
+- **`down.rs`** → `down`
+- **`config.rs`** → `read-configuration`
+- **`outdated.rs`** → `outdated` (bonus — not in FR-007 but discovered during research)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Plan identified 2 call sites; codebase grep found 4 — tasks cover all 4
+- No new dependencies needed (serde, tracing, thiserror, clap all existing)
+- All new tests are unit tests — no nextest group config changes needed
+- Research.md D2 broadened scope: `.jsonc` support added to ALL priority levels, not just priority 3


### PR DESCRIPTION
## Summary

This PR combines two pieces of work on the `014-named-config-search` branch:

### Lifecycle Code Deduplication (maintenance refactor)

Four areas of duplication identified in code review of the `012-fix-lifecycle-formats` work:

- **Test helpers**: Extract shared `make_shell_command_list()` to `crates/core/tests/common/mod.rs` — removes 4 identical copies from integration test files
- **Progress callbacks**: Extract `make_progress_callback()` to `commands/shared/progress.rs` — removes 6 inline closures across `up/lifecycle`, `up/container`, `run_user_commands`, `build/mod`; standardizes on `match` + `warn!` variant (no silent fallback)
- **Phase lifecycle helpers**: Extract 5 shared helpers into `container_lifecycle.rs` (`PhaseResult::new`, `build_phase_command_strings`, `emit_phase_begin_event`, `substitute_shell_and_log`, `aggregate_parallel_failures`); fix Shell error branches to use `emit_phase_end_event()` consistently
- **Phase aggregation loop**: Add `ContainerLifecycleCommands::set_phase()`; replace 5 repetitive ~28-line blocks (~150 lines) with a single loop (~35 lines) in `execute_lifecycle_commands`

### Spec 014 — Named Config Folder Search

Design artifacts for the upcoming named config search implementation:
- `spec.md` — feature specification
- `research.md`, `data-model.md`, `plan.md`, `tasks.md` — implementation planning
- `contracts/config-discovery.md` — behavioral contracts
- `quickstart.md` — quick reference

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [x] `make test-nextest-fast` — 1803 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)