### PR TITLE
fix(run-user-commands): honor --prebuild (stop after updateContent)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,7 +67,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=up_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -168,7 +168,7 @@ filter = 'binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=up_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -26,7 +26,6 @@ pub struct RunUserCommandsArgs {
     pub skip_post_create: bool,
     pub skip_post_attach: bool,
     pub skip_non_blocking_commands: bool,
-    #[allow(dead_code)] // Future feature: prebuild mode
     pub prebuild: bool,
     #[allow(dead_code)] // Future feature: stop for personalization
     pub stop_for_personalization: bool,
@@ -161,7 +160,7 @@ async fn execute_lifecycle_commands(
         force_pty: false,
         // run-user-commands does not install dotfiles - that is handled by `up` command
         dotfiles: None,
-        is_prebuild: false,
+        is_prebuild: args.prebuild,
         config_hash: None,
     };
 
@@ -222,7 +221,12 @@ async fn execute_lifecycle_commands(
     }
 
     // Phase 3: postCreate (container, can be skipped)
+    // In prebuild mode the run stops after updateContent (postCreate, dotfiles,
+    // postStart, postAttach are all skipped — see InvocationMode::Prebuild in
+    // core::lifecycle and the `up` parity path), so gate postCreate onward on
+    // `!args.prebuild` in addition to `--skip-post-create`.
     if !args.skip_post_create
+        && !args.prebuild
         && should_queue_phase_for_wait_for(
             args.skip_non_blocking_commands,
             wait_for,
@@ -236,12 +240,15 @@ async fn execute_lifecycle_commands(
         }
     }
 
-    // Phase 4: postStart (container, non-blocking, can be skipped)
-    if should_queue_phase_for_wait_for(
-        args.skip_non_blocking_commands,
-        wait_for,
-        LifecyclePhase::PostStart,
-    ) {
+    // Phase 4: postStart (container, non-blocking, can be skipped).
+    // Also skipped in prebuild mode (stops after updateContent).
+    if !args.prebuild
+        && should_queue_phase_for_wait_for(
+            args.skip_non_blocking_commands,
+            wait_for,
+            LifecyclePhase::PostStart,
+        )
+    {
         if let Some(ref post_start) = config.post_start_command {
             if let Some(cmd_list) = parse_phase_command(post_start, "postStartCommand")? {
                 commands = commands.with_post_start(cmd_list);

--- a/crates/deacon/tests/run_user_commands_prebuild.rs
+++ b/crates/deacon/tests/run_user_commands_prebuild.rs
@@ -1,0 +1,163 @@
+//! Integration test for `run-user-commands --prebuild` lifecycle boundary.
+//!
+//! Per `docs/subcommand-specs/run-user-commands/SPEC.md`, `--prebuild` stops
+//! after `onCreateCommand` and `updateContentCommand`, skipping postCreate,
+//! dotfiles, postStart, and postAttach (the same set as
+//! `core::lifecycle::LifecyclePhase::is_skipped_in_prebuild`).
+//!
+//! Unlike the `up_prebuild.rs` tests (which defer marker inspection to manual
+//! testing), this test verifies the boundary concretely by inspecting marker
+//! files written by each lifecycle phase inside the container.
+//!
+//! Requires Docker; self-skips when unavailable.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Marker name -> true if the flag file must exist in the container.
+fn marker_present(container_id: &str, marker: &str) -> bool {
+    std::process::Command::new("docker")
+        .args([
+            "exec",
+            container_id,
+            "test",
+            "-f",
+            &format!("/tmp/{}.flag", marker),
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn find_container(name: &str) -> Option<String> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=devcontainer.source=deacon",
+            "--filter",
+            &format!("label=devcontainer.name={}", name),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .ok()?;
+    let id = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    id
+}
+
+/// Removes the named container on drop so cleanup runs even if an assertion
+/// panics mid-test.
+struct ContainerGuard(String);
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+#[test]
+fn test_run_user_commands_prebuild_stops_after_update_content() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_run_user_commands_prebuild_stops_after_update_content: Docker not available");
+        return;
+    }
+
+    let name = "Deacon Prebuild RUC Test";
+    let temp_dir = TempDir::new().unwrap();
+    let config = format!(
+        r#"{{
+    "name": "{name}",
+    "image": "alpine:3.18",
+    "remoteUser": "root",
+    "workspaceFolder": "/workspace",
+    "onCreateCommand": "echo onCreate > /tmp/onCreate.flag",
+    "updateContentCommand": "echo updateContent > /tmp/updateContent.flag",
+    "postCreateCommand": "echo postCreate > /tmp/postCreate.flag",
+    "postStartCommand": "echo postStart > /tmp/postStart.flag",
+    "postAttachCommand": "echo postAttach > /tmp/postAttach.flag"
+}}"#
+    );
+    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/devcontainer.json"),
+        config,
+    )
+    .unwrap();
+
+    // Bring the container up with postCreate+ suppressed so only onCreate and
+    // updateContent fire during `up`.
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(&temp_dir)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .arg("--remove-existing-container")
+        .arg("--skip-post-create")
+        .assert()
+        .success();
+
+    let container_id = find_container(name).expect("container should exist after up");
+    let _guard = ContainerGuard(container_id.clone());
+
+    // Ensure no later markers leaked in, then prove --prebuild does not create them.
+    let _ = std::process::Command::new("docker")
+        .args([
+            "exec",
+            &container_id,
+            "sh",
+            "-c",
+            "rm -f /tmp/postCreate.flag /tmp/postStart.flag /tmp/postAttach.flag",
+        ])
+        .status();
+
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(&temp_dir)
+        .arg("run-user-commands")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .arg("--prebuild")
+        .assert()
+        .success();
+
+    // onCreate + updateContent run; postCreate/postStart/postAttach must NOT.
+    assert!(
+        marker_present(&container_id, "updateContent"),
+        "updateContent should run in prebuild mode"
+    );
+    assert!(
+        !marker_present(&container_id, "postCreate"),
+        "postCreate must be skipped in prebuild mode"
+    );
+    assert!(
+        !marker_present(&container_id, "postStart"),
+        "postStart must be skipped in prebuild mode"
+    );
+    assert!(
+        !marker_present(&container_id, "postAttach"),
+        "postAttach must be skipped in prebuild mode"
+    );
+}


### PR DESCRIPTION
## Summary

`run-user-commands --prebuild` was parsed but **ignored** — the flag carried `#[allow(dead_code)] // Future feature` and `is_prebuild` was hardcoded to `false`, so every invocation ran the full lifecycle (onCreate → postAttach) regardless of `--prebuild`.

Per [`run-user-commands/SPEC.md`](docs/subcommand-specs/run-user-commands/SPEC.md), `--prebuild` *"stops after onCreateCommand and updateContentCommand"*, skipping postCreate, dotfiles, postStart, and postAttach — the same phase set as `core::lifecycle::LifecyclePhase::is_skipped_in_prebuild`, which `up` already honors via its `InvocationContext`.

## Fix
- Gate the postCreate phase on `!args.prebuild` (alongside `--skip-post-create`).
- Gate the postStart/postAttach block on `!args.prebuild`.
- Propagate `is_prebuild: args.prebuild` into the lifecycle config (marker recording + dotfiles skip).

## How it was found
The `examples/run-user-commands/basic` canary (scenario 3, *"--prebuild stops after updateContent"*) failed with postCreate present. After the fix, all five scenarios pass.

## Testing
- New Docker-gated integration test `run_user_commands_prebuild` verifies the boundary concretely by inspecting in-container marker files (stronger than the existing `up_prebuild.rs` tests, which defer marker inspection). It would have caught this bug.
- Grouped `docker-exclusive` in `.config/nextest.toml` across the `default` and `dev-fast` profiles, mirroring `up_prebuild`.
- `cargo fmt`/`clippy` clean; the new test passes locally against Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)