### PR TITLE
fix(up): report the full container ID on reconnect/reuse

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,7 +67,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -168,7 +168,7 @@ filter = 'binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1178,7 +1178,12 @@ impl Docker for CliRuntime {
             label_selector
         );
 
-        let mut args: Vec<String> = vec!["ps", "--all", "--format", "{{json .}}"]
+        // `--no-trunc` so `.ID` is the full 64-char container ID, matching what
+        // `create`/`run` return. Without it `docker ps` emits the short 12-char
+        // form, so the reconnect/reuse path would report a different-looking
+        // `containerId` than the original create (a spec-fidelity inconsistency,
+        // and it breaks naive ID equality checks).
+        let mut args: Vec<String> = vec!["ps", "--all", "--no-trunc", "--format", "{{json .}}"]
             .into_iter()
             .map(|s| s.to_string())
             .collect();

--- a/crates/deacon/tests/up_reconnect_full_id.rs
+++ b/crates/deacon/tests/up_reconnect_full_id.rs
@@ -1,0 +1,112 @@
+//! Regression test: `up` reports the FULL container ID consistently on both
+//! the initial create and on reconnect/reuse.
+//!
+//! `docker ps` emits the short 12-char ID by default, so the reconnect path
+//! (which resolves the existing container via `list_containers`) used to report
+//! a short `containerId` while the initial create reported the full 64-char ID.
+//! `list_containers` now passes `--no-trunc`, so both are the full ID.
+//!
+//! Requires Docker; self-skips when unavailable.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+struct ContainerGuard(String);
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+/// Parse `containerId` out of `deacon up`'s stdout (a single pretty-printed
+/// JSON document).
+fn container_id_from_stdout(stdout: &[u8]) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_slice(stdout).ok()?;
+    v.get("containerId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+#[test]
+fn test_up_reports_full_container_id_on_reconnect() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_up_reports_full_container_id_on_reconnect: Docker not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    fs::create_dir_all(root.join(".devcontainer")).unwrap();
+    fs::write(
+        root.join(".devcontainer/devcontainer.json"),
+        r#"{
+  "name": "Full ID Reconnect Test",
+  "image": "alpine:3.18",
+  "remoteUser": "root",
+  "workspaceFolder": "/workspace"
+}"#,
+    )
+    .unwrap();
+
+    let run_up = || {
+        Command::cargo_bin("deacon")
+            .unwrap()
+            .current_dir(root)
+            .arg("up")
+            .arg("--workspace-folder")
+            .arg(root)
+            .env("DEACON_LOG", "warn")
+            .output()
+            .expect("spawn deacon up")
+    };
+
+    // First up: create.
+    let out1 = run_up();
+    assert!(
+        out1.status.success(),
+        "first up failed: {}",
+        String::from_utf8_lossy(&out1.stderr)
+    );
+    let id1 =
+        container_id_from_stdout(&out1.stdout).expect("first up should emit containerId on stdout");
+    let _guard = ContainerGuard(id1.clone());
+
+    // Second up: reconnect/reuse.
+    let out2 = run_up();
+    assert!(
+        out2.status.success(),
+        "second up failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+    let id2 = container_id_from_stdout(&out2.stdout)
+        .expect("second up should emit containerId on stdout");
+
+    // Both must be the same full 64-char container ID.
+    assert_eq!(
+        id1.len(),
+        64,
+        "create containerId should be the full 64-char id, got {} ({} chars)",
+        id1,
+        id1.len()
+    );
+    assert_eq!(
+        id1, id2,
+        "reconnect must report the same full containerId as create (id1={id1}, id2={id2})"
+    );
+}


### PR DESCRIPTION
## Summary

`list_containers` ran `docker ps --format "{{json .}}"`, whose `.ID` field is the **short** 12-char container ID. So the reconnect/reuse path (which resolves the existing container via `list_containers`) reported a short `containerId`, while the initial `create` reported the **full** 64-char ID.

Same container, inconsistent output — it diverges from the reference CLI (always full) and breaks naive container-ID equality checks. It surfaced in the `examples/up/id-labels-reconnect` and `examples/up/remove-existing` canaries, which reported a spurious *"got a new container"* even though deacon **had** reconnected/reused correctly.

## Fix
Add `--no-trunc` to the `docker ps` invocation so `.ID` is the full ID, matching `create`/`run`. Reconnect now reports the same full ID as create.

## Testing
- New docker-gated regression test `up_reconnect_full_id` (grouped docker-exclusive): runs `up` twice and asserts the reported `containerId` is 64 chars and identical across create and reconnect.
- Verified end-to-end: both `id-labels-reconnect` (`✓ Reconnected to existing container`) and `remove-existing` (`✓ Reused existing container` / `✓ Container was replaced after removal`) canaries now pass.
- `container::`/`docker::` unit tests pass; `cargo fmt`/`clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)