### PR TITLE
fix(state): stamp lifecycle markers with config_hash and invalidate on drift (#93)

### DIFF
--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -8,7 +8,7 @@ use crate::errors::{ConfigError, DeaconError, Result};
 use crate::lifecycle::LifecyclePhase;
 use crate::progress::{ProgressEvent, ProgressTracker};
 use crate::redaction::{redact_if_enabled, RedactionConfig};
-use crate::state::record_phase_executed;
+use crate::state::record_phase_executed_with_config_hash;
 use crate::variable::{SubstitutionContext, SubstitutionReport, VariableSubstitution};
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -508,6 +508,14 @@ pub struct ContainerLifecycleConfig {
     pub dotfiles: Option<DotfilesConfig>,
     /// Whether running in prebuild mode (skips dotfiles)
     pub is_prebuild: bool,
+    /// Resolved configuration hash stamped on lifecycle markers (#93).
+    ///
+    /// When `Some`, every marker the lifecycle runner writes records this
+    /// hash; subsequent reads via `read_all_markers_for_config` will drop
+    /// markers whose hash doesn't match the current config, forcing a
+    /// rerun. `None` writes legacy markers (no hash) — compatible with
+    /// older deacon installs.
+    pub config_hash: Option<String>,
 }
 
 /// Execute lifecycle commands in a container with full variable substitution
@@ -733,10 +741,11 @@ where
 
         // Per FR-002: Record marker for blocking phase on successful execution
         if phase_result.success {
-            if let Err(e) = record_phase_executed(
+            if let Err(e) = record_phase_executed_with_config_hash(
                 &workspace_folder,
                 LifecyclePhase::OnCreate,
                 updated_config.is_prebuild,
+                updated_config.config_hash.as_deref(),
             )
             .await
             {
@@ -768,10 +777,11 @@ where
 
         // Per FR-002: Record marker for blocking phase on successful execution
         if phase_result.success {
-            if let Err(e) = record_phase_executed(
+            if let Err(e) = record_phase_executed_with_config_hash(
                 &workspace_folder,
                 LifecyclePhase::UpdateContent,
                 updated_config.is_prebuild,
+                updated_config.config_hash.as_deref(),
             )
             .await
             {
@@ -804,10 +814,11 @@ where
 
             // Per FR-002: Record marker for blocking phase on successful execution
             if phase_result.success {
-                if let Err(e) = record_phase_executed(
+                if let Err(e) = record_phase_executed_with_config_hash(
                     &workspace_folder,
                     LifecyclePhase::PostCreate,
                     updated_config.is_prebuild,
+                    updated_config.config_hash.as_deref(),
                 )
                 .await
                 {
@@ -844,10 +855,11 @@ where
 
                 // Per FR-002: Record marker for blocking phase on successful execution
                 if phase_result.success {
-                    if let Err(e) = record_phase_executed(
+                    if let Err(e) = record_phase_executed_with_config_hash(
                         &workspace_folder,
                         LifecyclePhase::Dotfiles,
                         updated_config.is_prebuild,
+                        updated_config.config_hash.as_deref(),
                     )
                     .await
                     {
@@ -2609,9 +2621,13 @@ impl ContainerLifecycleResult {
                     // Runtime hooks (postStart, postAttach) always rerun on resume but still
                     // need their markers updated with new timestamps per data-model.md.
                     if phase_result.success {
-                        if let Err(e) =
-                            record_phase_executed(&spec.workspace_folder, spec.phase, spec.prebuild)
-                                .await
+                        if let Err(e) = record_phase_executed_with_config_hash(
+                            &spec.workspace_folder,
+                            spec.phase,
+                            spec.prebuild,
+                            spec.config.config_hash.as_deref(),
+                        )
+                        .await
                         {
                             warn!(
                                 "Failed to record marker for phase {}: {}",
@@ -2702,6 +2718,7 @@ mod tests {
             force_pty: false,
             dotfiles: None,
             is_prebuild: false,
+            config_hash: None,
         };
 
         assert_eq!(config.container_id, "test-container");
@@ -2827,6 +2844,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),
@@ -2890,6 +2908,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),
@@ -2967,6 +2986,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_millis(100), // Very short timeout
@@ -3031,6 +3051,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),
@@ -3117,6 +3138,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context.clone(),
             timeout: Duration::from_secs(30),
@@ -3141,6 +3163,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),
@@ -3217,6 +3240,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),
@@ -3299,6 +3323,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context.clone(),
             timeout: Duration::from_secs(30),
@@ -3323,6 +3348,7 @@ mod tests {
                 force_pty: false,
                 dotfiles: None,
                 is_prebuild: false,
+                config_hash: None,
             },
             context: substitution_context,
             timeout: Duration::from_secs(30),

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -207,6 +207,20 @@ pub struct LifecyclePhaseState {
     /// Timestamp when the marker was written (if available)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    /// Resolved-config hash at the time this marker was written.
+    ///
+    /// Per #93, re-invocations of `up` with a different `--override-config`
+    /// (or any other change that yields a different resolved config) MUST
+    /// rerun the lifecycle phases — the previous marker is stale relative
+    /// to the new effective config. Readers compare this field against
+    /// the current `ContainerIdentity::config_hash` and treat a mismatch
+    /// as a missing marker.
+    ///
+    /// Older markers (written before this field existed) deserialize with
+    /// `config_hash = None`; treated as compatible with any current hash
+    /// to avoid spuriously rerunning lifecycle for users upgrading deacon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_hash: Option<String>,
 }
 
 impl LifecyclePhaseState {
@@ -218,6 +232,7 @@ impl LifecyclePhaseState {
             reason: None,
             marker_path,
             timestamp: None,
+            config_hash: None,
         }
     }
 
@@ -229,6 +244,7 @@ impl LifecyclePhaseState {
             reason: None,
             marker_path,
             timestamp: Some(chrono::Utc::now()),
+            config_hash: None,
         }
     }
 
@@ -244,6 +260,7 @@ impl LifecyclePhaseState {
             reason: Some(reason.into()),
             marker_path,
             timestamp: None,
+            config_hash: None,
         }
     }
 
@@ -259,7 +276,16 @@ impl LifecyclePhaseState {
             reason: Some(reason.into()),
             marker_path,
             timestamp: None,
+            config_hash: None,
         }
+    }
+
+    /// Attach the resolved-config hash to this marker. Readers compare
+    /// the value against the current config to decide whether the marker
+    /// is still applicable (#93).
+    pub fn with_config_hash(mut self, config_hash: impl Into<String>) -> Self {
+        self.config_hash = Some(config_hash.into());
+        self
     }
 
     /// Mark this phase as executed (updates status and sets timestamp)

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -652,7 +652,23 @@ pub async fn read_all_markers(
     workspace: &Path,
     prebuild: bool,
 ) -> Result<Vec<LifecyclePhaseState>> {
+    read_all_markers_for_config(workspace, prebuild, None).await
+}
+
+/// Read every marker for `workspace`, then drop any whose recorded
+/// `config_hash` doesn't match `current_config_hash`. Markers without a
+/// recorded hash (legacy from older deacon builds) are kept so we don't
+/// regress users upgrading deacon.
+///
+/// Caller passes `None` to skip the filter and read everything (#93).
+#[instrument(skip_all, fields(workspace = %workspace.display(), prebuild))]
+pub async fn read_all_markers_for_config(
+    workspace: &Path,
+    prebuild: bool,
+    current_config_hash: Option<&str>,
+) -> Result<Vec<LifecyclePhaseState>> {
     let mut markers = Vec::new();
+    let mut dropped = 0usize;
 
     for phase in LifecyclePhase::spec_order() {
         let path = if prebuild {
@@ -662,15 +678,33 @@ pub async fn read_all_markers(
         };
 
         if let Some(state) = read_phase_marker(&path).await? {
+            // Drop the marker when its recorded config hash differs from
+            // the current config — this forces a rerun, matching what the
+            // user expects after `--override-config` (or any other input
+            // that changes the resolved config). Markers without a
+            // recorded hash predate #93 and are kept as compatible.
+            if let (Some(current), Some(recorded)) = (current_config_hash, &state.config_hash) {
+                if current != recorded {
+                    debug!(
+                        "Dropping stale marker for phase {}: marker config_hash={} current={}",
+                        state.phase.as_str(),
+                        recorded,
+                        current
+                    );
+                    dropped += 1;
+                    continue;
+                }
+            }
             markers.push(state);
         }
     }
 
     debug!(
-        "Read {} markers from {} (prebuild={})",
+        "Read {} markers from {} (prebuild={}; {} dropped as stale)",
         markers.len(),
         workspace.display(),
-        prebuild
+        prebuild,
+        dropped
     );
 
     Ok(markers)
@@ -882,13 +916,33 @@ pub async fn record_phase_executed(
     phase: LifecyclePhase,
     prebuild: bool,
 ) -> Result<LifecyclePhaseState> {
+    record_phase_executed_with_config_hash(workspace, phase, prebuild, None).await
+}
+
+/// Record a phase as executed and stamp the marker with the resolved
+/// configuration hash so future runs can detect a config drift (#93).
+///
+/// Callers that have a `ContainerIdentity` available (i.e. `up` and the
+/// in-process lifecycle runner) should pass `Some(identity.config_hash)`.
+/// Callers without identity context can pass `None`; the marker is
+/// considered universally compatible in that case.
+#[instrument(skip_all, fields(workspace = %workspace.display(), phase = %phase.as_str(), prebuild))]
+pub async fn record_phase_executed_with_config_hash(
+    workspace: &Path,
+    phase: LifecyclePhase,
+    prebuild: bool,
+    config_hash: Option<&str>,
+) -> Result<LifecyclePhaseState> {
     let marker_path = if prebuild {
         prebuild_marker_path_for_phase(workspace, phase)
     } else {
         marker_path_for_phase(workspace, phase)
     };
 
-    let state = LifecyclePhaseState::new_executed(phase, marker_path.clone());
+    let mut state = LifecyclePhaseState::new_executed(phase, marker_path.clone());
+    if let Some(hash) = config_hash {
+        state = state.with_config_hash(hash);
+    }
     write_phase_marker(&marker_path, &state).await?;
 
     info!(

--- a/crates/core/tests/integration_container_lifecycle.rs
+++ b/crates/core/tests/integration_container_lifecycle.rs
@@ -41,6 +41,7 @@ async fn test_container_lifecycle_with_variable_substitution() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Define lifecycle commands with variable substitution
@@ -113,6 +114,7 @@ async fn test_container_lifecycle_with_skip_flags() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     let commands = ContainerLifecycleCommands::new()
@@ -169,6 +171,7 @@ fn test_container_lifecycle_config_validation() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     assert_eq!(config.container_id, "test-container");
@@ -234,6 +237,7 @@ async fn test_all_lifecycle_phases_ordering() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Define all 6 lifecycle phases

--- a/crates/core/tests/integration_mock_runtime.rs
+++ b/crates/core/tests/integration_mock_runtime.rs
@@ -344,6 +344,7 @@ async fn test_lifecycle_execution_with_mock_docker() -> Result<()> {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands
@@ -442,6 +443,7 @@ async fn test_lifecycle_execution_with_skip_flags() -> Result<()> {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands
@@ -509,6 +511,7 @@ async fn test_lifecycle_execution_with_command_failure() -> Result<()> {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with a failing command
@@ -615,6 +618,7 @@ async fn test_non_blocking_command_skip_behavior() -> Result<()> {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands

--- a/crates/core/tests/integration_non_blocking_lifecycle.rs
+++ b/crates/core/tests/integration_non_blocking_lifecycle.rs
@@ -46,6 +46,7 @@ async fn test_non_blocking_phases_are_deferred() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with all phases
@@ -152,6 +153,7 @@ async fn test_skip_non_blocking_commands_behavior() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with all phases
@@ -225,6 +227,7 @@ async fn test_non_blocking_phases_sync_execution() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with all phases
@@ -348,6 +351,7 @@ async fn test_non_blocking_phase_command_failures_are_handled() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with all phases
@@ -466,6 +470,7 @@ async fn test_non_blocking_phase_timeout_handling() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands
@@ -542,6 +547,7 @@ async fn test_non_blocking_phases_with_progress_streaming() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with non-blocking phases

--- a/crates/core/tests/integration_per_command_events.rs
+++ b/crates/core/tests/integration_per_command_events.rs
@@ -77,6 +77,7 @@ async fn test_per_command_events_emitted() {
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Create lifecycle commands with multiple commands in a phase

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -162,6 +162,7 @@ async fn execute_lifecycle_commands(
         // run-user-commands does not install dotfiles - that is handled by `up` command
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Build lifecycle commands from configuration using typed parser

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -387,6 +387,7 @@ async fn execute_lifecycle_hooks(
         force_pty: false,
         dotfiles: build_dotfiles_config(args),
         is_prebuild: false,
+        config_hash: None,
     };
 
     let mut commands = ContainerLifecycleCommands::new();

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -574,12 +574,22 @@ pub(crate) async fn execute_container_up(
     // T014: Read prior lifecycle markers for resume decision logic
     // Per SC-002: On resume, skip onCreate, updateContent, postCreate, dotfiles; run postStart, postAttach
     // Per FR-004: On partial resume, skip completed phases, run remaining from earliest incomplete
-    let prior_markers = deacon_core::state::read_all_markers(workspace_folder, args.prebuild)
-        .await
-        .unwrap_or_else(|e| {
-            debug!("Failed to read prior lifecycle markers: {}", e);
-            Vec::new()
-        });
+    //
+    // Spec parity (#93): filter markers by the *current* config_hash so
+    // a re-invocation with a different `--override-config` (or any input
+    // that produces a different resolved config) reruns lifecycle from
+    // scratch. Markers without a recorded config_hash predate this
+    // change and remain compatible with any current hash.
+    let prior_markers = deacon_core::state::read_all_markers_for_config(
+        workspace_folder,
+        args.prebuild,
+        Some(&identity.config_hash),
+    )
+    .await
+    .unwrap_or_else(|e| {
+        debug!("Failed to read prior lifecycle markers: {}", e);
+        Vec::new()
+    });
 
     debug!(
         "Prior lifecycle markers: {} markers loaded (prebuild={})",
@@ -599,6 +609,7 @@ pub(crate) async fn execute_container_up(
         cache_folder,
         resolved_features.as_deref().unwrap_or(&[]),
         prior_markers,
+        Some(&identity.config_hash),
     )
     .await?;
 

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -144,6 +144,7 @@ pub(crate) async fn execute_lifecycle_commands(
     cache_folder: &Option<PathBuf>,
     resolved_features: &[ResolvedFeature],
     prior_markers: Vec<LifecyclePhaseState>,
+    config_hash: Option<&str>,
 ) -> Result<()> {
     use deacon_core::container_lifecycle::{
         execute_container_lifecycle_with_progress_callback, ContainerLifecycleCommands,
@@ -251,6 +252,7 @@ pub(crate) async fn execute_lifecycle_commands(
         force_pty,
         dotfiles: dotfiles_config,
         is_prebuild: args.prebuild,
+        config_hash: config_hash.map(String::from),
     };
 
     // Build lifecycle commands from configuration, respecting resume decisions
@@ -514,6 +516,7 @@ pub(crate) async fn execute_initialize_command(
         force_pty: false,
         dotfiles: None,
         is_prebuild: false,
+        config_hash: None,
     };
 
     // Execute only the initialize phase (host-side)


### PR DESCRIPTION
## Summary

Deacon's lifecycle markers were keyed only by workspace path + phase name. Two `up` invocations against the same workspace would skip phases on the second run even when `--override-config` (or any input that changes the resolved config) altered the lifecycle. Practical regression: `examples/up/update-remote-user-uid/exec.sh` scenario 2 inherited scenario 1's `postCreate.json` marker.

Implementation:
- `LifecyclePhaseState` gains an optional `config_hash` field (serde-skipped when absent so older markers remain compatible).
- `record_phase_executed_with_config_hash` writes markers stamped with the resolved config hash.
- `read_all_markers_for_config(workspace, prebuild, current_hash)` drops markers whose recorded hash differs from the current one. Markers without a hash are kept (legacy compatibility).
- `ContainerLifecycleConfig` gains `config_hash: Option<String>`; the internal runner threads it through every marker-write call.
- The up flow plumbs `identity.config_hash` through `read_all_markers_for_config` → `execute_lifecycle_commands` → `ContainerLifecycleConfig`.

`ContainerIdentity::config_hash` is computed before deacon mutates the config mid-flight (workspace_mount injection, image-metadata merge), so the same hash is reproducible across re-invocations with the same effective config.

Closes #93.

## Verification

`examples/up/update-remote-user-uid/exec.sh`:

- Before: scenario 2 inherited scenario 1's marker; `postCreate` didn't rerun; `/tmp/uid` was missing.
- After:
  > == Scenario 1: updateRemoteUserUID: true ==
  >   container UID/GID: 1000/1000
  >   ok: container UID matches host
  > == Scenario 2: updateRemoteUserUID: false ==
  >   container UID (no sync): 5000
  >   ok: UID preserved from image
  > All scenarios passed.

## Test plan

- [x] `make test-nextest-fast` (2114 passing)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- [x] Manual end-to-end against `examples/up/update-remote-user-uid/exec.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)