### PR TITLE
docs(examples): fix invalid python one-liner in with-features canary

### DIFF
--- a/examples/up/with-features/exec.sh
+++ b/examples/up/with-features/exec.sh
@@ -15,8 +15,10 @@ run() {
 extract_container_id() {
 	local json_out=""
 	if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
-		json_out="$(printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; lines = [ln.strip() for ln in sys.stdin.read().splitlines() if ln.strip()]; if lines:; try:; data = json.loads(lines[-1]); cid = data.get("containerId", ""); if cid:; print(cid); sys.exit(0); except json.JSONDecodeError:; pass; sys.exit(0)'
-)" || json_out=""
+		# `deacon up` prints a single (pretty-printed) JSON document on stdout;
+		# parse it whole and read containerId. On any parse error python exits
+		# non-zero and the `|| json_out=""` below falls back to docker discovery.
+		json_out="$(printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; print(json.load(sys.stdin).get("containerId", ""))')" || json_out=""
 		if [ -n "$json_out" ]; then
 			printf '%s' "$json_out"
 			return 0


### PR DESCRIPTION
## Summary

`examples/up/with-features/exec.sh`'s `extract_container_id` passed an invalid `python3 -c` program: `if`/`try` compound statements joined with semicolons (`if lines:; try:; …`), which raises `SyntaxError`. It also assumed line-delimited JSON, but `deacon up` prints a **single pretty-printed JSON document**.

## Fix
Replace it with a valid one-liner that parses the whole stdout as one JSON document and reads `containerId`. On any parse error python exits non-zero and the existing `|| json_out=""` falls back to docker label discovery.

## Testing
- `with-features` canary now runs all three scenarios with no `SyntaxError`, exit 0.

Docs/examples only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)