### PR TITLE
feat(build): support feature installation on image-reference configs

### DIFF
--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -637,24 +637,27 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
 
     // PR-4c: feature installation during build.
     //
-    // Dockerfile-based builds support features via a post-build layering pass
-    // (we run the user's `docker build`, then layer a feature-install stage
-    // on top of the resulting image using `build_image_with_features` —
-    // the same helper the `up` command uses, which also produces a lockfile).
+    // Dockerfile- and image-reference-based builds support features via a
+    // post-build layering pass (we run the base build, then layer a
+    // feature-install stage on top of the resulting image using
+    // `build_image_with_features` — the same helper the `up` command uses,
+    // which also produces a lockfile). Image-reference builds already route
+    // through `execute_docker_build` (synthetic `FROM <image>` Dockerfile),
+    // which applies the deterministic `deacon-build:<hash>` tag, so the same
+    // post-build pass at the end of this function handles them transparently.
     //
-    // Compose and image-reference builds still fail fast: they need different
-    // integration patterns (compose-build is workspace-of-services, image-ref
-    // wraps a pre-built upstream image with a synthetic Dockerfile) and the
-    // work to support each is tracked separately.
+    // Compose builds still fail fast: they're a workspace-of-services and
+    // layering features onto a targeted service's image needs the compose
+    // integration path (the `up` compose flow); that work is tracked separately.
     let features_present = !config.features.is_null()
         && config
             .features
             .as_object()
             .is_some_and(|obj| !obj.is_empty());
-    if features_present && (config.uses_compose() || config.image.is_some()) {
+    if features_present && config.uses_compose() {
         return Err(anyhow!(
-            "Feature installation during build is not yet supported for compose or \
-             image-reference configurations. Use a Dockerfile-based build, or run \
+            "Feature installation during build is not yet supported for Docker Compose \
+             configurations. Use a Dockerfile- or image-based build, or run \
              'deacon up' which supports all configurations."
         ));
     }
@@ -748,7 +751,20 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
             .first()
             .cloned()
             .unwrap_or_else(|| result.image_id.clone());
-        apply_features_and_lockfile(&config, &base_ref, &workspace_folder, &config_path).await?
+        let (feature_image, lockfile) =
+            apply_features_and_lockfile(&config, &base_ref, &workspace_folder, &config_path)
+                .await?;
+
+        // Re-point the base build's tags (the deterministic `deacon-build:<hash>`
+        // tag plus any `--image-name`s) at the feature-extended image. Without
+        // this, `--image-name` would still resolve to the pre-feature base image
+        // and the installed features would be invisible to consumers that pull
+        // the named tag.
+        for tag in &result.tags {
+            retag_image(&feature_image, tag).await?;
+        }
+
+        (feature_image, lockfile)
     } else {
         (result.image_id, None)
     };
@@ -1346,9 +1362,10 @@ async fn execute_image_reference_build(
         escaped_metadata
     ));
 
-    // TODO: Apply features if specified in config
-    // This would require feature resolution and installation script generation
-    // For now, image-reference builds with features are a future enhancement
+    // Features (if any) are layered on top of this base by the post-build
+    // `apply_features_and_lockfile` pass in `execute_build`: this synthetic
+    // image is tagged `deacon-build:<hash>` by `execute_docker_build` below,
+    // and that tag becomes the `FROM` base for the feature-install stage.
 
     let dockerfile_path = temp_dir.join("Dockerfile");
     tokio::fs::write(&dockerfile_path, dockerfile_content).await?;
@@ -1372,6 +1389,39 @@ async fn execute_image_reference_build(
     let _ = tokio::fs::remove_dir_all(&temp_dir).await;
 
     result
+}
+
+/// Apply `target` as an additional tag on the local image `source`
+/// (`docker tag source target`).
+///
+/// Used after the post-build feature pass to re-point the base build's tags at
+/// the feature-extended image, so `--image-name` resolves to the image that
+/// actually contains the installed features.
+async fn retag_image(source: &str, target: &str) -> Result<()> {
+    let output = tokio::process::Command::new("docker")
+        .args(["tag", source, target])
+        .output()
+        .await
+        .map_err(|e| {
+            DeaconError::Docker(DockerError::CLIError(format!(
+                "Failed to run 'docker tag {} {}': {}",
+                source, target, e
+            )))
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DeaconError::Docker(DockerError::CLIError(format!(
+            "Failed to tag '{}' as '{}': {}",
+            source,
+            target,
+            stderr.trim()
+        )))
+        .into());
+    }
+
+    debug!("Re-tagged feature image '{}' as '{}'", source, target);
+    Ok(())
 }
 
 /// PR-4c: layer features on top of the just-built image and write the

--- a/crates/deacon/tests/integration_build.rs
+++ b/crates/deacon/tests/integration_build.rs
@@ -206,7 +206,11 @@ fn test_build_image_reference_with_features_tags_final_image() {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains(r#""outcome":"success"#), "stdout: {}", stdout);
+    assert!(
+        stdout.contains(r#""outcome":"success"#),
+        "stdout: {}",
+        stdout
+    );
 
     // The named tag must contain the feature's marker file.
     let run = std::process::Command::new("docker")
@@ -217,8 +221,7 @@ fn test_build_image_reference_with_features_tags_final_image() {
         .args(["rmi", "-f", image_tag])
         .output();
     assert!(
-        run.status.success()
-            && String::from_utf8_lossy(&run.stdout).contains("installed"),
+        run.status.success() && String::from_utf8_lossy(&run.stdout).contains("installed"),
         "--image-name should resolve to the feature-extended image; stdout={:?} stderr={:?}",
         String::from_utf8_lossy(&run.stdout),
         String::from_utf8_lossy(&run.stderr)

--- a/crates/deacon/tests/integration_build.rs
+++ b/crates/deacon/tests/integration_build.rs
@@ -145,6 +145,86 @@ fn test_build_with_image_config() {
     }
 }
 
+/// Image-reference config + features: `build` now layers the declared features
+/// on top of the base image (post-build pass), and the user-supplied
+/// `--image-name` must resolve to the *feature-extended* image — not the
+/// pre-feature base. Regression guard for the retag step in `execute_build`.
+#[test]
+fn test_build_image_reference_with_features_tags_final_image() {
+    let temp_dir = TempDir::new().unwrap();
+
+    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+
+    // Local feature (resolved relative to the config dir) that drops a marker
+    // file during install.
+    let feature_dir = temp_dir.path().join(".devcontainer/features/marker");
+    fs::create_dir_all(&feature_dir).unwrap();
+    fs::write(
+        feature_dir.join("devcontainer-feature.json"),
+        r#"{ "id": "marker", "version": "1.0.0", "name": "Marker" }"#,
+    )
+    .unwrap();
+    fs::write(
+        feature_dir.join("install.sh"),
+        "#!/usr/bin/env bash\nset -e\necho installed > /feature-marker.txt\n",
+    )
+    .unwrap();
+
+    fs::write(
+        temp_dir.path().join(".devcontainer/devcontainer.json"),
+        r#"{
+    "name": "Image Ref With Features",
+    "image": "debian:bookworm-slim",
+    "remoteUser": "root",
+    "features": { "./features/marker": {} }
+}
+"#,
+    )
+    .unwrap();
+
+    let image_tag = "deacon-test/imgref-features:latest";
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let assert = cmd
+        .current_dir(&temp_dir)
+        .arg("build")
+        .arg("--image-name")
+        .arg(image_tag)
+        .arg("--output-format")
+        .arg("json")
+        .assert();
+
+    let output = assert.get_output();
+    if !output.status.success() {
+        // Docker unavailable / not permitted: ensure it failed for that reason.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("Docker") || stderr.contains("permission denied"),
+            "Expected Docker-related error, got: {}",
+            stderr
+        );
+        return;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(r#""outcome":"success"#), "stdout: {}", stdout);
+
+    // The named tag must contain the feature's marker file.
+    let run = std::process::Command::new("docker")
+        .args(["run", "--rm", image_tag, "cat", "/feature-marker.txt"])
+        .output()
+        .expect("docker run");
+    let _ = std::process::Command::new("docker")
+        .args(["rmi", "-f", image_tag])
+        .output();
+    assert!(
+        run.status.success()
+            && String::from_utf8_lossy(&run.stdout).contains("installed"),
+        "--image-name should resolve to the feature-extended image; stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
 #[test]
 fn test_build_command_flags() {
     let temp_dir = TempDir::new().unwrap();

--- a/examples/build/image-reference-with-features/.devcontainer.json
+++ b/examples/build/image-reference-with-features/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "image-reference-with-features",
-  "image": "alpine:3.19",
+  "image": "debian:bookworm-slim",
   "features": { "./features/hello": {} },
   "remoteUser": "root"
 }


### PR DESCRIPTION
## Summary

Addresses half of the deferred *"feature installation during build is not yet supported for compose or image-reference configurations"* gate (`build/mod.rs`), surfaced this session by the `image-reference-with-features` canary.

Image-reference builds already route through `execute_docker_build` (a synthetic `FROM <image>` Dockerfile) which applies the deterministic `deacon-build:<hash>` tag, so the existing post-build feature-layering pass handles them with **no new integration path** — only the gate needed to stop rejecting them. Compose builds still fail fast (tracked separately): layering features onto a targeted compose service needs the `up` compose flow.

## Latent bug also fixed
After features are layered into a *new* image, the base build's tags (the `--image-name`s and the deterministic tag) still pointed at the **pre-feature base** image — so `--image-name` resolved to an image *without* the features. `execute_build` now re-tags the feature-extended image with each of those tags (new `retag_image` helper). This also corrects the **Dockerfile + features** path, whose canaries previously only checked the JSON outcome, not image contents.

## Changes
- `build/mod.rs`: narrow the feature-install gate to compose-only; re-tag the feature-extended image with the base build's tags; refresh stale comments.
- `examples/build/image-reference-with-features`: base `alpine:3.19` → `debian:bookworm-slim` (bash feature script); canary verifies the feature artifact in the named image.
- New `integration_build` regression test asserting `--image-name` resolves to the feature-extended image.

## Testing
- New test `test_build_image_reference_with_features_tags_final_image` passes (Docker).
- `buildkit-gated-feature`, `dockerfile-with-features`, `image-reference-with-features` canaries all pass end-to-end (feature artifact present in the named image).
- `cargo fmt`/`clippy` clean.

## Remaining deferral
Compose + features build (`compose-with-features` canary) — needs the compose-service feature-layering path; left as a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)