### PR TITLE
fix(down): sweep stale containers by local_folder + idempotent teardown

### DIFF
--- a/crates/core/src/container.rs
+++ b/crates/core/src/container.rs
@@ -249,6 +249,27 @@ impl ContainerIdentity {
             self.config_hash
         )
     }
+
+    /// Build a broad, workspace-scoped label selector for sweeping *all*
+    /// containers belonging to this workspace — regardless of config drift.
+    ///
+    /// Unlike [`label_selector`](Self::label_selector) (which pins
+    /// `source` + `workspace_hash` + `config_hash` to find the one container
+    /// matching the *current* config), this matches purely on the
+    /// spec-canonical `devcontainer.local_folder` label. That is the durable
+    /// "which workspace does this container belong to" identity used by the
+    /// VS Code Dev Containers extension and the reference CLI, so it also
+    /// catches genuinely *stale* containers created under an older/different
+    /// config (different `config_hash`). Used by `down --all`.
+    ///
+    /// Returns `None` when the workspace path could not be canonicalized at
+    /// identity-construction time (so no reliable `local_folder` is known) —
+    /// callers should fall back to [`label_selector`](Self::label_selector).
+    pub fn workspace_label_selector(&self) -> Option<String> {
+        self.local_folder
+            .as_ref()
+            .map(|p| format!("{}={}", LABEL_LOCAL_FOLDER, p.display()))
+    }
 }
 
 fn canonicalize_json(value: &mut Value) {
@@ -422,6 +443,35 @@ mod tests {
             LABEL_WORKSPACE_HASH, identity.workspace_hash
         )));
         assert!(selector.contains(&format!("{}={}", LABEL_CONFIG_HASH, identity.config_hash)));
+    }
+
+    #[test]
+    fn test_workspace_label_selector_matches_local_folder() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+
+        let config = DevContainerConfig {
+            name: Some("test".to_string()),
+            image: Some("ubuntu:20.04".to_string()),
+            ..Default::default()
+        };
+
+        let identity = ContainerIdentity::new(workspace_path, &config);
+        let selector = identity
+            .workspace_label_selector()
+            .expect("local_folder should be set for an existing temp dir");
+
+        let expected_local_folder = workspace_path.canonicalize().unwrap().display().to_string();
+        assert_eq!(
+            selector,
+            format!("{}={}", LABEL_LOCAL_FOLDER, expected_local_folder),
+            "workspace_label_selector must pin only devcontainer.local_folder so it sweeps stale containers across config drift"
+        );
+
+        // It must NOT include the config-pinned hash labels — otherwise a
+        // container created under an older config would never be swept.
+        assert!(!selector.contains(LABEL_CONFIG_HASH));
+        assert!(!selector.contains(LABEL_WORKSPACE_HASH));
     }
 
     #[test]

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1276,7 +1276,13 @@ impl Docker for CliRuntime {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            if stderr.contains("No such object") || stderr.contains("No such container") {
+            // A missing container is not an error for callers, who treat
+            // `None` as "already gone". Match case-insensitively: Docker has
+            // emitted both "Error: No such object" and "error: no such
+            // object" across versions (and Podman uses lowercase).
+            let stderr_lower = stderr.to_ascii_lowercase();
+            if stderr_lower.contains("no such object") || stderr_lower.contains("no such container")
+            {
                 return Ok(None);
             }
             return Err(

--- a/crates/deacon/src/commands/down.rs
+++ b/crates/deacon/src/commands/down.rs
@@ -160,13 +160,17 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
 
     let docker = CliDocker::new();
 
-    // Build label selector from identity. The values here are hashes,
-    // so use the hash-labeled keys (#68 — previously this combined hash
-    // *values* with path-shaped *names* and matched nothing). Containers
-    // created by deacon get both this hash pair and the spec-mandated
-    // `devcontainer.local_folder` / `devcontainer.config_file` path
-    // labels emitted by `ContainerIdentity::labels()`.
-    let label_selector = identity.label_selector();
+    // `--all` sweeps *every* container for this workspace, including stale
+    // ones created under an older/different config. Match on the durable,
+    // spec-canonical `devcontainer.local_folder` label (the workspace path)
+    // rather than the config-pinned `source`+`workspace_hash`+`config_hash`
+    // selector used to find the single current container — otherwise a
+    // container whose config has drifted (different `config_hash`) would
+    // never be swept, defeating the purpose of `--all`. Fall back to the
+    // strict selector if the workspace path could not be canonicalized.
+    let label_selector = identity
+        .workspace_label_selector()
+        .unwrap_or_else(|| identity.label_selector());
 
     debug!("Label selector: {}", label_selector);
 
@@ -188,7 +192,13 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
     // Get timeout value (use provided or default to 30)
     let stop_timeout = args.timeout.or(Some(30));
 
-    // Stop and optionally remove each container
+    // Stop and optionally remove each container. `--all` is a best-effort
+    // sweep across potentially many containers, so a per-container failure
+    // must NOT abort the whole sweep — log it and keep going, then fail at
+    // the end only if a container genuinely survived. Errors that just mean
+    // "the container is already gone" (e.g. a `--rm` container auto-removed
+    // on stop, or a concurrent removal) are treated as success.
+    let mut failures = 0usize;
     for container in containers {
         debug!("Processing container: {}", container.id);
 
@@ -198,7 +208,15 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
                 "Stopping container {} with timeout: {:?}",
                 container.id, stop_timeout
             );
-            docker.stop_container(&container.id, stop_timeout).await?;
+            if let Err(e) = docker.stop_container(&container.id, stop_timeout).await {
+                if is_already_gone(&e) {
+                    debug!("Container {} already gone while stopping", container.id);
+                } else {
+                    warn!("Failed to stop container {}: {}", container.id, e);
+                    failures += 1;
+                    continue;
+                }
+            }
         } else {
             debug!(
                 "Container {} is not running (state: {})",
@@ -209,12 +227,41 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
         // Remove if requested
         if args.remove || args.force || args.volumes {
             debug!("Removing container {}", container.id);
-            remove_container_with_options(&docker, &container.id, args).await?;
+            if let Err(e) = remove_container_with_options(&docker, &container.id, args).await {
+                if is_already_gone(&e) {
+                    debug!("Container {} already removed", container.id);
+                } else {
+                    warn!("Failed to remove container {}: {}", container.id, e);
+                    failures += 1;
+                }
+            }
+        }
+    }
+
+    if failures > 0 {
+        anyhow::bail!("{} container(s) could not be torn down by --all", failures);
+    }
+
+    // The current workspace's container was just swept (if it had one), so
+    // drop its saved state — otherwise a subsequent plain `down` would read
+    // state pointing at a now-removed container. Best-effort: a missing state
+    // entry is fine.
+    if args.remove || args.force || args.volumes {
+        if let Ok(mut state_manager) = StateManager::new() {
+            state_manager.remove_workspace_state(&identity.workspace_hash);
         }
     }
 
     info!("All matching containers processed successfully");
     Ok(())
+}
+
+/// Returns true if a Docker error simply means the container is already gone
+/// (concurrently removed, auto-removed via `--rm` on stop, or never existed).
+/// Such errors are benign for a teardown whose goal is the container's absence.
+fn is_already_gone(err: &impl std::fmt::Display) -> bool {
+    let msg = err.to_string().to_ascii_lowercase();
+    msg.contains("no such container") || msg.contains("already in progress")
 }
 
 /// Execute down for single container configurations

--- a/crates/deacon/tests/smoke_down.rs
+++ b/crates/deacon/tests/smoke_down.rs
@@ -148,3 +148,121 @@ fn test_down_after_up_idempotent() {
         );
     }
 }
+
+/// Test `down --all` sweeps *every* container carrying this workspace's
+/// `devcontainer.local_folder` label — including a stale container that was
+/// NOT created by deacon (no `source`/hash labels) and whose config never
+/// matched. Regression test for `--all` over-pinning on `config_hash`.
+#[test]
+fn test_down_all_sweeps_stale_by_local_folder() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_down_all_sweeps_stale_by_local_folder: Docker not available");
+        return;
+    }
+    let temp_dir = TempDir::new().unwrap();
+    // Canonical workspace path — matches what deacon writes to the
+    // devcontainer.local_folder label and what we filter on below.
+    let workspace = temp_dir.path().canonicalize().unwrap();
+
+    let devcontainer_config = r#"{
+    "name": "Down All Stale Test",
+    "image": "alpine:3.19",
+    "workspaceFolder": "/workspace"
+}"#;
+    fs::create_dir(workspace.join(".devcontainer")).unwrap();
+    fs::write(
+        workspace.join(".devcontainer/devcontainer.json"),
+        devcontainer_config,
+    )
+    .unwrap();
+
+    // Bring up the deacon-managed container.
+    let up_output = Command::cargo_bin("deacon")
+        .unwrap()
+        .arg("up")
+        .arg("--skip-post-create")
+        .arg("--skip-non-blocking-commands")
+        .arg("--workspace-folder")
+        .arg(&workspace)
+        .output()
+        .unwrap();
+    assert!(
+        up_output.status.success(),
+        "Up failed: {}",
+        String::from_utf8_lossy(&up_output.stderr)
+    );
+
+    // Create a *stale* container that only carries the workspace's
+    // local_folder label (simulating a container from an older deacon run
+    // whose state file / config no longer matches).
+    let local_folder_label = format!("devcontainer.local_folder={}", workspace.display());
+    let stale = std::process::Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--rm",
+            "--label",
+            &local_folder_label,
+            "alpine:3.19",
+            "sleep",
+            "300",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        stale.status.success(),
+        "Failed to create stale container: {}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    let stale_id = String::from_utf8_lossy(&stale.stdout).trim().to_string();
+
+    // Count containers with this workspace label before sweep (expect >= 2).
+    let count_label = || -> usize {
+        let out = std::process::Command::new("docker")
+            .args([
+                "ps",
+                "-a",
+                "--filter",
+                &format!("label={}", local_folder_label),
+                "-q",
+            ])
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count()
+    };
+    assert!(
+        count_label() >= 2,
+        "expected at least the deacon container + stale container before sweep"
+    );
+
+    // Sweep everything with --all --remove.
+    let down_output = Command::cargo_bin("deacon")
+        .unwrap()
+        .arg("down")
+        .arg("--workspace-folder")
+        .arg(&workspace)
+        .arg("--all")
+        .arg("--remove")
+        .arg("--force")
+        .output()
+        .unwrap();
+
+    let remaining = count_label();
+    // Best-effort cleanup of the stale container regardless of assertion outcome.
+    let _ = std::process::Command::new("docker")
+        .args(["rm", "-f", &stale_id])
+        .output();
+
+    assert!(
+        down_output.status.success(),
+        "down --all failed: {}",
+        String::from_utf8_lossy(&down_output.stderr)
+    );
+    assert_eq!(
+        remaining, 0,
+        "down --all --remove must sweep ALL containers labeled for this workspace (including the stale, non-deacon one); {remaining} remained"
+    );
+}

--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -49,7 +49,7 @@ Last broad sweep: **2026-05-29** (against `main` including PRs #129/#131/#132/
 | configuration/secrets-declarative | ✅ pass | 2026-05-29 | |
 | doctor/gpu-host-requirements | ✅ pass | 2026-05-29 | |
 | doctor/host-requirements-failure | ✅ pass | 2026-05-29 | |
-| down/basic | ❓ unverified | — | not run in the 2026-05-29 sweep |
+| down/basic | ✅ pass | 2026-05-29 | `--all` now sweeps by `devcontainer.local_folder` + idempotent down on gone container (#147) |
 | exec/container-id-targeting | ⚠️ fixture | 2026-05-29 | git-root mount: `/workspace/test-script.sh` lands under `/workspace/examples/...`; pass with `--mount-workspace-git-root false` |
 | exec/exit-code-handling | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/*.sh`) |
 | exec/id-label-targeting | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/app.py`) |


### PR DESCRIPTION
## Summary

Verifying the `down/basic` canary (the last `❓ unverified` row in `examples/CANARY_STATUS.md`) surfaced **three real bugs** in `deacon down`:

1. **`--all` never swept genuinely-stale containers.** It filtered on the config-pinned `source`+`workspace_hash`+`config_hash` selector, so a container whose config had drifted (different `config_hash`) — i.e. exactly the "stale" case `--all` exists to clean up — was never matched. It now matches on the durable, spec-canonical `devcontainer.local_folder` label (the workspace path), via a new `ContainerIdentity::workspace_label_selector()`, falling back to the strict selector if the workspace path can't be canonicalized. This is the same label the VS Code Dev Containers extension and the reference CLI use to identify a workspace's containers.

2. **`--all` aborted on the first per-container error.** A `--rm` container auto-removes when stopped, so deacon's follow-up `docker rm` raced and failed with *"removal already in progress"*, aborting the whole sweep. The loop is now best-effort: benign "already gone" errors count as success, other failures are logged and the sweep continues, failing only at the end if a container genuinely survived. `--all` also now clears the current workspace's saved state so a subsequent plain `down` doesn't read a dangling container reference.

3. **Plain `down` wasn't idempotent on an already-removed container.** `inspect_container` matched the missing-container stderr case-sensitively (`"No such object"`), but this Docker emits lowercase (`"no such object"`), so `down` errored instead of being a no-op. The check is now case-insensitive (also covers Podman's lowercase output).

## Tests

- New docker-gated smoke test (`test_down_all_sweeps_stale_by_local_folder`) asserting `--all --remove` sweeps a stale, non-deacon container carrying only the workspace's `local_folder` label.
- New unit test for `workspace_label_selector()`.
- All existing `down` integration + smoke tests pass.
- `examples/down/basic/exec.sh` now passes all 6 scenarios end-to-end (was failing at scenario 5/6).

Flips `down/basic` to ✅ in `CANARY_STATUS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)