### PR TITLE
feat: workspace-trust gate for host-side lifecycle (#52 task 2)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -136,6 +136,11 @@ test-group = 'fs-heavy'
 slow-timeout = "5m"
 
 [[profile.default.overrides]]
+filter = 'binary(=integration_trust)'
+test-group = 'fs-heavy'
+slow-timeout = "2m"
+
+[[profile.default.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
@@ -223,6 +228,11 @@ slow-timeout = { period = "10m", terminate-after = 1 }
 [[profile.dev-fast.overrides]]
 filter = 'binary(=integration_config) | binary(=integration_layered_merge) | binary(=integration_lockfile) | binary(=integration_templates) | binary(=up_lockfile_frozen)'
 test-group = 'fs-heavy'
+
+[[profile.dev-fast.overrides]]
+filter = 'binary(=integration_trust)'
+test-group = 'fs-heavy'
+slow-timeout = "2m"
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
@@ -330,6 +340,11 @@ test-group = 'docker-shared'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
 [[profile.docker.overrides]]
+filter = 'binary(=integration_trust)'
+test-group = 'fs-heavy'
+slow-timeout = "2m"
+
+[[profile.docker.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
@@ -401,6 +416,11 @@ slow-timeout = { period = "10m", terminate-after = 1 }
 [[profile.full.overrides]]
 filter = 'binary(=integration_config) | binary(=integration_layered_merge) | binary(=integration_lockfile) | binary(=integration_templates) | binary(=up_lockfile_frozen)'
 test-group = 'fs-heavy'
+
+[[profile.full.overrides]]
+filter = 'binary(=integration_trust)'
+test-group = 'fs-heavy'
+slow-timeout = "2m"
 
 [[profile.full.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
@@ -484,6 +504,11 @@ slow-timeout = { period = "10m", terminate-after = 1 }
 filter = 'binary(=integration_config) | binary(=integration_layered_merge) | binary(=integration_lockfile) | binary(=integration_templates) | binary(=up_lockfile_frozen)'
 test-group = 'fs-heavy'
 threads-required = 1
+
+[[profile.ci.overrides]]
+filter = 'binary(=integration_trust)'
+test-group = 'fs-heavy'
+slow-timeout = "2m"
 
 [[profile.ci.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,38 @@ sg --pattern 'old_fn($ARG)' --rewrite 'new_fn($ARG)' --lang rust --update-all
 - Don't forget to update test mocks when changing trait methods
 - Do test with realistic mock responses matching OCI distribution spec
 
+## Workspace-Trust Gate (Host-Side Lifecycle Hooks)
+
+`initializeCommand` runs **on the developer's host** before any container
+sandboxing. Any code path that wants to exec host shell from a
+workspace-resident source (e.g. `devcontainer.json`, a future dotfiles
+config in the workspace) MUST go through `crates/core/src/trust.rs`.
+
+**Resolution order** (from `cli.rs` global flags → `core::trust::resolve_policy`):
+
+1. `--trust-workspace` or `--trust-workspace-persist` → `AlwaysAllow`
+   (persist also records to `{user_data_folder}/trusted_workspaces.json`).
+2. `DEACON_NO_PROMPT=1` → `Deny` (CI fail-closed).
+3. Default → `Allowlist({user_data_folder}/trusted_workspaces.json)`;
+   pass only if the canonicalized workspace path is in the store.
+
+On deny, return `DeaconError::WorkspaceUntrusted { workspace, reason,
+instructions }`. The display string already names the workspace and the
+opt-in flags — don't reformat at higher layers.
+
+**Adding a new host-side exec site:**
+1. Resolve the policy at the CLI tier (don't pass raw flags deeper).
+2. Call `check_workspace_trust(&workspace, policy).await?`.
+3. Convert via `decision_to_result(decision)?` — `Trusted` becomes
+   `Ok(())`, `Denied` becomes `DeaconError::WorkspaceUntrusted`.
+4. If the trust source is workspace-resident, set the appropriate
+   `HostTrustSource` on the consumer struct (see `DotfilesPhaseConfig`).
+
+**This gate is deacon-specific.** The upstream containers.dev spec does
+not mandate it. See `SECURITY.md` for the threat model and end-user
+documentation. Refusing to add the gate to a new host-side exec site is
+a security regression — surface it in code review.
+
 ## Container Environment Probe Caching
 
 **Architecture Overview:**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,6 +57,35 @@ The following are **out of scope**:
 - Denial-of-service against the local CLI process (e.g. crafted
   `devcontainer.json` that triggers an OOM).
 
+## Workspace-trust model (host-side lifecycle hooks)
+
+`initializeCommand` (and any other host-side hook that runs unsandboxed
+shell on the developer's machine, e.g. a workspace-sourced dotfiles
+install command) is gated by a workspace-trust check. The threat the
+gate addresses: `git clone <hostile-repo> && deacon up` would otherwise
+execute arbitrary shell from `devcontainer.json` on the host before any
+container sandboxing.
+
+**Policy resolution** (see `crates/core/src/trust.rs`):
+
+- `--trust-workspace` — one-shot trust for the current invocation.
+- `--trust-workspace-persist` — one-shot trust plus appends the
+  canonicalized workspace path to
+  `{user_data_folder}/trusted_workspaces.json` so future invocations
+  pass the gate without a flag.
+- `DEACON_NO_PROMPT=1` — switches the default from "allowlist-then-fail"
+  to a hard `Deny`. Set this in CI so untrusted workspaces fail loudly
+  instead of silently looking like a normal run failure.
+- Default (no flag, no env) — consult the persisted allowlist; if the
+  current canonical workspace path is present, allow; otherwise refuse.
+
+The trust file is written atomically (write-temp-then-rename) so a
+mid-write crash leaves either the previous file or the new file on
+disk, never a partial one.
+
+This trust check is **deacon-specific**: the upstream
+[containers.dev spec](https://containers.dev) does not mandate it.
+
 ## Security-relevant CI gates
 
 - `cargo-deny` (advisories + bans + licenses + sources) runs on every PR

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 json5 = "1.3"
 regex = "1.0"
-tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util"] }
+tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util", "fs"] }
 once_cell.workspace = true
 # Use rustls for a pure-Rust TLS stack to simplify cross-compilation (musl, aarch64) and avoid OpenSSL toolchain requirements.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/core/src/dotfiles.rs
+++ b/crates/core/src/dotfiles.rs
@@ -40,7 +40,8 @@
 //! ```
 
 use crate::errors::{GitError, Result};
-use std::path::Path;
+use crate::trust::{check_workspace_trust, decision_to_result, WorkspaceTrustPolicy};
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, info, instrument, warn};
 
@@ -237,6 +238,29 @@ pub async fn apply_dotfiles(
 // Lifecycle Integration
 // =============================================================================
 
+/// Provenance of the install command, used by the workspace-trust gate to
+/// decide whether to require an explicit opt-in before exec'ing host shell.
+///
+/// `UserCliFlag` describes a command that came directly from a `--dotfiles-*`
+/// CLI flag — the user typed it, so it's already trusted by virtue of having
+/// been passed on the command line. `WorkspaceSourced` describes a command
+/// that came from `devcontainer.json` (or any future workspace-resident
+/// source); it MUST be gated by [`check_workspace_trust`] before exec.
+#[derive(Debug, Clone, Default)]
+pub enum HostTrustSource {
+    /// Came from a CLI flag the user typed; no extra gate needed.
+    #[default]
+    UserCliFlag,
+    /// Came from a workspace-resident source (e.g. `devcontainer.json`).
+    /// Gate via the supplied trust policy before exec'ing any host shell.
+    WorkspaceSourced {
+        /// Workspace path used to look up the trust decision.
+        workspace: PathBuf,
+        /// Trust policy resolved by the caller (CLI tier).
+        policy: WorkspaceTrustPolicy,
+    },
+}
+
 /// Configuration for executing dotfiles as a lifecycle phase.
 ///
 /// This struct captures the CLI arguments and configuration needed to execute
@@ -252,6 +276,9 @@ pub struct DotfilesPhaseConfig {
     pub target_path: Option<String>,
     /// Custom install command (fallback if no install.sh/setup.sh is auto-detected)
     pub install_command: Option<String>,
+    /// Provenance of the install command — controls whether the host-trust
+    /// gate fires before exec. See [`HostTrustSource`].
+    pub host_trust: HostTrustSource,
 }
 
 impl DotfilesPhaseConfig {
@@ -275,6 +302,12 @@ impl DotfilesPhaseConfig {
     /// Set a custom install command
     pub fn with_install_command(mut self, cmd: impl Into<String>) -> Self {
         self.install_command = Some(cmd.into());
+        self
+    }
+
+    /// Mark the install command as workspace-sourced for the trust gate.
+    pub fn with_host_trust(mut self, host_trust: HostTrustSource) -> Self {
+        self.host_trust = host_trust;
         self
     }
 
@@ -403,9 +436,14 @@ pub async fn execute_dotfiles_phase(config: &DotfilesPhaseConfig) -> Result<Dotf
     let result = apply_dotfiles(&repository, target, &options).await?;
 
     // If custom install command was provided and no script was auto-detected,
-    // execute the custom command
+    // execute the custom command (gated by workspace trust when the command
+    // came from a workspace-resident source — see HostTrustSource).
     if let Some(ref custom_cmd) = config.install_command {
         if !result.script_executed {
+            if let HostTrustSource::WorkspaceSourced { workspace, policy } = &config.host_trust {
+                let decision = check_workspace_trust(workspace, policy.clone()).await?;
+                decision_to_result(decision)?;
+            }
             info!("Executing custom dotfiles install command: {}", custom_cmd);
             execute_custom_install_command(target, custom_cmd).await?;
         }
@@ -818,6 +856,7 @@ mod tests {
             repository: None,
             target_path: Some("/path".to_string()),
             install_command: None,
+            host_trust: HostTrustSource::UserCliFlag,
         };
         assert!(!with_target_only.is_configured());
     }

--- a/crates/core/src/dotfiles.rs
+++ b/crates/core/src/dotfiles.rs
@@ -29,6 +29,7 @@
 //!     repository: Some("https://github.com/user/dotfiles".to_string()),
 //!     target_path: Some("/home/user/.dotfiles".to_string()),
 //!     install_command: None,
+//!     ..Default::default()
 //! };
 //!
 //! // Returns Ok(None) if no dotfiles configured (graceful skip)

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -251,6 +251,20 @@ pub enum DeaconError {
     #[error("Runtime error: {0}")]
     Runtime(String),
 
+    /// Workspace is not trusted; host-side lifecycle hooks were refused.
+    ///
+    /// See `crates/core/src/trust.rs` and the `--trust-workspace[-persist]`
+    /// CLI surface for opt-in mechanics.
+    #[error("Workspace `{workspace}` is not trusted: {reason}\n{instructions}")]
+    WorkspaceUntrusted {
+        /// Workspace path that failed the check.
+        workspace: std::path::PathBuf,
+        /// Short reason intended for logs.
+        reason: String,
+        /// User-facing opt-in instructions.
+        instructions: String,
+    },
+
     /// Feature not implemented
     #[error("Feature not implemented: {feature}")]
     NotImplemented { feature: String },

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod semver_utils;
 pub mod state;
 pub mod templates;
 pub mod text;
+pub mod trust;
 pub mod user_mapping;
 pub mod variable;
 pub mod workspace;

--- a/crates/core/src/trust.rs
+++ b/crates/core/src/trust.rs
@@ -1,0 +1,498 @@
+//! Workspace-trust policy and persistence.
+//!
+//! Host-side hooks (`initializeCommand`, dotfiles `installCommand` when sourced
+//! from a workspace) execute arbitrary shell on the developer's machine before
+//! any container sandboxing. A hostile `devcontainer.json` cloned into a
+//! workspace would otherwise gain that capability the moment a user runs
+//! `deacon up`. This module gates those entry points behind an explicit trust
+//! decision.
+//!
+//! The trust set is persisted as a JSON file under the configured
+//! `user_data_folder` (see [`trust_store_path`]). Entries store the canonical
+//! (`fs::canonicalize`d) workspace path and a last-trusted-at timestamp.
+//!
+//! The model is consumer-only and intentionally upstream-divergent: the
+//! containers.dev spec does not mandate a workspace-trust check. See
+//! `SECURITY.md` and `CLAUDE.md` for the rationale.
+
+use crate::errors::{DeaconError, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tracing::{debug, warn};
+
+/// Policy governing how an untrusted workspace is handled at a host-side hook.
+///
+/// `AlwaysAllow` corresponds to the legacy / spec-aligned behavior; the other
+/// variants are the new fail-closed surface.
+#[derive(Debug, Clone)]
+pub enum WorkspaceTrustPolicy {
+    /// Skip the gate entirely. The default when neither
+    /// `--trust-workspace[-persist]` nor `DEACON_NO_PROMPT=1` is set today.
+    /// Future: flip the default to `Allowlist(...)`.
+    AlwaysAllow,
+    /// Prompt the user interactively. In non-interactive contexts (no TTY) the
+    /// caller should downgrade this to `Deny` — `DEACON_NO_PROMPT=1` makes
+    /// that explicit.
+    Prompt,
+    /// Trust only if the workspace appears in the allowlist at this path.
+    /// Adding entries is done via [`record_trusted_workspace`].
+    Allowlist(PathBuf),
+    /// Always deny. Used in CI via `DEACON_NO_PROMPT=1`.
+    Deny,
+}
+
+/// Outcome of a trust check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustDecision {
+    /// Workspace is trusted; the host-side hook may run.
+    Trusted,
+    /// Workspace is not trusted; the caller MUST refuse to run the hook.
+    Denied {
+        /// Canonical workspace path that failed the check (best-effort: the
+        /// original path is used if canonicalization fails).
+        workspace: PathBuf,
+        /// Short reason intended for logs / error messages.
+        reason: String,
+    },
+}
+
+/// Errors raised by the trust module itself (distinct from a `Denied` decision).
+#[derive(Debug, thiserror::Error)]
+pub enum TrustError {
+    /// Failed to read or write the trust store.
+    #[error("Failed to access workspace trust store at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Trust store on disk could not be parsed as JSON.
+    #[error("Corrupt workspace trust store at {path}: {message}")]
+    Corrupt { path: PathBuf, message: String },
+}
+
+impl From<TrustError> for DeaconError {
+    fn from(err: TrustError) -> Self {
+        DeaconError::Internal(crate::errors::InternalError::Generic {
+            message: err.to_string(),
+        })
+    }
+}
+
+/// A single trusted-workspace record.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustedWorkspace {
+    /// Canonical (`fs::canonicalize`d) workspace path at the time it was
+    /// added.
+    pub path: PathBuf,
+    /// Last-trusted-at timestamp in UTC.
+    #[serde(rename = "lastTrustedAt")]
+    pub last_trusted_at: DateTime<Utc>,
+}
+
+/// On-disk trust store. Serialized as `{ "workspaces": [...] }` for forward
+/// compatibility with future top-level fields.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustStore {
+    #[serde(default)]
+    pub workspaces: Vec<TrustedWorkspace>,
+}
+
+impl TrustStore {
+    /// Returns true when an entry matches the given canonical path.
+    pub fn contains(&self, canonical: &Path) -> bool {
+        self.workspaces.iter().any(|w| w.path == canonical)
+    }
+
+    /// Insert-or-update an entry, refreshing the timestamp on existing matches.
+    pub fn upsert(&mut self, canonical: PathBuf, now: DateTime<Utc>) {
+        if let Some(existing) = self.workspaces.iter_mut().find(|w| w.path == canonical) {
+            existing.last_trusted_at = now;
+        } else {
+            self.workspaces.push(TrustedWorkspace {
+                path: canonical,
+                last_trusted_at: now,
+            });
+        }
+    }
+}
+
+/// Derive the trust-store path under a `user_data_folder`. When
+/// `user_data_folder` is `None` we fall back to `~/.deacon/` as the default
+/// host-side user data root.
+pub fn trust_store_path(user_data_folder: Option<&Path>) -> Result<PathBuf> {
+    let base = match user_data_folder {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let dirs = directories_next::BaseDirs::new().ok_or_else(|| {
+                DeaconError::Internal(crate::errors::InternalError::Generic {
+                    message: "Could not determine user home directory for trust store".to_string(),
+                })
+            })?;
+            dirs.home_dir().join(".deacon")
+        }
+    };
+    Ok(base.join("trusted_workspaces.json"))
+}
+
+/// Best-effort canonicalization. When the path does not exist yet we fall back
+/// to lexical normalization so callers can still compare/store the value.
+pub fn canonicalize_workspace(workspace: &Path) -> PathBuf {
+    match std::fs::canonicalize(workspace) {
+        Ok(canon) => canon,
+        Err(e) => {
+            debug!(
+                "canonicalize failed for {} ({}); using path as-is",
+                workspace.display(),
+                e
+            );
+            workspace.to_path_buf()
+        }
+    }
+}
+
+/// Read the on-disk trust store, returning an empty store if the file is
+/// missing. Uses `tokio::fs` so it is safe to call from async contexts.
+pub async fn load_trust_store(path: &Path) -> std::result::Result<TrustStore, TrustError> {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| TrustError::Corrupt {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(TrustStore::default()),
+        Err(e) => Err(TrustError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        }),
+    }
+}
+
+/// Persist the trust store atomically. Writes to a sibling temp file in the
+/// same directory and `rename`s it into place so a mid-write crash leaves
+/// either the previous file or the new file on disk — never a partial one.
+pub async fn save_trust_store(
+    path: &Path,
+    store: &TrustStore,
+) -> std::result::Result<(), TrustError> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| TrustError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+    }
+
+    let mut json = serde_json::to_string_pretty(store).map_err(|e| TrustError::Corrupt {
+        path: path.to_path_buf(),
+        message: e.to_string(),
+    })?;
+    json.push('\n');
+
+    let temp_path = match path.parent() {
+        Some(parent) => parent.join(format!(
+            ".{}.tmp",
+            path.file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("trusted_workspaces.json")
+        )),
+        None => PathBuf::from(".trusted_workspaces.json.tmp"),
+    };
+
+    tokio::fs::write(&temp_path, json.as_bytes())
+        .await
+        .map_err(|e| TrustError::Io {
+            path: temp_path.clone(),
+            source: e,
+        })?;
+
+    #[cfg(windows)]
+    {
+        if tokio::fs::try_exists(path).await.unwrap_or(false) {
+            tokio::fs::remove_file(path)
+                .await
+                .map_err(|e| TrustError::Io {
+                    path: path.to_path_buf(),
+                    source: e,
+                })?;
+        }
+    }
+
+    tokio::fs::rename(&temp_path, path)
+        .await
+        .map_err(|e| TrustError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })
+}
+
+/// Persist `workspace` (canonicalized) into the store at
+/// `trust_store_path(user_data_folder)`.
+pub async fn record_trusted_workspace(
+    workspace: &Path,
+    user_data_folder: Option<&Path>,
+) -> Result<()> {
+    let store_path = trust_store_path(user_data_folder)?;
+    let mut store = load_trust_store(&store_path).await?;
+    let canon = canonicalize_workspace(workspace);
+    store.upsert(canon, Utc::now());
+    save_trust_store(&store_path, &store).await?;
+    Ok(())
+}
+
+/// Apply the trust policy to a workspace path.
+///
+/// The host-facing CLI assembles a `WorkspaceTrustPolicy` per invocation (from
+/// `--trust-workspace*` flags, the `DEACON_NO_PROMPT` env var, and the
+/// default), then invokes this function before any host-side shell exec.
+///
+/// `Prompt` is conservatively treated as `Deny` in this synchronous core API —
+/// the CLI is responsible for translating a `Prompt` decision into an actual
+/// interactive prompt when stdin is a TTY. This keeps the core trust gate
+/// async-safe and IO-free apart from the (already async) store load.
+pub async fn check_workspace_trust(
+    workspace: &Path,
+    policy: WorkspaceTrustPolicy,
+) -> Result<TrustDecision> {
+    let canon = canonicalize_workspace(workspace);
+    match policy {
+        WorkspaceTrustPolicy::AlwaysAllow => Ok(TrustDecision::Trusted),
+        WorkspaceTrustPolicy::Deny => Ok(TrustDecision::Denied {
+            workspace: canon,
+            reason: "trust policy is Deny (e.g. DEACON_NO_PROMPT=1)".to_string(),
+        }),
+        WorkspaceTrustPolicy::Prompt => {
+            // Core surface treats Prompt as Deny — caller should resolve
+            // interactivity above this layer.
+            Ok(TrustDecision::Denied {
+                workspace: canon,
+                reason: "interactive prompt required but not available in this context".to_string(),
+            })
+        }
+        WorkspaceTrustPolicy::Allowlist(store_path) => {
+            let store = match load_trust_store(&store_path).await {
+                Ok(store) => store,
+                Err(TrustError::Corrupt { path, message }) => {
+                    // Fail closed on corrupt store.
+                    warn!(
+                        "Workspace trust store at {} is corrupt: {}",
+                        path.display(),
+                        message
+                    );
+                    return Ok(TrustDecision::Denied {
+                        workspace: canon,
+                        reason: format!("trust store corrupt at {}", path.display()),
+                    });
+                }
+                Err(e) => return Err(e.into()),
+            };
+            if store.contains(&canon) {
+                Ok(TrustDecision::Trusted)
+            } else {
+                Ok(TrustDecision::Denied {
+                    workspace: canon,
+                    reason: format!("workspace not in allowlist at {}", store_path.display()),
+                })
+            }
+        }
+    }
+}
+
+/// Render the user-facing opt-in instructions emitted when a host-side hook is
+/// refused. Kept here so the wording is consistent between `up` (initialize)
+/// and dotfiles call sites.
+pub fn opt_in_instructions(workspace: &Path) -> String {
+    format!(
+        "Refusing to run host-side lifecycle hooks for workspace `{}` because it is not trusted.\n\
+         Re-run with one of:\n  \
+         --trust-workspace             (one-shot trust for this invocation)\n  \
+         --trust-workspace-persist     (one-shot + remember for future runs)\n\
+         To run automated builds in CI, set DEACON_NO_PROMPT=1 to fail closed and \
+         pre-populate the trust store via --trust-workspace-persist locally first.",
+        workspace.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_workspace(tmp: &TempDir, name: &str) -> PathBuf {
+        let p = tmp.path().join(name);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn always_allow_returns_trusted() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "ws");
+        let decision = check_workspace_trust(&ws, WorkspaceTrustPolicy::AlwaysAllow)
+            .await
+            .unwrap();
+        assert_eq!(decision, TrustDecision::Trusted);
+    }
+
+    #[tokio::test]
+    async fn deny_returns_denied() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "ws");
+        let decision = check_workspace_trust(&ws, WorkspaceTrustPolicy::Deny)
+            .await
+            .unwrap();
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn prompt_is_denied_in_core_api() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "ws");
+        let decision = check_workspace_trust(&ws, WorkspaceTrustPolicy::Prompt)
+            .await
+            .unwrap();
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn allowlist_match_after_record() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "trusted");
+        let store_path = tmp.path().join("trusted_workspaces.json");
+
+        // Miss before recording.
+        let miss = check_workspace_trust(&ws, WorkspaceTrustPolicy::Allowlist(store_path.clone()))
+            .await
+            .unwrap();
+        assert!(matches!(miss, TrustDecision::Denied { .. }));
+
+        // Record and re-check.
+        let mut store = TrustStore::default();
+        store.upsert(canonicalize_workspace(&ws), Utc::now());
+        save_trust_store(&store_path, &store).await.unwrap();
+        let hit = check_workspace_trust(&ws, WorkspaceTrustPolicy::Allowlist(store_path))
+            .await
+            .unwrap();
+        assert_eq!(hit, TrustDecision::Trusted);
+    }
+
+    #[tokio::test]
+    async fn allowlist_miss_for_sibling() {
+        let tmp = TempDir::new().unwrap();
+        let trusted = make_workspace(&tmp, "trusted");
+        let untrusted = make_workspace(&tmp, "untrusted");
+        let store_path = tmp.path().join("trusted_workspaces.json");
+
+        let mut store = TrustStore::default();
+        store.upsert(canonicalize_workspace(&trusted), Utc::now());
+        save_trust_store(&store_path, &store).await.unwrap();
+
+        let decision =
+            check_workspace_trust(&untrusted, WorkspaceTrustPolicy::Allowlist(store_path))
+                .await
+                .unwrap();
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    #[tokio::test]
+    async fn persistence_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "round-trip");
+        let store_path = tmp.path().join("trusted_workspaces.json");
+
+        let now = Utc::now();
+        let mut store = TrustStore::default();
+        store.upsert(canonicalize_workspace(&ws), now);
+        save_trust_store(&store_path, &store).await.unwrap();
+
+        let loaded = load_trust_store(&store_path).await.unwrap();
+        assert_eq!(loaded.workspaces.len(), 1);
+        assert_eq!(loaded.workspaces[0].path, canonicalize_workspace(&ws));
+        // Timestamp round-trips at second granularity at minimum.
+        assert_eq!(loaded.workspaces[0].last_trusted_at, now);
+    }
+
+    #[tokio::test]
+    async fn upsert_refreshes_timestamp_no_duplicates() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "ws");
+        let store_path = tmp.path().join("store.json");
+
+        record_trusted_workspace(&ws, Some(tmp.path()))
+            .await
+            .unwrap();
+        // Re-record the same workspace; must not duplicate.
+        record_trusted_workspace(&ws, Some(tmp.path()))
+            .await
+            .unwrap();
+
+        let expected_path = trust_store_path(Some(tmp.path())).unwrap();
+        assert_eq!(expected_path, tmp.path().join("trusted_workspaces.json"));
+        let _ = store_path; // path constructed inline for symmetry above
+        let loaded = load_trust_store(&expected_path).await.unwrap();
+        assert_eq!(loaded.workspaces.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn atomic_write_no_partial_file_on_simulated_failure() {
+        // Crash safety: simulate by writing to a temp path manually, then
+        // verifying that an aborted rename leaves the previous good file
+        // untouched. We do this by writing a known-good store, then attempting
+        // to write a second one with a path whose temp sibling we control.
+        let tmp = TempDir::new().unwrap();
+        let store_path = tmp.path().join("trusted_workspaces.json");
+
+        // Good write #1.
+        let mut store = TrustStore::default();
+        store.upsert(PathBuf::from("/good/path"), Utc::now());
+        save_trust_store(&store_path, &store).await.unwrap();
+        let bytes_before = tokio::fs::read(&store_path).await.unwrap();
+
+        // Pre-create a stale temp file with garbage; the next save must
+        // overwrite it cleanly (write-then-rename), leaving no partial state.
+        let temp_path = tmp.path().join(".trusted_workspaces.json.tmp");
+        tokio::fs::write(&temp_path, b"PARTIAL_GARBAGE")
+            .await
+            .unwrap();
+
+        // Good write #2 — must rename our fresh temp over the previous file.
+        store.upsert(PathBuf::from("/another/path"), Utc::now());
+        save_trust_store(&store_path, &store).await.unwrap();
+
+        let bytes_after = tokio::fs::read(&store_path).await.unwrap();
+        assert_ne!(bytes_before, bytes_after);
+        // Stale temp must have been consumed by the second save.
+        assert!(
+            !temp_path.exists(),
+            "temp file should have been renamed away"
+        );
+        // Final file must parse cleanly.
+        let loaded = load_trust_store(&store_path).await.unwrap();
+        assert_eq!(loaded.workspaces.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn corrupt_store_yields_denied_decision() {
+        let tmp = TempDir::new().unwrap();
+        let ws = make_workspace(&tmp, "ws");
+        let store_path = tmp.path().join("trusted_workspaces.json");
+        tokio::fs::write(&store_path, b"{not valid json")
+            .await
+            .unwrap();
+
+        let decision = check_workspace_trust(&ws, WorkspaceTrustPolicy::Allowlist(store_path))
+            .await
+            .unwrap();
+        assert!(matches!(decision, TrustDecision::Denied { .. }));
+    }
+
+    #[test]
+    fn opt_in_instructions_mentions_flags() {
+        let msg = opt_in_instructions(Path::new("/repo"));
+        assert!(msg.contains("--trust-workspace"));
+        assert!(msg.contains("--trust-workspace-persist"));
+        assert!(msg.contains("DEACON_NO_PROMPT"));
+        assert!(msg.contains("/repo"));
+    }
+}

--- a/crates/core/src/trust.rs
+++ b/crates/core/src/trust.rs
@@ -299,6 +299,55 @@ pub async fn check_workspace_trust(
     }
 }
 
+/// Resolve a [`WorkspaceTrustPolicy`] from CLI / env inputs.
+///
+/// Rules:
+/// - `trust_one_shot = true` or `trust_persist = true` → `AlwaysAllow`.
+/// - `deacon_no_prompt = true` (typically `DEACON_NO_PROMPT=1`) → `Deny`.
+///   Used by CI to fail closed without surprising a user with a hidden
+///   prompt.
+/// - Otherwise → `Allowlist(trust_store_path(user_data_folder))`. Workspaces
+///   previously recorded via `--trust-workspace-persist` will pass; any
+///   other workspace will be denied at the gate. The caller is responsible
+///   for translating the `Denied` decision into the right user-facing
+///   message — we deliberately do NOT prompt from inside core to keep this
+///   layer IO-free apart from the store load.
+pub fn resolve_policy(
+    trust_one_shot: bool,
+    trust_persist: bool,
+    deacon_no_prompt: bool,
+    user_data_folder: Option<&Path>,
+) -> Result<WorkspaceTrustPolicy> {
+    if trust_one_shot || trust_persist {
+        return Ok(WorkspaceTrustPolicy::AlwaysAllow);
+    }
+    if deacon_no_prompt {
+        return Ok(WorkspaceTrustPolicy::Deny);
+    }
+    Ok(WorkspaceTrustPolicy::Allowlist(trust_store_path(
+        user_data_folder,
+    )?))
+}
+
+/// Convert a `Denied` [`TrustDecision`] into a [`DeaconError::WorkspaceUntrusted`].
+///
+/// `Trusted` decisions become `Ok(())` so call sites can write
+/// `decision_to_result(check_workspace_trust(...).await?)?` and have the
+/// gate behave like any other fallible step.
+pub fn decision_to_result(decision: TrustDecision) -> Result<()> {
+    match decision {
+        TrustDecision::Trusted => Ok(()),
+        TrustDecision::Denied { workspace, reason } => {
+            let instructions = opt_in_instructions(&workspace);
+            Err(DeaconError::WorkspaceUntrusted {
+                workspace,
+                reason,
+                instructions,
+            })
+        }
+    }
+}
+
 /// Render the user-facing opt-in instructions emitted when a host-side hook is
 /// refused. Kept here so the wording is consistent between `up` (initialize)
 /// and dotfiles call sites.
@@ -494,5 +543,56 @@ mod tests {
         assert!(msg.contains("--trust-workspace-persist"));
         assert!(msg.contains("DEACON_NO_PROMPT"));
         assert!(msg.contains("/repo"));
+    }
+
+    #[test]
+    fn resolve_policy_trust_one_shot_means_always_allow() {
+        let tmp = TempDir::new().unwrap();
+        let p = resolve_policy(true, false, false, Some(tmp.path())).unwrap();
+        assert!(matches!(p, WorkspaceTrustPolicy::AlwaysAllow));
+    }
+
+    #[test]
+    fn resolve_policy_trust_persist_means_always_allow() {
+        let tmp = TempDir::new().unwrap();
+        let p = resolve_policy(false, true, false, Some(tmp.path())).unwrap();
+        assert!(matches!(p, WorkspaceTrustPolicy::AlwaysAllow));
+    }
+
+    #[test]
+    fn resolve_policy_no_prompt_means_deny() {
+        let tmp = TempDir::new().unwrap();
+        let p = resolve_policy(false, false, true, Some(tmp.path())).unwrap();
+        assert!(matches!(p, WorkspaceTrustPolicy::Deny));
+    }
+
+    #[test]
+    fn resolve_policy_default_is_allowlist() {
+        let tmp = TempDir::new().unwrap();
+        let p = resolve_policy(false, false, false, Some(tmp.path())).unwrap();
+        match p {
+            WorkspaceTrustPolicy::Allowlist(path) => {
+                assert!(path.ends_with("trusted_workspaces.json"));
+            }
+            other => panic!("expected Allowlist, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decision_to_result_trusted_is_ok() {
+        assert!(decision_to_result(TrustDecision::Trusted).is_ok());
+    }
+
+    #[test]
+    fn decision_to_result_denied_is_workspace_untrusted() {
+        let err = decision_to_result(TrustDecision::Denied {
+            workspace: PathBuf::from("/repo"),
+            reason: "test".to_string(),
+        })
+        .unwrap_err();
+        assert!(matches!(err, DeaconError::WorkspaceUntrusted { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("/repo"));
+        assert!(msg.contains("--trust-workspace"));
     }
 }

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -876,6 +876,27 @@ pub struct Cli {
     )]
     pub default_user_env_probe: DefaultUserEnvProbe,
 
+    /// Trust the current workspace for this invocation only.
+    ///
+    /// Gates host-side lifecycle hooks (`initializeCommand`, dotfiles
+    /// installs) behind explicit user opt-in. Without this flag (or
+    /// --trust-workspace-persist) the workspace must have been previously
+    /// persisted to the trust store; otherwise the host-side hook is
+    /// refused with a clear error.
+    ///
+    /// Conflicts with --trust-workspace-persist.
+    #[arg(long, global = true, conflicts_with = "trust_workspace_persist")]
+    pub trust_workspace: bool,
+
+    /// Trust the current workspace for this invocation AND persist it to
+    /// `{user_data_folder}/trusted_workspaces.json`. Future invocations
+    /// against the same canonicalized workspace path will pass the gate
+    /// automatically.
+    ///
+    /// Conflicts with --trust-workspace.
+    #[arg(long, global = true, conflicts_with = "trust_workspace")]
+    pub trust_workspace_persist: bool,
+
     /// Terminal columns for output formatting (requires --terminal-rows)
     #[arg(long, global = true, requires = "terminal_rows")]
     pub terminal_columns: Option<u32>,
@@ -1172,6 +1193,8 @@ impl Cli {
                     // JSON log format auto-forces PTY allocation so lifecycle exec output
                     // stays usable; the explicit flag remains as a manual override.
                     force_tty_if_json: self.force_tty_if_json || json_format,
+                    trust_workspace: self.trust_workspace,
+                    trust_workspace_persist: self.trust_workspace_persist,
                 };
 
                 // Execute up and emit JSON output per contract (specs/001-up-gap-spec/contracts/up.md)
@@ -1856,6 +1879,42 @@ mod tests {
     fn test_validate_accepts_no_dimensions() {
         let cli = Cli::parse_from(["deacon"]);
         assert!(cli.validate().is_ok());
+    }
+
+    /// `--trust-workspace` is a global flag.
+    #[test]
+    fn test_trust_workspace_global_flag_parses() {
+        let cli = Cli::parse_from(["deacon", "--trust-workspace"]);
+        assert!(cli.trust_workspace);
+        assert!(!cli.trust_workspace_persist);
+    }
+
+    /// `--trust-workspace-persist` is a separate global flag.
+    #[test]
+    fn test_trust_workspace_persist_flag_parses() {
+        let cli = Cli::parse_from(["deacon", "--trust-workspace-persist"]);
+        assert!(!cli.trust_workspace);
+        assert!(cli.trust_workspace_persist);
+    }
+
+    /// Both trust flags cannot be combined — clap enforces mutual exclusion.
+    #[test]
+    fn test_trust_workspace_flags_are_mutually_exclusive() {
+        let result =
+            Cli::try_parse_from(["deacon", "--trust-workspace", "--trust-workspace-persist"]);
+        assert!(
+            result.is_err(),
+            "expected mutual-exclusion error, got: {:?}",
+            result.ok()
+        );
+    }
+
+    /// Default state: neither trust flag is set.
+    #[test]
+    fn test_trust_workspace_default_off() {
+        let cli = Cli::parse_from(["deacon"]);
+        assert!(!cli.trust_workspace);
+        assert!(!cli.trust_workspace_persist);
     }
 
     #[test]

--- a/crates/deacon/src/commands/up/args.rs
+++ b/crates/deacon/src/commands/up/args.rs
@@ -417,6 +417,11 @@ pub struct UpArgs {
     pub redaction_config: deacon_core::redaction::RedactionConfig,
     pub secret_registry: deacon_core::redaction::SecretRegistry,
     pub force_tty_if_json: bool,
+
+    /// `--trust-workspace` flag (one-shot trust, does not persist).
+    pub trust_workspace: bool,
+    /// `--trust-workspace-persist` flag (one-shot + writes to the trust store).
+    pub trust_workspace_persist: bool,
 }
 
 impl Default for UpArgs {
@@ -474,6 +479,8 @@ impl Default for UpArgs {
             redaction_config: deacon_core::redaction::RedactionConfig::default(),
             secret_registry: deacon_core::redaction::global_registry().clone(),
             force_tty_if_json: false,
+            trust_workspace: false,
+            trust_workspace_persist: false,
         }
     }
 }

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -10,7 +10,7 @@ use super::features_build::{
     build_image_with_features, build_image_with_features_from_dockerfile, FeatureBuildOutput,
 };
 use super::helpers::handle_lockfile_post_build;
-use super::lifecycle::{execute_initialize_command, resolve_force_pty};
+use super::lifecycle::{execute_initialize_command, resolve_force_pty, HostTrustArgs};
 use super::merged_config::{
     build_merged_configuration_with_options, inspect_for_merged_configuration,
 };
@@ -239,7 +239,18 @@ pub(crate) async fn execute_compose_up(
 
     // Execute initializeCommand on host before starting compose operations
     if let Some(ref initialize) = config.initialize_command {
-        execute_initialize_command(initialize, workspace_folder, &args.progress_tracker).await?;
+        let trust_args = HostTrustArgs {
+            trust_workspace: args.trust_workspace,
+            trust_workspace_persist: args.trust_workspace_persist,
+            user_data_folder: args.user_data_folder.as_deref(),
+        };
+        execute_initialize_command(
+            initialize,
+            workspace_folder,
+            &args.progress_tracker,
+            trust_args,
+        )
+        .await?;
     }
 
     // Stop existing containers if requested

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -7,7 +7,7 @@
 use super::args::UpArgs;
 use super::features_build::build_image_with_features;
 use super::helpers::{apply_user_mapping, handle_lockfile_post_build};
-use super::lifecycle::{execute_initialize_command, execute_lifecycle_commands};
+use super::lifecycle::{execute_initialize_command, execute_lifecycle_commands, HostTrustArgs};
 use super::merged_config::{
     build_merged_configuration_with_options, inspect_for_merged_configuration,
 };
@@ -159,7 +159,18 @@ pub(crate) async fn execute_container_up(
 
     // Execute initializeCommand on host before any container operations
     if let Some(ref initialize) = config.initialize_command {
-        execute_initialize_command(initialize, workspace_folder, &args.progress_tracker).await?;
+        let trust_args = HostTrustArgs {
+            trust_workspace: args.trust_workspace,
+            trust_workspace_persist: args.trust_workspace_persist,
+            user_data_folder: args.user_data_folder.as_deref(),
+        };
+        execute_initialize_command(
+            initialize,
+            workspace_folder,
+            &args.progress_tracker,
+            trust_args,
+        )
+        .await?;
     }
 
     // Check Docker availability after host-side initialization

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -4,7 +4,8 @@
 //! - `resolve_force_pty` - Resolve PTY preference based on flags and environment
 //! - `build_invocation_context` - Build InvocationContext from CLI args and prior state
 //! - `execute_lifecycle_commands` - Execute lifecycle phases in container
-//! - `execute_initialize_command` - Execute initializeCommand on host
+//! - `execute_initialize_command` - Execute initializeCommand on host (with workspace-trust gate)
+//! - `HostTrustArgs` / `enforce_host_trust` - Workspace-trust gate primitives
 
 use super::args::UpArgs;
 use super::{ENV_FORCE_TTY_IF_JSON, ENV_LOG_FORMAT};
@@ -381,14 +382,87 @@ pub(crate) async fn execute_lifecycle_commands(
     Ok(())
 }
 
+/// Inputs needed to resolve the workspace-trust policy for a host-side
+/// lifecycle hook.
+///
+/// Borrowed view to avoid forcing callers to clone every flag — the
+/// `up`-tier already owns the underlying buffers.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HostTrustArgs<'a> {
+    /// `--trust-workspace` flag (one-shot trust, no persistence).
+    pub trust_workspace: bool,
+    /// `--trust-workspace-persist` flag (one-shot + writes to the trust store).
+    pub trust_workspace_persist: bool,
+    /// Host-side user data folder (where the trust store lives). When
+    /// `None`, the default `~/.deacon/` is used.
+    pub user_data_folder: Option<&'a Path>,
+}
+
+/// Read `DEACON_NO_PROMPT` from the environment. `1`, `true`, `yes`
+/// (case-insensitive) are truthy; anything else (including unset) is falsey.
+fn deacon_no_prompt_env() -> bool {
+    std::env::var("DEACON_NO_PROMPT")
+        .ok()
+        .map(|v| {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes"
+        })
+        .unwrap_or(false)
+}
+
+/// Enforce the workspace-trust gate before a host-side lifecycle hook runs.
+///
+/// On success this also handles the `--trust-workspace-persist` side-effect
+/// (writing the workspace into the trust store) so callers don't have to
+/// thread the persistence step separately.
+pub(crate) async fn enforce_host_trust(
+    workspace_folder: &Path,
+    args: &HostTrustArgs<'_>,
+) -> Result<()> {
+    use deacon_core::trust::{
+        check_workspace_trust, decision_to_result, record_trusted_workspace, resolve_policy,
+    };
+
+    let policy = resolve_policy(
+        args.trust_workspace,
+        args.trust_workspace_persist,
+        deacon_no_prompt_env(),
+        args.user_data_folder,
+    )
+    .context("Failed to resolve workspace trust policy")?;
+
+    let decision = check_workspace_trust(workspace_folder, policy)
+        .await
+        .context("Workspace trust check failed")?;
+
+    decision_to_result(decision).map_err(anyhow::Error::from)?;
+
+    if args.trust_workspace_persist {
+        record_trusted_workspace(workspace_folder, args.user_data_folder)
+            .await
+            .context("Failed to persist workspace trust entry")?;
+    }
+
+    Ok(())
+}
+
 /// Execute initializeCommand on the host before container creation
-#[instrument(skip(initialize_command, progress_tracker))]
+///
+/// `initializeCommand` runs arbitrary shell on the **developer's host** before
+/// any container sandboxing. The trust check below is the only thing standing
+/// between `git clone <hostile-repo> && deacon up` and arbitrary code
+/// execution on the host. Callers MUST pass the resolved trust args
+/// (`--trust-workspace`, `--trust-workspace-persist`, `DEACON_NO_PROMPT`)
+/// through `trust_args`; see [`HostTrustArgs`] for the source-of-truth
+/// resolution rules.
+#[instrument(skip(initialize_command, progress_tracker, trust_args))]
 pub(crate) async fn execute_initialize_command(
     initialize_command: &serde_json::Value,
     workspace_folder: &Path,
     progress_tracker: &std::sync::Arc<
         std::sync::Mutex<Option<deacon_core::progress::ProgressTracker>>,
     >,
+    trust_args: HostTrustArgs<'_>,
 ) -> Result<()> {
     use deacon_core::container_lifecycle::ContainerLifecycleCommands;
     use deacon_core::variable::SubstitutionContext;
@@ -407,6 +481,9 @@ pub(crate) async fn execute_initialize_command(
             return Ok(());
         }
     };
+
+    // Trust gate: refuse to run host-side shell from an untrusted workspace.
+    enforce_host_trust(workspace_folder, &trust_args).await?;
 
     // Build a LifecycleCommandList from the parsed value
     let command_list = LifecycleCommandList {

--- a/crates/deacon/tests/integration_trust.rs
+++ b/crates/deacon/tests/integration_trust.rs
@@ -1,0 +1,200 @@
+//! Integration tests for the workspace-trust gate on host-side lifecycle hooks.
+//!
+//! Coverage matrix (per issue #52 Task 2 acceptance criteria):
+//! - `deacon up` on a workspace with `initializeCommand` and no trust → fails
+//!   with the WorkspaceUntrusted error (and the host shell never runs).
+//! - `--trust-workspace` → host shell runs, side effects appear.
+//! - `DEACON_NO_PROMPT=1` without trust → fails (fail-closed).
+//!
+//! These tests do not require Docker: they assert behavior at the point where
+//! the trust gate fires, BEFORE any container operations. The host-side
+//! initializeCommand either runs (and leaves a marker on disk) or doesn't.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_devcontainer_with_init(workspace: &std::path::Path, init_cmd: &str) {
+    let dc_dir = workspace.join(".devcontainer");
+    fs::create_dir_all(&dc_dir).unwrap();
+    let config = format!(
+        r#"{{
+  "name": "trust-gate-test",
+  "image": "alpine:3.19",
+  "workspaceFolder": "/workspace",
+  "initializeCommand": "{}"
+}}"#,
+        init_cmd
+    );
+    fs::write(dc_dir.join("devcontainer.json"), config).unwrap();
+}
+
+/// Default policy (no flag, no DEACON_NO_PROMPT) refuses to run the host hook.
+///
+/// The marker file MUST NOT exist after the run; the run MUST fail with a
+/// message naming the workspace and `--trust-workspace`.
+#[test]
+fn untrusted_workspace_refuses_initialize_command() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path();
+    let marker = workspace.join("should-not-exist.txt");
+    write_devcontainer_with_init(workspace, &format!("echo trusted > {}", marker.display()));
+
+    // Point user_data_folder at a fresh dir so we don't read the host's
+    // real allowlist (which might have any path in it on a developer's box).
+    let user_data = tmp.path().join("user-data");
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let output = cmd
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(workspace)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "deacon up MUST fail on an untrusted workspace; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !marker.exists(),
+        "initializeCommand MUST NOT have run; marker exists at {}",
+        marker.display()
+    );
+
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        combined.contains("not trusted") || combined.contains("WorkspaceUntrusted"),
+        "error output should mention trust refusal: {}",
+        combined
+    );
+    assert!(
+        combined.contains("--trust-workspace"),
+        "error output should advertise --trust-workspace opt-in: {}",
+        combined
+    );
+}
+
+/// `--trust-workspace` (one-shot) allows the host-side hook to run.
+///
+/// The marker file MUST exist after the run, even when the downstream
+/// container creation fails (we don't have Docker in this hermetic test).
+#[test]
+fn trust_workspace_flag_allows_initialize_command() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path();
+    let marker = workspace.join("ran.txt");
+    write_devcontainer_with_init(workspace, &format!("echo trusted > {}", marker.display()));
+
+    let user_data = tmp.path().join("user-data");
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let _ = cmd
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .arg("--trust-workspace")
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(workspace)
+        .output()
+        .unwrap();
+
+    assert!(
+        marker.exists(),
+        "initializeCommand should have run with --trust-workspace; marker missing at {}",
+        marker.display()
+    );
+}
+
+/// `DEACON_NO_PROMPT=1` without an explicit `--trust-workspace*` flag forces
+/// Deny (fail-closed in CI).
+#[test]
+fn deacon_no_prompt_denies_without_explicit_trust() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path();
+    let marker = workspace.join("should-not-exist.txt");
+    write_devcontainer_with_init(workspace, &format!("echo trusted > {}", marker.display()));
+
+    let user_data = tmp.path().join("user-data");
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let output = cmd
+        .env("DEACON_NO_PROMPT", "1")
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(workspace)
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "DEACON_NO_PROMPT=1 MUST cause untrusted workspaces to fail closed"
+    );
+    assert!(
+        !marker.exists(),
+        "initializeCommand MUST NOT have run with DEACON_NO_PROMPT=1; marker exists at {}",
+        marker.display()
+    );
+}
+
+/// `--trust-workspace-persist` records the workspace into the trust store so
+/// subsequent runs without any flag are also allowed.
+#[test]
+fn trust_workspace_persist_remembers_for_next_run() {
+    let tmp = TempDir::new().unwrap();
+    let workspace = tmp.path().join("ws");
+    fs::create_dir_all(&workspace).unwrap();
+    let marker1 = workspace.join("first.txt");
+    let marker2 = workspace.join("second.txt");
+
+    // Two devcontainers can't coexist, so we rewrite for each run.
+    let user_data = tmp.path().join("user-data");
+
+    // Run 1: persist trust + verify marker1.
+    write_devcontainer_with_init(&workspace, &format!("echo first > {}", marker1.display()));
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let _ = cmd
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .arg("--trust-workspace-persist")
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(&workspace)
+        .output()
+        .unwrap();
+    assert!(marker1.exists(), "first run should have created marker1");
+
+    // Run 2: NO flag, NO DEACON_NO_PROMPT — the store should have remembered.
+    write_devcontainer_with_init(&workspace, &format!("echo second > {}", marker2.display()));
+    let mut cmd2 = Command::cargo_bin("deacon").unwrap();
+    let _ = cmd2
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        marker2.exists(),
+        "second run (no flag) should still trust persisted workspace; marker missing"
+    );
+
+    // Sanity check the on-disk store.
+    let store_path = user_data.join("trusted_workspaces.json");
+    assert!(
+        store_path.exists(),
+        "trust store should exist at {}",
+        store_path.display()
+    );
+}

--- a/crates/deacon/tests/integration_up_initialize_command.rs
+++ b/crates/deacon/tests/integration_up_initialize_command.rs
@@ -37,6 +37,7 @@ fn test_initialize_command_creates_host_marker() {
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let _ = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -96,6 +97,7 @@ fn test_initialize_command_array_syntax() {
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let _ = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -153,6 +155,7 @@ fn test_initialize_command_runs_before_container() {
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let _ = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -210,6 +213,7 @@ services:
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let _ = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -258,6 +262,7 @@ fn test_initialize_command_failure_prevents_container_creation() {
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let up_output = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -309,6 +314,7 @@ fn test_initialize_command_variable_substitution() {
     let mut up_cmd = Command::cargo_bin("deacon").unwrap();
     let _up_output = up_cmd
         .current_dir(&temp_dir)
+        .arg("--trust-workspace")
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())


### PR DESCRIPTION
## Summary
- Adds a workspace-trust gate before any host-side hook (`initializeCommand`, dotfiles custom install). Untrusted workspaces now fail closed with `DeaconError::WorkspaceUntrusted`.
- New `crates/core/src/trust.rs` module with `WorkspaceTrustPolicy`, allowlist persistence (`trusted_workspaces.json`, atomic write via write-temp-then-rename), and `check_workspace_trust`.
- New CLI: `--trust-workspace` (one-shot), `--trust-workspace-persist` (one-shot + remember), `DEACON_NO_PROMPT=1` env var (CI fail-closed).
- Closes part of #52 (Task 2, audit gap #3 — P0 / security).

## Known limitations
- `WorkspaceTrustPolicy::Prompt` is currently treated as `Deny` (fail-closed). The interactive TTY prompt is not yet wired — `--trust-workspace` / `--trust-workspace-persist` are the user's opt-in paths. If we add an interactive prompt later, it belongs at the CLI tier above `check_workspace_trust` to keep the core API IO-light.
- The dotfiles `HostTrustSource::WorkspaceSourced` arm is wired but no current caller sets it. It's in place so the gate fires the moment a `devcontainer.json`-sourced dotfiles install path is added.

## Test plan
- [x] 16 unit tests in `trust.rs`: allowlist match/miss, canonical-path resolution, persistence round-trip, simulated crash safety, corrupt-store fail-closed, `resolve_policy`, `decision_to_result`.
- [x] 4 integration tests in `crates/deacon/tests/integration_trust.rs`: untrusted refusal, `--trust-workspace` allows, persist+remember across runs, `DEACON_NO_PROMPT=1` fail-closed.
- [x] 4 CLI parsing tests: flags + mutual exclusion + default-off.
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `make test-nextest-fast` (2072 passed / 30 skipped).
- [x] Updated existing `integration_up_initialize_command.rs` tests to pass `--trust-workspace` (intentional behavior change documented in commit 2).
- [ ] Reviewer: this is ~1118 LoC across 3 commits. The issue suggested splitting at ~600 LoC; commits 1 and 2+3 are independent and cleanly separable if you'd prefer a 2-PR split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
