### PR TITLE
fix(container): emit standard devcontainer.local_folder/config_file labels (#68)

### DIFF
--- a/crates/core/src/container.rs
+++ b/crates/core/src/container.rs
@@ -9,7 +9,7 @@ use crate::errors::{ContainerSelectorError, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::{debug, instrument};
 
 /// Container label schema for DevContainer identification
@@ -17,6 +17,13 @@ pub const LABEL_SOURCE: &str = "devcontainer.source";
 pub const LABEL_WORKSPACE_HASH: &str = "devcontainer.workspaceHash";
 pub const LABEL_CONFIG_HASH: &str = "devcontainer.configHash";
 pub const LABEL_NAME: &str = "devcontainer.name";
+
+/// Spec-mandated labels matching the upstream `@devcontainers/cli`
+/// convention (`src/spec-node/singleContainer.ts`). These are what VS
+/// Code's Dev Containers extension and parity tooling filter on when
+/// finding an existing container for a workspace (#68).
+pub const LABEL_LOCAL_FOLDER: &str = "devcontainer.local_folder";
+pub const LABEL_CONFIG_FILE: &str = "devcontainer.config_file";
 
 /// Source identifier for containers created by deacon
 pub const DEACON_SOURCE: &str = "deacon";
@@ -32,6 +39,14 @@ pub struct ContainerIdentity {
     pub name: Option<String>,
     /// Custom container name (overrides generated name)
     pub custom_name: Option<String>,
+    /// Absolute host path to the workspace folder. Emitted as the
+    /// `devcontainer.local_folder` label so VS Code's Dev Containers
+    /// extension and `docker ps --filter` queries can match this
+    /// container by workspace (#68).
+    pub local_folder: Option<PathBuf>,
+    /// Absolute host path to the resolved `devcontainer.json`. Emitted as
+    /// the `devcontainer.config_file` label (#68).
+    pub config_file: Option<PathBuf>,
 }
 
 /// Container creation result
@@ -97,6 +112,13 @@ impl ContainerIdentity {
         let config_hash = Self::hash_config(config);
         let name = config.name.clone();
 
+        // Canonicalize the workspace path for the `devcontainer.local_folder`
+        // label so consumers can do `docker ps --filter label=...=<abs>`
+        // reliably. If canonicalization fails (path no longer exists,
+        // permission), fall through to None — better to skip the label
+        // than emit a relative or symlinked one (#68).
+        let local_folder = workspace_path.canonicalize().ok();
+
         debug!(
             workspace_hash = %workspace_hash,
             config_hash = %config_hash,
@@ -110,7 +132,20 @@ impl ContainerIdentity {
             config_hash,
             name,
             custom_name,
+            local_folder,
+            config_file: None,
         }
+    }
+
+    /// Attach the resolved `devcontainer.json` path to this identity so
+    /// the `devcontainer.config_file` label can be emitted (#68).
+    pub fn with_config_file(mut self, config_file: impl Into<PathBuf>) -> Self {
+        let p = config_file.into();
+        // Canonicalize for the label; fall back to the raw path if the
+        // file has been deleted between load and container create (rare,
+        // but emit *something* useful rather than dropping the label).
+        self.config_file = Some(p.canonicalize().unwrap_or(p));
+        self
     }
 
     /// Generate a deterministic hash from the workspace path
@@ -180,6 +215,23 @@ impl ContainerIdentity {
 
         if let Some(ref name) = self.name {
             labels.insert(LABEL_NAME.to_string(), name.clone());
+        }
+
+        // Spec-mandated upstream labels (#68). Emitted as absolute paths
+        // so `docker ps --filter "label=devcontainer.local_folder=<abs>"`
+        // and the VS Code Dev Containers extension reconnect path both
+        // find this container by workspace.
+        if let Some(ref local_folder) = self.local_folder {
+            labels.insert(
+                LABEL_LOCAL_FOLDER.to_string(),
+                local_folder.display().to_string(),
+            );
+        }
+        if let Some(ref config_file) = self.config_file {
+            labels.insert(
+                LABEL_CONFIG_FILE.to_string(),
+                config_file.display().to_string(),
+            );
         }
 
         labels
@@ -303,6 +355,51 @@ mod tests {
         );
         assert_eq!(labels.get(LABEL_CONFIG_HASH), Some(&identity.config_hash));
         assert_eq!(labels.get(LABEL_NAME), Some(&"test-container".to_string()));
+
+        // #68: devcontainer.local_folder is the canonical absolute
+        // workspace path. devcontainer.config_file is only emitted once
+        // `with_config_file` has been called (see test below).
+        let expected_local_folder = workspace_path.canonicalize().unwrap().display().to_string();
+        assert_eq!(
+            labels.get(LABEL_LOCAL_FOLDER),
+            Some(&expected_local_folder),
+            "devcontainer.local_folder must be the canonical absolute workspace path"
+        );
+        assert!(
+            !labels.contains_key(LABEL_CONFIG_FILE),
+            "devcontainer.config_file is opt-in via with_config_file()"
+        );
+    }
+
+    #[test]
+    fn test_labels_include_config_file_when_set() {
+        // #68: VS Code Dev Containers reconnect filters on
+        // devcontainer.local_folder + devcontainer.config_file. Make sure
+        // both labels are present once `with_config_file` is wired in.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+        let devcontainer_dir = workspace_path.join(".devcontainer");
+        std::fs::create_dir_all(&devcontainer_dir).unwrap();
+        let config_file = devcontainer_dir.join("devcontainer.json");
+        std::fs::write(&config_file, r#"{"image":"alpine:3.18"}"#).unwrap();
+
+        let config = DevContainerConfig {
+            name: Some("with-cfg".to_string()),
+            image: Some("alpine:3.18".to_string()),
+            ..Default::default()
+        };
+
+        let identity =
+            ContainerIdentity::new(workspace_path, &config).with_config_file(config_file.clone());
+        let labels = identity.labels();
+
+        let expected_config_file = config_file.canonicalize().unwrap().display().to_string();
+        assert_eq!(
+            labels.get(LABEL_CONFIG_FILE),
+            Some(&expected_config_file),
+            "devcontainer.config_file must be the absolute path to the resolved devcontainer.json"
+        );
+        assert!(labels.contains_key(LABEL_LOCAL_FOLDER));
     }
 
     #[test]

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -3136,6 +3136,8 @@ mod tests {
             config_hash: "config456".to_string(),
             name: Some("test-dev".to_string()),
             custom_name: None,
+            local_folder: None,
+            config_file: None,
         };
 
         let config = DevContainerConfig {

--- a/crates/deacon/src/commands/down.rs
+++ b/crates/deacon/src/commands/down.rs
@@ -160,11 +160,13 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
 
     let docker = CliDocker::new();
 
-    // Build label selector from identity
-    let label_selector = format!(
-        "devcontainer.local_folder={},devcontainer.config_file={}",
-        identity.workspace_hash, identity.config_hash
-    );
+    // Build label selector from identity. The values here are hashes,
+    // so use the hash-labeled keys (#68 — previously this combined hash
+    // *values* with path-shaped *names* and matched nothing). Containers
+    // created by deacon get both this hash pair and the spec-mandated
+    // `devcontainer.local_folder` / `devcontainer.config_file` path
+    // labels emitted by `ContainerIdentity::labels()`.
+    let label_selector = identity.label_selector();
 
     debug!("Label selector: {}", label_selector);
 

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -146,12 +146,15 @@ pub(crate) async fn execute_container_up(
     let emit_progress_event =
         crate::commands::shared::progress::make_progress_callback(&args.progress_tracker);
 
-    // Create container identity for deterministic naming and labels
+    // Create container identity for deterministic naming and labels.
+    // Carry the resolved devcontainer.json path so the spec-mandated
+    // `devcontainer.config_file` label is applied at create time (#68).
     let identity = ContainerIdentity::new_with_custom_name(
         workspace_folder,
         &config,
         args.container_name.clone(),
-    );
+    )
+    .with_config_file(config_path);
     debug!("Container identity: {:?}", identity);
 
     // Initialize Docker client


### PR DESCRIPTION
## Summary

- Add the two upstream-mandated labels (`devcontainer.local_folder`, `devcontainer.config_file`) to every container created by `deacon up`. VS Code's Dev Containers extension and `docker ps --filter` workflows can now locate deacon containers.
- `ContainerIdentity` gains `local_folder` (canonical workspace path, populated automatically) and `config_file` (canonical devcontainer.json path, opt-in via the new `with_config_file` builder).
- Up's single-container path threads the resolved config path through to the label.
- Bonus fix: `down --all` was building a label selector with hash *values* under path-shaped *names* and matching nothing. Switched to `identity.label_selector()`.

Internal labels (`devcontainer.source`, `workspaceHash`, `configHash`, `name`) keep working — they remain the primary identity mechanism.

Closes #68. Unblocks `down/basic` scenario 5 per #74.

## Test plan

- [x] `make test-nextest-fast` (2090 passing, +1 new)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- New / extended tests:
  - `test_labels_generation` — asserts `devcontainer.local_folder` and confirms `devcontainer.config_file` is opt-in
  - `test_labels_include_config_file_when_set` — positive case for the builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)