### PR TITLE
feat(run-user-commands): aggregate feature-contributed lifecycle commands (fixes #137)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,7 +67,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -168,7 +168,7 @@ filter = 'binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -7,9 +7,8 @@ use crate::commands::shared::{load_config, ConfigLoadArgs, ConfigLoadResult};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_progress_callback, AggregatedLifecycleCommand,
+    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback,
     ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandList,
-    LifecycleCommandSource, LifecycleCommandValue,
 };
 use deacon_core::lifecycle::{should_queue_phase_for_wait_for, wait_for_phase, LifecyclePhase};
 use deacon_core::variable::SubstitutionContext;
@@ -164,35 +163,56 @@ async fn execute_lifecycle_commands(
         config_hash: None,
     };
 
-    // Build lifecycle commands from configuration using typed parser
+    // Resolve declared features (fail-fast) so feature-contributed lifecycle
+    // commands are aggregated alongside the config's, matching `up`. Local
+    // feature paths (`./`, `../`, `/abs`) resolve relative to the config's
+    // directory. If a declared feature cannot be resolved (missing local path,
+    // OCI fetch error, dependency cycle), we propagate the error rather than
+    // silently running a partial set of hooks.
+    let config_dir = if let Some(cfg) = args.config_path.as_deref() {
+        if cfg.is_dir() {
+            cfg.to_path_buf()
+        } else {
+            cfg.parent().unwrap_or(workspace_folder).to_path_buf()
+        }
+    } else {
+        let dc = workspace_folder.join(".devcontainer");
+        if dc.is_dir() {
+            dc
+        } else {
+            workspace_folder.to_path_buf()
+        }
+    };
+    let fetcher =
+        deacon_core::oci::default_fetcher().context("Failed to initialize OCI feature fetcher")?;
+    let resolved_features = crate::commands::shared::feature_resolver::resolve_features_ordered(
+        config,
+        &config_dir,
+        &fetcher,
+    )
+    .await
+    .context("Failed to resolve features for lifecycle command aggregation")?;
+    if !resolved_features.is_empty() {
+        debug!(
+            feature_count = resolved_features.len(),
+            "Aggregating feature-contributed lifecycle commands"
+        );
+    }
+
+    // Build lifecycle commands: feature-contributed commands (in install order)
+    // first, then the config's command, per `aggregate_lifecycle_commands` —
+    // identical to the `up` flow.
     let mut commands = ContainerLifecycleCommands::new();
 
-    // Helper to parse a JSON value into a LifecycleCommandList
-    let parse_phase_command =
-        |json_val: &serde_json::Value, phase_name: &str| -> Result<Option<LifecycleCommandList>> {
-            let parsed = LifecycleCommandValue::from_json_value(json_val)
-                .with_context(|| format!("Failed to parse {} command", phase_name))?;
-            match parsed {
-                Some(cmd) if !cmd.is_empty() => Ok(Some(LifecycleCommandList {
-                    commands: vec![AggregatedLifecycleCommand {
-                        command: cmd,
-                        source: LifecycleCommandSource::Config,
-                    }],
-                })),
-                _ => Ok(None),
-            }
-        };
-
-    // TODO(012): This only collects lifecycle commands from the user's devcontainer.json config.
-    // Feature-defined lifecycle commands (onCreateCommand, etc.) are not aggregated here.
-    // The `up` command uses `aggregate_lifecycle_commands()` which includes features.
-    // To reach parity, we need resolved features from image metadata (container labels).
-
-    // Handle different lifecycle phases based on configuration
-    // Note: initializeCommand is intentionally omitted here. It is a host-side command
-    // that runs before container creation and belongs only in the `up` workflow.
-
+    // initializeCommand is intentionally omitted: it is a host-side command that
+    // runs before container creation and belongs only to the `up` workflow.
     let wait_for = wait_for_phase(config.wait_for.as_deref())?;
+
+    // Aggregate a phase's commands (features + config); `None` when empty.
+    let aggregate = |phase: LifecyclePhase| -> Result<Option<LifecycleCommandList>> {
+        let list = aggregate_lifecycle_commands(phase, &resolved_features, config)?;
+        Ok((!list.commands.is_empty()).then_some(list))
+    };
 
     // Phase 1: onCreate (container)
     if should_queue_phase_for_wait_for(
@@ -200,10 +220,8 @@ async fn execute_lifecycle_commands(
         wait_for,
         LifecyclePhase::OnCreate,
     ) {
-        if let Some(ref on_create) = config.on_create_command {
-            if let Some(cmd_list) = parse_phase_command(on_create, "onCreateCommand")? {
-                commands = commands.with_on_create(cmd_list);
-            }
+        if let Some(list) = aggregate(LifecyclePhase::OnCreate)? {
+            commands = commands.with_on_create(list);
         }
     }
 
@@ -213,10 +231,8 @@ async fn execute_lifecycle_commands(
         wait_for,
         LifecyclePhase::UpdateContent,
     ) {
-        if let Some(ref update_content) = config.update_content_command {
-            if let Some(cmd_list) = parse_phase_command(update_content, "updateContentCommand")? {
-                commands = commands.with_update_content(cmd_list);
-            }
+        if let Some(list) = aggregate(LifecyclePhase::UpdateContent)? {
+            commands = commands.with_update_content(list);
         }
     }
 
@@ -233,10 +249,8 @@ async fn execute_lifecycle_commands(
             LifecyclePhase::PostCreate,
         )
     {
-        if let Some(ref post_create) = config.post_create_command {
-            if let Some(cmd_list) = parse_phase_command(post_create, "postCreateCommand")? {
-                commands = commands.with_post_create(cmd_list);
-            }
+        if let Some(list) = aggregate(LifecyclePhase::PostCreate)? {
+            commands = commands.with_post_create(list);
         }
     }
 
@@ -249,10 +263,8 @@ async fn execute_lifecycle_commands(
             LifecyclePhase::PostStart,
         )
     {
-        if let Some(ref post_start) = config.post_start_command {
-            if let Some(cmd_list) = parse_phase_command(post_start, "postStartCommand")? {
-                commands = commands.with_post_start(cmd_list);
-            }
+        if let Some(list) = aggregate(LifecyclePhase::PostStart)? {
+            commands = commands.with_post_start(list);
         }
 
         // Phase 5: postAttach (container, non-blocking, can be skipped)
@@ -263,10 +275,8 @@ async fn execute_lifecycle_commands(
                 LifecyclePhase::PostAttach,
             )
         {
-            if let Some(ref post_attach) = config.post_attach_command {
-                if let Some(cmd_list) = parse_phase_command(post_attach, "postAttachCommand")? {
-                    commands = commands.with_post_attach(cmd_list);
-                }
+            if let Some(list) = aggregate(LifecyclePhase::PostAttach)? {
+                commands = commands.with_post_attach(list);
             }
         }
     }

--- a/crates/deacon/src/commands/shared/feature_resolver.rs
+++ b/crates/deacon/src/commands/shared/feature_resolver.rs
@@ -1,0 +1,190 @@
+//! Shared feature resolution.
+//!
+//! Resolves the features declared in a `DevContainerConfig` into an ordered
+//! `Vec<ResolvedFeature>` (full metadata included), honoring local paths
+//! (`./`, `../`, `/abs`) and OCI references, then applies dependency / install
+//! order resolution. This is the common primitive behind `read-configuration`
+//! (which groups the result by registry) and `run-user-commands` (which feeds
+//! it to `aggregate_lifecycle_commands` for feature-contributed lifecycle
+//! hooks).
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::path::Path;
+
+use deacon_core::config::DevContainerConfig;
+use deacon_core::features::{
+    parse_feature_metadata, FeatureDependencyResolver, OptionValue, ResolvedFeature,
+};
+use deacon_core::oci::{FeatureFetcher, FeatureRef, HttpClient};
+use deacon_core::registry_parser::parse_registry_reference;
+
+/// Resolve `config.features` into install-ordered `ResolvedFeature`s.
+///
+/// - Local feature ids (`./`, `../`, absolute) are read from disk relative to
+///   `config_dir`; OCI ids are fetched via `fetcher`.
+/// - Returns an empty vec when no features are declared.
+/// - **Fails fast**: any unresolvable feature (missing local path, missing
+///   `devcontainer-feature.json`, OCI fetch error, dependency cycle) is
+///   propagated with context rather than silently dropped.
+pub(crate) async fn resolve_features_ordered<C: HttpClient>(
+    config: &DevContainerConfig,
+    config_dir: &Path,
+    fetcher: &FeatureFetcher<C>,
+) -> Result<Vec<ResolvedFeature>> {
+    let features_map = match config.features.as_object() {
+        Some(map) if !map.is_empty() => map,
+        _ => return Ok(Vec::new()),
+    };
+
+    let mut resolved_features = Vec::with_capacity(features_map.len());
+
+    for (feature_id, feature_value) in features_map {
+        let is_local = feature_id.starts_with("./")
+            || feature_id.starts_with("../")
+            || feature_id.starts_with('/');
+
+        let (canonical_id, source_string, metadata) = if is_local {
+            let resolved = config_dir.join(feature_id);
+            let canonical_path = resolved.canonicalize().map_err(|e| {
+                anyhow::anyhow!(
+                    "Local feature path '{}' (resolved to '{}' relative to {}) is not accessible: {}",
+                    feature_id,
+                    resolved.display(),
+                    config_dir.display(),
+                    e
+                )
+            })?;
+            let metadata_path = canonical_path.join("devcontainer-feature.json");
+            if !metadata_path.exists() {
+                anyhow::bail!(
+                    "Local feature at '{}' is missing devcontainer-feature.json (resolved from '{}' relative to {})",
+                    canonical_path.display(),
+                    feature_id,
+                    config_dir.display()
+                );
+            }
+            let metadata = parse_feature_metadata(&metadata_path).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to parse local feature metadata at '{}': {}",
+                    metadata_path.display(),
+                    e
+                )
+            })?;
+            let canonical_id = format!("local:{}", canonical_path.display());
+            (canonical_id, feature_id.clone(), metadata)
+        } else {
+            let (registry_url, namespace, name, tag) = parse_registry_reference(feature_id)?;
+            let feature_ref = FeatureRef::new(registry_url, namespace, name, tag);
+            let downloaded = fetcher
+                .fetch_feature(&feature_ref)
+                .await
+                .with_context(|| format!("Failed to fetch feature '{}'", feature_id))?;
+            (
+                downloaded.metadata.id.clone(),
+                feature_ref.reference(),
+                downloaded.metadata,
+            )
+        };
+
+        // Extract per-feature options from the config entry.
+        let options: HashMap<String, OptionValue> = match feature_value {
+            serde_json::Value::Object(map) => map
+                .clone()
+                .into_iter()
+                .map(|(k, v)| {
+                    let option_value = match v {
+                        serde_json::Value::Bool(b) => OptionValue::Boolean(b),
+                        serde_json::Value::String(s) => OptionValue::String(s),
+                        serde_json::Value::Number(n) => OptionValue::Number(n),
+                        serde_json::Value::Array(a) => OptionValue::Array(a),
+                        serde_json::Value::Object(o) => OptionValue::Object(o),
+                        serde_json::Value::Null => OptionValue::Null,
+                    };
+                    (k, option_value)
+                })
+                .collect(),
+            serde_json::Value::String(s) => {
+                let mut map = HashMap::new();
+                map.insert("version".to_string(), OptionValue::String(s.clone()));
+                map
+            }
+            _ => HashMap::new(),
+        };
+
+        resolved_features.push(ResolvedFeature {
+            id: canonical_id,
+            source: source_string,
+            options,
+            metadata,
+        });
+    }
+
+    // Apply dependency / install-order resolution (honors
+    // overrideFeatureInstallOrder). Propagate cycle/ordering errors.
+    let resolver = FeatureDependencyResolver::new(config.override_feature_install_order.clone());
+    let plan = resolver
+        .resolve(&resolved_features)
+        .context("Failed to resolve feature installation order")?;
+
+    Ok(plan.features)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_core::oci::default_fetcher;
+
+    #[tokio::test]
+    async fn resolves_local_feature_with_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let feat = dir.path().join("features/hi");
+        std::fs::create_dir_all(&feat).unwrap();
+        std::fs::write(
+            feat.join("devcontainer-feature.json"),
+            r#"{ "id": "hi", "version": "1.0.0", "name": "Hi",
+                 "postCreateCommand": "echo hi" }"#,
+        )
+        .unwrap();
+        std::fs::write(feat.join("install.sh"), "#!/bin/sh\ntrue\n").unwrap();
+
+        let config: DevContainerConfig =
+            serde_json::from_value(serde_json::json!({ "features": { "./features/hi": {} } }))
+                .unwrap();
+
+        let fetcher = default_fetcher().unwrap();
+        let resolved = resolve_features_ordered(&config, dir.path(), &fetcher)
+            .await
+            .expect("local feature resolves without network");
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].metadata.name.as_deref(), Some("Hi"));
+        assert!(resolved[0].metadata.post_create_command.is_some());
+    }
+
+    #[tokio::test]
+    async fn no_features_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = DevContainerConfig::default();
+        let fetcher = default_fetcher().unwrap();
+        let resolved = resolve_features_ordered(&config, dir.path(), &fetcher)
+            .await
+            .unwrap();
+        assert!(resolved.is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_local_feature_fails_fast() {
+        let dir = tempfile::tempdir().unwrap();
+        let config: DevContainerConfig =
+            serde_json::from_value(serde_json::json!({ "features": { "./features/nope": {} } }))
+                .unwrap();
+        let fetcher = default_fetcher().unwrap();
+        let err = resolve_features_ordered(&config, dir.path(), &fetcher)
+            .await
+            .expect_err("missing local feature must error");
+        assert!(
+            err.to_string().contains("not accessible") || err.to_string().contains("nope"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod config_loader;
 pub mod env_user;
+pub mod feature_resolver;
 pub mod progress;
 pub mod remote_env;
 pub mod terminal;

--- a/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
+++ b/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
@@ -1,0 +1,159 @@
+//! Integration test for `run-user-commands` aggregating feature-contributed
+//! lifecycle commands (T031, issue #137).
+//!
+//! Before T031, `run-user-commands` only executed the config's own lifecycle
+//! commands. Now it resolves the declared features and aggregates their
+//! lifecycle hooks too (feature commands in install order, then the config's),
+//! matching `up`.
+//!
+//! This test installs a local feature that declares a `postCreateCommand`, runs
+//! `up --skip-post-create` (so no postCreate fires yet), then runs
+//! `run-user-commands` and asserts BOTH the feature's and the config's
+//! postCreate markers appear.
+//!
+//! Requires Docker; self-skips when unavailable.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn marker_present(container_id: &str, marker: &str) -> bool {
+    std::process::Command::new("docker")
+        .args(["exec", container_id, "test", "-f", marker])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn find_container(name: &str) -> Option<String> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=devcontainer.source=deacon",
+            "--filter",
+            &format!("label=devcontainer.name={}", name),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+struct ContainerGuard(String);
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+#[test]
+fn test_run_user_commands_runs_feature_lifecycle_commands() {
+    if !is_docker_available() {
+        eprintln!(
+            "Skipping test_run_user_commands_runs_feature_lifecycle_commands: Docker not available"
+        );
+        return;
+    }
+
+    let name = "Deacon RUC Feature Lifecycle Test";
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // Local feature that declares a postCreateCommand (and a trivial install).
+    let feat = root.join(".devcontainer/features/lc");
+    fs::create_dir_all(&feat).unwrap();
+    fs::write(
+        feat.join("devcontainer-feature.json"),
+        r#"{
+  "id": "lc",
+  "version": "1.0.0",
+  "name": "Lifecycle Feature",
+  "postCreateCommand": "echo feat > /tmp/feat-postcreate.flag"
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        feat.join("install.sh"),
+        "#!/usr/bin/env bash\nset -e\ntrue\n",
+    )
+    .unwrap();
+
+    fs::write(
+        root.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "{name}",
+  "image": "debian:bookworm-slim",
+  "remoteUser": "root",
+  "workspaceFolder": "/workspace",
+  "features": {{ "./features/lc": {{}} }},
+  "postCreateCommand": "echo cfg > /tmp/cfg-postcreate.flag"
+}}"#
+        ),
+    )
+    .unwrap();
+
+    // Bring the container up with postCreate suppressed, so neither the
+    // feature's nor the config's postCreate has fired yet.
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(root)
+        .arg("--remove-existing-container")
+        .arg("--skip-post-create")
+        .assert()
+        .success();
+
+    let container_id = find_container(name).expect("container should exist after up");
+    let _guard = ContainerGuard(container_id.clone());
+
+    assert!(
+        !marker_present(&container_id, "/tmp/feat-postcreate.flag"),
+        "feature postCreate must not have run yet (up --skip-post-create)"
+    );
+
+    // Drive the remaining phases; postCreate should now run for BOTH the
+    // feature and the config.
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("run-user-commands")
+        .arg("--workspace-folder")
+        .arg(root)
+        .assert()
+        .success();
+
+    assert!(
+        marker_present(&container_id, "/tmp/feat-postcreate.flag"),
+        "run-user-commands must execute the FEATURE's postCreateCommand (T031)"
+    );
+    assert!(
+        marker_present(&container_id, "/tmp/cfg-postcreate.flag"),
+        "run-user-commands must still execute the config's postCreateCommand"
+    );
+}


### PR DESCRIPTION
## Summary

`run-user-commands` previously executed only the **config's** lifecycle commands — feature-contributed hooks (a feature's own `onCreateCommand`/`postCreateCommand`/etc.) were dropped, diverging from `up`. This was the `TODO(012)` in `run_user_commands.rs`. **Fixes #137 (T031).**

## Changes
- **New shared resolver** `commands/shared/feature_resolver::resolve_features_ordered`: resolves `config.features` into install-ordered `Vec<ResolvedFeature>` (full metadata), honoring local paths (`./`,`../`,`/abs`) and OCI refs, then applying dependency/install-order resolution.
  - **Fails fast** (per your call): any unresolvable feature — missing local path, missing `devcontainer-feature.json`, OCI fetch error, or dependency cycle — is propagated with context, never silently skipped.
- **`run-user-commands`** now resolves features and builds each phase via `aggregate_lifecycle_commands(phase, &resolved, config)` (feature commands in install order, then the config's) — identical to `up`. Local feature paths resolve relative to the config directory. All existing gating (`--skip-post-create`, `--prebuild`, `--skip-non-blocking-commands`, `--skip-post-attach`, `waitFor`) is preserved.

## Testing
- **Unit (hermetic, no network)**: local-feature resolution incl. metadata; empty-features → empty; **missing-feature → fail-fast error**.
- **Docker-gated integration** `run_user_commands_feature_lifecycle`: a local feature declaring `postCreateCommand` → `up --skip-post-create` leaves it unfired → `run-user-commands` fires **both** the feature's and the config's postCreate. Grouped `docker-exclusive` (mirrors `run_user_commands_prebuild`).
- `run-user-commands/basic` canary still green (no-features path unchanged); `cargo fmt`/`clippy --all-targets --all-features` clean.

## Note
`read-configuration` keeps its own resolution path (it additionally handles `--additional-features`, the auto-mapping toggle, and registry-grouped output). A future cleanup could unify both behind this helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)