### PR TITLE
fix(read-configuration): accept --config alone (#66)

### DIFF
--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -863,15 +863,18 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         args.secrets_files.len()
     );
 
-    // Selector validation per spec (§2, §9):
-    // At least one of --container-id, --id-label, or --workspace-folder is required.
-    // Note: --config alone does NOT satisfy this requirement.
+    // Selector validation:
+    // At least one of --container-id, --id-label, --workspace-folder, or
+    // --config is required. Spec parity (#66): the upstream reference CLI
+    // accepts `--config <path>` on its own — `read-configuration` can parse
+    // a config file without any workspace context. We mirror that here.
     let has_container_id = args.container_id.is_some();
     let has_id_label = !args.id_label.is_empty();
     let has_workspace_folder = args.workspace_folder.is_some();
-    if !has_container_id && !has_id_label && !has_workspace_folder {
+    let has_config = args.config_path.is_some();
+    if !has_container_id && !has_id_label && !has_workspace_folder && !has_config {
         anyhow::bail!(
-            "Missing required argument: One of --container-id, --id-label or --workspace-folder is required."
+            "Missing required argument: One of --container-id, --id-label, --workspace-folder, or --config is required."
         );
     }
 
@@ -907,8 +910,24 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         && args.workspace_folder.is_none()
         && args.override_config_path.is_none();
 
-    // Determine workspace folder
-    let workspace_folder = args.workspace_folder.as_deref().unwrap_or(Path::new("."));
+    // Determine workspace folder.
+    //
+    // Spec parity (#66): when only `--config` is provided (no
+    // `--workspace-folder`), default workspace to the directory containing
+    // the config file. This matches the upstream reference CLI behavior of
+    // accepting `--config` on its own and keeps `${localWorkspaceFolder}`
+    // substitutions meaningful.
+    let config_parent_workspace = args
+        .workspace_folder
+        .is_none()
+        .then(|| args.config_path.as_deref().and_then(|p| p.parent()))
+        .flatten()
+        .map(|p| p.to_path_buf());
+    let workspace_folder = args
+        .workspace_folder
+        .as_deref()
+        .or(config_parent_workspace.as_deref())
+        .unwrap_or(Path::new("."));
 
     // Load configuration using shared helper (aligns with up/exec behavior)
     let (config, substitution_report) = if container_only_mode {

--- a/crates/deacon/tests/test_read_configuration_validation.rs
+++ b/crates/deacon/tests/test_read_configuration_validation.rs
@@ -8,8 +8,25 @@ use std::fs;
 use tempfile::TempDir;
 
 #[test]
-fn test_selector_requirement_no_selectors() {
-    // When no selector flags are provided (only --config), should fail with exact message
+fn test_selector_requirement_no_selectors_no_config() {
+    // When no selector flags AND no --config are provided, fail with the
+    // updated exact message that lists --config as an accepted selector
+    // (spec parity #66).
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    cmd.arg("read-configuration");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Missing required argument: One of --container-id, --id-label, --workspace-folder, or --config is required.",
+        ));
+}
+
+#[test]
+fn test_selector_requirement_with_only_config() {
+    // Spec parity (#66): --config alone is sufficient. The upstream
+    // reference CLI accepts an explicit config path without any workspace
+    // selector; deacon now matches.
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("devcontainer.json");
     fs::write(&config_path, r#"{"name": "test", "image": "ubuntu:22.04"}"#).unwrap();
@@ -19,12 +36,7 @@ fn test_selector_requirement_no_selectors() {
         .arg("--config")
         .arg(&config_path);
 
-    // Should fail because --config alone does not satisfy the selector requirement
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "Missing required argument: One of --container-id, --id-label or --workspace-folder is required.",
-        ));
+    cmd.assert().success();
 }
 
 #[test]

--- a/docs/subcommand-specs/completed-specs/read-configuration/SPEC.md
+++ b/docs/subcommand-specs/completed-specs/read-configuration/SPEC.md
@@ -43,13 +43,13 @@
   - Other:
     - `--user-data-folder <PATH>` Accepted but not used by this subcommand (present for parity).
 - Flag Taxonomy:
-  - Required vs Optional: At least one of `--container-id`, `--id-label`, or `--workspace-folder` is required. All others are optional.
+  - Required vs Optional: At least one of `--container-id`, `--id-label`, `--workspace-folder`, or `--config` is required (#66). All others are optional.
   - Paired requirements: `--terminal-columns` implies `--terminal-rows` and vice versa.
   - Mutually exclusive: None enforced by this subcommand.
   - Deprecated: None.
 - Argument Validation Rules:
   - `--id-label` must match `<name>=<value>`; regex `/.+=.+/` (value must be non-empty). Multiple occurrences allowed.
-  - If none of `--container-id`, `--id-label`, or `--workspace-folder` are present: error “Missing required argument: One of --container-id, --id-label or --workspace-folder is required.”
+  - If none of `--container-id`, `--id-label`, `--workspace-folder`, or `--config` are present: error “Missing required argument: One of --container-id, --id-label, --workspace-folder, or --config is required.” When `--config` is supplied alone, the workspace defaults to the config file’s parent directory for substitution purposes.
   - `--additional-features` must parse as JSON object mapping string->(string|boolean|object); on parse error: command error.
   - For this subcommand, `--config` filename is not strictly validated; it is treated as a path and read as-is.
 
@@ -243,7 +243,7 @@ END FUNCTION
 
 ## 9. Error Handling Strategy
 - User Errors:
-  - Missing required selector: Exit 1; message: “Missing required argument: One of --container-id, --id-label or --workspace-folder is required.” Remediation: provide one.
+  - Missing required selector: Exit 1; message: “Missing required argument: One of --container-id, --id-label, --workspace-folder, or --config is required.” Remediation: provide one (#66).
   - Invalid `--id-label` format: Exit 1; message: “Unmatched argument format: id-label must match <name>=<value>.” Remediation: correct format.
   - Config not found when requested: Exit 1; message includes resolved path. Remediation: adjust `--config`/`--workspace-folder`/`--override-config`.
   - Malformed JSON in `--additional-features` or config file: Exit 1; message indicates parse/validation failure.


### PR DESCRIPTION
## Summary

- `read-configuration --config <path>` no longer requires `--workspace-folder`, `--container-id`, or `--id-label`. Upstream `@devcontainers/cli` treats these as independently optional; deacon now matches.
- When `--config` is supplied alone, the workspace defaults to the config file's parent directory so `${localWorkspaceFolder}` substitutions remain meaningful.
- The missing-selector error message now lists `--config` alongside the existing selectors.

Closes #66. Unblocks `doctor/gpu-host-requirements` and `configuration/extends-chain-cycle` example scenarios per #74.

## Test plan

- [x] `make test-nextest-fast` (2090 passing)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- Tests:
  - `test_selector_requirement_with_only_config` — positive case
  - `test_selector_requirement_no_selectors_no_config` — negative case with updated wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)