### PR TITLE
fix(core): remove three runtime expect()/panic sites

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1533,10 +1533,21 @@ impl ConfigLoader {
                 Ok(DiscoveryResult::None(default_path))
             }
             1 => {
-                let path = named_configs
-                    .into_iter()
-                    .next()
-                    .expect("named_configs confirmed to have exactly 1 element by match arm");
+                // The match arm gate (`named_configs.len() == 1`) makes the
+                // `next()` a guaranteed `Some`, but we still pull it via a
+                // pattern match rather than `.expect(...)` so a future caller
+                // that builds the vec differently can't accidentally panic.
+                let mut iter = named_configs.into_iter();
+                let path = match iter.next() {
+                    Some(p) => p,
+                    None => {
+                        return Err(ConfigError::Validation {
+                            message: "internal: named_configs.len() was 1 but iterator was empty"
+                                .to_string(),
+                        }
+                        .into());
+                    }
+                };
                 debug!("Found single named config: {}", path.display());
                 Ok(DiscoveryResult::Single(path))
             }

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -163,8 +163,11 @@ where
     Fut: std::future::Future<Output = std::result::Result<T, E>>,
     E: std::fmt::Debug,
 {
-    let mut last_error = None;
-
+    // Iterate attempts 0..=max_attempts inclusive. On the LAST iteration's
+    // Err branch we return the error directly instead of stashing it for a
+    // post-loop unwrap — that removes the historical `expect("Should have at
+    // least one error")` panic site without changing externally observable
+    // behavior.
     for attempt in 0..=config.max_attempts {
         debug!("Retry attempt {} of {}", attempt, config.max_attempts);
 
@@ -184,8 +187,8 @@ where
                     return Err(error);
                 }
 
-                // Don't sleep after the last attempt
                 if attempt < config.max_attempts {
+                    // More attempts remaining — sleep with backoff then loop.
                     let delay = config.calculate_delay(attempt);
                     warn!(
                         "Retrying after transient error (attempt {}/{}): {:?}; next delay {:?}",
@@ -194,23 +197,32 @@ where
                         error,
                         delay
                     );
-                    last_error = Some(error);
                     tokio::time::sleep(delay).await;
                 } else {
-                    last_error = Some(error);
+                    // Last attempt — return the captured error directly.
+                    warn!(
+                        "All {} retry attempts exhausted, final error: {:?}",
+                        config.max_attempts + 1,
+                        error
+                    );
+                    return Err(error);
                 }
             }
         }
     }
 
-    // All attempts exhausted
-    let final_error = last_error.expect("Should have at least one error");
-    warn!(
-        "All {} retry attempts exhausted, final error: {:?}",
-        config.max_attempts + 1,
-        final_error
+    // Unreachable: `config.max_attempts: u32` so the range `0..=max_attempts`
+    // has at least one iteration (when max_attempts == 0). That iteration
+    // must return either via `Ok(result)` or the last-attempt `Err` branch
+    // above. The empty fallback below is defense-in-depth — it should be
+    // statically impossible to reach.
+    debug_assert!(
+        false,
+        "retry_async reached the loop fallthrough — should be unreachable"
     );
-    Err(final_error)
+    unreachable!(
+        "retry_async: 0..=max_attempts always runs at least once and either returns Ok or Err"
+    );
 }
 
 #[cfg(test)]

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -223,11 +223,10 @@ impl StateManager {
     }
 }
 
-impl Default for StateManager {
-    fn default() -> Self {
-        Self::new().expect("Failed to create default StateManager")
-    }
-}
+// NOTE: deliberately no `Default` impl. `StateManager::new()` is fallible
+// (it derives a cache directory and may hit IO errors), so a Default impl
+// that calls `.expect(...)` would panic at runtime. Use `StateManager::new()`
+// or `StateManager::new_with_cache_dir(path)` and propagate the `Result`.
 
 // =============================================================================
 // Lifecycle Phase Marker Helpers


### PR DESCRIPTION
Audit flagged three production paths where `.expect(...)` could panic if a "should be impossible" invariant got violated. Exemplary CLI code should not panic in runtime paths.

Closes gap #7 from the post-1.0 audit.

## Changes

**`crates/core/src/state.rs:226-229`** — removed `impl Default for StateManager`:
- The Default impl called `Self::new().expect("Failed to create default StateManager")`.
- `StateManager::new()` is fallible (derives a cache directory + does IO) — a Default impl that hides the Result is wrong-shaped.
- Audit confirmed **no production callers** use `StateManager::default()`; every site uses `new()?` / `new_with_cache_dir(path)?` and propagates.
- Replaced with a NOTE comment so a future contributor doesn't accidentally re-add it.

**`crates/core/src/config.rs:1536-1540`** — `named_configs` single-match path:
- The match arm gates `named_configs.len() == 1`, so `next()` is guaranteed `Some` — but the `.expect(...)` was guarding it anyway.
- Replaced with a pattern match that returns a `ConfigError::Validation` on the impossible `None` case. Defense-in-depth.

**`crates/core/src/retry.rs:206-213`** — restructured retry loop:
- Returns the error DIRECTLY on the last attempt instead of stashing in `last_error: Option<E>` and unwrapping after the loop.
- Removes `.expect("Should have at least one error")`.
- Adds `debug_assert!(false, ...) + unreachable!(...)` as defense — `0..=max_attempts` (`u32`) always runs at least once.

## Verification

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` → 280 deacon + 1081 deacon-core pass (no regression)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)