### PR TITLE
fix(build): emit devcontainer.metadata label as JSON array (PR-2 of 7)

### DIFF
--- a/crates/core/src/build/metadata.rs
+++ b/crates/core/src/build/metadata.rs
@@ -42,11 +42,17 @@ pub struct FeatureMetadata {
 impl DevcontainerMetadata {
     /// Serializes metadata to a JSON string for inclusion in image labels.
     ///
+    /// Per the devcontainer spec (devcontainers/cli#1199, v0.86.0), the
+    /// `devcontainer.metadata` label is always a JSON array, even for a single
+    /// metadata entry. Readers iterate the array and merge entries in order.
+    ///
     /// # Errors
     ///
     /// Returns an error if serialization fails.
     pub fn to_json(&self) -> Result<String> {
-        serde_json::to_string(self).map_err(|e| {
+        // Always wrap in an array per the upstream spec, even with a single entry.
+        let array = [self];
+        serde_json::to_string(&array).map_err(|e| {
             crate::errors::DeaconError::Internal(crate::errors::InternalError::Generic {
                 message: format!("Failed to serialize devcontainer metadata: {}", e),
             })
@@ -55,11 +61,24 @@ impl DevcontainerMetadata {
 
     /// Deserializes metadata from a JSON string (for reading from images).
     ///
+    /// Accepts both the spec array form `[{...}]` and the legacy single-object
+    /// form `{...}` emitted by older Deacon builds. Always returns a vector;
+    /// callers merge entries in order.
+    ///
     /// # Errors
     ///
     /// Returns an error if deserialization fails.
-    pub fn from_json(json: &str) -> Result<Self> {
-        serde_json::from_str(json).map_err(|e| {
+    pub fn from_json(json: &str) -> Result<Vec<Self>> {
+        let value: serde_json::Value = serde_json::from_str(json).map_err(|e| {
+            crate::errors::DeaconError::Internal(crate::errors::InternalError::Generic {
+                message: format!("Failed to parse devcontainer metadata JSON: {}", e),
+            })
+        })?;
+        let result = match value {
+            serde_json::Value::Array(_) => serde_json::from_value::<Vec<Self>>(value),
+            _ => serde_json::from_value::<Self>(value).map(|v| vec![v]),
+        };
+        result.map_err(|e| {
             crate::errors::DeaconError::Internal(crate::errors::InternalError::Generic {
                 message: format!("Failed to deserialize devcontainer metadata: {}", e),
             })
@@ -98,35 +117,85 @@ pub fn merge_labels(
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_metadata_roundtrip() {
-        let metadata = DevcontainerMetadata {
+    fn sample_metadata() -> DevcontainerMetadata {
+        DevcontainerMetadata {
             config: serde_json::json!({"name": "test"}),
             features: vec![],
             customizations: None,
             lockfile_hash: None,
-        };
+        }
+    }
+
+    #[test]
+    fn test_metadata_roundtrip() {
+        let metadata = sample_metadata();
 
         let json = metadata.to_json().unwrap();
         let parsed = DevcontainerMetadata::from_json(&json).unwrap();
 
-        assert_eq!(metadata, parsed);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], metadata);
     }
 
     #[test]
-    fn test_merge_labels() {
-        let user_labels = vec![("custom.label".to_string(), "value".to_string())];
+    fn test_to_json_emits_array() {
+        let metadata = sample_metadata();
+        let json = metadata.to_json().unwrap();
 
-        let metadata = DevcontainerMetadata {
-            config: serde_json::json!({"name": "test"}),
-            features: vec![],
-            customizations: None,
-            lockfile_hash: None,
-        };
+        // Per spec (devcontainers/cli#1199), the label value is always a JSON array
+        // even for a single entry.
+        assert!(json.starts_with('['), "expected array form, got: {}", json);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_from_json_handles_legacy_object_form() {
+        // Older Deacon builds emitted a single JSON object, not an array.
+        // The reader must remain tolerant for backwards compatibility.
+        let legacy = serde_json::json!({
+            "config": {"name": "legacy"},
+            "features": [],
+            "customizations": null,
+            "lockfile_hash": null,
+        })
+        .to_string();
+
+        let parsed = DevcontainerMetadata::from_json(&legacy).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].config, serde_json::json!({"name": "legacy"}));
+    }
+
+    #[test]
+    fn test_from_json_handles_array_form_with_multiple_entries() {
+        let array = serde_json::json!([
+            {"config": {"name": "first"},  "features": [], "customizations": null, "lockfile_hash": null},
+            {"config": {"name": "second"}, "features": [], "customizations": null, "lockfile_hash": null},
+        ])
+        .to_string();
+
+        let parsed = DevcontainerMetadata::from_json(&array).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].config, serde_json::json!({"name": "first"}));
+        assert_eq!(parsed[1].config, serde_json::json!({"name": "second"}));
+    }
+
+    #[test]
+    fn test_merge_labels_emits_array_label_value() {
+        let user_labels = vec![("custom.label".to_string(), "value".to_string())];
+        let metadata = sample_metadata();
 
         let labels = merge_labels(&user_labels, &metadata).unwrap();
 
         assert!(labels.contains_key("custom.label"));
-        assert!(labels.contains_key("devcontainer.metadata"));
+        let label_value = labels
+            .get("devcontainer.metadata")
+            .expect("devcontainer.metadata label must be present");
+        assert!(
+            label_value.starts_with('['),
+            "label value must be a JSON array per spec, got: {}",
+            label_value
+        );
     }
 }

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1269,12 +1269,14 @@ async fn execute_image_reference_build(
         dockerfile_content.push('\n');
     }
 
-    // Add devcontainer metadata label
-    // Serialize basic configuration metadata
-    let metadata = serde_json::json!({
+    // Add devcontainer metadata label.
+    // Per spec (devcontainers/cli#1199, v0.86.0), the label value is always a
+    // JSON array of partial-config entries, even when only a single entry is
+    // present. Consumers (VS Code, Zed, envbuilder) iterate and merge.
+    let metadata = serde_json::json!([{
         "name": config.name.as_ref().unwrap_or(&"devcontainer".to_string()),
         "image": image,
-    });
+    }]);
     let metadata_str = serde_json::to_string(&metadata)?;
     let escaped_metadata = metadata_str.replace('"', "\\\"");
     dockerfile_content.push_str(&format!(
@@ -1543,11 +1545,13 @@ async fn execute_docker_build(
         build_args.push("--label".to_string());
         build_args.push(label);
 
-        // Add devcontainer metadata label (simplified for T011)
-        // This stores basic config info in the image for downstream tooling
-        let metadata_json = serde_json::json!({
+        // Add devcontainer metadata label (simplified for T011).
+        // Per spec (devcontainers/cli#1199, v0.86.0), the label value is always a
+        // JSON array of partial-config entries, even when only a single entry is
+        // present. Consumers (VS Code, Zed, envbuilder) iterate and merge.
+        let metadata_json = serde_json::json!([{
             "configHash": config_hash,
-        });
+        }]);
         let metadata_str = serde_json::to_string(&metadata_json)
             .map_err(|e| anyhow!("Failed to serialize metadata: {}", e))?;
         build_args.push("--label".to_string());

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -408,7 +408,7 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
     );
 
     if let Some(container_info) = container_info {
-        // Container-based merge: extract devcontainer.metadata label
+        // Container-based merge: extract devcontainer.metadata label.
         let metadata_label = container_info.labels.get("devcontainer.metadata");
         let metadata_str = metadata_label.ok_or_else(|| {
             anyhow::anyhow!(
@@ -420,7 +420,10 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
 
         debug!("Found devcontainer.metadata label: {}", metadata_str);
 
-        // Parse the metadata JSON
+        // The label MAY be either:
+        // - A JSON array of partial config entries (spec form, devcontainers/cli#1199, v0.86.0)
+        // - A single JSON object (legacy form from older Deacon builds)
+        // Tolerate both.
         let metadata_value: serde_json::Value =
             serde_json::from_str(metadata_str).with_context(|| {
                 format!(
@@ -429,28 +432,34 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
                 )
             })?;
 
-        // Convert to DevContainerConfig
-        let metadata_config: deacon_core::config::DevContainerConfig =
-            serde_json::from_value(metadata_value)
-                .with_context(|| {
-                    format!(
-                        "Failed to deserialize devcontainer.metadata into DevContainerConfig from container '{}'",
-                        container_info.id
-                    )
-                })?;
+        let entries: Vec<serde_json::Value> = match metadata_value {
+            serde_json::Value::Array(arr) => arr,
+            other => vec![other],
+        };
 
-        // Apply container substitution to the metadata
         let container_context = container_context.ok_or_else(|| {
             anyhow::anyhow!("Container context required for container-based merged configuration")
         })?;
-        let (substituted_metadata, _) =
-            metadata_config.apply_variable_substitution(container_context);
 
-        // Merge base config with substituted metadata
-        let merged = deacon_core::config::ConfigMerger::merge_configs(&[
-            base_config.clone(),
-            substituted_metadata,
-        ]);
+        // Deserialize each array entry as a partial DevContainerConfig, apply
+        // variable substitution, then merge in declaration order with the base
+        // config (later entries override earlier per spec merge semantics).
+        let mut chain: Vec<deacon_core::config::DevContainerConfig> =
+            Vec::with_capacity(1 + entries.len());
+        chain.push(base_config.clone());
+        for (idx, entry) in entries.into_iter().enumerate() {
+            let cfg: deacon_core::config::DevContainerConfig = serde_json::from_value(entry)
+                .with_context(|| {
+                    format!(
+                        "Failed to deserialize devcontainer.metadata entry [{}] from container '{}'",
+                        idx, container_info.id
+                    )
+                })?;
+            let (substituted, _) = cfg.apply_variable_substitution(container_context);
+            chain.push(substituted);
+        }
+
+        let merged = deacon_core::config::ConfigMerger::merge_configs(&chain);
 
         debug!("Container-based merged configuration computed successfully");
         Ok(serde_json::to_value(&merged)?)


### PR DESCRIPTION
Per upstream [PR #1199 (v0.86.0)](https://github.com/devcontainers/cli/pull/1199), the `devcontainer.metadata` image label is always a JSON array, even when only a single entry is present. VS Code, Zed, and envbuilder iterate the array and merge entries in order. Writers emitting a single object break this contract.

## Summary

**Writer changes (three sites):**
- `crates/core/src/build/metadata.rs` — `DevcontainerMetadata::to_json` wraps in `[...]`. `from_json` returns `Vec<Self>` and accepts either array form or legacy single-object form.
- `crates/deacon/src/commands/build/mod.rs` — both inline metadata writers (image-reference path at ~L1272; docker build path at ~L1546) wrapped in `[...]`.

**Reader change:**
- `crates/deacon/src/commands/read_configuration.rs` (`compute_merged_configuration`, ~L411) — parses the label as `serde_json::Value`, normalizes to a `Vec` of entries (array as-is; object wrapped in single-element vec), then deserializes each entry as a partial `DevContainerConfig`, applies variable substitution, and merges with the base config in declaration order.
  - **Behavior for upstream-built images (array form) is now correct** — was failing before this PR.
  - Behavior for legacy Deacon-built images (object form) is preserved.

## Tests added

In `crates/core/src/build/metadata.rs`:
- `test_to_json_emits_array` — asserts label starts with `[`
- `test_from_json_handles_legacy_object_form` — legacy single-object fixture
- `test_from_json_handles_array_form_with_multiple_entries` — spec-form multi-entry fixture
- `test_metadata_roundtrip` — updated for `Vec` return type
- `test_merge_labels_emits_array_label_value` — end-to-end label assertion

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --profile dev-fast --no-default-features` → **1930/1930 pass**, 30 skipped
- [x] `cargo test --doc --workspace` → **130/130 pass**
- [x] 38/38 merged-configuration adjacent tests pass
- [ ] CI green
- [ ] Manual end-to-end: `deacon build` against `examples/build/`, then `docker inspect <image> | jq '.[0].Config.Labels["devcontainer.metadata"]'` — should start with `[`

## Known follow-up (not in scope; file separate ticket)

The `DevcontainerMetadata` struct wraps the config under a `"config"` subkey alongside `features`/`customizations`/`lockfile_hash`. Upstream array entries are **flat partial-config shapes**. Deacon-emitted entries today are not directly merge-able as `DevContainerConfig` — a latent issue pre-dating this PR. Flattening the struct to match upstream's array-entry shape would be its own refactor.

This PR ships the spec-mandated wire format change; the deeper shape alignment is post-1.0 cleanup.

## Refs

`docs/ROADMAP_TO_1.0.md` Tier 1 item "devcontainer.metadata label JSON array (CLI parity B.2)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)