### PR TITLE
docs(examples): fix python heredoc stdin collision in 13 canaries (#115)

### DIFF
--- a/examples/up/additional-mounts/exec.sh
+++ b/examples/up/additional-mounts/exec.sh
@@ -21,11 +21,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cleanup_container() {

--- a/examples/up/basic-image/exec.sh
+++ b/examples/up/basic-image/exec.sh
@@ -21,11 +21,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cd "$SCRIPT_DIR"

--- a/examples/up/configuration-output/exec.sh
+++ b/examples/up/configuration-output/exec.sh
@@ -21,11 +21,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cleanup_container() {

--- a/examples/up/dockerfile-build/exec.sh
+++ b/examples/up/dockerfile-build/exec.sh
@@ -25,11 +25,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cleanup_container() {

--- a/examples/up/dotfiles-integration/exec.sh
+++ b/examples/up/dotfiles-integration/exec.sh
@@ -25,11 +25,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cleanup_container() {

--- a/examples/up/gpu-modes/exec.sh
+++ b/examples/up/gpu-modes/exec.sh
@@ -21,11 +21,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cd "$SCRIPT_DIR"

--- a/examples/up/id-labels-reconnect/exec.sh
+++ b/examples/up/id-labels-reconnect/exec.sh
@@ -25,11 +25,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 labels=(

--- a/examples/up/lifecycle-hooks/exec.sh
+++ b/examples/up/lifecycle-hooks/exec.sh
@@ -21,11 +21,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cd "$SCRIPT_DIR"

--- a/examples/up/prebuild-mode/exec.sh
+++ b/examples/up/prebuild-mode/exec.sh
@@ -25,11 +25,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cd "$SCRIPT_DIR"

--- a/examples/up/remote-env-secrets/exec.sh
+++ b/examples/up/remote-env-secrets/exec.sh
@@ -25,11 +25,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cleanup_container() {

--- a/examples/up/remove-existing/exec.sh
+++ b/examples/up/remove-existing/exec.sh
@@ -24,11 +24,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 deacon_up() {

--- a/examples/up/skip-lifecycle/exec.sh
+++ b/examples/up/skip-lifecycle/exec.sh
@@ -24,11 +24,7 @@ run() {
 }
 
 extract_container_id() {
-	printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data.get("containerId", ""))
-PY
+	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
 cd "$SCRIPT_DIR"

--- a/examples/up/with-features/exec.sh
+++ b/examples/up/with-features/exec.sh
@@ -15,20 +15,7 @@ run() {
 extract_container_id() {
 	local json_out=""
 	if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
-		json_out="$(printf '%s' "$1" | "$PYTHON_BIN" - <<'PY'
-import json, sys
-lines = [ln.strip() for ln in sys.stdin.read().splitlines() if ln.strip()]
-if lines:
-    try:
-        data = json.loads(lines[-1])
-        cid = data.get("containerId", "")
-        if cid:
-            print(cid)
-            sys.exit(0)
-    except json.JSONDecodeError:
-        pass
-sys.exit(0)
-PY
+		json_out="$(printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; lines = [ln.strip() for ln in sys.stdin.read().splitlines() if ln.strip()]; if lines:; try:; data = json.loads(lines[-1]); cid = data.get("containerId", ""); if cid:; print(cid); sys.exit(0); except json.JSONDecodeError:; pass; sys.exit(0)'
 )" || json_out=""
 		if [ -n "$json_out" ]; then
 			printf '%s' "$json_out"


### PR DESCRIPTION
Fixes #115.

## Summary
Rewrites \`extract_container_id\` (or equivalent) across 13 canaries from broken-heredoc \`python3 - <<'PY' ... PY\` to inline \`python3 -c '...'\`. The heredoc form clobbered stdin so printf's piped JSON was dropped and python parsed its own script as JSON.

## Affected canaries
\`up/skip-lifecycle\`, \`up/gpu-modes\`, \`up/lifecycle-hooks\`, \`up/id-labels-reconnect\`, \`up/additional-mounts\`, \`up/remote-env-secrets\`, \`up/basic-image\`, \`up/prebuild-mode\`, \`up/remove-existing\`, \`up/dockerfile-build\`, \`up/configuration-output\`, \`up/with-features\`, \`up/dotfiles-integration\`.

## Test plan
- [x] \`up/skip-lifecycle/exec.sh\` runs end-to-end (exit 0) after #114's deacon-side fix is in
- [x] Pattern verified: \`printf '%s' '{"containerId":"abc"}' | python3 -c 'import json, sys; print(json.load(sys.stdin).get("containerId", ""))'\` → \`abc\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)