### PR TITLE
fix: shell-injection-safe command construction in dotfiles paths

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.0"
 async-trait = "0.1"
 linked-hash-map = "0.5"
 indexmap = { version = "2.0", features = ["serde"] }
+shell-words.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 postcard = { version = "1", default-features = false, features = ["alloc"] }
 zip = "2.1"

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -2074,12 +2074,17 @@ where
         // Auto-detect install script
         debug!("Auto-detecting install script in dotfiles repository");
 
+        // `target_path` derives from `--dotfiles-target-path` (user-controllable)
+        // or from `$HOME` inside the container. Quote it so paths with spaces,
+        // single-quotes, or `$(...)` interpolate as a single shell token rather
+        // than allowing command injection.
+        let target_quoted = shell_words::quote(target_path.as_str()).into_owned();
         let detect_script_command = vec![
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "if [ -f {}/install.sh ]; then echo 'install.sh'; elif [ -f {}/setup.sh ]; then echo 'setup.sh'; fi",
-                target_path, target_path
+                "if [ -f {tq}/install.sh ]; then echo 'install.sh'; elif [ -f {tq}/setup.sh ]; then echo 'setup.sh'; fi",
+                tq = target_quoted,
             ),
         ];
 
@@ -2096,9 +2101,16 @@ where
                 let script_name = result.stdout.trim();
                 debug!("Auto-detected install script: {}", script_name);
 
-                // Use detected shell or fallback to bash
+                // Use detected shell or fallback to bash. Script name is one
+                // of "install.sh" / "setup.sh" (known-safe), but the path
+                // gets quoted unconditionally.
                 let shell = detected_shell.unwrap_or("bash");
-                Some(format!("{} {}/{}", shell, target_path, script_name))
+                Some(format!(
+                    "{shell} {tq}/{name}",
+                    shell = shell,
+                    tq = target_quoted,
+                    name = script_name
+                ))
             }
             _ => {
                 debug!("No install script found in dotfiles repository");
@@ -2111,10 +2123,18 @@ where
     if let Some(install_cmd) = install_command_str {
         info!("Executing dotfiles install command: {}", install_cmd);
 
+        // `cd` target gets shell-quoted; the install command itself is
+        // user-supplied shell (custom install command) and inherently
+        // executes as shell — that trust boundary is the workspace-trust
+        // gate (separate concern, tracked in gap #3), not this layer.
         let install_command = vec![
             "sh".to_string(),
             "-c".to_string(),
-            format!("cd {} && {}", target_path, install_cmd),
+            format!(
+                "cd {tq} && {cmd}",
+                tq = shell_words::quote(target_path.as_str()),
+                cmd = install_cmd
+            ),
         ];
 
         let install_start = Instant::now();

--- a/crates/core/src/dotfiles.rs
+++ b/crates/core/src/dotfiles.rs
@@ -414,7 +414,18 @@ pub async fn execute_dotfiles_phase(config: &DotfilesPhaseConfig) -> Result<Dotf
     Ok(DotfilesPhaseResult::executed(result))
 }
 
-/// Execute a custom install command in the dotfiles directory
+/// Execute a custom install command in the dotfiles directory.
+///
+/// Trust boundary note: `command` is interpreted as shell by `bash -c`,
+/// which is the design intent (it accepts pipelines, redirects, etc.).
+/// The trust gate is the *source* of the command — currently
+/// `--dotfiles-install-command` (CLI, user opt-in) — not this exec
+/// layer. If a future caller plumbs through devcontainer.json's
+/// dotfiles config, that path needs the workspace-trust check (audit
+/// gap #3 / spec §12) before reaching here.
+///
+/// `target` is passed through `current_dir`, which is a syscall argument
+/// (not a shell interpolation), so no quoting is needed for the path.
 #[instrument]
 async fn execute_custom_install_command(target: &Path, command: &str) -> Result<()> {
     let output = Command::new("bash")

--- a/crates/deacon/src/commands/up/dotfiles.rs
+++ b/crates/deacon/src/commands/up/dotfiles.rs
@@ -185,13 +185,20 @@ pub(crate) async fn execute_dotfiles_installation(
         // Auto-detect install script
         debug!("Auto-detecting install script in dotfiles repository");
 
-        // Check for install.sh first, then setup.sh
+        // Check for install.sh first, then setup.sh.
+        //
+        // `target_path` may carry user-controlled characters (it derives from
+        // `--dotfiles-target-path` or from `$HOME` inside the container —
+        // both can contain spaces, single-quotes, or `$(...)`). Pass it
+        // through `shell_words::quote` so it interpolates as a single
+        // shell token, eliminating injection via crafted paths.
+        let target_quoted = shell_words::quote(target_path.as_str()).into_owned();
         let detect_script_command = vec![
             "sh".to_string(),
             "-c".to_string(),
             format!(
-                "if [ -f {}/install.sh ]; then echo 'install.sh'; elif [ -f {}/setup.sh ]; then echo 'setup.sh'; fi",
-                target_path, target_path
+                "if [ -f {tq}/install.sh ]; then echo 'install.sh'; elif [ -f {tq}/setup.sh ]; then echo 'setup.sh'; fi",
+                tq = target_quoted,
             ),
         ];
 
@@ -203,7 +210,13 @@ pub(crate) async fn execute_dotfiles_installation(
             Ok(result) if !result.stdout.trim().is_empty() => {
                 let script_name = result.stdout.trim();
                 debug!("Auto-detected install script: {}", script_name);
-                Some(format!("bash {}/{}", target_path, script_name))
+                // Auto-detected script name is one of "install.sh" /
+                // "setup.sh" — known-safe values, but quote the path anyway.
+                Some(format!(
+                    "bash {tq}/{name}",
+                    tq = target_quoted,
+                    name = script_name
+                ))
             }
             _ => {
                 debug!("No install script found in dotfiles repository");
@@ -216,10 +229,18 @@ pub(crate) async fn execute_dotfiles_installation(
     if let Some(install_cmd) = install_command_str {
         info!("Executing dotfiles install command: {}", install_cmd);
 
+        // `cd` target gets shell-quoted; the install command itself is
+        // user-supplied shell (custom install command) and inherently
+        // executes as shell — that trust boundary is the workspace-trust
+        // gate (separate concern, tracked in gap #3), not this layer.
         let install_command = vec![
             "sh".to_string(),
             "-c".to_string(),
-            format!("cd {} && {}", target_path, install_cmd),
+            format!(
+                "cd {tq} && {cmd}",
+                tq = shell_words::quote(target_path.as_str()),
+                cmd = install_cmd
+            ),
         ];
 
         let install_result = docker
@@ -242,4 +263,85 @@ pub(crate) async fn execute_dotfiles_installation(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod shell_quoting_tests {
+    //! Pin the shell-quoting behavior for `target_path` interpolation. The
+    //! tests don't exec anything — they check that `shell_words::quote`
+    //! handles the adversarial path strings we care about so the shell
+    //! command builder is provably safe by construction.
+
+    #[test]
+    fn shell_quote_handles_spaces_in_target_path() {
+        let quoted = shell_words::quote("/home/me/my dotfiles");
+        // Result should be a single shell token. The exact form may use
+        // single quotes or backslash escapes — both are acceptable.
+        let parsed = shell_words::split(&quoted).unwrap();
+        assert_eq!(parsed, vec!["/home/me/my dotfiles".to_string()]);
+    }
+
+    #[test]
+    fn shell_quote_neutralizes_command_substitution() {
+        // The literal `$(rm -rf /)` would execute as a sub-shell if
+        // interpolated unquoted. Quoting must preserve it as data.
+        let evil = "/tmp/foo$(rm -rf /)";
+        let quoted = shell_words::quote(evil);
+        let parsed = shell_words::split(&quoted).unwrap();
+        assert_eq!(parsed, vec![evil.to_string()]);
+        // And the quoted form must contain no unescaped `$(`.
+        assert!(
+            !quoted.contains("$(") || quoted.starts_with('\''),
+            "command substitution must be quoted/escaped, got: {}",
+            quoted
+        );
+    }
+
+    #[test]
+    fn shell_quote_neutralizes_semicolon_chain() {
+        let evil = "/tmp/foo; touch /tmp/owned";
+        let quoted = shell_words::quote(evil);
+        let parsed = shell_words::split(&quoted).unwrap();
+        assert_eq!(parsed, vec![evil.to_string()]);
+    }
+
+    #[test]
+    fn shell_quote_neutralizes_backticks() {
+        let evil = "/tmp/foo`whoami`";
+        let quoted = shell_words::quote(evil);
+        let parsed = shell_words::split(&quoted).unwrap();
+        assert_eq!(parsed, vec![evil.to_string()]);
+    }
+
+    #[test]
+    fn shell_quote_neutralizes_embedded_single_quotes() {
+        // POSIX single-quoting can't contain a literal `'`, so quoters
+        // must escape via `'\''` or switch strategies. Round-trip is the
+        // invariant that matters.
+        let evil = "/tmp/it's broken";
+        let quoted = shell_words::quote(evil);
+        let parsed = shell_words::split(&quoted).unwrap();
+        assert_eq!(parsed, vec![evil.to_string()]);
+    }
+
+    #[test]
+    fn detect_script_command_is_a_single_shell_token_for_evil_path() {
+        // Reproduce the format string from the production code and verify
+        // the path stays one token after parsing.
+        let target = "/tmp/foo; rm -rf /";
+        let tq = shell_words::quote(target);
+        let cmd = format!(
+            "if [ -f {tq}/install.sh ]; then echo 'install.sh'; elif [ -f {tq}/setup.sh ]; then echo 'setup.sh'; fi",
+            tq = tq
+        );
+        // Parse the assembled shell — the `;` inside the target_path must
+        // NOT terminate the `[ -f ... ]` token. With proper quoting the
+        // path appears as `/tmp/foo;rm -rf //install.sh` (single arg) and
+        // `[` will fail-closed on the missing file rather than executing.
+        let tokens = shell_words::split(&cmd).unwrap();
+        // The `[`, `-f`, then the quoted-path-with-suffix should appear
+        // as three sequential tokens, not split apart by the embedded `;`.
+        let idx = tokens.iter().position(|t| t == "-f").unwrap();
+        assert_eq!(tokens[idx + 1], "/tmp/foo; rm -rf //install.sh");
+    }
 }


### PR DESCRIPTION
Audit gap #2: three sites in the dotfiles flow raw-interpolated user-controllable strings into `sh -c` / `bash -c` command strings. A `target_path` containing `/tmp/foo; rm -rf /` (or `$(...)`, backticks, embedded single-quotes) would inject arbitrary commands.

All path interpolations now go through `shell_words::quote(...)`, which is already a workspace dep (added to the core crate as well).

## Changes

- **`crates/deacon/src/commands/up/dotfiles.rs`** — quote `target_path` in both the auto-detect probe and the install command's `cd` target. Added a `shell_quoting_tests` module with **6 unit tests** that prove the quoting handles:
  - spaces in paths
  - command substitution (`$(...)`)
  - semicolon chains
  - backticks
  - embedded single quotes
  - the full assembled detect script parses back with the evil path intact (not split by the embedded `;`)
- **`crates/core/src/container_lifecycle.rs`** — same fix in the core lifecycle helper's dotfiles path.
- **`crates/core/src/dotfiles.rs`** — the HOST-side `execute_custom_install_command` uses `Command::new("bash").arg("-c").arg(command)` which separates args at the OS level (no shell-side injection of the command name). The `command` body IS interpreted as shell — design intent for a user-supplied install command. Added a trust-boundary comment pointing at gap #3 (workspace trust gate) for the upstream-source check.
- **`crates/core/Cargo.toml`** — added `shell-words` workspace dependency.

## Verification

- [x] `cargo build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` → **291 deacon (6 new) + 1081 deacon-core** pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)