### PR TITLE
fix(docker): inspect_image parser shape (#70 follow-up)

### DIFF
--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1328,8 +1328,13 @@ impl Docker for CliRuntime {
     async fn inspect_image(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
         debug!("Inspecting image: {}", image_ref);
 
+        // Use the default array-of-objects output (no --format). With
+        // `--format "{{json .}}"` Docker emits a single bare object per
+        // image, which the array parser below would reject; this surfaced
+        // when image-metadata merging started actually consuming the
+        // labels (#70).
         let output = Command::new(&self.runtime_path)
-            .args(["image", "inspect", "--format", "{{json .}}", image_ref])
+            .args(["image", "inspect", image_ref])
             .output()
             .await
             .map_err(|e| {
@@ -1346,19 +1351,32 @@ impl Docker for CliRuntime {
             );
         }
 
-        // Parse JSON output - it's an array with one element
+        // `docker image inspect <ref>` returns a JSON array with one
+        // element per matching image. We accept the array form by default
+        // and also a bare object (defensive — some Docker variants and
+        // older Podman releases print a single object).
         let stdout = String::from_utf8(output.stdout).map_err(|e| {
             DockerError::CLIError(format!("Invalid UTF-8 in runtime output: {}", e))
         })?;
 
-        let images: Vec<serde_json::Value> = serde_json::from_str(&stdout).map_err(|e| {
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).map_err(|e| {
             DockerError::CLIError(format!("Failed to parse image inspect output: {}", e))
         })?;
 
-        let image = images
-            .into_iter()
-            .next()
-            .ok_or_else(|| DockerError::CLIError("Empty image inspect output".to_string()))?;
+        let image = match parsed {
+            serde_json::Value::Array(mut arr) => arr
+                .drain(..)
+                .next()
+                .ok_or_else(|| DockerError::CLIError("Empty image inspect output".to_string()))?,
+            obj @ serde_json::Value::Object(_) => obj,
+            other => {
+                return Err(DockerError::CLIError(format!(
+                    "Unexpected image inspect output shape: {}",
+                    other
+                ))
+                .into());
+            }
+        };
 
         let id = image
             .get("Id")


### PR DESCRIPTION
## Summary

`Docker::inspect_image` was passing `--format "{{json .}}"` to `docker image inspect`, which emits a single bare object per image, but the parser expected `Vec<serde_json::Value>`. The bug was latent (no production code consumed image labels) until PR #83 (#70) started reading the `devcontainer.metadata` label and tripped the deserializer with:

    invalid type: map, expected a sequence at line 1 column 0

Result: every image-based `up` silently warned and skipped the spec-mandated metadata merge.

Fix: drop the `--format` flag (default output is `[{...}]`) and accept both array and bare-object shapes in the parser.

## Verification

Re-ran `examples/up/image-metadata-merge/exec.sh`:

- Before: `FAIL: IMAGE_LAYER missing (image metadata not merged)`
- After: `IMAGE_LAYER=from-image-label` shows up in the running container's env alongside `CONFIG_LAYER` from devcontainer.json.

Tested with `docker 29.4.3`. Both `docker image inspect <ref>` (array) and any future single-object variants are now tolerated.

## Test plan

- [x] `make test-nextest-fast` (2114 passing, no regressions)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- [x] `examples/up/image-metadata-merge/exec.sh` — scenarios 1-3 now pass

Scenario 4 of the example (`read-configuration --include-merged-configuration` surfacing image labels without `--container-id`) is a separate spec gap: read-configuration does not yet auto-discover the workspace's container, so the merged-config branch falls through to the features-only path. Tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)