### PR TITLE
refactor(core): migrate json5 → jsonc-parser (#52 task 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
  "fastrand",
  "futures",
  "indexmap 2.14.0",
- "json5",
+ "jsonc-parser",
  "libc",
  "linked-hash-map",
  "num_cpus",
@@ -1571,13 +1571,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "1.3.1"
+name = "jsonc-parser"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+checksum = "840785e1a8b4fdb27be18440a35a81af64820dc185c3973ff8b012d4c6282512"
 dependencies = [
- "serde",
- "ucd-trie",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3144,12 +3143,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-json5 = "1.3"
+jsonc-parser = { version = "0.32", default-features = false, features = ["preserve_order"] }
 regex = "1.0"
 tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util"] }
 once_cell.workspace = true

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,8 +1,9 @@
 //! Configuration resolution and parsing
 //!
 //! This module handles devcontainer.json parsing following the Development Containers Specification.
-//! It supports JSON-with-comments (JSONC) parsing using the json5 crate to handle comments and
-//! trailing commas commonly found in devcontainer configuration files.
+//! It supports JSON-with-comments (JSONC) parsing via the `crate::jsonc` adapter so that
+//! comments and trailing commas commonly found in devcontainer configuration files are
+//! accepted.
 //!
 //! The configuration model mirrors the subset of fields needed for early implementation,
 //! with full type safety for known fields and flexibility for future extensions.
@@ -1781,7 +1782,7 @@ impl ConfigLoader {
     ///
     /// This method:
     /// 1. Reads the file as UTF-8 text
-    /// 2. Parses JSON-with-comments using json5
+    /// 2. Parses JSON-with-comments (JSONC) via the `crate::jsonc` adapter
     /// 3. Deserializes into strongly typed configuration
     /// 4. Logs unknown top-level keys at DEBUG level
     /// 5. Performs basic validation
@@ -1830,12 +1831,10 @@ impl ConfigLoader {
             DeaconError::Config(ConfigError::Io(e))
         })?;
 
-        // Parse JSON5 (JSON with comments and trailing commas)
-        let raw_value: serde_json::Value = json5::from_str(&content).map_err(|e| {
+        // Parse JSONC (JSON with comments and trailing commas).
+        let raw_value: serde_json::Value = crate::jsonc::parse(&content).map_err(|e| {
             debug!("Failed to parse configuration file: {}", e);
-            DeaconError::Config(ConfigError::Parsing {
-                message: format!("JSON parsing error: {}", e),
-            })
+            e
         })?;
 
         // Ensure root is a JSON object per spec
@@ -2648,7 +2647,11 @@ mod tests {
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Parsing { message }) => {
-                assert!(message.contains("JSON parsing error"));
+                assert!(
+                    message.contains("JSONC parsing error"),
+                    "unexpected error message: {}",
+                    message
+                );
             }
             _ => panic!("Expected Config(Parsing) error"),
         }

--- a/crates/core/src/jsonc.rs
+++ b/crates/core/src/jsonc.rs
@@ -1,0 +1,187 @@
+//! JSONC (JSON-with-comments) parsing adapter.
+//!
+//! `devcontainer.json` files are conventionally JSONC: standard JSON plus `//` and
+//! `/* */` comments and optional trailing commas. This module wraps the
+//! [`jsonc-parser`](https://docs.rs/jsonc-parser) crate and translates its AST into
+//! [`serde_json::Value`] so the rest of the codebase can keep consuming `Value`s
+//! unchanged.
+//!
+//! Object key order is preserved end-to-end: `jsonc-parser` is compiled with the
+//! `preserve_order` feature (its `JsonObject` is backed by an `IndexMap`), and the
+//! conversion inserts entries into a `serde_json::Map` in encounter order. The
+//! `serde_json` crate in this workspace is built with `preserve_order`, so the
+//! `Map` itself is also order-preserving.
+
+use crate::errors::{ConfigError, DeaconError, Result};
+use jsonc_parser::{parse_to_value, JsonValue, ParseOptions};
+use serde_json::{Map, Number, Value};
+
+/// Parse a JSONC string into a `serde_json::Value`.
+///
+/// Accepts the full set of JSONC conveniences (single-line and block comments,
+/// trailing commas). JSON5-only sugar (single-quoted strings, hexadecimal
+/// numbers, unary `+`, unquoted property names) is also tolerated by the
+/// underlying parser's default options; real-world `devcontainer.json` files
+/// do not use it, but we keep the permissive defaults to match the prior
+/// `json5`-based behaviour.
+///
+/// Returns `ConfigError::Parsing` on malformed input or on a number literal
+/// that cannot be represented as a `serde_json::Number`.
+pub fn parse(text: &str) -> Result<Value> {
+    let parsed = parse_to_value(text, &ParseOptions::default()).map_err(|e| {
+        DeaconError::Config(ConfigError::Parsing {
+            message: format!("JSONC parsing error: {}", e),
+        })
+    })?;
+
+    match parsed {
+        Some(value) => convert(value),
+        None => Ok(Value::Null),
+    }
+}
+
+fn convert(value: JsonValue<'_>) -> Result<Value> {
+    Ok(match value {
+        JsonValue::Null => Value::Null,
+        JsonValue::Boolean(b) => Value::Bool(b),
+        JsonValue::String(s) => Value::String(s.into_owned()),
+        JsonValue::Number(raw) => Value::Number(parse_number(raw)?),
+        JsonValue::Array(arr) => {
+            let elems = arr.take_inner();
+            let mut out = Vec::with_capacity(elems.len());
+            for el in elems {
+                out.push(convert(el)?);
+            }
+            Value::Array(out)
+        }
+        JsonValue::Object(obj) => {
+            let mut map = Map::with_capacity(obj.len());
+            for (k, v) in obj.into_iter() {
+                map.insert(k, convert(v)?);
+            }
+            Value::Object(map)
+        }
+    })
+}
+
+fn parse_number(raw: &str) -> Result<Number> {
+    // Strip optional unary plus, accepted by jsonc-parser with default options.
+    let stripped = raw.strip_prefix('+').unwrap_or(raw);
+
+    // Hexadecimal: jsonc-parser tolerates `0x...` / `-0x...`. JSON itself
+    // does not, but we preserve permissive semantics by converting to i64.
+    let (sign, hex_body) = if let Some(rest) = stripped
+        .strip_prefix("-0x")
+        .or_else(|| stripped.strip_prefix("-0X"))
+    {
+        (-1i128, Some(rest))
+    } else if let Some(rest) = stripped
+        .strip_prefix("0x")
+        .or_else(|| stripped.strip_prefix("0X"))
+    {
+        (1i128, Some(rest))
+    } else {
+        (1i128, None)
+    };
+    if let Some(body) = hex_body {
+        if let Ok(magnitude) = i128::from_str_radix(body, 16) {
+            let signed = sign
+                .checked_mul(magnitude)
+                .ok_or_else(|| number_error(raw))?;
+            if let Ok(v) = i64::try_from(signed) {
+                return Ok(Number::from(v));
+            }
+            if signed >= 0 {
+                if let Ok(v) = u64::try_from(signed) {
+                    return Ok(Number::from(v));
+                }
+            }
+        }
+        return Err(number_error(raw));
+    }
+
+    if let Ok(v) = stripped.parse::<i64>() {
+        return Ok(Number::from(v));
+    }
+    if let Ok(v) = stripped.parse::<u64>() {
+        return Ok(Number::from(v));
+    }
+    if let Ok(v) = stripped.parse::<f64>() {
+        if let Some(n) = Number::from_f64(v) {
+            return Ok(n);
+        }
+    }
+    Err(number_error(raw))
+}
+
+fn number_error(raw: &str) -> DeaconError {
+    DeaconError::Config(ConfigError::Parsing {
+        message: format!("Invalid number literal in configuration: {}", raw),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_json() {
+        let value = parse(r#"{"a": 1, "b": "two", "c": true}"#).unwrap();
+        assert_eq!(value["a"], 1);
+        assert_eq!(value["b"], "two");
+        assert_eq!(value["c"], true);
+    }
+
+    #[test]
+    fn parses_comments_and_trailing_commas() {
+        let value = parse(
+            r#"{
+                // line comment
+                "name": "demo", /* block */
+                "list": [1, 2, 3,],
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(value["name"], "demo");
+        assert_eq!(value["list"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn preserves_object_key_order() {
+        let value = parse(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        let keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(keys, vec!["z", "a", "m"]);
+    }
+
+    #[test]
+    fn empty_input_yields_null() {
+        let value = parse("").unwrap();
+        assert_eq!(value, Value::Null);
+    }
+
+    #[test]
+    fn reports_parse_errors() {
+        let err = parse("{not valid").unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("JSONC parsing error"), "got: {}", msg);
+    }
+
+    #[test]
+    fn numbers_match_serde_json_for_common_shapes() {
+        let cases = [
+            ("0", Value::from(0u64)),
+            ("-1", Value::from(-1i64)),
+            ("2.5", serde_json::json!(2.5)),
+            ("1e10", serde_json::json!(1e10)),
+        ];
+        for (input, expected) in cases {
+            let got = parse(&format!("{{\"n\": {}}}", input)).unwrap();
+            assert_eq!(got["n"], expected, "input: {}", input);
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod features;
 pub mod gpu;
 pub mod host_requirements;
 pub mod io;
+pub mod jsonc;
 pub mod lifecycle;
 pub mod lockfile;
 pub mod logging;

--- a/crates/core/tests/integration_config.rs
+++ b/crates/core/tests/integration_config.rs
@@ -171,7 +171,7 @@ fn test_error_line_col_information() {
             message,
         }) => {
             // Should contain some indication of parsing error
-            assert!(message.contains("JSON parsing error"));
+            assert!(message.contains("JSONC parsing error"));
         }
         err => panic!("Expected Config(Parsing) error, got: {:?}", err),
     }

--- a/crates/deacon/tests/integration_e2e.rs
+++ b/crates/deacon/tests/integration_e2e.rs
@@ -675,7 +675,7 @@ fn test_e2e_error_handling() {
     ]);
     result
         .assert_failure()
-        .assert_stderr_contains("JSON parsing error");
+        .assert_stderr_contains("JSONC parsing error");
 
     println!("✅ Error handling test completed successfully");
 }


### PR DESCRIPTION
## Summary
- Migrates devcontainer.json parsing from `json5` to `jsonc-parser`. The new parser more accurately matches what users actually write (JSONC = JSON with comments, not JSON5).
- New adapter at `crates/core/src/jsonc.rs` parses to `jsonc-parser`'s AST and translates to `serde_json::Value` so downstream code is unchanged.
- Number parsing follows i64 → u64 → f64 with explicit handling for hex (`0x…`) and unary `+` so behavior matches the old loose `json5` defaults. Key order is preserved.
- Closes part of #52 (Task 5, audit gap #9 — P2).

## Behavior change
The error-message prefix changes from `"JSON parsing error: …"` to `"JSONC parsing error: …"` — a strict accuracy improvement. Two test assertions updated in the same commit. No JSON5-only sugar (hex literals, unquoted keys, single-quoted strings) was found in `examples/` fixtures, so no fixture changes were required.

## Test plan
- [x] 6 new unit tests in `jsonc.rs`: basic, comments + trailing commas, key-order preservation, empty input → null, parse-error reporting, numeric shapes.
- [x] Existing `test_load_valid_config_with_comments` still passes.
- [x] During development, a temporary comparison harness walked all 47 `examples/**/devcontainer.json[c]` fixtures and asserted byte-identical `serde_json::Value` between the old and new parser; passed, then was deleted along with `json5` as the task instructed.
- [x] `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `make test-nextest-fast` (2050 passed / 30 skipped).
- [x] `cargo tree -i json5` confirmed empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
