### PR TITLE
feat(lifecycle): prefix parallel command output with [key] in real time (fixes #138)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,7 +67,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=lifecycle_parallel_output)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=lifecycle_parallel_output) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -168,7 +168,7 @@ filter = 'binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=lifecycle_parallel_output)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -1811,7 +1811,18 @@ where
                                     stderr: String::new(),
                                 };
                             }
-                            match docker.exec(container_id, &command_args, exec_config).await {
+                            // Prefix each output line with `[key]` so concurrent
+                            // parallel-command output is attributable in real time.
+                            let line_prefix = format!("[{}] ", key);
+                            match docker
+                                .exec_with_line_prefix(
+                                    container_id,
+                                    &command_args,
+                                    exec_config,
+                                    &line_prefix,
+                                )
+                                .await
+                            {
                                 Ok(result) => ParallelCommandResult {
                                     key,
                                     exit_code: result.exit_code,

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -612,6 +612,24 @@ pub trait Docker {
         config: ExecConfig,
     ) -> Result<ExecResult>;
 
+    /// Like [`exec`](Self::exec), but when output is streamed (non-silent) each
+    /// stdout/stderr line is prefixed with `line_prefix` and forwarded to
+    /// deacon's stderr. Used to attribute concurrent parallel-lifecycle output
+    /// (e.g. `[build] ...`, `[install] ...`).
+    ///
+    /// The default implementation ignores the prefix and delegates to `exec`,
+    /// which is sufficient for mocks and runtimes that don't stream live output.
+    async fn exec_with_line_prefix(
+        &self,
+        container_id: &str,
+        command: &[String],
+        config: ExecConfig,
+        line_prefix: &str,
+    ) -> Result<ExecResult> {
+        let _ = line_prefix;
+        self.exec(container_id, command, config).await
+    }
+
     /// Stop a container with optional timeout
     async fn stop_container(&self, container_id: &str, timeout: Option<u32>) -> Result<()>;
 }
@@ -1069,6 +1087,63 @@ impl CliRuntime {
     }
 }
 
+/// Build the `exec` CLI argument vector from an [`ExecConfig`]. Shared by the
+/// plain `exec` path and the line-prefixed streaming path.
+fn build_exec_args(container_id: &str, command: &[String], config: &ExecConfig) -> Vec<String> {
+    let mut args = vec!["exec".to_string()];
+
+    if config.tty {
+        args.push("-t".to_string());
+    }
+    if config.interactive {
+        args.push("-i".to_string());
+    }
+    if config.detach {
+        args.push("-d".to_string());
+    }
+    if let Some(ref user) = config.user {
+        args.push("-u".to_string());
+        args.push(user.clone());
+    }
+    if let Some(ref workdir) = config.working_dir {
+        args.push("-w".to_string());
+        args.push(workdir.clone());
+    }
+    for (k, v) in &config.env {
+        args.push("-e".to_string());
+        args.push(format!("{}={}", k, v));
+    }
+
+    // Note: '--sig-proxy' is not supported by 'docker exec' (only 'docker run').
+
+    args.push(container_id.to_string());
+    for cmd_part in command {
+        args.push(cmd_part.clone());
+    }
+    args
+}
+
+/// Spawn a task that reads `reader` line-by-line and writes each line to
+/// deacon's stderr prefixed with `prefix` (e.g. `[build] `). One `write_all`
+/// per line keeps each prefixed line intact when multiple forwarders interleave.
+fn spawn_prefixed_forwarder<R>(reader: R, prefix: String) -> tokio::task::JoinHandle<()>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let mut lines = BufReader::new(reader).lines();
+        let mut err = tokio::io::stderr();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let mut buf = Vec::with_capacity(prefix.len() + line.len() + 1);
+            buf.extend_from_slice(prefix.as_bytes());
+            buf.extend_from_slice(line.as_bytes());
+            buf.push(b'\n');
+            let _ = err.write_all(&buf).await;
+        }
+    })
+}
+
 impl Docker for CliRuntime {
     #[instrument(skip(self))]
     async fn ping(&self) -> Result<()> {
@@ -1412,49 +1487,7 @@ impl Docker for CliRuntime {
     ) -> Result<ExecResult> {
         debug!("Executing command in container: {}", container_id);
 
-        let mut args = vec!["exec".to_string()];
-
-        // Add TTY and interactive flags
-        if config.tty {
-            args.push("-t".to_string());
-        }
-        if config.interactive {
-            args.push("-i".to_string());
-        }
-
-        // Add detach flag
-        if config.detach {
-            args.push("-d".to_string());
-        }
-
-        // Add user if specified
-        if let Some(ref user) = config.user {
-            args.push("-u".to_string());
-            args.push(user.clone());
-        }
-
-        // Add working directory if specified
-        if let Some(ref workdir) = config.working_dir {
-            args.push("-w".to_string());
-            args.push(workdir.clone());
-        }
-
-        // Add environment variables
-        for (k, v) in &config.env {
-            args.push("-e".to_string());
-            args.push(format!("{}={}", k, v));
-        }
-
-        // Note: '--sig-proxy' is not supported by 'docker exec' (only 'docker run').
-        // Do not add it here to avoid 'unknown flag: --sig-proxy' errors.
-
-        // Add container ID
-        args.push(container_id.to_string());
-
-        // Add the command and arguments
-        for cmd_part in command {
-            args.push(cmd_part.clone());
-        }
+        let args = build_exec_args(container_id, command, &config);
 
         debug!("Runtime exec args: {:?}", args);
 
@@ -1581,6 +1614,58 @@ impl Docker for CliRuntime {
                 stderr: String::new(),
             })
         }
+    }
+
+    #[instrument(skip(self, line_prefix))]
+    async fn exec_with_line_prefix(
+        &self,
+        container_id: &str,
+        command: &[String],
+        config: ExecConfig,
+        line_prefix: &str,
+    ) -> Result<ExecResult> {
+        // A PTY merges stdout/stderr and is incompatible with separate piped
+        // line forwarding; fall back to the normal inherited-stdio path.
+        if config.tty {
+            return self.exec(container_id, command, config).await;
+        }
+
+        let args = build_exec_args(container_id, command, &config);
+        debug!("Runtime exec (line-prefixed) args: {:?}", args);
+
+        let mut cmd = tokio::process::Command::new(&self.runtime_path);
+        cmd.args(&args);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| DockerError::CLIError(format!("Failed to spawn runtime exec: {}", e)))?;
+
+        // Forward both streams to deacon's stderr (lifecycle output never goes to
+        // stdout, which is reserved for result JSON), prefixing each line so
+        // concurrent parallel-command output stays attributable in real time.
+        let mut forwarders = Vec::new();
+        if let Some(out) = child.stdout.take() {
+            forwarders.push(spawn_prefixed_forwarder(out, line_prefix.to_string()));
+        }
+        if let Some(err) = child.stderr.take() {
+            forwarders.push(spawn_prefixed_forwarder(err, line_prefix.to_string()));
+        }
+
+        let exit_status = child.wait().await.map_err(|e| {
+            DockerError::CLIError(format!("Failed to wait for runtime exec: {}", e))
+        })?;
+        for f in forwarders {
+            let _ = f.await;
+        }
+
+        Ok(ExecResult {
+            exit_code: resolve_exit_code(exit_status),
+            success: exit_status.success(),
+            stdout: String::new(),
+            stderr: String::new(),
+        })
     }
 
     #[instrument(skip(self))]

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -180,6 +180,27 @@ impl Docker for ContainerRuntimeImpl {
         }
     }
 
+    async fn exec_with_line_prefix(
+        &self,
+        container_id: &str,
+        command: &[String],
+        config: ExecConfig,
+        line_prefix: &str,
+    ) -> Result<ExecResult> {
+        match self {
+            Self::Docker(runtime) => {
+                runtime
+                    .exec_with_line_prefix(container_id, command, config, line_prefix)
+                    .await
+            }
+            Self::Podman(runtime) => {
+                runtime
+                    .exec_with_line_prefix(container_id, command, config, line_prefix)
+                    .await
+            }
+        }
+    }
+
     async fn stop_container(&self, container_id: &str, timeout: Option<u32>) -> Result<()> {
         match self {
             Self::Docker(runtime) => runtime.stop_container(container_id, timeout).await,
@@ -367,6 +388,18 @@ impl Docker for DockerRuntime {
         self.docker.exec(container_id, command, config).await
     }
 
+    async fn exec_with_line_prefix(
+        &self,
+        container_id: &str,
+        command: &[String],
+        config: ExecConfig,
+        line_prefix: &str,
+    ) -> Result<ExecResult> {
+        self.docker
+            .exec_with_line_prefix(container_id, command, config, line_prefix)
+            .await
+    }
+
     async fn stop_container(&self, container_id: &str, timeout: Option<u32>) -> Result<()> {
         self.docker.stop_container(container_id, timeout).await
     }
@@ -505,6 +538,18 @@ impl Docker for PodmanRuntime {
         config: ExecConfig,
     ) -> Result<ExecResult> {
         self.runtime.exec(container_id, command, config).await
+    }
+
+    async fn exec_with_line_prefix(
+        &self,
+        container_id: &str,
+        command: &[String],
+        config: ExecConfig,
+        line_prefix: &str,
+    ) -> Result<ExecResult> {
+        self.runtime
+            .exec_with_line_prefix(container_id, command, config, line_prefix)
+            .await
     }
 
     async fn stop_container(&self, container_id: &str, timeout: Option<u32>) -> Result<()> {

--- a/crates/deacon/tests/lifecycle_parallel_output.rs
+++ b/crates/deacon/tests/lifecycle_parallel_output.rs
@@ -1,0 +1,119 @@
+//! Integration test for real-time `[key]` prefixing of parallel lifecycle
+//! command output (T032, issue #138).
+//!
+//! An object-form lifecycle command runs its entries concurrently; each entry's
+//! output is now forwarded to deacon's stderr prefixed with `[key]` so the
+//! interleaved streams stay attributable.
+//!
+//! Requires Docker; self-skips when unavailable.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+struct ContainerGuard(String);
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+fn find_container(name: &str) -> Option<String> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=devcontainer.source=deacon",
+            "--filter",
+            &format!("label=devcontainer.name={}", name),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[test]
+fn test_parallel_lifecycle_output_is_key_prefixed() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_parallel_lifecycle_output_is_key_prefixed: Docker not available");
+        return;
+    }
+
+    let name = "Deacon Parallel Output Test";
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    fs::create_dir_all(root.join(".devcontainer")).unwrap();
+    fs::write(
+        root.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "{name}",
+  "image": "debian:bookworm-slim",
+  "remoteUser": "root",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": {{
+    "alpha": "echo hello-from-alpha",
+    "beta": "echo hello-from-beta"
+  }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(root)
+        .arg("--remove-existing-container")
+        .env("DEACON_LOG", "warn")
+        .output()
+        .expect("spawn deacon up");
+
+    // Clean up the container regardless of assertion outcome.
+    let _guard = find_container(name).map(ContainerGuard);
+
+    assert!(
+        output.status.success(),
+        "deacon up failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Lifecycle output is forwarded to stderr; each parallel entry's line must
+    // carry its `[key]` prefix.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("[alpha] hello-from-alpha"),
+        "expected '[alpha] hello-from-alpha' in stderr; got:\n{}",
+        stderr
+    );
+    assert!(
+        stderr.contains("[beta] hello-from-beta"),
+        "expected '[beta] hello-from-beta' in stderr; got:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION
## Summary

Object-form lifecycle commands (e.g. `"postCreateCommand": { "build": "...", "install": "..." }`) run their entries **concurrently**, but their output was streamed to the terminal un-attributed — the `[key]` prefix only appeared in the post-hoc `CommandResult`, so interleaved concurrent output was ambiguous. **Fixes #138 (T032).**

## Changes
- **New `Docker::exec_with_line_prefix` trait method** with a default impl that delegates to `exec` — so mocks and non-streaming runtimes need no changes.
- **`CliRuntime`** implements it: pipes **both** stdout and stderr and forwards each line to deacon's stderr **prefixed in real time**. Falls back to plain `exec` when a PTY is requested (a pty merges the streams, making per-stream line-prefixing moot).
- `ContainerRuntimeImpl` / `DockerRuntime` / `PodmanRuntime` delegators forward to it.
- Extracted `build_exec_args` (shared by `exec` and the prefixed path) and a `spawn_prefixed_forwarder` helper (one `write_all` per line keeps each prefixed line intact under concurrent interleaving — no field churn on `ExecConfig`).
- The container parallel-lifecycle path now calls `exec_with_line_prefix` with an `[<key>] ` prefix. Lifecycle output stays on **stderr** (stdout reserved for result JSON).

## Testing
- New docker-gated `lifecycle_parallel_output` test: a parallel `postCreateCommand {alpha, beta}` → asserts deacon's stderr contains `[alpha] hello-from-alpha` and `[beta] hello-from-beta`. Grouped `docker-exclusive` in nextest.
- Manually verified end-to-end (both prefixed lines appear in real time).
- Existing mock-based lifecycle tests (`integration_mock_runtime`, `integration_per_command_events`, `integration_non_blocking_lifecycle`) and all `container_lifecycle` unit tests pass — they inherit the default `exec_with_line_prefix` → `exec` delegation, so behavior is unchanged.
- `cargo fmt --all` + `clippy --all-targets --all-features` clean.

## Note
This covers the in-container parallel path (where lifecycle hooks run). The host-side parallel path (`initializeCommand`) uses a different `spawn_blocking` mechanism and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)