### PR TITLE
chore: SECURITY.md, CodeQL workflow, package metadata, refresh CONTRIBUTING

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+# CodeQL scanning for the Rust codebase. Runs on every PR targeting `main`,
+# on push to `main`, and weekly to catch newly-published rule additions.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday at 06:00 UTC. Offsets from the daily cargo-deny job
+    # (07:00 UTC) so the two security checks don't queue together.
+    - cron: '0 6 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+          # Reproducible Rust analysis: use the same MSRV as the rest of
+          # the build matrix (see Cargo.toml `workspace.package.rust-version`).
+          # CodeQL picks the toolchain from rust-toolchain.toml when present;
+          # we keep no rust-toolchain.toml so stable is used.
+
+      - name: Build
+        # CodeQL needs to observe the compilation to extract artifacts.
+        # Build with default features (no `--no-default-features`) so the
+        # full subcommand surface is analyzed.
+        run: cargo build --workspace --all-targets
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:rust"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,27 @@ cd deacon
 # Build all crates
 cargo build
 
-# Run the CLI (currently shows placeholder)
+# Run the CLI
 cargo run -- --help
 cargo run -- --version
-cargo run
+cargo run -- up                # start a devcontainer in the current dir
+cargo run -- read-configuration
 
-# Run all tests
-cargo test
+# Fast development loop: fmt + clippy + fast tests (recommended during iteration)
+make dev-fast
+
+# Run the fast test suite via cargo-nextest (excludes docker/smoke tests)
+make test-nextest-fast
 
 # Format and lint
 cargo fmt --all
 cargo clippy --all-targets -- -D warnings
 ```
+
+`cargo-nextest` is the standard test runner — install it once with
+`cargo install cargo-nextest --locked`. The `make` targets shell out to
+`cargo nextest run` with the right profile, parallelism, and grouping
+(see `.config/nextest.toml`).
 
 ## Development Workflow
 1. **Fork the repository** on GitHub
@@ -55,12 +64,26 @@ docs/
 | Task | Command |
 |------|---------|
 | Build | `cargo build` |
-| Build (full release feature set) | `cargo build --release` |
-| Test | `cargo test` |
+| Build (release) | `cargo build --release` |
+| Fast dev loop (fmt + clippy + fast tests) | `make dev-fast` |
+| Fast tests (unit + bins + examples + doctests; excludes docker/smoke) | `make test-nextest-fast` |
+| Unit tests only (super fast) | `make test-nextest-unit` |
+| Docker integration tests | `make test-nextest-docker` |
+| High-level smoke tests | `make test-nextest-smoke` |
+| Full parallel suite (before PR) | `make test-nextest` |
+| Full quality gate (fmt + clippy + test + build) | `make release-check` |
+| View test group assignments | `make test-nextest-audit` |
 | Format code | `cargo fmt --all` |
 | Lint (clippy) | `cargo clippy --all-targets -- -D warnings` |
 | Update dependencies | `cargo update` |
 | Clean build | `cargo clean` |
+| Coverage report | `make coverage` |
+
+Test groups live in `.config/nextest.toml` (`docker-exclusive`,
+`docker-shared`, `fs-heavy`, `long-running`, `smoke`, `parity`). When you
+add an integration test that touches Docker or filesystem heavily, add a
+group override to all profiles in that file so the suite stays
+parallel-safe.
 
 ## Adding Dependencies
 Add to workspace root for shared dependencies:
@@ -81,37 +104,26 @@ cargo add --manifest-path crates/<crate>/Cargo.toml <crate_name>
 - **Performance**: Keep tests fast (< 2s) for quick feedback, e2e tests < 30s total
 - **Deterministic**: Tests should not depend on external networks or random data
 
-### Running End-to-End Tests
-The e2e test suite validates the complete integration of:
-- Configuration discovery and loading
-- Variable substitution
-- Feature parsing and handling
-- Lifecycle command processing
-- Plugin customization support
-- Logging and error handling
+### Running specific tests
 
 ```bash
-# Run all e2e tests
-cargo test --test integration_e2e --manifest-path crates/deacon/Cargo.toml
+# Run a single test by name (cargo-nextest, parallel)
+cargo nextest run test_name
 
-# Run specific e2e test scenarios
-cargo test test_e2e_basic_config_read --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_variable_substitution --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_features_configuration --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_plugin_customizations --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_lifecycle_simulation --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_performance_under_30s --manifest-path crates/deacon/Cargo.toml
-cargo test test_e2e_error_handling --manifest-path crates/deacon/Cargo.toml
+# Run a test pattern across the workspace
+cargo nextest run 'test(integration_)*'
+
+# Traditional cargo test still works if you need it (serial)
+cargo test test_name -- --test-threads=1
 ```
 
-The e2e tests are designed to run quickly (total runtime < 30 seconds) and validate:
-1. **Basic config reading**: Configuration discovery, loading, and JSON output
-2. **Variable substitution**: Replacement of workspace and environment variables
-3. **Feature configuration**: Parsing of local and remote feature references
-4. **Plugin customizations**: VSCode extensions and settings handling
-5. **Lifecycle simulation**: Command processing with variable substitution
-6. **Performance validation**: Ensuring operations complete within time limits
-7. **Error handling**: Proper handling of missing files and invalid JSON
+### E2E + integration tests
+
+End-to-end tests live alongside the unit tests in each crate's `tests/`
+directory and run as part of `make test-nextest`. They are deterministic
+and hermetic by default (no network); tests that need Docker are gated
+into the `docker-shared` or `docker-exclusive` nextest groups so they're
+opted out of the fast loop.
 
 ## Coding Standards
 - **Follow `rustfmt` defaults** - run `cargo fmt --all` before committing
@@ -134,16 +146,18 @@ RUST_LOG=debug cargo run -- --help
 ```
 
 ## CI/CD
-- **GitHub Actions** runs tests on every PR and push to main
-- **Ubuntu checks on PR/merge**:
-  - Lint: rustfmt check, cargo check, clippy, doctests
-  - Test: `make test-nextest-fast` (parallel via cargo-nextest)
-  - Smoke: `make test-smoke` (serial)
-  - Coverage: cargo-llvm-cov with LCOV upload (threshold enforced via `MIN_COVERAGE`)
-- **Nextest CI timing**: `make test-nextest-ci` produces `artifacts/nextest/ci-timing.json` for timing comparison
-- **macOS/Windows checks (manual)**: Trigger the "CI (Other OS)" workflow via "Run workflow" in GitHub Actions to run macOS and Windows jobs on demand (macOS uses Colima for Docker)
-- **Release builds** are automatically created on version tags (`v*.*.*`)
-- **Format and clippy checks** must pass for PR approval
+- **GitHub Actions** runs on every PR and push to main:
+  - **Lint** (`.github/workflows/ci.yml`): rustfmt check + clippy (zero warnings)
+  - **Test (MVP fast)** on Ubuntu + macOS: `make test-nextest-fast`
+  - **Test (MVP integration)** on Ubuntu: full integration suite
+  - **Security (cargo-deny)**: advisories + bans + licenses + sources;
+    also runs on a daily schedule
+  - **CodeQL** (`.github/workflows/codeql.yml`): security scanning, PR +
+    weekly schedule
+  - **Validate PR title**: enforces Conventional Commits
+- **Release builds** trigger on version tags (`v*.*.*`) and produce
+  SLSA-attested artifacts (see `.github/workflows/release.yml`).
+- **Format and clippy must pass** for merge — no exceptions.
 
 ### Running macOS/Windows CI manually
 To validate on other operating systems without gating PRs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2021"
 license = "MIT"
 authors = ["get2knowio <dev@get2know.io>"]
 repository = "https://github.com/get2knowio/deacon"
+homepage = "https://github.com/get2knowio/deacon"
+documentation = "https://docs.rs/deacon-core"
+keywords = ["devcontainer", "containers", "docker", "development", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 rust-version = "1.82"
 
 [workspace.dependencies]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅ (active development) |
+| `1.0.x` | ✅ (once cut) |
+| `< 1.0` | ❌ |
+
+## Reporting a vulnerability
+
+If you believe you've found a security vulnerability in deacon, **please do
+not file a public issue.** Instead, use one of the private channels below:
+
+- **GitHub Security Advisory** (preferred): open a private report at
+  <https://github.com/get2knowio/deacon/security/advisories/new>.
+- **Email**: send details to `security@get2know.io` with the subject line
+  starting `[deacon]`.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Reproduction steps or a proof-of-concept, if available.
+- The affected version(s) (commit hash or release tag).
+- Your name/handle for credit (or "anonymous" if you prefer).
+
+We aim to acknowledge reports within **3 business days** and to provide a
+remediation plan within **14 days** of acknowledgement. Critical issues
+affecting users of released versions will be prioritized.
+
+## Scope
+
+deacon is a command-line tool that manages DevContainers. The following
+attack surfaces are in scope for reports:
+
+- **Command injection** via untrusted workspace inputs (lifecycle commands,
+  dotfiles install commands, feature option strings, etc.).
+- **Path traversal** in feature/template extraction, lockfile derivation, or
+  configuration file resolution.
+- **Secret leakage** through logs, JSON output, or persisted state — the
+  redaction layer (`crates/core/src/redaction.rs`) is the trust boundary.
+- **TLS / OCI authentication** in the registry client
+  (`crates/core/src/oci/`).
+- **Container runtime privilege escalation** via mount, capability, or
+  security-option handling.
+
+The following are **out of scope**:
+
+- Vulnerabilities in upstream Docker / Podman / BuildKit. Please report
+  those to the respective projects.
+- Vulnerabilities in features authored by third parties. The
+  feature-installer trust boundary is documented in `CLAUDE.md`.
+- Sandboxed compromise of feature install scripts running inside the
+  containers deacon launches — by design these run with whatever
+  privileges the container/Dockerfile grant.
+- Denial-of-service against the local CLI process (e.g. crafted
+  `devcontainer.json` that triggers an OOM).
+
+## Security-relevant CI gates
+
+- `cargo-deny` (advisories + bans + licenses + sources) runs on every PR
+  and on a daily schedule. See `.github/workflows/ci.yml` `security` job
+  and `deny.toml`.
+- CodeQL scanning runs on every PR and weekly. See
+  `.github/workflows/codeql.yml`.
+- Release artifacts are attested via SLSA provenance. See
+  `.github/workflows/release.yml`.
+
+## Coordinated disclosure
+
+We follow a 90-day coordinated-disclosure window. Once a fix is released
+and users have had a reasonable upgrade period, the advisory is
+published with credit to the reporter.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "Core library for deacon — DevContainer configuration resolution, OCI feature/template fetching, container runtime abstraction (Docker/Podman), lifecycle execution, and lockfile management."
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+description = "Rust implementation of the Development Containers CLI (containers.dev). Consumer-side commands: up, down, exec, build, read-configuration, run-user-commands, set-up, upgrade, templates apply, doctor."
+readme = "../../README.md"
 
 [features]
 default = ["full"]


### PR DESCRIPTION
Bundles three P2 polish items from the post-1.0 audit.

## SECURITY.md (gap #10 policy half)

New top-level file documenting supported versions, private reporting channels (GitHub Security Advisory + email), in/out-of-scope, coordinated-disclosure window, and pointer to the CI security gates.

## CodeQL workflow (gap #10 scanning half)

New `.github/workflows/codeql.yml` — Rust analysis on PR + push to main + weekly schedule (Monday 06:00 UTC, staggered from cargo-deny's 07:00 UTC daily).

## Cargo manifest metadata (gap #12)

Added `homepage`, `documentation`, `keywords`, `categories` to `[workspace.package]` + per-package `description` and `readme`. Unblocks crates.io publish with proper search discoverability.

## CONTRIBUTING.md refresh (gap #13)

The Quick Start + Common Tasks sections centered on raw `cargo test`, but the repo standardized on `cargo-nextest` + `make` targets long ago. Updated:
- Quick Start leads with `make dev-fast` / `make test-nextest-fast`
- Common Tasks table now reflects the make-target taxonomy (`test-nextest-fast`, `test-nextest-unit`, `test-nextest-docker`, `test-nextest-smoke`, `release-check`, `test-nextest-audit`, `coverage`)
- Drops the long e2e-by-name list (the suite has grown past the original 7 named tests)
- CI/CD section now matches what actually runs: `ci.yml` + `codeql.yml` + cargo-deny + Conventional-Commits PR title

## Verification

- [x] `cargo build` ✓
- [x] `cargo fmt --all -- --check` ✓
- [ ] CI green

Refs: gaps #10, #12, #13 from the post-1.0 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)