### PR TITLE
fix(up): clear lifecycle markers on --remove-existing-container (#117)

### DIFF
--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -575,6 +575,20 @@ pub(crate) async fn execute_container_up(
     // Per SC-002: On resume, skip onCreate, updateContent, postCreate, dotfiles; run postStart, postAttach
     // Per FR-004: On partial resume, skip completed phases, run remaining from earliest incomplete
     //
+    // Spec parity (#117): `--remove-existing-container` destroys and
+    // recreates the container. A new container has never had any lifecycle
+    // phase run on it, so wipe the workspace's prior markers before we
+    // build the invocation context — otherwise onCreate / updateContent /
+    // postCreate are silently skipped on the fresh container.
+    if args.remove_existing_container {
+        if let Err(e) = deacon_core::state::clear_markers(workspace_folder, args.prebuild).await {
+            debug!(
+                "Failed to clear lifecycle markers for --remove-existing-container: {}",
+                e
+            );
+        }
+    }
+
     // Spec parity (#93): filter markers by the *current* config_hash so
     // a re-invocation with a different `--override-config` (or any input
     // that produces a different resolved config) reruns lifecycle from


### PR DESCRIPTION
Fixes #117.

## Summary
When \`--remove-existing-container\` is set, \`up\` now wipes the workspace's \`.devcontainer-state/\` markers before reading prior phase state. A new container has never had any lifecycle phase run on it, so the leftover markers must not gate the fresh run — pre-fix they did, and \`onCreateCommand\` was silently skipped on the recreated container.

Compose path is unaffected (\`execute_compose_post_create\` runs unconditionally and doesn't consult markers).

## Test plan
- [x] \`cargo nextest run -p deacon-core\` — 1440/1440 pass
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] e2e \`examples/up/remove-existing/exec.sh\` — \`✓ Container was replaced after removal\`, \`/tmp/created.txt\` present on the recreated container with a fresh timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)