### PR TITLE
fix(features): translate overrideFeatureInstallOrder + skip local features in lockfile (#69 follow-up)

### DIFF
--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -537,8 +537,28 @@ async fn resolve_and_stage_features(
         });
     }
 
-    // Resolve dependencies
-    let override_order = config.override_feature_install_order.clone();
+    // Resolve dependencies.
+    //
+    // The user expresses `overrideFeatureInstallOrder` with the feature
+    // IDs *as written in devcontainer.json* (e.g. `./feature-charlie`,
+    // `ghcr.io/foo/bar:1`). Internally we key every feature by its
+    // *canonical* ID (`local:<abs path>` for local features, the
+    // registry/namespace/name triple for OCI refs). Translate the
+    // override list to canonical form before handing it to the
+    // resolver — otherwise `validate_override_order` complains that the
+    // user-given path "does not exist in feature set" (#69 follow-up).
+    let canonical_by_user: HashMap<String, String> = user_id_by_canonical
+        .iter()
+        .map(|(canon, user)| (user.clone(), canon.clone()))
+        .collect();
+    let override_order = config.override_feature_install_order.clone().map(|order| {
+        order
+            .into_iter()
+            .map(|user_id| {
+                canonical_by_user.get(&user_id).cloned().unwrap_or(user_id) // unknown ids surface in the validate step with the user form
+            })
+            .collect::<Vec<_>>()
+    });
     let resolver = FeatureDependencyResolver::new(override_order);
     let installation_plan = resolver.resolve(&resolved_features)?;
 
@@ -646,6 +666,22 @@ fn build_lockfile_from_features(
             );
             continue;
         };
+
+        // Local features (`./foo`, `../shared/bar`) have no fetchable
+        // OCI identity — their canonical id is `local:<abs path>` and
+        // their FeatureRef is a synthetic placeholder. They MUST NOT be
+        // recorded in the lockfile: the lockfile's `resolved` schema
+        // demands a `registry/path@sha256:...` form, and a local
+        // checkout's content can change underneath us anyway. Upstream
+        // `@devcontainers/cli` excludes local features from the lockfile
+        // for the same reasons (#69 follow-up).
+        if canonical_id.starts_with("local:") {
+            debug!(
+                feature = %canonical_id,
+                "Skipping lockfile entry for local feature (no OCI identity to record)"
+            );
+            continue;
+        }
 
         let user_id = user_id_by_canonical
             .get(canonical_id)


### PR DESCRIPTION
## Summary

PR #82 (#69) keyed every feature internally by a *canonical* id — `local:<abs>` for local features, `registry/namespace/name` for OCI refs. Two downstream flows still used the user-given ids and broke:

1. **`overrideFeatureInstallOrder`** validation compared user-given ids against canonical-keyed `resolved_features`, producing:
   > Feature './feature-charlie' in overrideFeatureInstallOrder does not exist in feature set
2. **Lockfile assembly** rejected local features because the placeholder OCI ref didn't match the `registry/path@sha256:<digest>` schema.

Fixes:
- Translate the override list to canonical ids before handing it to `FeatureDependencyResolver`. Unknown ids pass through unchanged so the resolver's existing diagnostic still names the user-given form.
- Skip lockfile entries for canonical ids starting with `local:`. Mirrors upstream `@devcontainers/cli`, which excludes local features from the lockfile (their content can change underneath us). A `debug!` line records the skip.

## Verification

`examples/features/override-install-order/exec.sh`:

- Before: `Feature './feature-charlie' in overrideFeatureInstallOrder does not exist in feature set`
- After:
  > expected: charlie,alpha,bravo
  > actual:   charlie,alpha,bravo
  > ok: overrideFeatureInstallOrder honored

## Test plan

- [x] `make test-nextest-fast` (2114 passing)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- [x] Manual: `examples/features/override-install-order/exec.sh` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)