### PR TITLE
fix(up): support standalone 'readonly' and split external from read-only (#119)

### DIFF
--- a/crates/core/src/mount.rs
+++ b/crates/core/src/mount.rs
@@ -232,8 +232,15 @@ impl Mount {
             }
         }
 
-        // Add additional options
+        // Add additional options.
+        //
+        // Per #119, `external` is a deacon-internal marker (externally-
+        // managed volume — don't create/manage) and is not a valid Docker
+        // `--mount` option. Filter it out before handing to docker.
         for (key, value) in &self.options {
+            if key == "external" {
+                continue;
+            }
             if value.is_empty() {
                 mount_str.push_str(&format!(",{}", key));
             } else {
@@ -291,6 +298,11 @@ impl Mount {
                 "bind-propagation" | "tmpfs-size" | "tmpfs-mode" | "volume-driver"
                 | "volume-label" | "volume-nocopy" | "volume-opt" => {
                     debug!("Using Docker mount option: {}", key);
+                }
+                // Deacon-internal: externally-managed volume marker, filtered
+                // out before handing to docker. Per #119.
+                "external" => {
+                    debug!("external=... is a deacon-internal volume marker");
                 }
                 _ => {
                     warn!("Unknown mount option '{}' may not be supported", key);

--- a/crates/deacon/src/commands/up/args.rs
+++ b/crates/deacon/src/commands/up/args.rs
@@ -24,8 +24,13 @@ pub struct NormalizedMount {
     pub mount_type: MountType,
     pub source: String,
     pub target: String,
-    /// Whether the mount is read-only (adds `:ro` suffix to the volume)
-    /// Parsed from CLI `external=true` for backward compatibility
+    /// Whether the volume is externally managed (not created by deacon). Per
+    /// the spec data model — distinct from read-only. CLI accepts
+    /// `external=true|false`.
+    pub external: bool,
+    /// Whether the mount is read-only. CLI accepts the Docker-aligned
+    /// `readonly` (bare), `readonly=true|false`, or `ro` (bare). Per #119,
+    /// distinct from `external`.
     pub read_only: bool,
     /// Mount consistency option (cached, consistent, delegated)
     /// Only applicable to bind mounts on macOS for performance tuning
@@ -42,11 +47,12 @@ pub enum MountType {
 impl NormalizedMount {
     /// Parse and validate a mount string from CLI.
     ///
-    /// Expected format: `type=(bind|volume),source=<path>,target=<path>[,external=(true|false)][,consistency=(cached|consistent|delegated)]`
+    /// Expected format: `type=(bind|volume),source=<path>,target=<path>[,external=(true|false)][,readonly|readonly=(true|false)|ro][,consistency=(cached|consistent|delegated)]`
     ///
-    /// Note: The `external` option in CLI maps to `read_only` field internally.
-    /// This maintains backward compatibility while using clearer naming in code.
-    /// The optional fields (external, consistency) can appear in any order.
+    /// Per #119, `readonly` (bare or `=true/false`) and `ro` (bare) are
+    /// Docker-aligned aliases for the read-only flag — distinct from
+    /// `external`, which marks externally-managed volumes per the spec data
+    /// model. Optional fields may appear in any order.
     ///
     /// Returns error if format is invalid or required fields are missing.
     pub fn parse(mount_str: &str) -> Result<Self> {
@@ -55,6 +61,7 @@ impl NormalizedMount {
         let mut source: Option<&str> = None;
         let mut target: Option<&str> = None;
         let mut external: Option<&str> = None;
+        let mut read_only_flag: Option<&str> = None;
         let mut consistency: Option<&str> = None;
 
         for part in mount_str.split(',') {
@@ -64,6 +71,8 @@ impl NormalizedMount {
                     "source" => source = Some(value),
                     "target" => target = Some(value),
                     "external" => external = Some(value),
+                    "readonly" => read_only_flag = Some(value),
+                    "ro" => read_only_flag = Some(value),
                     "consistency" => consistency = Some(value),
                     _ => {
                         return Err(DeaconError::Config(
@@ -78,15 +87,24 @@ impl NormalizedMount {
                     }
                 }
             } else {
-                return Err(
-                    DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-                        message: format!(
-                            "Invalid mount format: '{}'. Expected key=value format",
-                            mount_str
-                        ),
-                    })
-                    .into(),
-                );
+                // Per Docker `--mount` syntax and #119, bare keywords
+                // `readonly` and `ro` set read-only on the mount.
+                match part {
+                    "readonly" | "ro" => {
+                        read_only_flag = Some("true");
+                    }
+                    _ => {
+                        return Err(DeaconError::Config(
+                            deacon_core::errors::ConfigError::Validation {
+                                message: format!(
+                                    "Invalid mount format: '{}'. Expected key=value format",
+                                    mount_str
+                                ),
+                            },
+                        )
+                        .into());
+                    }
+                }
             }
         }
 
@@ -136,7 +154,7 @@ impl NormalizedMount {
         };
 
         // Validate external value if provided
-        let read_only = match external {
+        let external_flag = match external {
             Some("true") => true,
             Some("false") | None => false,
             Some(val) => {
@@ -144,6 +162,22 @@ impl NormalizedMount {
                     DeaconError::Config(deacon_core::errors::ConfigError::Validation {
                         message: format!(
                         "Invalid mount format: '{}'. external must be 'true' or 'false', got: '{}'",
+                        mount_str, val
+                    ),
+                    })
+                    .into(),
+                )
+            }
+        };
+
+        let read_only = match read_only_flag {
+            Some("true") | Some("") => true,
+            Some("false") | None => false,
+            Some(val) => {
+                return Err(
+                    DeaconError::Config(deacon_core::errors::ConfigError::Validation {
+                        message: format!(
+                        "Invalid mount format: '{}'. readonly must be 'true' or 'false' (or bare), got: '{}'",
                         mount_str, val
                     ),
                     })
@@ -175,6 +209,7 @@ impl NormalizedMount {
             mount_type,
             source: source.to_string(),
             target: target.to_string(),
+            external: external_flag,
             read_only,
             consistency,
         })
@@ -194,8 +229,13 @@ impl NormalizedMount {
             format!("target={}", self.target),
         ];
 
+        // Per #119, `external` is a deacon-internal marker (externally-
+        // managed volume) — not a valid `docker --mount` option. It lives
+        // on NormalizedMount.external for downstream logic and is NOT
+        // round-tripped into the docker mount string.
+
         if self.read_only {
-            parts.push("external=true".to_string());
+            parts.push("readonly".to_string());
         }
 
         if let Some(ref consistency) = self.consistency {

--- a/crates/deacon/src/commands/up/tests.rs
+++ b/crates/deacon/src/commands/up/tests.rs
@@ -218,12 +218,14 @@ fn test_normalized_mount_parse_bind() {
 
 #[test]
 fn test_normalized_mount_parse_volume_with_external() {
+    // Per #119: external is distinct from read_only.
     let mount =
         NormalizedMount::parse("type=volume,source=myvolume,target=/data,external=true").unwrap();
     assert!(matches!(mount.mount_type, MountType::Volume));
     assert_eq!(mount.source, "myvolume");
     assert_eq!(mount.target, "/data");
-    assert!(mount.read_only);
+    assert!(mount.external);
+    assert!(!mount.read_only);
     assert!(mount.consistency.is_none());
 }
 
@@ -260,11 +262,13 @@ fn test_normalized_mount_parse_with_consistency_consistent() {
 
 #[test]
 fn test_normalized_mount_parse_with_external_and_consistency() {
+    // Per #119: external is distinct from read_only.
     let mount = NormalizedMount::parse(
         "type=bind,source=/host/path,target=/container/path,external=true,consistency=cached",
     )
     .unwrap();
-    assert!(mount.read_only);
+    assert!(mount.external);
+    assert!(!mount.read_only);
     assert_eq!(mount.consistency, Some("cached".to_string()));
 }
 
@@ -275,8 +279,34 @@ fn test_normalized_mount_parse_with_consistency_before_external() {
         "type=bind,source=/host/path,target=/container/path,consistency=cached,external=true",
     )
     .unwrap();
-    assert!(mount.read_only);
+    assert!(mount.external);
+    assert!(!mount.read_only);
     assert_eq!(mount.consistency, Some("cached".to_string()));
+}
+
+#[test]
+fn test_normalized_mount_parse_readonly_bare() {
+    // Per #119: Docker's `readonly` bare keyword is accepted and is
+    // distinct from `external`.
+    let mount =
+        NormalizedMount::parse("type=bind,source=/host,target=/container,readonly").unwrap();
+    assert!(mount.read_only);
+    assert!(!mount.external);
+}
+
+#[test]
+fn test_normalized_mount_parse_ro_bare() {
+    let mount = NormalizedMount::parse("type=bind,source=/host,target=/container,ro").unwrap();
+    assert!(mount.read_only);
+    assert!(!mount.external);
+}
+
+#[test]
+fn test_normalized_mount_parse_readonly_and_external_are_distinct() {
+    let mount =
+        NormalizedMount::parse("type=volume,source=v,target=/data,external=true,readonly").unwrap();
+    assert!(mount.external);
+    assert!(mount.read_only);
 }
 
 #[test]
@@ -285,6 +315,7 @@ fn test_normalized_mount_to_spec_string_with_consistency() {
         mount_type: MountType::Bind,
         source: "/host/path".to_string(),
         target: "/container/path".to_string(),
+        external: false,
         read_only: false,
         consistency: Some("cached".to_string()),
     };
@@ -297,17 +328,36 @@ fn test_normalized_mount_to_spec_string_with_consistency() {
 }
 
 #[test]
-fn test_normalized_mount_to_spec_string_with_external_and_consistency() {
+fn test_normalized_mount_to_spec_string_does_not_emit_external() {
+    // Per #119: `external` is a deacon-internal flag, not a Docker
+    // `--mount` option. NormalizedMount keeps the bit on `.external`
+    // for downstream logic but doesn't round-trip it into the mount
+    // string handed to docker (docker rejects unknown options).
     let mount = NormalizedMount {
         mount_type: MountType::Bind,
         source: "/host/path".to_string(),
         target: "/container/path".to_string(),
-        read_only: true,
+        external: true,
+        read_only: false,
         consistency: Some("delegated".to_string()),
     };
     let spec_string = mount.to_spec_string();
-    assert!(spec_string.contains("external=true"));
+    assert!(!spec_string.contains("external"));
     assert!(spec_string.contains("consistency=delegated"));
+}
+
+#[test]
+fn test_normalized_mount_to_spec_string_emits_readonly() {
+    let mount = NormalizedMount {
+        mount_type: MountType::Bind,
+        source: "/host/path".to_string(),
+        target: "/container/path".to_string(),
+        external: false,
+        read_only: true,
+        consistency: None,
+    };
+    let spec_string = mount.to_spec_string();
+    assert!(spec_string.ends_with(",readonly"));
 }
 
 #[test]

--- a/crates/deacon/tests/up_validation.rs
+++ b/crates/deacon/tests/up_validation.rs
@@ -22,12 +22,15 @@ fn test_normalized_mount_validation_bind_basic() {
 
 #[test]
 fn test_normalized_mount_validation_volume_with_external() {
+    // Per #119: external (externally-managed volume marker) is distinct
+    // from read_only.
     let result = NormalizedMount::parse("type=volume,source=myvolume,target=/data,external=true");
     assert!(result.is_ok());
     let mount = result.unwrap();
     assert_eq!(mount.source, "myvolume");
     assert_eq!(mount.target, "/data");
-    assert!(mount.read_only);
+    assert!(mount.external);
+    assert!(!mount.read_only);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #119.

## Summary
Two related defects in \`--mount\` parsing:
1. Docker's bare \`readonly\` keyword (and \`ro\` alias) was rejected with \"Expected key=value format\".
2. \`NormalizedMount.read_only\` was being set from CLI \`external=true\` and serialized back as \`external=true\`, conflating two distinct spec concepts.

Fixes:
- Split \`NormalizedMount\` into \`external\` (externally-managed volume marker per the data model) and \`read_only\` (Docker read-only flag).
- Accept \`readonly\`, \`readonly=true|false\`, and \`ro\` per Docker's mount syntax.
- \`to_spec_string\` emits \`readonly\` when set; \`external\` is kept on the struct for downstream logic but NOT serialized into the docker mount string (docker rejects unknown options).
- Defensive filter in \`core::mount::Mount::to_docker_args\` in case \`external\` sneaks through via JSON config.mounts.

## Test plan
- [x] \`cargo nextest run -p deacon up::tests\` — 116 pass (new: \`readonly_bare\`, \`ro_bare\`, \`readonly_and_external_are_distinct\`, \`to_spec_string_does_not_emit_external\`, \`to_spec_string_emits_readonly\`)
- [x] \`cargo nextest run -p deacon-core\` — 1440/1440 pass
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`examples/up/additional-mounts/exec.sh\` runs all 3 scenarios (basic + runtime mounts with \`readonly\` + external volume) end-to-end without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)