### PR TITLE
fix(docker_retry): use /usr/bin/true for macOS portability

### DIFF
--- a/crates/core/src/docker_retry.rs
+++ b/crates/core/src/docker_retry.rs
@@ -525,8 +525,9 @@ mod tests {
     }
 
     /// The retry loop recovers once the synthetic transient failure counter
-    /// drains. We run against `/bin/true` so that the real subprocess
-    /// succeeds on the recovery attempt (no Docker daemon required).
+    /// drains. We run against `/usr/bin/true` (present on both Linux and macOS
+    /// runners; `/bin/true` is absent on macOS GHA images) so that the real
+    /// subprocess succeeds on the recovery attempt (no Docker daemon required).
     #[tokio::test]
     async fn run_build_recovers_after_transient_failures() {
         let _guard = ENV_LOCK.lock().await;
@@ -535,7 +536,7 @@ mod tests {
         std::env::set_var(DEACON_TEST_DOCKER_FAIL_N, "2");
 
         let result =
-            run_build_with_retry(std::path::Path::new("/bin/true"), &[] as &[String]).await;
+            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
 
         assert!(
             result.is_ok(),
@@ -561,7 +562,7 @@ mod tests {
         std::env::set_var(DEACON_TEST_DOCKER_FAIL_N, "10");
 
         let result =
-            run_build_with_retry(std::path::Path::new("/bin/true"), &[] as &[String]).await;
+            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
 
         assert!(
             result.is_err(),
@@ -589,7 +590,7 @@ mod tests {
         clear_fail_hook();
 
         let result =
-            run_build_with_retry(std::path::Path::new("/bin/true"), &[] as &[String]).await;
+            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
 
         assert!(result.is_ok(), "expected success, got {:?}", result);
     }


### PR DESCRIPTION
Three retry-loop tests in \`crates/core/src/docker_retry.rs\` pass \`/bin/true\` as a stand-in runtime path to invoke a real subprocess that succeeds without a Docker daemon. \`/bin/true\` is absent on the macOS GitHub Actions runner images, so these tests have been failing on the \`Test (MVP fast) (macos)\` job since they were added.

\`/usr/bin/true\` exists on both Linux (Ubuntu CI) and macOS GHA runners (verified locally on Linux: \`ls -la /bin/true /usr/bin/true\`). Switching fixes the failure with no semantic change to the tests.

## Affected tests

- \`run_build_succeeds_on_first_attempt_without_hook\`
- \`run_build_recovers_after_transient_failures\`
- \`run_build_gives_up_after_exhausting_retries\`

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo nextest run --profile dev-fast --no-default-features -E 'test(/docker_retry::tests::run_build_/)'\` → 3/3 pass
- [ ] CI green on macOS runner

## Context

Surfaced while reviewing CI on #26 (MSRV bump + cargo-deny). Once this lands, #26 and #27 can be rerun and macOS will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)