### PR TITLE
fix(up): make the container keep-alive command PATH-independent

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -67,7 +67,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_keepalive_path)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -168,7 +168,7 @@ filter = 'binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output)'
+filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_keepalive_path)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1881,11 +1881,20 @@ impl ContainerOps for CliRuntime {
         // Reference: DevContainer spec "overrideCommand".
         let override_cmd = config.override_command.unwrap_or(true);
         if override_cmd {
-            // Use a portable keep-alive: prefer 'sleep infinity' (GNU coreutils),
-            // fall back to 'tail -f /dev/null' for BusyBox/Alpine images.
+            // Portable keep-alive: prefer `sleep infinity` (GNU coreutils), fall
+            // back to `tail -f /dev/null` (BusyBox/Alpine, where `sleep infinity`
+            // is rejected). Prepend a standard PATH first: some features (e.g.
+            // `node`, via nvm) replace the image's `PATH` with their own bin dir,
+            // which would otherwise drop `/usr/bin`+`/bin` and make the bare
+            // `sleep`/`tail` here resolve to "not found" (exit 127 → the
+            // container dies before any lifecycle command can run).
             args.push("/bin/sh".to_string());
             args.push("-c".to_string());
-            args.push("sleep infinity || tail -f /dev/null".to_string());
+            args.push(
+                "export PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}\"; \
+                 sleep infinity || tail -f /dev/null"
+                    .to_string(),
+            );
         }
 
         // Execute container create command

--- a/crates/deacon/tests/up_keepalive_path.rs
+++ b/crates/deacon/tests/up_keepalive_path.rs
@@ -1,0 +1,125 @@
+//! Regression test: the container keep-alive command must not depend on the
+//! image's `PATH`.
+//!
+//! `up` keeps the container alive with `/bin/sh -c "sleep infinity || tail -f
+//! /dev/null"`. Some features (e.g. `node` via nvm) replace the image `PATH`
+//! with their own bin dir, dropping `/usr/bin`+`/bin`; the bare `sleep`/`tail`
+//! then resolve to "not found" (exit 127) and the container dies before any
+//! lifecycle command runs. The keep-alive now prepends a standard `PATH`.
+//!
+//! This reproduces the class deterministically (no features/network) by
+//! clobbering `PATH` via `containerEnv`. Requires Docker; self-skips otherwise.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+struct ContainerGuard(String);
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rm", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+#[test]
+fn test_keepalive_survives_path_clobbering_container_env() {
+    if !is_docker_available() {
+        eprintln!(
+            "Skipping test_keepalive_survives_path_clobbering_container_env: Docker not available"
+        );
+        return;
+    }
+
+    let name = "Deacon Keepalive PATH Test";
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    fs::create_dir_all(root.join(".devcontainer")).unwrap();
+    fs::write(
+        root.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "{name}",
+  "image": "debian:bookworm-slim",
+  "remoteUser": "root",
+  "workspaceFolder": "/workspace",
+  "containerEnv": {{ "PATH": "/nonexistent/bin" }}
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(root)
+        .arg("--remove-existing-container")
+        .arg("--skip-post-create")
+        .env("DEACON_LOG", "warn")
+        .output()
+        .expect("spawn deacon up");
+
+    // Discover + guard the container regardless of outcome.
+    let cid = String::from_utf8_lossy(
+        &std::process::Command::new("docker")
+            .args([
+                "ps",
+                "-a",
+                "--filter",
+                &format!("label=devcontainer.name={}", name),
+                "--format",
+                "{{.ID}}",
+            ])
+            .output()
+            .map(|o| o.stdout)
+            .unwrap_or_default(),
+    )
+    .lines()
+    .next()
+    .unwrap_or("")
+    .trim()
+    .to_string();
+    let _guard = if cid.is_empty() {
+        None
+    } else {
+        Some(ContainerGuard(cid.clone()))
+    };
+
+    assert!(
+        output.status.success(),
+        "up failed with a PATH-clobbering containerEnv: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!cid.is_empty(), "container should have been created");
+
+    // The keep-alive must have survived: the container is still running.
+    let state = String::from_utf8_lossy(
+        &std::process::Command::new("docker")
+            .args(["inspect", "-f", "{{.State.Status}}", &cid])
+            .output()
+            .map(|o| o.stdout)
+            .unwrap_or_default(),
+    )
+    .trim()
+    .to_string();
+    assert_eq!(
+        state, "running",
+        "container should stay running despite a clobbered PATH (keep-alive must not depend on PATH)"
+    );
+}


### PR DESCRIPTION
## Summary

`up` keeps the container running with `/bin/sh -c "sleep infinity || tail -f /dev/null"`. Some features replace the image `PATH` with their own bin dir — the **`node`** feature (via nvm) sets `ENV PATH=/usr/local/share/nvm/…:…` **without** `/usr/bin`+`/bin`. The bare `sleep`/`tail` then resolve to *"not found"*, the keep-alive exits **127**, and the container dies immediately. Every subsequent step then fails with *"container is not running"* (user mapping, env probe, lifecycle).

## Fix
Prepend a standard `PATH` in the keep-alive command so `sleep`/`tail` resolve regardless of how a feature mangled the image `PATH`:
```sh
export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"; sleep infinity || tail -f /dev/null
```

## How it was found
`examples/up/prebuild-mode` (ubuntu:22.04 + `common-utils` + `node`) — the container exited 127 before onCreate. Confirmed: `node` clobbers PATH; `common-utils` alone stays running.

## Testing
- New docker-gated regression test `up_keepalive_path` that clobbers `PATH` via `containerEnv` (deterministic — no features/network) and asserts the container stays `running`. Grouped docker-exclusive.
- Verified the prebuild-mode repro now keeps the container running (`up` exit 0).
- `cargo fmt`/`clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)