### PR TITLE
fix(examples): set-up/basic must pass --include-configuration (closes #92)

### DIFF
--- a/examples/set-up/basic/exec.sh
+++ b/examples/set-up/basic/exec.sh
@@ -45,6 +45,8 @@ SETUP_ERR="$(mktemp)"
 snapshot="$(run "$DEACON_BIN" set-up \
 	--container-id "$CID" \
 	--config "$SCRIPT_DIR/devcontainer.json" \
+	--include-configuration \
+	--include-merged-configuration \
 	--log-format json 2> "$SETUP_ERR")" || {
 	echo "FAIL: set-up exited non-zero" >&2
 	sed 's/^/  | /' "$SETUP_ERR" >&2


### PR DESCRIPTION
## Summary

#92 reported set-up's snapshot fields (`remoteUser`, `remoteEnv.DEACON_SET_UP_DEMO`) as missing. Investigation shows this is an **example bug**, not a deacon spec violation:

- Upstream `devcontainerCli.ts` set-up implementation explicitly flag-gates both fields:
  ```js
  configuration:        parsed.includeConfig       ? updatedConfig  : undefined,
  mergedConfiguration:  parsed.includeMergedConfig ? updatedMerged  : undefined,
  ```
- Deacon mirrors this contract.
- The example just forgot to ask for the fields.

Add `--include-configuration --include-merged-configuration` to the `set-up` invocation. Closes #92.

## Verification

`examples/set-up/basic/exec.sh`:

- Before: `FAIL: remoteUser != root`
- After:
  > ok: /tmp/onCreate.flag present
  > ok: /tmp/postCreate.flag present
  > ok: /tmp/postStart.flag present
  > remoteUser=root
  > DEACON_SET_UP_DEMO=1
  > ok: lifecycle suppressed
  > All scenarios passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)