### PR TITLE
fix(up): keep --workspace-folder for discovery; git root drives mount only (#67)

### DIFF
--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -56,25 +56,32 @@ pub(crate) async fn execute_compose_up(
 
     // Apply default workspace mount for Compose when consistency is provided
     // Per FR-001: workspace_mount_consistency MUST apply to both Docker and Compose outputs
-    // This mirrors the Docker behavior in execute_docker_up()
+    // This mirrors the Docker behavior in execute_docker_up().
+    //
+    // Spec parity (#67): when `--mount-workspace-git-root` is true, the
+    // mount *source* walks up to the enclosing git root so git operations
+    // inside the container work; otherwise the user's workspace folder.
+    // Discovery has already used the user's path by this point.
     let mut additional_mounts = Vec::new();
     if args.workspace_mount_consistency.is_some() {
-        // Compute target path (container path) - same logic as Docker path
+        let mount_source = if args.mount_workspace_git_root {
+            deacon_core::workspace::resolve_workspace_root(workspace_folder)?
+        } else {
+            workspace_folder.to_path_buf()
+        };
         let target_path = config.workspace_folder.clone().unwrap_or_else(|| {
             format!(
                 "/workspaces/{}",
-                workspace_folder
+                mount_source
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("workspace")
             )
         });
-        // Source path is the resolved workspace_folder (already canonicalized in execute_up)
-        let source_path = workspace_folder.display().to_string();
 
         additional_mounts.push(deacon_core::compose::ComposeMount {
             mount_type: "bind".to_string(),
-            source: source_path,
+            source: mount_source.display().to_string(),
             target: target_path,
             read_only: false,
             consistency: args.workspace_mount_consistency.clone(),

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -92,56 +92,69 @@ pub(crate) async fn execute_container_up(
         );
     }
 
-    // Build the default workspace mount.
+    // Apply workspace mount consistency when using default workspace mount.
     //
-    // Spec parity (#67): the mount *source* is the enclosing git root when
-    // `--mount-workspace-git-root` is true (the default) so git operations
-    // inside the container work; otherwise the user's workspace folder. The
-    // mount *target* defaults to `/workspaces/<basename(source)>`, matching
-    // the upstream reference CLI.
-    //
-    // Discovery (`load_config`) has already used the user's workspace
-    // folder by this point — the git-root walk no longer affects which
-    // `.devcontainer/devcontainer.json` is loaded.
+    // We keep the behavior tight: only inject `config.workspace_mount` here
+    // when the user explicitly requested a consistency mode. Container
+    // identity (computed later) hashes the entire config — so injecting a
+    // mount string here that depends on host paths would change the
+    // workspace+config hash and break `deacon up` ↔ `deacon exec`
+    // reconnection. The default mount (without consistency) is built later
+    // by `Docker::create_container` from the `workspace_path` argument; #67
+    // re-anchors that argument to the git root via `workspace_mount_source`
+    // below.
     if config.workspace_mount.is_none() {
-        let mount_source = if args.mount_workspace_git_root {
-            let git_root = deacon_core::workspace::find_git_repository_root(workspace_folder)?;
-            if git_root.is_none() {
-                info!(
-                    "Git root requested (--mount-workspace-git-root) but no git repository found at '{}'. Using workspace folder for the workspace mount source.",
-                    workspace_folder.display()
-                );
-            }
-            deacon_core::workspace::resolve_workspace_root(workspace_folder)?
-        } else {
-            workspace_folder.canonicalize().with_context(|| {
+        if let Some(ref consistency) = args.workspace_mount_consistency {
+            let target_path = config.workspace_folder.clone().unwrap_or_else(|| {
                 format!(
-                    "Failed to canonicalize workspace folder '{}' for mounting: path does not exist or cannot be accessed",
-                    workspace_folder.display()
+                    "/workspaces/{}",
+                    workspace_folder
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("workspace")
                 )
-            })?
-        };
-        let target_path = config.workspace_folder.clone().unwrap_or_else(|| {
-            format!(
-                "/workspaces/{}",
-                mount_source
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("workspace")
-            )
-        });
-        let consistency_suffix = args
-            .workspace_mount_consistency
-            .as_ref()
-            .map(|c| format!(",consistency={}", c))
-            .unwrap_or_default();
-        config.workspace_mount = Some(format!(
-            "type=bind,source={},target={}{}",
-            mount_source.display(),
-            target_path,
-            consistency_suffix
-        ));
+            });
+            let source_path = workspace_folder
+                .canonicalize()
+                .with_context(|| {
+                    format!(
+                        "Failed to canonicalize workspace folder '{}' for mounting: path does not exist or cannot be accessed",
+                        workspace_folder.display()
+                    )
+                })?
+                .display()
+                .to_string();
+            config.workspace_mount = Some(format!(
+                "type=bind,source={},target={},consistency={}",
+                source_path, target_path, consistency
+            ));
+        }
     }
+
+    // Spec parity (#67): the workspace mount *source* is the enclosing git
+    // root when `--mount-workspace-git-root=true` (default), so git
+    // operations inside the container work even when the user passes a
+    // sub-project directory as `--workspace-folder`. Discovery already used
+    // the user's path (above, in `load_config`) — this only affects the
+    // bind mount source. When git-root walking is disabled, fall back to
+    // the canonicalized workspace folder.
+    let workspace_mount_source: PathBuf = if args.mount_workspace_git_root {
+        if deacon_core::workspace::find_git_repository_root(workspace_folder)?.is_none() {
+            info!(
+                "Git root requested (--mount-workspace-git-root) but no git repository found at '{}'. Using workspace folder for the workspace mount source.",
+                workspace_folder.display()
+            );
+        }
+        deacon_core::workspace::resolve_workspace_root(workspace_folder)?
+    } else {
+        workspace_folder.canonicalize().with_context(|| {
+            format!(
+                "Failed to canonicalize workspace folder '{}' for mounting: path does not exist or cannot be accessed",
+                workspace_folder.display()
+            )
+        })?
+    };
+
     if !args.forward_ports.is_empty() {
         use deacon_core::config::PortSpec;
         debug!(
@@ -422,12 +435,19 @@ pub(crate) async fn execute_container_up(
         debug!("GPU mode: {:?}", args.gpu_mode);
     }
 
-    // Create container using DockerLifecycle trait
+    // Create container using DockerLifecycle trait.
+    //
+    // We pass `workspace_mount_source` (#67), not the raw workspace folder,
+    // so the default workspace bind mount inside
+    // `Docker::create_container` sources from the git root when
+    // `--mount-workspace-git-root=true`. Container identity has already
+    // been computed from the user's workspace folder above, so this only
+    // affects the bind mount and not workspace+config hashing.
     let container_result = docker
         .up(
             &identity,
             &config,
-            workspace_folder,
+            &workspace_mount_source,
             args.remove_existing_container,
             args.gpu_mode,
             &merged_security,

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -92,33 +92,55 @@ pub(crate) async fn execute_container_up(
         );
     }
 
-    // Apply workspace mount consistency when using default workspace mount
+    // Build the default workspace mount.
+    //
+    // Spec parity (#67): the mount *source* is the enclosing git root when
+    // `--mount-workspace-git-root` is true (the default) so git operations
+    // inside the container work; otherwise the user's workspace folder. The
+    // mount *target* defaults to `/workspaces/<basename(source)>`, matching
+    // the upstream reference CLI.
+    //
+    // Discovery (`load_config`) has already used the user's workspace
+    // folder by this point — the git-root walk no longer affects which
+    // `.devcontainer/devcontainer.json` is loaded.
     if config.workspace_mount.is_none() {
-        let target_path = config.workspace_folder.clone().unwrap_or_else(|| {
-            format!(
-                "/workspaces/{}",
-                workspace_folder
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("workspace")
-            )
-        });
-        let source_path = workspace_folder
-            .canonicalize()
-            .with_context(|| {
+        let mount_source = if args.mount_workspace_git_root {
+            let git_root = deacon_core::workspace::find_git_repository_root(workspace_folder)?;
+            if git_root.is_none() {
+                info!(
+                    "Git root requested (--mount-workspace-git-root) but no git repository found at '{}'. Using workspace folder for the workspace mount source.",
+                    workspace_folder.display()
+                );
+            }
+            deacon_core::workspace::resolve_workspace_root(workspace_folder)?
+        } else {
+            workspace_folder.canonicalize().with_context(|| {
                 format!(
                     "Failed to canonicalize workspace folder '{}' for mounting: path does not exist or cannot be accessed",
                     workspace_folder.display()
                 )
             })?
-            .display()
-            .to_string();
-        if let Some(ref consistency) = args.workspace_mount_consistency {
-            config.workspace_mount = Some(format!(
-                "type=bind,source={},target={},consistency={}",
-                source_path, target_path, consistency
-            ));
-        }
+        };
+        let target_path = config.workspace_folder.clone().unwrap_or_else(|| {
+            format!(
+                "/workspaces/{}",
+                mount_source
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("workspace")
+            )
+        });
+        let consistency_suffix = args
+            .workspace_mount_consistency
+            .as_ref()
+            .map(|c| format!(",consistency={}", c))
+            .unwrap_or_default();
+        config.workspace_mount = Some(format!(
+            "type=bind,source={},target={}{}",
+            mount_source.display(),
+            target_path,
+            consistency_suffix
+        ));
     }
     if !args.forward_ports.is_empty() {
         use deacon_core::config::PortSpec;

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -107,28 +107,24 @@ pub async fn execute_up(args: UpArgs) -> Result<UpContainerInfo> {
     debug!("Starting up command execution");
     debug!("Up args: {:?}", args);
 
-    // Normalize workspace folder for git-root mounting when requested
+    // Normalize the workspace folder.
+    //
+    // Spec parity (#67): `--mount-workspace-git-root` controls only the
+    // *mount source* for the default workspace bind mount. Discovery of
+    // `.devcontainer/devcontainer.json` and `${localWorkspaceFolder}`
+    // substitution stay anchored at the user-provided `--workspace-folder`
+    // so that running deacon against a sub-project inside a larger git
+    // repository does not silently load the enclosing repo's devcontainer
+    // configuration. The git-root walk happens later, only when
+    // constructing the workspace mount source in `execute_container_up`.
     let mut args = args;
     if let Some(ws) = args.workspace_folder.clone() {
-        let resolved = if args.mount_workspace_git_root {
-            // Check if git root exists before resolving
-            let git_root_result = deacon_core::workspace::find_git_repository_root(&ws)?;
-            if git_root_result.is_none() {
-                // T016: Log fallback when git root requested but not found
-                info!(
-                    "Git root requested (--mount-workspace-git-root) but no git repository found at '{}'. Using workspace root instead.",
-                    ws.display()
-                );
-            }
-            deacon_core::workspace::resolve_workspace_root(&ws)?
-        } else {
-            ws.canonicalize().with_context(|| {
-                format!(
-                    "Failed to resolve workspace path '{}': path does not exist or cannot be accessed",
-                    ws.display()
-                )
-            })?
-        };
+        let resolved = ws.canonicalize().with_context(|| {
+            format!(
+                "Failed to resolve workspace path '{}': path does not exist or cannot be accessed",
+                ws.display()
+            )
+        })?;
         args.workspace_folder = Some(resolved);
     }
 

--- a/crates/deacon/tests/integration_workspace_discovery_in_git_repo.rs
+++ b/crates/deacon/tests/integration_workspace_discovery_in_git_repo.rs
@@ -1,0 +1,112 @@
+//! Spec parity (#67): config discovery uses `--workspace-folder` as
+//! provided, even when the workspace lives inside a larger git repository.
+//!
+//! Before the fix, deacon walked up from the user's `--workspace-folder`
+//! to the enclosing git root and used the git root for *both* mounting and
+//! discovery. That made any sub-project inside a git repo silently load
+//! the enclosing repo's `.devcontainer/devcontainer.json` instead of its
+//! own. These tests pin discovery to the user's path.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+/// Build a temp tree:
+///   <root>/                ← initialized as a git repo
+///     .devcontainer/
+///       devcontainer.json  ← parent repo's config ("outer-config")
+///     sub/                 ← the user's actual workspace
+///       .devcontainer/
+///         devcontainer.json← sub-project's config ("inner-config")
+fn build_nested_workspace() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path();
+
+    StdCommand::new("git")
+        .arg("init")
+        .arg(root)
+        .output()
+        .expect("git init must succeed for this test");
+
+    let outer_dc = root.join(".devcontainer");
+    fs::create_dir_all(&outer_dc).unwrap();
+    fs::write(
+        outer_dc.join("devcontainer.json"),
+        r#"{
+  "name": "outer-config",
+  "image": "alpine:3.18"
+}
+"#,
+    )
+    .unwrap();
+
+    let sub = root.join("sub");
+    let inner_dc = sub.join(".devcontainer");
+    fs::create_dir_all(&inner_dc).unwrap();
+    fs::write(
+        inner_dc.join("devcontainer.json"),
+        r#"{
+  "name": "inner-config",
+  "image": "alpine:3.18"
+}
+"#,
+    )
+    .unwrap();
+
+    temp
+}
+
+fn run_read_configuration(sub: &std::path::Path, extra: &[&str]) -> Value {
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    cmd.arg("read-configuration")
+        .arg("--workspace-folder")
+        .arg(sub);
+    for a in extra {
+        cmd.arg(a);
+    }
+    let output = cmd.output().expect("deacon must run");
+    assert!(
+        output.status.success(),
+        "deacon read-configuration failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice::<Value>(&output.stdout).expect("output must be JSON")
+}
+
+#[test]
+fn read_configuration_in_subdir_loads_inner_config_not_git_root() {
+    let temp = build_nested_workspace();
+    let sub = temp.path().join("sub");
+
+    let json = run_read_configuration(&sub, &[]);
+
+    // The example's config should win, not the parent repo's. The
+    // `configuration.name` and `workspace.configFolderPath` fields both
+    // surface the regression cleanly if the bug returns.
+    assert_eq!(
+        json["configuration"]["name"], "inner-config",
+        "discovery must use the user's --workspace-folder (#67)"
+    );
+    let config_folder = json["workspace"]["configFolderPath"]
+        .as_str()
+        .expect("configFolderPath must be a string");
+    assert!(
+        config_folder.contains("/sub/.devcontainer")
+            || config_folder.ends_with("sub/.devcontainer"),
+        "configFolderPath must point at the sub-project's .devcontainer, got: {config_folder}"
+    );
+}
+
+#[test]
+fn read_configuration_in_subdir_with_explicit_git_root_flag_still_loads_inner() {
+    // --mount-workspace-git-root=true (the default) controls the workspace
+    // *mount*, not discovery (#67). The inner config must still win.
+    let temp = build_nested_workspace();
+    let sub = temp.path().join("sub");
+
+    let json = run_read_configuration(&sub, &["--mount-workspace-git-root=true"]);
+
+    assert_eq!(json["configuration"]["name"], "inner-config");
+}

--- a/docs/subcommand-specs/completed-specs/read-configuration/SPEC.md
+++ b/docs/subcommand-specs/completed-specs/read-configuration/SPEC.md
@@ -23,7 +23,7 @@
     - `--workspace-folder <PATH>` Optional. Root used to discover config; also used to infer id-labels when locating a container.
     - `--config <PATH>` Optional. Explicit devcontainer.json path. For this subcommand, the filename is not strictly enforced.
     - `--override-config <PATH>` Optional. Override devcontainer.json path; required when no base config exists.
-    - `--mount-workspace-git-root` Optional boolean, default true. Influences workspace discovery/mount in workspace resolution.
+    - `--mount-workspace-git-root` Optional boolean, default true. Controls the workspace *mount source* (walks up to the enclosing git root when true so git operations inside the container work). Config discovery is anchored to `--workspace-folder` and is **not** affected by this flag (#67).
   - Container selection:
     - `--container-id <ID>` Optional. Target container ID; enables container-based substitutions and metadata reads.
     - `--id-label <name=value>` Optional, repeatable. Used to locate the container if `--container-id` is not provided. If neither `--container-id` nor `--id-label` is set, one is inferred from `--workspace-folder`.

--- a/docs/subcommand-specs/up/SPEC.md
+++ b/docs/subcommand-specs/up/SPEC.md
@@ -28,7 +28,7 @@
     - --config <path-to-devcontainer.json>
     - --override-config <path-to-devcontainer.json>
     - --id-label <name=value> (repeatable)
-    - --mount-workspace-git-root [boolean, default true]
+    - --mount-workspace-git-root [boolean, default true] — controls the workspace *mount source* only. Config discovery is anchored to `--workspace-folder` and is **not** affected by this flag (#67).
   - Logging/terminal:
     - --log-level <info|debug|trace> (default info)
     - --log-format <text|json> (default text)


### PR DESCRIPTION
## Summary

- `--mount-workspace-git-root` no longer overwrites the workspace folder for config discovery. The flag now controls **only** the workspace bind mount source.
- `execute_up` canonicalizes `args.workspace_folder` but does not walk up to the git root. Discovery, `${localWorkspaceFolder}`, image-metadata merging, id-label discovery, container identity, and Dockerfile resolution all use the user-provided path.
- The git-root walk happens inside `execute_container_up` / `execute_compose_up` when constructing the default workspace bind mount. When `--mount-workspace-git-root=true` (the default), the mount source is the enclosing git root so git operations inside the container still work.

Container identity is unchanged — `ContainerIdentity::hash_workspace_path` already calls `resolve_workspace_root` internally, so the workspace hash label stays stable.

Closes #67. **Unblocks the bulk of `examples/*` per #74's "Workaround dependency" section** — `--mount-workspace-git-root false` is no longer needed to run examples inside the deacon repo.

## Test plan

- [x] `make test-nextest-fast` (2091 passing, +2 new)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- New integration tests:
  - `read_configuration_in_subdir_loads_inner_config_not_git_root`
  - `read_configuration_in_subdir_with_explicit_git_root_flag_still_loads_inner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)