### PR TITLE
chore: bump MSRV to 1.82 + cargo-deny security gate (PR-1 of 7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,33 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Daily 07:00 UTC — surfaces new advisories without spamming PRs.
+    # Only the `security` job runs on this trigger; see job-level `if` guards.
+    - cron: '0 7 * * *'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  security:
+    name: Security (cargo deny)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install cargo-deny
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-deny
+
+    - name: Run cargo deny
+      run: cargo deny check
+
   lint:
     name: Lint (fmt + clippy)
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
     - name: Free disk space
@@ -51,6 +71,7 @@ jobs:
 
   test-fast:
     name: Test (MVP fast) (${{ matrix.os }})
+    if: github.event_name != 'schedule'
     needs: lint
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 20
@@ -99,6 +120,7 @@ jobs:
 
   test-integration:
     name: Test (MVP integration)
+    if: github.event_name != 'schedule'
     needs: test-fast
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ edition = "2021"
 license = "MIT"
 authors = ["get2knowio <dev@get2know.io>"]
 repository = "https://github.com/get2knowio/deacon"
-rust-version = "1.70"
+rust-version = "1.82"
 
 [workspace.dependencies]
-deacon-core = { path = "crates/core" }
+# Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
+deacon-core = { path = "crates/core", version = "0.2.0" }
 clap = { version = "4.5", features = ["derive", "color"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration for Deacon.
+#
+# Run locally: `cargo deny check`
+# CI gate: `.github/workflows/ci.yml` job `security`
+#
+# Schema: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+# Per-advisory exceptions go here with rationale. None currently in effect —
+# the json5 RUSTSEC-2025-0120 advisory does not apply to the 1.x line (we use
+# json5 1.3 at crates/core/src/config.rs).
+
+[licenses]
+version = 2
+# Allowlist intentionally narrow — additions require review.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    # Community Data License Agreement (Mozilla-classified permissive).
+    # Pulled in by webpki-roots; bundle of trust anchors with permissive terms.
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.93
+
+[bans]
+# TODO(post-1.0): tighten to "deny" once duplicate-version count is reduced.
+multiple-versions = "warn"
+wildcards = "deny"
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
First of the Tier 1 PRs from `docs/ROADMAP_TO_1.0.md`. Pure infra/CI; no behavior changes.

## Summary

- **MSRV 1.70 → 1.82** in workspace `Cargo.toml`. Unblocks modern deps under the MSRV-aware resolver (default since cargo 1.84). Toolchain stays on `stable`; no version-gated `cfg` in tree, so no code changes follow.
- **`deny.toml`** at repo root — cargo-deny policy covering advisories, licenses, bans, and sources. `cargo deny check` passes cleanly locally (`advisories ok, bans ok, licenses ok, sources ok`).
- **`.github/workflows/ci.yml`** — new `security` job runs `cargo deny check` on PR/push and daily at `07:00 UTC`. Existing jobs (lint, test-fast, test-integration) are gated with `if: github.event_name != 'schedule'` so the cron only fires the security gate.
- **`deacon-core` workspace dep** now pins `version = "0.2.0"` alongside `path` so cargo-deny does not flag it as a wildcard.

## Discoveries during execution

- **RUSTSEC-2025-0120 (`json5` unmaintained) does not apply to `json5 1.x`** — the advisory targets the 0.4 line. No ignore needed. Roadmap can be updated to drop "migrate off json5" as a 1.0 item.
- **`webpki-roots 1.0.7`** ships under `CDLA-Permissive-2.0` (Mozilla-classified permissive license bundle). Added to the license allowlist with a comment.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo deny check` → all four checks ok
- [ ] CI green on this PR (security + lint + test-fast + test-integration)
- [ ] Verify scheduled run: confirm only the `security` job fires after the daily cron (next 07:00 UTC tick)

## Refs

`docs/ROADMAP_TO_1.0.md` Tier 1 items: **MSRV bump**, **cargo-audit + cargo-deny in CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)