### PR TITLE
fix(up): route lifecycle command stdout to stderr (#113)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 jsonc-parser = { version = "0.32", default-features = false, features = ["preserve_order"] }
 regex = "1.0"
-tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util", "fs"] }
+tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util", "io-std", "fs"] }
 once_cell.workspace = true
 # Use rustls for a pure-Rust TLS stack to simplify cross-compilation (musl, aarch64) and avoid OpenSSL toolchain requirements.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -416,6 +416,7 @@ impl ContainerEnvironmentProber {
             interactive: false,
             detach: false,
             silent: true, // Suppress output for shell detection probes
+            stdout_to_stderr: false,
             terminal_size: None,
         };
 
@@ -483,6 +484,7 @@ impl ContainerEnvironmentProber {
             interactive: false,
             detach: false,
             silent: true, // Suppress output for environment probes
+            stdout_to_stderr: false,
             terminal_size: None,
         };
 
@@ -734,6 +736,7 @@ where
                 interactive: false,
                 detach: false,
                 silent: true,
+                stdout_to_stderr: false,
                 terminal_size: None,
             },
         )

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -1437,6 +1437,7 @@ where
                     interactive: false,
                     detach: false,
                     silent: false,
+                    stdout_to_stderr: true,
                     terminal_size: None,
                 };
 
@@ -1613,6 +1614,7 @@ where
                     interactive: false,
                     detach: false,
                     silent: false,
+                    stdout_to_stderr: true,
                     terminal_size: None,
                 };
 
@@ -1789,6 +1791,7 @@ where
                             interactive: false,
                             detach: false,
                             silent: false,
+                            stdout_to_stderr: true,
                             terminal_size: None,
                         };
                         let container_id = &config.container_id;
@@ -1997,6 +2000,7 @@ where
         interactive: false,
         detach: false,
         silent: false,
+        stdout_to_stderr: true,
         terminal_size: None,
     };
 

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -450,6 +450,11 @@ pub struct ExecConfig {
     pub detach: bool,
     /// Whether to suppress stdout/stderr (for internal probe commands)
     pub silent: bool,
+    /// Route the child's stdout into deacon's stderr instead of stdout. Used
+    /// for lifecycle commands during `up` so the result JSON stays the sole
+    /// stdout content (per the streams contract in CLAUDE.md). Ignored when
+    /// `silent` is true (no inheritance in that path). #113.
+    pub stdout_to_stderr: bool,
     /// Optional terminal size hint when allocating a PTY
     pub terminal_size: Option<TerminalSize>,
 }
@@ -1514,8 +1519,13 @@ impl Docker for CliRuntime {
                 stderr,
             })
         } else {
-            // Inherit stdio for real-time display (user-facing commands)
-            // Output cannot be captured in this mode, but user sees it immediately
+            // Inherit stdio for real-time display (user-facing commands).
+            // For lifecycle commands during `up` (stdout_to_stderr=true) the
+            // child's stdout is piped and forwarded to deacon's stderr so the
+            // final result JSON stays the sole stdout content. #113.
+            if config.stdout_to_stderr {
+                cmd.stdout(std::process::Stdio::piped());
+            }
             let mut child = cmd.spawn().map_err(|e| {
                 // Detect PTY-specific errors when PTY was requested
                 if config.tty {
@@ -1531,6 +1541,18 @@ impl Docker for CliRuntime {
                 }
                 DockerError::CLIError(format!("Failed to spawn runtime exec: {}", e))
             })?;
+
+            // Forward child stdout to deacon's stderr when stdout_to_stderr
+            // is set. Lifecycle output remains live-streamed, but it lands on
+            // stderr so the result JSON on stdout stays single-document. #113.
+            if config.stdout_to_stderr {
+                if let Some(mut stdout) = child.stdout.take() {
+                    tokio::spawn(async move {
+                        let mut stderr = tokio::io::stderr();
+                        let _ = tokio::io::copy(&mut stdout, &mut stderr).await;
+                    });
+                }
+            }
 
             let exit_status = child.wait().await.map_err(|e| {
                 // Detect PTY-specific errors when PTY was requested
@@ -3073,6 +3095,7 @@ mod tests {
             interactive: true,
             detach: false,
             silent: false,
+            stdout_to_stderr: false,
             terminal_size: None,
         };
 
@@ -3125,6 +3148,7 @@ mod tests {
             interactive: false,
             detach: false,
             silent: false,
+            stdout_to_stderr: false,
             terminal_size: None,
         };
 

--- a/crates/core/src/user_mapping.rs
+++ b/crates/core/src/user_mapping.rs
@@ -540,6 +540,7 @@ impl<T: Docker> DockerUserMapper<T> {
             interactive: false,
             detach: false,
             silent: true,
+            stdout_to_stderr: false,
             terminal_size: None,
         };
         self.docker.exec(container_id, command, config).await
@@ -976,6 +977,7 @@ impl<T: Docker + Send + Sync> UserMapper for DockerUserMapper<T> {
             interactive: false,
             detach: false,
             silent: true,
+            stdout_to_stderr: false,
             terminal_size: None,
         };
         let result = self.docker.exec(container_id, command, config).await?;

--- a/crates/core/tests/integration_mock_runtime.rs
+++ b/crates/core/tests/integration_mock_runtime.rs
@@ -72,6 +72,7 @@ async fn test_exec_with_mock_docker_success() -> Result<()> {
         interactive: true,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
 
@@ -128,6 +129,7 @@ async fn test_exec_with_mock_docker_failure() -> Result<()> {
         interactive: false,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
 
@@ -173,6 +175,7 @@ async fn test_exec_with_tty_flag_capture() -> Result<()> {
         interactive: true,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
 
@@ -197,6 +200,7 @@ async fn test_exec_with_tty_flag_capture() -> Result<()> {
         interactive: false,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
 
@@ -588,6 +592,7 @@ async fn test_docker_daemon_unavailable_error() -> Result<()> {
         interactive: false,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
 

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -137,6 +137,7 @@ pub fn build_exec_config(
         interactive: true,
         detach: false,
         silent: false,
+        stdout_to_stderr: false,
         terminal_size,
     }
 }

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -665,6 +665,7 @@ async fn run_root_shell<D: Docker>(docker: &D, container_id: &str, script: &str)
         // so set-up's JSON output stays clean. The lifecycle helper handles
         // its own streaming separately.
         silent: true,
+        stdout_to_stderr: false,
         terminal_size: None,
     };
     let result = docker

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -557,6 +557,7 @@ pub(crate) async fn execute_compose_post_create(
                         interactive: false,
                         detach: false,
                         silent: false,
+                        stdout_to_stderr: true,
                         terminal_size: None,
                     },
                 )


### PR DESCRIPTION
Fixes #113.

## Summary
- New \`ExecConfig.stdout_to_stderr\` flag (default false). When set, the inherit-stdio branch in \`docker.rs\` pipes the child's stdout and forwards it to deacon's stderr via a small tokio task. Real-time streaming preserved; result JSON on stdout stays single-document.
- Flag set true at the four lifecycle exec sites in \`container_lifecycle.rs\` plus the compose lifecycle exec in \`up/compose.rs\`. Other callers (\`exec\`, \`set_up\`, probes, user_mapping, mock runtime, etc.) keep the default.
- Adds tokio \`io-std\` feature for \`tokio::io::stderr()\`.

## Test plan
- [x] \`cargo nextest run -p deacon-core\` — 1440/1440 pass
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] e2e: \`deacon up\` against \`examples/up/skip-lifecycle\` emits result JSON as the sole stdout content (lifecycle's \"postAttach executed\", \"Welcome!\" etc. now go to stderr)
- [x] Spot-checked failing deacon-crate tests (\`test_initialize_command_array_syntax\`, \`test_feature_capabilities_applied\`) — same failures on main, pre-existing, unrelated to this change

## Aside
The \`skip-lifecycle\` canary has an unrelated bash bug in its python heredoc invocation that still defeats it post-fix (\`printf | python3 - <<'PY'\` — the heredoc clobbers stdin so printf's JSON is dropped and python tries to parse its own script as JSON). 13 canaries are affected by that pattern; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)