### PR TITLE
feat(build): support feature installation for Docker Compose configs

### DIFF
--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -637,30 +637,18 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
 
     // PR-4c: feature installation during build.
     //
-    // Dockerfile- and image-reference-based builds support features via a
-    // post-build layering pass (we run the base build, then layer a
-    // feature-install stage on top of the resulting image using
-    // `build_image_with_features` — the same helper the `up` command uses,
-    // which also produces a lockfile). Image-reference builds already route
-    // through `execute_docker_build` (synthetic `FROM <image>` Dockerfile),
-    // which applies the deterministic `deacon-build:<hash>` tag, so the same
-    // post-build pass at the end of this function handles them transparently.
-    //
-    // Compose builds still fail fast: they're a workspace-of-services and
-    // layering features onto a targeted service's image needs the compose
-    // integration path (the `up` compose flow); that work is tracked separately.
+    // Feature installation is supported for all configuration shapes:
+    // - Dockerfile and image-reference builds layer features via a post-build
+    //   pass (run the base build → `deacon-build:<hash>` tagged image →
+    //   `build_image_with_features` FROMs that tag). See below.
+    // - Compose builds resolve the target service's shape and build a
+    //   feature-extended image via `execute_compose_build_with_features`
+    //   (the same `resolve_compose_feature_image` helper the `up` flow uses).
     let features_present = !config.features.is_null()
         && config
             .features
             .as_object()
             .is_some_and(|obj| !obj.is_empty());
-    if features_present && config.uses_compose() {
-        return Err(anyhow!(
-            "Feature installation during build is not yet supported for Docker Compose \
-             configurations. Use a Dockerfile- or image-based build, or run \
-             'deacon up' which supports all configurations."
-        ));
-    }
 
     // Check cache if not forced (skip cache if pushing or exporting).
     // When features are present we deliberately skip the cache check: the
@@ -696,7 +684,21 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
 
     // Dispatch to appropriate build function based on configuration type
     let result = if config.uses_compose() {
-        execute_compose_build(&config, &args, &workspace_folder, &labels, &config_hash).await
+        if features_present {
+            // Compose + features: build the feature-extended image for the target
+            // service directly (shape-aware), tag it, and write the lockfile.
+            execute_compose_build_with_features(
+                &config,
+                &args,
+                &workspace_folder,
+                &config_path,
+                &labels,
+                &config_hash,
+            )
+            .await
+        } else {
+            execute_compose_build(&config, &args, &workspace_folder, &labels, &config_hash).await
+        }
     } else if config.image.is_some() {
         execute_image_reference_build(&config, &args, &workspace_folder, &labels).await
     } else {
@@ -738,7 +740,11 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
     // feature install stages on top, then write the lockfile next to the
     // config file. This matches `up`'s feature flow (`build_image_with_features`)
     // which also returns a `Lockfile` ready for `write_lockfile`.
-    let (image_id, feature_lockfile) = if features_present {
+    // Compose + features is fully handled in the dispatch above
+    // (`execute_compose_build_with_features` already built, tagged, and wrote the
+    // lockfile), so only the Dockerfile / image-reference shapes need this
+    // generic post-build layering pass.
+    let (image_id, feature_lockfile) = if features_present && !config.uses_compose() {
         // Layer features on top of the just-built image. We pass a real tag
         // (the deterministic `deacon-build:<hash>` tag, always applied by
         // `execute_docker_build`) rather than the bare `sha256:...` image ID:
@@ -1309,6 +1315,104 @@ async fn execute_compose_build(
         image_id: format!("{}-{}", project.name, service),
         tags: image_names,
         build_duration,
+        metadata,
+        config_hash: config_hash.to_string(),
+    })
+}
+
+/// Execute a Compose build that also installs declared features.
+///
+/// Unlike `execute_compose_build` (a plain `docker compose build`), this resolves
+/// the target service's shape (`image:` vs `build:`) and builds a
+/// feature-extended image via the same helper `up` uses
+/// (`resolve_compose_feature_image`), then tags that image with the
+/// deterministic `deacon-build:<hash>` tag plus any `--image-name`s and writes
+/// the feature lockfile next to the config.
+#[instrument(skip(config, args, workspace_folder, config_path, labels))]
+async fn execute_compose_build_with_features(
+    config: &DevContainerConfig,
+    args: &BuildArgs,
+    workspace_folder: &Path,
+    config_path: &Path,
+    labels: &[(String, String)],
+    config_hash: &str,
+) -> Result<BuildResult> {
+    use crate::commands::up::compose::resolve_compose_feature_image;
+    use deacon_core::compose::ComposeManager;
+    use deacon_core::container::ContainerIdentity;
+    use deacon_core::lockfile::{get_lockfile_path, write_lockfile};
+
+    let service = config
+        .service
+        .as_ref()
+        .ok_or_else(|| anyhow!("Docker Compose configuration must specify a service"))?;
+
+    let compose_manager = ComposeManager::new();
+    let project = compose_manager.create_project(config, workspace_folder)?;
+    if !compose_manager
+        .validate_service_exists(&project, service)
+        .await?
+    {
+        return Err(anyhow!(
+            "Service '{}' not found in Docker Compose configuration",
+            service
+        ));
+    }
+
+    // Namespace the produced image by workspace (+ `-build`) so it does not
+    // collide with `up`'s compose feature image on the same host.
+    let identity = ContainerIdentity::new(workspace_folder, config);
+    let workspace_hash = format!("{}-build", identity.workspace_hash);
+
+    let feature_build = resolve_compose_feature_image(
+        config,
+        &compose_manager,
+        &project,
+        workspace_folder,
+        config_path,
+        &workspace_hash,
+    )
+    .await?
+    .ok_or_else(|| anyhow!("Compose feature build produced no image (no features declared?)"))?;
+
+    // Tag the feature-extended image with the deterministic tag + user image names
+    // so `--image-name` resolves to the image with features installed.
+    let deterministic_tag = format!("deacon-build:{}", &config_hash[..12.min(config_hash.len())]);
+    let mut all_tags = vec![deterministic_tag];
+    all_tags.extend(args.image_names.clone());
+    for tag in &all_tags {
+        retag_image(&feature_build.image_tag, tag).await?;
+    }
+
+    // Write the feature lockfile next to the config (best-effort on read-only FS).
+    let lockfile_path = get_lockfile_path(config_path);
+    match write_lockfile(&lockfile_path, &feature_build.lockfile, true).await {
+        Ok(()) => debug!("Wrote feature lockfile to '{}'", lockfile_path.display()),
+        Err(e) => {
+            let e = anyhow::Error::from(e);
+            if is_readonly_filesystem_error(&e) {
+                warn!(
+                    path = %lockfile_path.display(),
+                    error = %e,
+                    "Lockfile write skipped (read-only workspace); continuing"
+                );
+            } else {
+                return Err(e).with_context(|| {
+                    format!("Failed to write lockfile to '{}'", lockfile_path.display())
+                });
+            }
+        }
+    }
+
+    let mut metadata = HashMap::new();
+    for (key, value) in labels {
+        metadata.insert(key.clone(), value.clone());
+    }
+
+    Ok(BuildResult {
+        image_id: feature_build.image_tag,
+        tags: all_tags,
+        build_duration: 0.0,
         metadata,
         config_hash: config_hash.to_string(),
     })

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -598,6 +598,40 @@ async fn install_features_for_compose(
     config_path: &Path,
     workspace_hash: &str,
 ) -> Result<Option<FeatureBuildOutput>> {
+    let output = match resolve_compose_feature_image(
+        config,
+        compose_manager,
+        project,
+        workspace_folder,
+        config_path,
+        workspace_hash,
+    )
+    .await?
+    {
+        Some(o) => o,
+        None => return Ok(None),
+    };
+
+    // `up` rewrites the target service's `image:` line to the extended tag so
+    // the container runs with features installed.
+    project.service_image_override = Some(output.image_tag.clone());
+    Ok(Some(output))
+}
+
+/// Resolve (and build) the feature-extended image for a compose service, without
+/// mutating the project. Shared by `up` (which then sets
+/// `service_image_override` to run the extended image) and `build` (which tags
+/// the produced image for the user and writes the lockfile). Returns `None` when
+/// the config declares no features.
+#[instrument(skip(config, compose_manager, project, workspace_folder))]
+pub(crate) async fn resolve_compose_feature_image(
+    config: &DevContainerConfig,
+    compose_manager: &ComposeManager,
+    project: &ComposeProject,
+    workspace_folder: &Path,
+    config_path: &Path,
+    workspace_hash: &str,
+) -> Result<Option<FeatureBuildOutput>> {
     // Nothing to install when features is missing or an empty object.
     let features_obj = match config.features.as_object() {
         Some(o) if !o.is_empty() => o,
@@ -755,10 +789,9 @@ async fn install_features_for_compose(
         service = %project.service,
         extended_image = %output.image_tag,
         feature_count = output.resolved_features.len(),
-        "Feature-extended image ready; rewriting compose service image"
+        "Feature-extended image ready"
     );
 
-    project.service_image_override = Some(output.image_tag.clone());
     Ok(Some(output))
 }
 

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -18,7 +18,7 @@
 //! - `helpers` - Utility functions
 
 mod args;
-mod compose;
+pub(crate) mod compose;
 mod container;
 // `dotfiles` module deleted: dotfiles execution is now integrated into
 // `deacon_core::container_lifecycle::execute_dotfiles_in_container`, which

--- a/crates/deacon/tests/integration_compose_features_build.rs
+++ b/crates/deacon/tests/integration_compose_features_build.rs
@@ -292,3 +292,110 @@ fn compose_features_build_shape_installs_feature() {
         String::from_utf8_lossy(&feature_exec.stderr)
     );
 }
+
+/// `deacon build` on a compose config with features must produce a
+/// feature-extended image for the target service and tag it with
+/// `--image-name`. Regression guard for `execute_compose_build_with_features`.
+///
+/// Uses a local feature (no OCI pull) writing a deterministic marker; asserts
+/// the named image contains it (i.e. `--image-name` resolves to the
+/// feature-extended image, not the bare base).
+#[test]
+fn build_compose_with_features_tags_final_image() {
+    if !is_docker_available() {
+        eprintln!("Skipping build_compose_with_features_tags_final_image: Docker not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().expect("tempdir");
+    let workspace = temp_dir.path();
+
+    // build-shape compose service on a bash-capable base.
+    fs::write(
+        workspace.join("Dockerfile"),
+        "FROM debian:bookworm-slim\nRUN echo base > /base.txt\nCMD [\"sleep\", \"infinity\"]\n",
+    )
+    .expect("write Dockerfile");
+    fs::write(
+        workspace.join("docker-compose.yml"),
+        "services:\n  app:\n    build:\n      context: .\n      dockerfile: Dockerfile\n    command: [\"sleep\", \"infinity\"]\n",
+    )
+    .expect("write compose");
+
+    let dc_dir = workspace.join(".devcontainer");
+    fs::create_dir_all(&dc_dir).expect("create .devcontainer");
+    // Local feature (resolved relative to the config dir) writing a marker.
+    let feat = dc_dir.join("features/marker");
+    fs::create_dir_all(&feat).expect("create feature dir");
+    fs::write(
+        feat.join("devcontainer-feature.json"),
+        r#"{ "id": "marker", "version": "1.0.0", "name": "Marker" }"#,
+    )
+    .expect("write feature json");
+    fs::write(
+        feat.join("install.sh"),
+        "#!/usr/bin/env bash\nset -e\necho installed > /compose-feature-marker.txt\n",
+    )
+    .expect("write install.sh");
+    fs::write(
+        dc_dir.join("devcontainer.json"),
+        r#"{
+  "name": "build-compose-features",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "remoteUser": "root",
+  "features": { "./features/marker": {} }
+}"#,
+    )
+    .expect("write devcontainer.json");
+
+    let image_tag = "deacon-test/compose-features:latest";
+    let out = Command::cargo_bin("deacon")
+        .expect("deacon binary")
+        .current_dir(workspace)
+        .args([
+            "build",
+            "--workspace-folder",
+            workspace.to_str().unwrap(),
+            "--image-name",
+            image_tag,
+            "--output-format",
+            "json",
+        ])
+        .env("DEACON_LOG", "warn")
+        .output()
+        .expect("spawn deacon build");
+
+    if !out.status.success() {
+        // Docker unavailable / not permitted is the only acceptable failure.
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            stderr.contains("Docker") || stderr.contains("permission denied"),
+            "deacon build (compose+features) failed unexpectedly: {}",
+            stderr
+        );
+        return;
+    }
+
+    let run = StdCommand::new("docker")
+        .args([
+            "run",
+            "--rm",
+            image_tag,
+            "cat",
+            "/compose-feature-marker.txt",
+        ])
+        .output()
+        .expect("docker run");
+    let _ = StdCommand::new("docker")
+        .args(["rmi", "-f", image_tag])
+        .output();
+
+    assert!(
+        run.status.success() && String::from_utf8_lossy(&run.stdout).contains("installed"),
+        "--image-name should resolve to the feature-extended compose image; \
+         stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}

--- a/examples/build/compose-with-features/Dockerfile
+++ b/examples/build/compose-with-features/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.19
+FROM debian:bookworm-slim
 RUN echo "compose feature base" > /compose.txt

--- a/examples/build/compose-with-features/README.md
+++ b/examples/build/compose-with-features/README.md
@@ -8,6 +8,14 @@ cd examples/build/compose-with-features
 deacon build --workspace-folder . --image-name myorg/compose-feature:latest --output-format json
 ```
 
+## Verify
+```sh
+# The feature's install.sh writes /hello.txt into the built image.
+docker run --rm myorg/compose-feature:latest cat /hello.txt
+```
+
 ## Notes
 - Demonstrates FR-010 (service targeting) & FR-008 (feature install).
+- The target service's shape (`build:` here, or `image:`) is resolved and a
+  feature-extended image is built; `--image-name` tags that final image.
 - Unsupported flags (e.g. `--push`, `--output`) should be rejected per spec.

--- a/examples/build/compose-with-features/exec.sh
+++ b/examples/build/compose-with-features/exec.sh
@@ -20,3 +20,8 @@ cd "$SCRIPT_DIR"
 
 echo "== Compose service build with feature (README: Usage) ==" >&2
 run "$DEACON_BIN" build --workspace-folder "$SCRIPT_DIR" --image-name "$IMAGE_TAG" --output-format json "$@"
+
+echo "== Verify feature artifact in the named image (README: Verify) ==" >&2
+# The --image-name must resolve to the feature-extended image, so /hello.txt
+# (written by the local feature's install.sh) must be present.
+run docker run --rm "$IMAGE_TAG" cat /hello.txt


### PR DESCRIPTION
## Summary

Closes the last part of the deferred *"feature installation during build is not yet supported for compose or image-reference configurations"* gate. The image-reference half landed in #134; this adds **compose**. `deacon build` on a compose config with `features` now resolves the target service's shape and builds a feature-extended image, tagged with `--image-name` — matching `up`. **Fixes #135.**

## Changes
- **Refactor (no behavior change for `up`)**: extracted the shape→feature-build core out of `up`'s `install_features_for_compose` into a reusable `pub(crate) resolve_compose_feature_image` (takes `&ComposeProject`, performs no project mutation). `up` calls it then sets `service_image_override`. Both existing compose-feature integration tests (`image:` and `build:` shapes) still pass.
- **`build`**: new `execute_compose_build_with_features` — resolves the service shape (`image:`/`build:`), builds the feature-extended image via the shared helper, tags it with the deterministic `deacon-build:<hash>` tag + any `--image-name`s (reuses `retag_image` from #134), and writes the feature lockfile. The generic Dockerfile/image-ref post-build layering pass is skipped for compose.
- Removed the compose feature-install rejection gate (all four config shapes — Dockerfile, image-ref, compose image, compose build — now support features).
- Example `compose-with-features`: base `alpine:3.19` → `debian:bookworm-slim`; `exec.sh` + README now verify `/hello.txt` is in the named image.

## Testing
- New docker-gated `build_compose_with_features_tags_final_image` in `integration_compose_features_build` (already grouped `docker-shared`): asserts `deacon build --image-name` on a compose+features config resolves to the feature-extended image (caught a fixture bug where `dockerComposeFile` is workspace-relative, not config-relative).
- `compose_features_{image,build}_shape_installs_feature` (`up`) still pass — refactor verified safe.
- `compose-with-features` canary passes end-to-end (`Hello Feature Installed (compose)`).
- `cargo fmt --all` + `clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)