### PR TITLE
fix(features): inject _REMOTE_USER / _CONTAINER_USER env vars during install (#89)

### DIFF
--- a/crates/core/src/dockerfile_generator.rs
+++ b/crates/core/src/dockerfile_generator.rs
@@ -24,6 +24,66 @@ pub struct DockerfileConfig {
     pub target_stage: String,
     /// Directory where features are downloaded on the host
     pub features_source_dir: String,
+    /// Spec-required env vars surfaced to every feature's `install.sh`
+    /// (`_REMOTE_USER`, `_REMOTE_USER_HOME`, `_CONTAINER_USER`,
+    /// `_CONTAINER_USER_HOME`). Populated by the caller from the resolved
+    /// devcontainer.json. Per the [features spec](https://containers.dev/implementors/features/#installation-environment)
+    /// these MUST be available; missing ones default to empty strings so
+    /// install scripts can branch on `${_REMOTE_USER:-}` (#89).
+    pub feature_install_env: FeatureInstallEnv,
+}
+
+/// The four well-known env vars the features spec guarantees to every
+/// `install.sh`. See [`DockerfileConfig::feature_install_env`].
+#[derive(Debug, Clone, Default)]
+pub struct FeatureInstallEnv {
+    /// `_REMOTE_USER` — the user lifecycle commands run as.
+    pub remote_user: Option<String>,
+    /// `_REMOTE_USER_HOME` — that user's home directory.
+    pub remote_user_home: Option<String>,
+    /// `_CONTAINER_USER` — the container's default user.
+    pub container_user: Option<String>,
+    /// `_CONTAINER_USER_HOME` — that user's home directory.
+    pub container_user_home: Option<String>,
+}
+
+impl FeatureInstallEnv {
+    /// Resolve the four env vars from the user-provided config values.
+    ///
+    /// Spec rules (mirrors upstream `@devcontainers/cli`):
+    /// - `_REMOTE_USER` defaults to `_CONTAINER_USER` when not specified.
+    /// - `_CONTAINER_USER` defaults to the image's `USER` (caller is
+    ///   responsible for passing it in via `image_user`; we never assume
+    ///   `"root"` here so callers that can't inspect the image surface
+    ///   the gap rather than guessing).
+    /// - `_*_HOME` defaults to `/root` for `root`, `/home/<user>`
+    ///   otherwise. Callers that know the actual home dir from
+    ///   `getent passwd` may pass it directly.
+    pub fn resolve(
+        remote_user: Option<&str>,
+        container_user: Option<&str>,
+        image_user: Option<&str>,
+    ) -> Self {
+        let container = container_user.or(image_user);
+        let remote = remote_user.or(container);
+
+        let home_for = |u: Option<&str>| -> Option<String> {
+            u.map(|name| {
+                if name == "root" {
+                    "/root".to_string()
+                } else {
+                    format!("/home/{}", name)
+                }
+            })
+        };
+
+        Self {
+            remote_user: remote.map(String::from),
+            remote_user_home: home_for(remote),
+            container_user: container.map(String::from),
+            container_user_home: home_for(container),
+        }
+    }
 }
 
 impl Default for DockerfileConfig {
@@ -32,6 +92,7 @@ impl Default for DockerfileConfig {
             base_image: String::new(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: String::new(),
+            feature_install_env: FeatureInstallEnv::default(),
         }
     }
 }
@@ -186,6 +247,29 @@ impl DockerfileGenerator {
                     Self::format_env_var(key, value)
                 ));
             }
+        }
+
+        // Spec-required env vars surfaced to every install.sh (#89). These
+        // four are guaranteed by the features spec regardless of whether
+        // the feature itself declares them in `options`. Use the same
+        // `export … &&` form so they propagate through the chain alongside
+        // the option env vars. Empty values are still emitted so
+        // `${_REMOTE_USER:-}` in install.sh resolves to the empty string
+        // rather than the literal `<unset>`.
+        let install_env = &self.config.feature_install_env;
+        for (key, value) in [
+            ("_REMOTE_USER", install_env.remote_user.as_deref()),
+            ("_REMOTE_USER_HOME", install_env.remote_user_home.as_deref()),
+            ("_CONTAINER_USER", install_env.container_user.as_deref()),
+            (
+                "_CONTAINER_USER_HOME",
+                install_env.container_user_home.as_deref(),
+            ),
+        ] {
+            command.push_str(&format!(
+                "    export {} && \\\n",
+                Self::format_env_var(key, value.unwrap_or(""))
+            ));
         }
 
         // Execute the install script
@@ -453,6 +537,7 @@ mod tests {
             base_image: "ubuntu:22.04".to_string(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
         };
 
         let generator = DockerfileGenerator::new(config);
@@ -486,6 +571,7 @@ mod tests {
             base_image: "unused-for-this-path".to_string(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
         };
         let generator = DockerfileGenerator::new(config);
         let stage = generator
@@ -517,6 +603,7 @@ mod tests {
             base_image: "ubuntu:22.04".to_string(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
         };
 
         let generator = DockerfileGenerator::new(config);
@@ -544,6 +631,7 @@ mod tests {
             base_image: "ubuntu:22.04".to_string(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
         };
 
         let build_options = BuildOptions {
@@ -584,6 +672,7 @@ mod tests {
             base_image: "ubuntu:22.04".to_string(),
             target_stage: "dev_containers_target_stage".to_string(),
             features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
         };
 
         // Default options should not add any cache arguments

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use deacon_core::build::BuildOptions;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
-use deacon_core::dockerfile_generator::{DockerfileConfig, DockerfileGenerator};
+use deacon_core::dockerfile_generator::{DockerfileConfig, DockerfileGenerator, FeatureInstallEnv};
 use deacon_core::errors::DeaconError;
 use deacon_core::features::{
     FeatureDependencyResolver, InstallationPlan, OptionValue, ResolvedFeature,
@@ -107,11 +107,25 @@ pub(crate) async fn build_image_with_features(
 
     let staged = resolve_and_stage_features(config, identity, config_path).await?;
 
-    // Generate Dockerfile
+    // Generate Dockerfile.
+    //
+    // Spec parity (#89): surface `_REMOTE_USER`, `_REMOTE_USER_HOME`,
+    // `_CONTAINER_USER`, `_CONTAINER_USER_HOME` to every feature's
+    // `install.sh`. Resolved from the user config; we don't currently
+    // probe the image for its baked-in USER, so callers relying on that
+    // fallback should set `containerUser` explicitly. Empty values are
+    // still emitted so `${_REMOTE_USER:-}` resolves to "" rather than
+    // `<unset>`.
+    let feature_install_env = FeatureInstallEnv::resolve(
+        config.remote_user.as_deref(),
+        config.container_user.as_deref(),
+        None,
+    );
     let dockerfile_config = DockerfileConfig {
         base_image: base_image.clone(),
         target_stage: "dev_containers_target_stage".to_string(),
         features_source_dir: staged.features_source_dir.display().to_string(),
+        feature_install_env,
     };
 
     let generator = DockerfileGenerator::new(dockerfile_config.clone());
@@ -238,10 +252,16 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
     // window is closed. The literal `FROM <stage>` form sidesteps that and
     // resolves directly to the previous stage in the same Dockerfile.
     let target_stage_name = "dev_containers_target_stage";
+    let feature_install_env = FeatureInstallEnv::resolve(
+        config.remote_user.as_deref(),
+        config.container_user.as_deref(),
+        None,
+    );
     let dockerfile_config = DockerfileConfig {
         base_image: base_dockerfile_final_stage.to_string(),
         target_stage: target_stage_name.to_string(),
         features_source_dir: staged.features_source_dir.display().to_string(),
+        feature_install_env,
     };
     let generator = DockerfileGenerator::new(dockerfile_config.clone());
     let feature_stage =


### PR DESCRIPTION
## Summary

The features spec guarantees four env vars to every `install.sh`:

- `_REMOTE_USER` — the user lifecycle commands run as
- `_REMOTE_USER_HOME` — that user's home directory
- `_CONTAINER_USER` — the container's default user
- `_CONTAINER_USER_HOME` — that user's home directory

Deacon emitted none of them. Features that legitimately read them (per-user dotfiles, shell config, workspace chown) saw `<unset>`.

Implementation:

- New `FeatureInstallEnv` struct with a `resolve(remote_user, container_user, image_user)` helper that walks the spec's fallback chain and computes default `_HOME` values (`/root` for root, `/home/<user>` otherwise).
- Added as a field on `DockerfileConfig`; the install RUN now emits all four `export _REMOTE_USER="…" && \` lines alongside the option env vars from #88.
- Builds on PR #95 (#88)'s `export … &&` chain — without that fix the inline form would still scope to `cd` only. **This PR is based on `fix/88-feature-option-key-sanitization`.**

Closes #89.

## Verification

`examples/features/feature-env-injection/exec.sh`:

- Before:
  > _REMOTE_USER=<unset>
  > _REMOTE_USER_HOME=<unset>
  > _CONTAINER_USER=<unset>
  > _CONTAINER_USER_HOME=<unset>
  > FAIL: _REMOTE_USER was <unset> during install.sh
- After:
  > ok: _REMOTE_USER=vscode
  > ok: _REMOTE_USER_HOME=/home/vscode
  > ok: _CONTAINER_USER=vscode
  > ok: _CONTAINER_USER_HOME=/home/vscode
  > All scenarios passed.

## Test plan

- [x] `make test-nextest-fast` (2115 passing)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- [x] Manual: `examples/features/feature-env-injection/exec.sh` all scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)