### PR TITLE
fix(cli): accept any --config / --override-config filename (#65)

### DIFF
--- a/crates/core/src/build/mod.rs
+++ b/crates/core/src/build/mod.rs
@@ -160,30 +160,17 @@ impl BuildRequest {
     ///
     /// # Validation Rules
     ///
-    /// - Config filename must be `devcontainer.json` or `.devcontainer.json` when provided
     /// - `push` and `output` are mutually exclusive
     /// - BuildKit-only flags require BuildKit availability (checked separately)
     /// - All image names must be valid image references
+    ///
+    /// The `--config` path is accepted as-is (any filename); see spec parity
+    /// note in #65.
     ///
     /// # Errors
     ///
     /// Returns an error if validation fails with a descriptive message.
     pub fn validate(&self) -> Result<()> {
-        // Validate config file name if provided
-        if let Some(config_file) = &self.config_file {
-            let filename = config_file
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("");
-
-            if filename != "devcontainer.json" && filename != ".devcontainer.json" {
-                return Err(crate::errors::DeaconError::Runtime(format!(
-                    "Configuration file must be named 'devcontainer.json' or '.devcontainer.json', got '{}'",
-                    filename
-                )));
-            }
-        }
-
         // Validate push/output mutual exclusivity
         if self.push && self.output.is_some() {
             return Err(crate::errors::DeaconError::Runtime(
@@ -387,7 +374,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_request_validate_config_filename() {
+    fn test_build_request_accepts_any_config_filename() {
+        // Spec parity (#65): the upstream reference CLI does not enforce a
+        // filename allow-list on --config; deacon follows suit.
         let mut request = BuildRequest {
             workspace_folder: PathBuf::from("/workspace"),
             config_file: Some(PathBuf::from("/workspace/.devcontainer/devcontainer.json")),
@@ -404,12 +393,16 @@ mod tests {
             skip_persist_customizations: false,
         };
 
-        // Valid config file name
         assert!(request.validate().is_ok());
 
-        // Invalid config file name
         request.config_file = Some(PathBuf::from("/workspace/.devcontainer/config.json"));
-        assert!(request.validate().is_err());
+        assert!(
+            request.validate().is_ok(),
+            "Non-standard --config filenames must be accepted (spec parity)"
+        );
+
+        request.config_file = Some(PathBuf::from("/workspace/alpha.json"));
+        assert!(request.validate().is_ok());
     }
 
     #[test]

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -847,36 +847,6 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
     }
 }
 
-/// Validate devcontainer configuration filename.
-///
-/// Per spec FR-004 and docs/subcommand-specs/up/SPEC.md §4:
-/// "IF configFile specified AND file name not devcontainer.json/.devcontainer.json:
-///     ERROR 'Filename must be devcontainer.json or .devcontainer.json'"
-///
-/// Note: We also accept .jsonc extensions (JSON with Comments) as they are widely
-/// used in the devcontainer ecosystem and supported by our JSON5 parser.
-///
-/// This validation applies to both --config and --override-config paths.
-fn validate_config_filename(config_path: &Path, flag_name: &str) -> Result<()> {
-    if let Some(filename) = config_path.file_name().and_then(|n| n.to_str()) {
-        let valid_names = [
-            "devcontainer.json",
-            ".devcontainer.json",
-            "devcontainer.jsonc",
-            ".devcontainer.jsonc",
-        ];
-
-        if !valid_names.contains(&filename) {
-            anyhow::bail!(
-                "Invalid {} filename: '{}'. Filename must be one of: devcontainer.json, .devcontainer.json, devcontainer.jsonc, or .devcontainer.jsonc.",
-                flag_name,
-                filename
-            );
-        }
-    }
-    Ok(())
-}
-
 /// Execute the read-configuration command
 #[instrument(skip(args))]
 pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<()> {
@@ -892,15 +862,6 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         args.override_config_path,
         args.secrets_files.len()
     );
-
-    // Validate devcontainer configuration filenames per FR-004
-    // Must be devcontainer.json or .devcontainer.json
-    if let Some(config_path) = args.config_path.as_ref() {
-        validate_config_filename(config_path, "--config")?;
-    }
-    if let Some(override_path) = args.override_config_path.as_ref() {
-        validate_config_filename(override_path, "--override-config")?;
-    }
 
     // Selector validation per spec (§2, §9):
     // At least one of --container-id, --id-label, or --workspace-folder is required.
@@ -1308,7 +1269,6 @@ mod tests {
     async fn test_read_configuration_with_override() {
         let temp_dir = TempDir::new().unwrap();
         let base_config_path = temp_dir.path().join("devcontainer.json");
-        // Per FR-004: override config must also be named devcontainer.json or .devcontainer.json
         let override_dir = temp_dir.path().join("override");
         fs::create_dir(&override_dir).unwrap();
         let override_config_path = override_dir.join("devcontainer.json");
@@ -3254,17 +3214,20 @@ API_KEY=another-secret
     }
 
     #[tokio::test]
-    async fn test_read_configuration_invalid_config_filename() {
-        // Test that invalid config filenames are rejected per FR-004
+    async fn test_read_configuration_arbitrary_config_filename_accepted() {
+        // Spec parity (#65): the upstream reference CLI does not enforce a
+        // filename allow-list on --config — any path that resolves to a
+        // readable devcontainer.json document is accepted. A non-existent
+        // path still surfaces the usual file-not-found error from the loader.
         let temp_dir = TempDir::new().unwrap();
-        let invalid_config_path = temp_dir.path().join("my-config.json");
+        let custom_config_path = temp_dir.path().join("my-config.json");
 
         let config_content = r#"{
             "name": "test-container",
             "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
         }"#;
 
-        fs::write(&invalid_config_path, config_content).unwrap();
+        fs::write(&custom_config_path, config_content).unwrap();
 
         let args = ReadConfigurationArgs {
             include_merged_configuration: false,
@@ -3280,7 +3243,7 @@ API_KEY=another-secret
             terminal_columns: None,
             terminal_rows: None,
             workspace_folder: Some(temp_dir.path().to_path_buf()),
-            config_path: Some(invalid_config_path),
+            config_path: Some(custom_config_path),
             override_config_path: None,
             secrets_files: vec![],
             redaction_config: RedactionConfig::default(),
@@ -3288,23 +3251,19 @@ API_KEY=another-secret
         };
 
         let result = execute_read_configuration(args).await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("Invalid --config filename")
-                && err_msg.contains("my-config.json")
-                && err_msg.contains("devcontainer.json"),
-            "Expected error message about invalid filename, got: {}",
-            err_msg
+            result.is_ok(),
+            "Expected arbitrary --config filename to be accepted, got: {:?}",
+            result.err()
         );
     }
 
     #[tokio::test]
-    async fn test_read_configuration_invalid_override_filename() {
-        // Test that invalid override-config filenames are rejected per FR-004
+    async fn test_read_configuration_arbitrary_override_filename_accepted() {
+        // Spec parity (#65): --override-config likewise accepts any filename.
         let temp_dir = TempDir::new().unwrap();
         let base_config_path = temp_dir.path().join("devcontainer.json");
-        let invalid_override_path = temp_dir.path().join("override.json");
+        let custom_override_path = temp_dir.path().join("override.json");
 
         let config_content = r#"{
             "name": "test-container",
@@ -3312,7 +3271,7 @@ API_KEY=another-secret
         }"#;
 
         fs::write(&base_config_path, config_content).unwrap();
-        fs::write(&invalid_override_path, config_content).unwrap();
+        fs::write(&custom_override_path, config_content).unwrap();
 
         let args = ReadConfigurationArgs {
             include_merged_configuration: false,
@@ -3329,21 +3288,17 @@ API_KEY=another-secret
             terminal_rows: None,
             workspace_folder: Some(temp_dir.path().to_path_buf()),
             config_path: Some(base_config_path),
-            override_config_path: Some(invalid_override_path),
+            override_config_path: Some(custom_override_path),
             secrets_files: vec![],
             redaction_config: RedactionConfig::default(),
             secret_registry: SecretRegistry::new(),
         };
 
         let result = execute_read_configuration(args).await;
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("Invalid --override-config filename")
-                && err_msg.contains("override.json")
-                && err_msg.contains("devcontainer.json"),
-            "Expected error message about invalid override filename, got: {}",
-            err_msg
+            result.is_ok(),
+            "Expected arbitrary --override-config filename to be accepted, got: {:?}",
+            result.err()
         );
     }
 

--- a/crates/deacon/src/commands/shared/config_loader.rs
+++ b/crates/deacon/src/commands/shared/config_loader.rs
@@ -49,22 +49,8 @@ pub async fn load_config(args: ConfigLoadArgs<'_>) -> Result<ConfigLoadResult> {
     };
 
     let mut config_path = if let Some(path) = args.config_path {
-        // Validate filename per spec: must be devcontainer.json(c) or .devcontainer.json(c)
-        // The .jsonc extension is allowed for JSON with comments
-        if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-            let valid_names = [
-                "devcontainer.json",
-                "devcontainer.jsonc",
-                ".devcontainer.json",
-                ".devcontainer.jsonc",
-            ];
-            if !valid_names.contains(&file_name) {
-                return Err(DeaconError::Config(ConfigError::Validation {
-                    message: "Filename must be devcontainer.json(c) or .devcontainer.json(c)"
-                        .to_string(),
-                }));
-            }
-        }
+        // Spec parity (#65): accept any --config filename; the loader will
+        // surface the usual file-not-found error if the path does not exist.
         path.to_path_buf()
     } else {
         match ConfigLoader::discover_config(&workspace_folder).await? {

--- a/docs/subcommand-specs/completed-specs/build/SPEC.md
+++ b/docs/subcommand-specs/completed-specs/build/SPEC.md
@@ -56,7 +56,7 @@
     - Compose configurations do not support `--platform`, `--push`, `--output`, `--cache-to`.
   - Deprecated: none.
 - Argument Validation Rules:
-  - `--config` filename must be `devcontainer.json` or `.devcontainer.json`; otherwise: error “Filename must be devcontainer.json or .devcontainer.json (...)”.
+  - `--config` is accepted as a path with any filename, matching the upstream reference CLI (#65). A non-existent path surfaces the usual file-not-found error from the loader.
   - `--label` and `--image-name` may be specified multiple times; order preserved.
   - `--additional-features` must be valid JSON mapping string->(string|boolean|object); on parse error: build error.
   - `--platform` value must match `os/arch` or `os/arch/variant`; otherwise: build error.
@@ -112,9 +112,8 @@ FUNCTION parse_command_arguments(args: CommandLineArgs) -> ParsedInput:
         RAISE InputError("--push true cannot be used with --output.")
     END IF
 
-    IF input.config_file AND NOT filename_is_devcontainer_json(input.config_file) THEN
-        RAISE InputError("Filename must be devcontainer.json or .devcontainer.json (...) ")
-    END IF
+    // input.config_file is accepted with any filename (#65); the loader
+    // will surface a file-not-found error if the path does not exist.
 
     IF input.additional_features_json THEN
         TRY
@@ -297,7 +296,7 @@ END FUNCTION
 
 ## 9. Error Handling Strategy
 - User Errors:
-  - Invalid `--config` filename → exit code 1, message: “Filename must be devcontainer.json or .devcontainer.json (...)”. Remediation: pass a proper path.
+  - Missing or unreadable `--config` path → exit code 1, message surfaced by the loader (e.g. file-not-found). Filename is not constrained (#65).
   - `--output` with `--push` → exit code 1, message: “--push true cannot be used with --output.” Remediation: choose one.
   - Compose with unsupported flags (`--platform`, `--push`, `--output`, `--cache-to`) → exit code 1, message: “... not supported.”
   - Invalid `--platform` value → exit code 1, message: “not supported/invalid platform”.

--- a/docs/subcommand-specs/up/SPEC.md
+++ b/docs/subcommand-specs/up/SPEC.md
@@ -109,8 +109,9 @@ END FUNCTION
 - Resolution Algorithm:
 ```pseudocode
 FUNCTION resolve_configuration(params, configFile, overrideConfig, providedIdLabels, additionalFeatures):
-    IF configFile specified AND file name not devcontainer.json/.devcontainer.json:
-        ERROR "Filename must be devcontainer.json or .devcontainer.json"
+    // configFile is accepted as a path with any filename, matching the
+    // upstream reference CLI; a non-existent path surfaces the usual
+    // file-not-found error from the loader (#65).
 
     workspace := workspaceFromPath(params.cliHost.path, params.cliHost.cwd OR workspaceFolder)
     candidateConfigPath :=


### PR DESCRIPTION
## Summary

- Drop the deacon-specific filename allow-list on `--config` and `--override-config`. Upstream `@devcontainers/cli` treats both as plain paths; deacon now matches.
- Three validators removed: `read_configuration::validate_config_filename`, `shared::config_loader` inline check, and the `BuildRequest::validate` filename branch.
- SPEC.md updates: `up/SPEC.md` and `completed-specs/build/SPEC.md` no longer state the filename gate.

The loader still surfaces a file-not-found error if the path is bogus. Existing canonical filenames (`devcontainer.json`, `.devcontainer.json`, `.jsonc` variants) keep working.

Closes #65. Unblocks `configuration/extends-chain-cycle` and `doctor/gpu-host-requirements` example scenarios per #74.

## Test plan

- [x] `make test-nextest-fast` (2089 passing)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- New unit tests:
  - `test_read_configuration_arbitrary_config_filename_accepted`
  - `test_read_configuration_arbitrary_override_filename_accepted`
  - `test_build_request_accepts_any_config_filename` (replaces the inverse assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)