### PR TITLE
fix(cli): map InteractiveShell to its own ContainerProbeMode variant

### DIFF
--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -36,10 +36,14 @@ use tracing::{debug, info, instrument, warn};
 pub enum ContainerProbeMode {
     /// No environment probing
     None,
-    /// Login shell only (-l)
+    /// Login shell only (`shell -lc 'env'`)
     #[default]
     LoginShell,
-    /// Login + Interactive shell (-l -i)
+    /// Interactive shell only (`shell -ic 'env'`) — sources interactive
+    /// startup files like `~/.bashrc` without sourcing login profiles.
+    /// Matches the spec's `interactiveShell` mode.
+    InteractiveShell,
+    /// Login + Interactive shell (`shell -lic 'env'`)
     LoginInteractiveShell,
 }
 
@@ -58,8 +62,7 @@ impl std::str::FromStr for ContainerProbeMode {
             | "login_interactive"
             | "logininteractive" => Ok(ContainerProbeMode::LoginInteractiveShell),
             "interactive" | "interactiveshell" | "interactive-shell" | "interactive_shell" => {
-                // Map legacy/ambiguous 'interactiveShell' to LoginShell for compatibility
-                Ok(ContainerProbeMode::LoginShell)
+                Ok(ContainerProbeMode::InteractiveShell)
             }
             other => Err(format!("Unknown container probe mode: {}", other)),
         }
@@ -447,6 +450,7 @@ impl ContainerEnvironmentProber {
                 ))
             }
             ContainerProbeMode::LoginShell => "-lc",
+            ContainerProbeMode::InteractiveShell => "-ic",
             ContainerProbeMode::LoginInteractiveShell => "-lic",
         };
 
@@ -969,9 +973,12 @@ mod tests {
                 .unwrap(),
             ContainerProbeMode::LoginInteractiveShell
         );
+        // `interactiveShell` is its own distinct mode per spec (`shell -ic 'env'`).
+        // Previously aliased to `LoginShell` "for compatibility" — that was
+        // spec-incorrect and lost user-intended behavior.
         assert_eq!(
             "interactiveShell".parse::<ContainerProbeMode>().unwrap(),
-            ContainerProbeMode::LoginShell
+            ContainerProbeMode::InteractiveShell
         );
     }
 

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -18,9 +18,67 @@ impl From<DefaultUserEnvProbe> for ContainerProbeMode {
         match p {
             DefaultUserEnvProbe::None => ContainerProbeMode::None,
             DefaultUserEnvProbe::LoginInteractiveShell => ContainerProbeMode::LoginInteractiveShell,
-            DefaultUserEnvProbe::InteractiveShell => ContainerProbeMode::LoginShell,
+            DefaultUserEnvProbe::InteractiveShell => ContainerProbeMode::InteractiveShell,
             DefaultUserEnvProbe::LoginShell => ContainerProbeMode::LoginShell,
         }
+    }
+}
+
+#[cfg(test)]
+mod default_user_env_probe_mapping_tests {
+    //! Pin every `DefaultUserEnvProbe` CLI variant to a distinct
+    //! `ContainerProbeMode` core variant. Catches the regression where
+    //! `InteractiveShell` silently aliased to `LoginShell` instead of the
+    //! spec-defined interactive-only mode.
+    use super::{ContainerProbeMode, DefaultUserEnvProbe};
+
+    #[test]
+    fn none_maps_to_none() {
+        let mode: ContainerProbeMode = DefaultUserEnvProbe::None.into();
+        assert_eq!(mode, ContainerProbeMode::None);
+    }
+
+    #[test]
+    fn login_interactive_shell_maps_through() {
+        let mode: ContainerProbeMode = DefaultUserEnvProbe::LoginInteractiveShell.into();
+        assert_eq!(mode, ContainerProbeMode::LoginInteractiveShell);
+    }
+
+    #[test]
+    fn interactive_shell_maps_to_interactive_shell() {
+        // Regression: this used to map to `LoginShell` (spec-incorrect).
+        // The spec defines `interactiveShell` as `shell -ic 'env'` — distinct
+        // from both `loginShell` (`-lc`) and `loginInteractiveShell` (`-lic`).
+        let mode: ContainerProbeMode = DefaultUserEnvProbe::InteractiveShell.into();
+        assert_eq!(mode, ContainerProbeMode::InteractiveShell);
+    }
+
+    #[test]
+    fn login_shell_maps_through() {
+        let mode: ContainerProbeMode = DefaultUserEnvProbe::LoginShell.into();
+        assert_eq!(mode, ContainerProbeMode::LoginShell);
+    }
+
+    #[test]
+    fn every_cli_variant_maps_to_a_distinct_core_variant() {
+        // The test fails if two CLI variants collide on the same
+        // `ContainerProbeMode` — catches accidental dedup if a future
+        // CLI addition lands without an accompanying core variant.
+        use std::collections::HashSet;
+        let mapped: HashSet<ContainerProbeMode> = [
+            DefaultUserEnvProbe::None,
+            DefaultUserEnvProbe::LoginInteractiveShell,
+            DefaultUserEnvProbe::InteractiveShell,
+            DefaultUserEnvProbe::LoginShell,
+        ]
+        .into_iter()
+        .map(ContainerProbeMode::from)
+        .collect();
+        assert_eq!(
+            mapped.len(),
+            4,
+            "every CLI probe variant must map to a distinct core variant"
+        );
     }
 }
 use std::io::IsTerminal;


### PR DESCRIPTION
\`DefaultUserEnvProbe::InteractiveShell\` was silently aliasing to \`ContainerProbeMode::LoginShell\`. Per the DevContainer spec, \`interactiveShell\` is a distinct mode (\`shell -ic 'env'\`) that sources interactive startup files like \`~/.bashrc\` without sourcing login profiles — different from both \`loginShell\` (\`-lc\`) and \`loginInteractiveShell\` (\`-lic\`).

Closes gap #8 from the post-1.0 audit.

## Changes

**\`crates/core/src/container_env_probe.rs\`:**
- Add \`ContainerProbeMode::InteractiveShell\` variant (\`-ic\` shell flags).
- \`FromStr\` for \"interactive*\" inputs now returns this variant instead of legacy-aliasing to \`LoginShell\`.
- Exhaustive match in the probe builder gets the new \`-ic\` arm.
- Updated \`test_parse_container_probe_mode_valid_inputs\` to pin the spec-correct mapping.

**\`crates/deacon/src/cli.rs\`:**
- Map \`DefaultUserEnvProbe::InteractiveShell\` to the new core variant (previously aliased to \`LoginShell\`).
- Added \`default_user_env_probe_mapping_tests\` module — 5 tests pinning every CLI variant to a distinct core variant. The \"every CLI variant maps to a distinct core variant\" test catches any future regression where two CLI variants alias to the same core mode.

## Tests

- \`cargo test --lib\` → **285 deacon + 1081 deacon-core pass** (no regression; 5 new + 1 updated)

Verification:
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)