### PR TITLE
fix(compose): apply deacon devcontainer.* labels to compose-managed containers (#100)

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -1046,6 +1046,7 @@ impl ComposeManager {
     ///     external_volumes: Vec::new(),
     ///     override_command: Some(false),
     ///     service_image_override: None,
+    ///     deacon_labels: IndexMap::new(),
     /// };
     ///
     /// let output = manager.build_service(&project, "web").await?;
@@ -1110,6 +1111,7 @@ impl ComposeManager {
     ///     external_volumes: Vec::new(),
     ///     override_command: Some(false),
     ///     service_image_override: None,
+    ///     deacon_labels: IndexMap::new(),
     /// };
     ///
     /// if manager.validate_service_exists(&project, "web").await? {

--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -47,6 +47,13 @@ pub struct ComposeProject {
     /// image, so the subsequent `docker compose up` runs the extended image instead of
     /// the original `image:` declared in the compose file.
     pub service_image_override: Option<String>,
+    /// Deacon-applied container labels — emitted into the injection
+    /// overlay under each service's `labels:` block so every container
+    /// in the project (primary + runServices) carries the spec-mandated
+    /// `devcontainer.local_folder`, `devcontainer.config_file`, etc.
+    /// Per #100. Populated by the up flow from
+    /// `ContainerIdentity::labels()`.
+    pub deacon_labels: IndexMap<String, String>,
 }
 
 /// Mount specification for Docker Compose volumes
@@ -800,6 +807,7 @@ impl ComposeManager {
             external_volumes: Vec::new(), // Will be populated via populate_external_volumes()
             override_command: config.override_command,
             service_image_override: None,
+            deacon_labels: IndexMap::new(), // Populated by the up flow from ContainerIdentity (#100)
         })
     }
 
@@ -1226,6 +1234,7 @@ impl ComposeProject {
             && self.additional_env.is_empty()
             && !override_cmd
             && self.service_image_override.is_none()
+            && self.deacon_labels.is_empty()
         {
             return None;
         }
@@ -1281,11 +1290,33 @@ impl ComposeProject {
             }
         }
 
+        // Per #100: emit deacon labels on the primary service plus every
+        // run_services entry, so external tooling (VS Code Dev
+        // Containers reconnect, `docker ps --filter`, `deacon exec
+        // --id-label`) finds compose-managed containers via the
+        // standard `devcontainer.*` keys.
+        if !self.deacon_labels.is_empty() {
+            yaml.push_str("    labels:\n");
+            for (key, value) in &self.deacon_labels {
+                let escaped = escape_yaml_value(value);
+                yaml.push_str(&format!("      {}: {}\n", key, escaped));
+            }
+            for svc in &self.run_services {
+                yaml.push_str(&format!("  {}:\n", svc));
+                yaml.push_str("    labels:\n");
+                for (key, value) in &self.deacon_labels {
+                    let escaped = escape_yaml_value(value);
+                    yaml.push_str(&format!("      {}: {}\n", key, escaped));
+                }
+            }
+        }
+
         debug!(
-            "Generated compose injection override for service '{}': {} env vars, {} mounts, override_command={}",
+            "Generated compose injection override for service '{}': {} env vars, {} mounts, {} labels, override_command={}",
             self.service,
             self.additional_env.len(),
             self.additional_mounts.len(),
+            self.deacon_labels.len(),
             override_cmd,
         );
 
@@ -1610,6 +1641,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let services = project.get_all_services();
@@ -1687,6 +1719,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let all_services = project.get_all_services();
@@ -1713,6 +1746,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let all_services = project.get_all_services();
@@ -1827,6 +1861,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         // No mounts or env, should return None
@@ -1852,6 +1887,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1892,6 +1928,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1926,6 +1963,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1958,6 +1996,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1990,6 +2029,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -2025,6 +2065,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: None,
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project
@@ -2053,6 +2094,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         assert!(project.generate_injection_override().is_none());
@@ -2077,6 +2119,7 @@ mod tests {
             external_volumes: Vec::new(),
             override_command: Some(true),
             service_image_override: None,
+            deacon_labels: IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -2486,6 +2529,7 @@ mod tests {
             external_volumes: vec![],
             override_command: Some(false),
             service_image_override: Some("deacon-features:abc123".into()),
+            deacon_labels: IndexMap::new(),
         };
         let yaml = project
             .generate_injection_override()
@@ -2518,6 +2562,7 @@ mod tests {
             external_volumes: vec![],
             override_command: Some(false),
             service_image_override: Some("img:tag".into()),
+            deacon_labels: IndexMap::new(),
         };
         assert!(project.generate_injection_override().is_some());
     }
@@ -2539,6 +2584,7 @@ mod tests {
             external_volumes: vec![],
             override_command: Some(false),
             service_image_override: Some(r#"weird"tag"#.into()),
+            deacon_labels: IndexMap::new(),
         };
         let yaml = project.generate_injection_override().unwrap();
         assert!(yaml.contains(r#"image: "weird\"tag""#));

--- a/crates/deacon/src/commands/down.rs
+++ b/crates/deacon/src/commands/down.rs
@@ -363,7 +363,8 @@ async fn execute_compose_down(
         additional_env: deacon_core::IndexMap::new(),
         external_volumes: Vec::new(), // Not needed for down operation
         override_command: None,       // Not needed for down operation
-        service_image_override: None, // Not needed for down operation
+        service_image_override: None,
+        deacon_labels: deacon_core::IndexMap::new(), // Not needed for down operation
     };
 
     // Check if project is still running

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -54,6 +54,29 @@ pub(crate) async fn execute_compose_up(
     // Add env files from CLI args
     project.env_files = args.env_file.clone();
 
+    // Spec parity (#100): apply the same deacon identity labels the
+    // single-container path uses to every compose service. Without
+    // these, VS Code Dev Containers reconnect / `docker ps --filter
+    // label=devcontainer.local_folder=<abs>` / `deacon exec --id-label`
+    // all miss compose-managed containers.
+    let identity = ContainerIdentity::new(workspace_folder, config).with_config_file(config_path);
+    let identity_labels = identity.labels();
+    for (key, value) in &identity_labels {
+        project.deacon_labels.insert(key.clone(), value.clone());
+    }
+
+    // Spec parity (#100): apply the same deacon identity labels the
+    // single-container path uses to every compose service. Without
+    // these, VS Code Dev Containers reconnect / `docker ps --filter
+    // label=devcontainer.local_folder=<abs>` / `deacon exec --id-label`
+    // all miss compose-managed containers.
+    let identity = deacon_core::container::ContainerIdentity::new(workspace_folder, config)
+        .with_config_file(config_path);
+    let identity_labels = identity.labels();
+    for (key, value) in &identity_labels {
+        project.deacon_labels.insert(key.clone(), value.clone());
+    }
+
     // Apply default workspace mount for Compose when consistency is provided
     // Per FR-001: workspace_mount_consistency MUST apply to both Docker and Compose outputs
     // This mirrors the Docker behavior in execute_docker_up().

--- a/crates/deacon/tests/integration_compose_enhancements.rs
+++ b/crates/deacon/tests/integration_compose_enhancements.rs
@@ -112,6 +112,7 @@ fn test_compose_project_all_services_inclusion() {
         external_volumes: Vec::new(),
         override_command: Some(false),
         service_image_override: None,
+        deacon_labels: deacon_core::IndexMap::new(),
     };
 
     let all_services = project.get_all_services();
@@ -230,6 +231,7 @@ async fn test_compose_get_all_container_ids() {
         external_volumes: Vec::new(),
         override_command: Some(false),
         service_image_override: None,
+        deacon_labels: deacon_core::IndexMap::new(),
     };
 
     let compose_manager = ComposeManager::new();
@@ -285,6 +287,7 @@ fn test_compose_service_targeting() {
         external_volumes: Vec::new(),
         override_command: Some(false),
         service_image_override: None,
+        deacon_labels: deacon_core::IndexMap::new(),
     };
 
     // Verify all services are accessible

--- a/crates/deacon/tests/workspace_mounts.rs
+++ b/crates/deacon/tests/workspace_mounts.rs
@@ -235,6 +235,7 @@ mod compose_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project
@@ -278,6 +279,7 @@ mod compose_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         // Generate override multiple times and verify determinism
@@ -312,6 +314,7 @@ mod compose_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -353,6 +356,7 @@ mod compose_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -891,6 +895,7 @@ mod default_workspace_discovery_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project
@@ -1035,6 +1040,7 @@ mod compose_git_root_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project
@@ -1082,6 +1088,7 @@ mod compose_git_root_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project
@@ -1132,6 +1139,7 @@ mod compose_git_root_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         // Verify all services are present
@@ -1185,6 +1193,7 @@ mod compose_git_root_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1230,6 +1239,7 @@ mod compose_git_root_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1267,6 +1277,7 @@ mod compose_git_root_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1304,6 +1315,7 @@ mod compose_git_root_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1342,6 +1354,7 @@ mod compose_git_root_consistency_tests {
                 external_volumes: Vec::new(),
                 override_command: Some(false),
                 service_image_override: None,
+                deacon_labels: deacon_core::IndexMap::new(),
             };
 
             let override_yaml = project.generate_injection_override().unwrap();
@@ -1380,6 +1393,7 @@ mod compose_git_root_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1417,6 +1431,7 @@ mod compose_git_root_consistency_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         let override_yaml = project.generate_injection_override().unwrap();
@@ -1581,6 +1596,7 @@ mod performance_tests {
             external_volumes: Vec::new(),
             override_command: Some(false),
             service_image_override: None,
+            deacon_labels: deacon_core::IndexMap::new(),
         };
 
         // Warm-up call
@@ -1661,6 +1677,7 @@ mod performance_tests {
                 external_volumes: Vec::new(),
                 override_command: Some(false),
                 service_image_override: None,
+                deacon_labels: deacon_core::IndexMap::new(),
             };
 
             // Step 5: Generate Compose override

--- a/examples/compose/multiple-compose-files/exec.sh
+++ b/examples/compose/multiple-compose-files/exec.sh
@@ -10,13 +10,11 @@ run() {
 }
 
 container_id() {
-	# Deacon-created compose containers don't carry deacon's name labels —
-	# only the standard docker-compose ones. Filter by compose project +
-	# service. Deacon derives the project name from the workspace dir's
-	# basename.
-	local project
-	project="$(basename "$SCRIPT_DIR")"
-	docker ps -a --filter "label=com.docker.compose.project=${project}" \
+	# Deacon applies the spec-mandated `devcontainer.local_folder` label
+	# to compose-managed containers as of #100/#101 — match upstream's
+	# discovery pattern (also used by VS Code Dev Containers and
+	# `deacon exec --id-label`).
+	docker ps -a --filter "label=devcontainer.local_folder=${SCRIPT_DIR}" \
 		--filter "label=com.docker.compose.service=app" --format '{{.ID}}' | head -n1
 }
 


### PR DESCRIPTION
## Summary

PR #80 (#68) added the spec-mandated `devcontainer.*` labels to single-container `up` but didn't extend to compose. Compose-created containers carried only `com.docker.compose.*` labels — VS Code Dev Containers reconnect missed them, `deacon exec --id-label` errored 'not found', `docker ps --filter` returned nothing.

Fix: extend `ComposeProject` with a `deacon_labels` map and emit them into the existing injection-override YAML under each service's `labels:` block — primary service + every `runServices` entry. Up populates the map from the same `ContainerIdentity::labels()` the single-container path uses.

Closes #100.

## Verification

`examples/compose/multiservice-basic`:

```
app: 23278ef364ca
  devcontainer.configHash=338d5426
  devcontainer.config_file=/tmp/.../devcontainer.json
  devcontainer.local_folder=/tmp/...
  devcontainer.name=Multiservice Compose Example
  devcontainer.source=deacon
  devcontainer.workspaceHash=52a2ee3c
redis: 8eb3cb714b21
  (same 6 labels)

$ deacon exec --id-label devcontainer.local_folder=$TMPDIR -- echo ok
Command completed with exit code: 0
```

Before this PR: `Error: Dev container not found.`

## Test plan

- [x] `make test-nextest-fast` (2115 passing)
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings`
- [x] Manual: labels visible on both primary and `runServices` containers
- [x] Manual: `exec --id-label devcontainer.local_folder=…` finds the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)