### PR TITLE
feat(variable): expand spec-mandated variables in more config fields (#107)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -704,6 +704,15 @@ impl DevContainerConfig {
 
         debug!("Applying variable substitution to DevContainer configuration");
 
+        // Substitute name
+        if let Some(ref name) = config.name {
+            config.name = Some(VariableSubstitution::substitute_string(
+                name,
+                context,
+                &mut report,
+            ));
+        }
+
         // Substitute workspace_folder
         if let Some(ref workspace_folder) = config.workspace_folder {
             config.workspace_folder = Some(VariableSubstitution::substitute_string(
@@ -747,6 +756,37 @@ impl DevContainerConfig {
                 )
             })
             .collect();
+
+        // Substitute remote_env values (per spec, variables expand inside any
+        // string value; remote_env values are strings — keys are not).
+        config.remote_env = config
+            .remote_env
+            .iter()
+            .map(|(key, value)| {
+                let substituted_value = value
+                    .as_ref()
+                    .map(|v| VariableSubstitution::substitute_string(v, context, &mut report));
+                (key.clone(), substituted_value)
+            })
+            .collect();
+
+        // Substitute container_user
+        if let Some(ref container_user) = config.container_user {
+            config.container_user = Some(VariableSubstitution::substitute_string(
+                container_user,
+                context,
+                &mut report,
+            ));
+        }
+
+        // Substitute remote_user
+        if let Some(ref remote_user) = config.remote_user {
+            config.remote_user = Some(VariableSubstitution::substitute_string(
+                remote_user,
+                context,
+                &mut report,
+            ));
+        }
 
         // Substitute lifecycle commands
         if let Some(ref cmd) = config.on_create_command {
@@ -855,6 +895,13 @@ impl DevContainerConfig {
 
         debug!("Applying advanced variable substitution to DevContainer configuration");
 
+        // Substitute name
+        if let Some(ref name) = config.name {
+            config.name = Some(VariableSubstitution::substitute_string_advanced(
+                name, context, options, report,
+            )?);
+        }
+
         // Substitute workspace_folder
         if let Some(ref workspace_folder) = config.workspace_folder {
             config.workspace_folder = Some(VariableSubstitution::substitute_string_advanced(
@@ -915,6 +962,26 @@ impl DevContainerConfig {
             }
         }
         config.remote_env = substituted_remote_env;
+
+        // Substitute container_user
+        if let Some(ref container_user) = config.container_user {
+            config.container_user = Some(VariableSubstitution::substitute_string_advanced(
+                container_user,
+                context,
+                options,
+                report,
+            )?);
+        }
+
+        // Substitute remote_user
+        if let Some(ref remote_user) = config.remote_user {
+            config.remote_user = Some(VariableSubstitution::substitute_string_advanced(
+                remote_user,
+                context,
+                options,
+                report,
+            )?);
+        }
 
         // Substitute lifecycle commands
         if let Some(ref on_create_command) = config.on_create_command {
@@ -3394,6 +3461,62 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_substitution_covers_name_remote_env_users() {
+        // Per #107 — apply_variable_substitution must expand variables in
+        // name, remoteEnv values, containerUser, remoteUser. Previously only
+        // workspace_folder/mount/run_args/container_env/lifecycle were
+        // covered, leaving these fields with literal `${...}` in
+        // read-configuration output.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let basename = workspace.file_name().unwrap().to_string_lossy().to_string();
+        let mut context = SubstitutionContext::new(workspace).unwrap();
+        context
+            .local_env
+            .insert("MY_VAR".to_string(), "hello".to_string());
+
+        let mut config = DevContainerConfig {
+            name: Some("rc-${localWorkspaceFolderBasename}".to_string()),
+            container_user: Some("${localEnv:MY_VAR}".to_string()),
+            remote_user: Some("${localEnv:MY_VAR:fallback}".to_string()),
+            ..Default::default()
+        };
+        config.remote_env.insert(
+            "FROM_LOCAL".to_string(),
+            Some("${localEnv:MY_VAR:default}".to_string()),
+        );
+        config.remote_env.insert(
+            "WS".to_string(),
+            Some("${localWorkspaceFolderBasename}".to_string()),
+        );
+        // Literal unset → resolve via default branch
+        config.remote_env.insert(
+            "UNSET".to_string(),
+            Some("${localEnv:NOT_SET:fallback}".to_string()),
+        );
+
+        let (substituted, _) = config.apply_variable_substitution(&context);
+        assert_eq!(
+            substituted.name.as_deref(),
+            Some(format!("rc-{basename}").as_str())
+        );
+        assert_eq!(substituted.container_user.as_deref(), Some("hello"));
+        assert_eq!(substituted.remote_user.as_deref(), Some("hello"));
+        assert_eq!(
+            substituted.remote_env.get("FROM_LOCAL").unwrap().as_deref(),
+            Some("hello")
+        );
+        assert_eq!(
+            substituted.remote_env.get("WS").unwrap().as_deref(),
+            Some(basename.as_str())
+        );
+        assert_eq!(
+            substituted.remote_env.get("UNSET").unwrap().as_deref(),
+            Some("fallback")
+        );
     }
 
     #[test]

--- a/crates/core/src/variable.rs
+++ b/crates/core/src/variable.rs
@@ -7,10 +7,13 @@
 //! ## Supported Variables
 //!
 //! - `${localWorkspaceFolder}` - Canonical workspace path
-//! - `${localEnv:VAR}` - Host environment variable
+//! - `${localWorkspaceFolderBasename}` - Basename of the workspace path
+//! - `${localEnv:VAR}` / `${localEnv:VAR:default}` - Host env var with optional default
+//! - `${env:VAR}` / `${env:VAR:default}` - Alias for `localEnv:` per upstream spec
 //! - `${devcontainerId}` - Deterministic hash ID (first 12 chars of SHA256 of workspace path)
 //! - `${containerWorkspaceFolder}` - Container workspace path (available after container start)
-//! - `${containerEnv:VAR}` - Container environment variable (available after container start)
+//! - `${containerWorkspaceFolderBasename}` - Basename of the container workspace path
+//! - `${containerEnv:VAR}` / `${containerEnv:VAR:default}` - Container env var with optional default
 //!
 //! ## Variable Substitution Workflow
 //!
@@ -452,25 +455,44 @@ impl VariableSubstitution {
     fn resolve_variable(variable_expr: &str, context: &SubstitutionContext) -> Option<String> {
         match variable_expr {
             "localWorkspaceFolder" => Some(context.local_workspace_folder.clone()),
+            "localWorkspaceFolderBasename" => Some(
+                std::path::Path::new(&context.local_workspace_folder)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+            ),
             "devcontainerId" => Some(context.devcontainer_id.clone()),
             "containerWorkspaceFolder" => context.container_workspace_folder.clone(),
+            "containerWorkspaceFolderBasename" => {
+                context.container_workspace_folder.as_ref().map(|p| {
+                    std::path::Path::new(p)
+                        .file_name()
+                        .map(|s| s.to_string_lossy().into_owned())
+                        .unwrap_or_default()
+                })
+            }
+            // Per containers.dev spec, `${env:VAR}` is an alias for
+            // `${localEnv:VAR}` (https://containers.dev/implementors/json_reference/).
+            expr if expr.starts_with("env:") => {
+                Some(resolve_env_with_default(&expr[4..], &context.local_env))
+            }
             expr if expr.starts_with("localEnv:") => {
-                let env_var = &expr[9..]; // Remove "localEnv:" prefix
-                Some(context.local_env.get(env_var).cloned().unwrap_or_default())
+                Some(resolve_env_with_default(&expr[9..], &context.local_env))
             }
             expr if expr.starts_with("containerEnv:") => {
-                let env_var = &expr[13..]; // Remove "containerEnv:" prefix
-                                           // Three-pass model per upstream (variableSubstitution.ts: `replaceWithContext`
-                                           // has NO case for containerEnv in pass 1; tokens fall through to the
-                                           // `default: return match` branch). When `container_env` is None we are in
-                                           // pass 1 (config load, pre-probe): leave the token literal so a later
-                                           // `containerSubstitute` pass can resolve it. Only when `container_env` is
-                                           // Some — pass 3, after the container env probe — do we resolve, returning
-                                           // empty string for missing vars (matching upstream `containerEnv[name] || ''`).
-                context
-                    .container_env
-                    .as_ref()
-                    .map(|env| env.get(env_var).cloned().unwrap_or_default())
+                let body = &expr[13..]; // Remove "containerEnv:" prefix
+                let (env_var, default) = split_env_default(body);
+                // Three-pass model per upstream (variableSubstitution.ts: `replaceWithContext`
+                // has NO case for containerEnv in pass 1; tokens fall through to the
+                // `default: return match` branch). When `container_env` is None we are in
+                // pass 1 (config load, pre-probe): leave the token literal so a later
+                // `containerSubstitute` pass can resolve it. Only when `container_env` is
+                // Some — pass 3, after the container env probe — do we resolve.
+                context.container_env.as_ref().map(|env| {
+                    env.get(env_var)
+                        .cloned()
+                        .unwrap_or_else(|| default.map(String::from).unwrap_or_default())
+                })
             }
             expr if expr.starts_with("feature:") => {
                 let feature_var = &expr[8..]; // Remove "feature:" prefix
@@ -486,7 +508,32 @@ impl VariableSubstitution {
             _ => None, // Unknown variable
         }
     }
+}
 
+/// Split an env-variable lookup body of the form `VAR` or `VAR:default` into
+/// the variable name and an optional fallback. The default may itself contain
+/// colons; only the *first* colon separates the name from the default.
+///
+/// Per upstream containers.dev, both `${localEnv:VAR:fallback}` and
+/// `${env:VAR:fallback}` resolve via this rule.
+fn split_env_default(body: &str) -> (&str, Option<&str>) {
+    match body.split_once(':') {
+        Some((name, default)) => (name, Some(default)),
+        None => (body, None),
+    }
+}
+
+/// Resolve `${localEnv:VAR}` / `${env:VAR}` (with optional default) against
+/// a host-env map. Missing without default yields empty string; missing with
+/// default yields the default string.
+fn resolve_env_with_default(body: &str, env: &std::collections::HashMap<String, String>) -> String {
+    let (name, default) = split_env_default(body);
+    env.get(name)
+        .cloned()
+        .unwrap_or_else(|| default.map(String::from).unwrap_or_default())
+}
+
+impl VariableSubstitution {
     /// Apply substitution to a JSON value recursively
     ///
     /// This method handles substitution in JSON values that may contain strings,
@@ -655,6 +702,82 @@ mod tests {
         assert!(report.replacements.contains_key(&format!("localEnv:{VAR}")));
 
         env::remove_var(VAR);
+        Ok(())
+    }
+
+    #[test]
+    fn test_local_workspace_folder_basename() -> anyhow::Result<()> {
+        // Per containers.dev json_reference, ${localWorkspaceFolderBasename}
+        // is the last path component of the workspace folder.
+        let temp_dir = TempDir::new()?;
+        let context = SubstitutionContext::new(temp_dir.path())?;
+        let mut report = SubstitutionReport::new();
+
+        let result = VariableSubstitution::substitute_string(
+            "name-${localWorkspaceFolderBasename}",
+            &context,
+            &mut report,
+        );
+
+        let expected_basename = temp_dir
+            .path()
+            .canonicalize()?
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(result, format!("name-{expected_basename}"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_env_alias_for_local_env() -> anyhow::Result<()> {
+        // `${env:VAR}` is the upstream-aligned alias for `${localEnv:VAR}`.
+        const VAR: &str = "DEACON_TEST_ENV_ALIAS";
+        env::set_var(VAR, "from-env-alias");
+
+        let temp_dir = TempDir::new()?;
+        let context = SubstitutionContext::new(temp_dir.path())?;
+        let mut report = SubstitutionReport::new();
+
+        let result = VariableSubstitution::substitute_string(
+            &format!("${{env:{VAR}}}"),
+            &context,
+            &mut report,
+        );
+
+        assert_eq!(result, "from-env-alias");
+        env::remove_var(VAR);
+        Ok(())
+    }
+
+    #[test]
+    fn test_local_env_with_default() -> anyhow::Result<()> {
+        // Per containers.dev, `${localEnv:VAR:default}` falls back to the
+        // default literal when VAR is unset. A set VAR ignores the default.
+        let temp_dir = TempDir::new()?;
+        let mut context = SubstitutionContext::new(temp_dir.path())?;
+        // Ensure clean slate: remove the keys from local_env, since
+        // SubstitutionContext::new captures the real env at construction.
+        context.local_env.remove("DEACON_TEST_DEFAULT_UNSET");
+        context
+            .local_env
+            .insert("DEACON_TEST_DEFAULT_SET".to_string(), "real-value".to_string());
+        let mut report = SubstitutionReport::new();
+
+        let unset = VariableSubstitution::substitute_string(
+            "${localEnv:DEACON_TEST_DEFAULT_UNSET:fallback-value}",
+            &context,
+            &mut report,
+        );
+        assert_eq!(unset, "fallback-value");
+
+        let set = VariableSubstitution::substitute_string(
+            "${localEnv:DEACON_TEST_DEFAULT_SET:fallback-value}",
+            &context,
+            &mut report,
+        );
+        assert_eq!(set, "real-value");
         Ok(())
     }
 

--- a/crates/core/src/variable.rs
+++ b/crates/core/src/variable.rs
@@ -760,9 +760,10 @@ mod tests {
         // Ensure clean slate: remove the keys from local_env, since
         // SubstitutionContext::new captures the real env at construction.
         context.local_env.remove("DEACON_TEST_DEFAULT_UNSET");
-        context
-            .local_env
-            .insert("DEACON_TEST_DEFAULT_SET".to_string(), "real-value".to_string());
+        context.local_env.insert(
+            "DEACON_TEST_DEFAULT_SET".to_string(),
+            "real-value".to_string(),
+        );
         let mut report = SubstitutionReport::new();
 
         let unset = VariableSubstitution::substitute_string(


### PR DESCRIPTION
Fixes #107.

## Summary
- \`apply_variable_substitution\` now also substitutes \`name\`, \`remoteEnv\` values, \`containerUser\`, and \`remoteUser\`. Mirrored in \`apply_variable_substitution_advanced\` (which already covered \`remoteEnv\`).
- \`resolve_variable\` gains three previously-missing spec tokens:
  - \`\${localWorkspaceFolderBasename}\` and \`\${containerWorkspaceFolderBasename}\`
  - \`\${env:VAR}\` (alias for \`\${localEnv:VAR}\` per upstream)
  - \`\${localEnv:VAR:default}\` / \`\${env:VAR:default}\` / \`\${containerEnv:VAR:default}\` fallback syntax — previously the entire body including the \`:default\` was treated as the env-var name.
- Updated module docs.

## Test plan
- [x] New \`config::tests::test_substitution_covers_name_remote_env_users\`
- [x] New \`variable::tests::test_local_workspace_folder_basename\`, \`test_env_alias_for_local_env\`, \`test_local_env_with_default\`
- [x] \`cargo nextest run -p deacon-core\` — 1440 tests pass
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] e2e against \`examples/read-configuration/with-variables\`:

\`\`\`
MY_VAR=hello deacon read-configuration --workspace-folder \"\$(pwd)\" \\
  --config \"\$(pwd)/devcontainer.jsonc\" | jq '.configuration | {name, workspaceFolder, remoteEnv}'

{
  \"name\": \"rc-vars-with-variables\",
  \"workspaceFolder\": \"/workspaces/with-variables\",
  \"remoteEnv\": {
    \"FROM_LOCAL_ENV\": \"hello\",
    \"WS_BASENAME\": \"with-variables\"
  }
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)