### PR TITLE
fix(exec): correct PTY allocation and accept camelCase env-probe values

### DIFF
--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -7,9 +7,17 @@ use deacon_core::container_env_probe::ContainerProbeMode;
 /// CLI-facing probe enum (value_enum for clap) to map into core probe mode
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum DefaultUserEnvProbe {
+    #[value(name = "none")]
     None,
+    // The spec and the upstream devcontainer CLI use camelCase probe-mode
+    // names (matching the `userEnvProbe` config values), and so does this
+    // flag's own help text. Make camelCase the canonical/displayed value and
+    // keep the derived kebab-case spelling as an alias for back-compat.
+    #[value(name = "loginInteractiveShell", alias = "login-interactive-shell")]
     LoginInteractiveShell,
+    #[value(name = "interactiveShell", alias = "interactive-shell")]
     InteractiveShell,
+    #[value(name = "loginShell", alias = "login-shell")]
     LoginShell,
 }
 
@@ -242,7 +250,7 @@ pub enum Commands {
         /// Default user environment probe mode when config omits userEnvProbe.
         /// Allowed values: `none`, `loginInteractiveShell`, `interactiveShell`, `loginShell`.
         /// Default: `loginInteractiveShell`.
-        #[arg(long, value_enum, default_value = "login-interactive-shell")]
+        #[arg(long, value_enum, default_value = "loginInteractiveShell")]
         default_user_env_probe: DefaultUserEnvProbe,
 
         // Mounts and environment
@@ -494,7 +502,7 @@ pub enum Commands {
         /// Default user environment probe mode when config omits `userEnvProbe`.
         /// Allowed values: `none`, `loginInteractiveShell`, `interactiveShell`, `loginShell`.
         /// Default: `loginInteractiveShell` (collects shell-initialized environment where possible).
-        #[arg(long, value_enum, default_value = "login-interactive-shell")]
+        #[arg(long, value_enum, default_value = "loginInteractiveShell")]
         default_user_env_probe: DefaultUserEnvProbe,
         /// Command and arguments to execute inside the container (positional; required).
         ///
@@ -879,7 +887,7 @@ pub struct Cli {
         long,
         global = true,
         value_enum,
-        default_value = "login-interactive-shell"
+        default_value = "loginInteractiveShell"
     )]
     pub default_user_env_probe: DefaultUserEnvProbe,
 

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -75,21 +75,28 @@ pub struct ExecArgs {
     pub terminal_dimensions: Option<TerminalDimensions>,
 }
 
-/// Compute whether we should allocate a PTY for exec.
+/// Compute whether we should allocate a PTY for `exec`.
+///
 /// Rules:
-/// - If `force_tty` is true, always allocate a PTY.
-/// - Otherwise, allocate a PTY only if `!no_tty` AND both stdin and stdout are TTYs.
+/// - Explicit `--no-tty` always wins: never allocate a PTY.
+/// - A PTY requires a real terminal on **stdin**. `docker exec -it` against a
+///   piped/redirected stdin is rejected by the daemon ("cannot attach stdin to
+///   a TTY-enabled container because stdin is not a terminal"), so `exec` can
+///   never use a PTY when stdin isn't a terminal — even under `force_tty`.
+/// - `force_tty` (e.g. JSON log format auto-forcing) bypasses only the
+///   *stdout*-is-a-terminal requirement, so an interactive user whose stdout is
+///   being captured (a JSON consumer) still gets a PTY.
+/// - Otherwise, allocate a PTY only when both stdin and stdout are TTYs.
 pub(crate) fn compute_should_use_tty(
     force_tty: bool,
     no_tty: bool,
     stdin_is_tty: bool,
     stdout_is_tty: bool,
 ) -> bool {
-    if force_tty {
-        true
-    } else {
-        !no_tty && stdin_is_tty && stdout_is_tty
+    if no_tty || !stdin_is_tty {
+        return false;
     }
+    force_tty || stdout_is_tty
 }
 
 fn map_config_error(err: DeaconError) -> anyhow::Error {
@@ -1051,9 +1058,19 @@ mod tests {
 
     #[test]
     fn test_compute_should_use_tty_variants() {
-        // When forced, always true
-        assert!(compute_should_use_tty(true, false, false, false));
-        // When not forced, need !no_tty and both stdin/stdout TTY
+        // A PTY is impossible without a terminal on stdin — even when forced.
+        // Regression: force_tty used to return `true` unconditionally, which
+        // made `exec --log-format json | consumer` fail with "cannot attach
+        // stdin to a TTY-enabled container because stdin is not a terminal".
+        assert!(!compute_should_use_tty(true, false, false, false));
+        assert!(!compute_should_use_tty(true, false, false, true));
+        // force_tty bypasses only the stdout-is-a-tty requirement: an
+        // interactive user (stdin tty) whose stdout is captured still gets a PTY.
+        assert!(compute_should_use_tty(true, false, true, false));
+        assert!(compute_should_use_tty(true, false, true, true));
+        // Explicit --no-tty always wins, even over force_tty.
+        assert!(!compute_should_use_tty(true, true, true, true));
+        // When not forced, need !no_tty and BOTH stdin/stdout to be TTYs.
         assert!(compute_should_use_tty(false, false, true, true));
         assert!(!compute_should_use_tty(false, true, true, true));
         assert!(!compute_should_use_tty(false, false, false, true));

--- a/crates/deacon/tests/integration_exec_pty.rs
+++ b/crates/deacon/tests/integration_exec_pty.rs
@@ -158,14 +158,29 @@ fn integration_exec_pty_behavior_unaffected_by_force_tty_if_json() {
         false, // stdout_is_tty=false
     );
 
-    // With force_tty_if_json=true, should force PTY allocation
+    // A PTY cannot be allocated without a real terminal on stdin — `docker
+    // exec -it` against a piped/redirected stdin is rejected by the daemon.
+    // So force_tty_if_json must NOT conjure a PTY in a non-TTY environment.
     assert!(
-        exec_config.tty,
-        "force_tty_if_json=true should allocate PTY"
+        !exec_config.tty,
+        "force_tty_if_json=true must NOT allocate a PTY when stdin is not a terminal"
     );
 
-    // Test 3: force_tty_if_json=true takes precedence over no_tty=true
-    // This verifies that exec uses compute_should_use_tty which checks force_tty first
+    // But force_tty DOES bypass the stdout-is-a-tty requirement: an
+    // interactive user (stdin tty) whose stdout is captured still gets a PTY.
+    let exec_config_stdin_tty = build_exec_config(
+        &args_with_force,
+        "/".to_string(),
+        HashMap::new(),
+        true,  // stdin_is_tty=true
+        false, // stdout_is_tty=false (e.g. captured by a JSON consumer)
+    );
+    assert!(
+        exec_config_stdin_tty.tty,
+        "force_tty_if_json=true should allocate a PTY when stdin is a terminal even if stdout is captured"
+    );
+
+    // Test 3: explicit no_tty=true wins even over force_tty_if_json=true
     let args_no_tty_override = ExecArgs {
         user: None,
         no_tty: true, // Explicit no-TTY
@@ -190,18 +205,19 @@ fn integration_exec_pty_behavior_unaffected_by_force_tty_if_json() {
         terminal_dimensions: None,
     };
 
+    // Even with stdin as a terminal, an explicit --no-tty disables the PTY.
     let exec_config = build_exec_config(
         &args_no_tty_override,
         "/".to_string(),
         HashMap::new(),
-        false,
-        false,
+        true, // stdin_is_tty=true
+        true, // stdout_is_tty=true
     );
 
-    // Per compute_should_use_tty: force_tty takes precedence over no_tty
+    // Per compute_should_use_tty: explicit no_tty wins over force_tty.
     assert!(
-        exec_config.tty,
-        "force_tty takes precedence over no_tty in exec"
+        !exec_config.tty,
+        "explicit --no-tty must disable the PTY even when force_tty_if_json is set"
     );
 
     // Test 4: no_tty=true without force should disable PTY even with TTY environment


### PR DESCRIPTION
## Summary

Two real `deacon exec` bugs surfaced while verifying the `exec/*` canaries:

### 1. PTY allocation forced a TTY without a terminal
`--log-format json` auto-sets `force_tty_if_json`, and `compute_should_use_tty` returned `true` **unconditionally** when forced — even when stdin is not a terminal. `docker exec -it` against a piped/redirected stdin is rejected by the daemon:

```
cannot attach stdin to a TTY-enabled container because stdin is not a terminal
```

So `deacon exec --log-format json <cmd> | consumer` (the common non-interactive JSON use case) failed. Now:
- A PTY requires a real terminal on **stdin**, regardless of `force_tty`.
- `force_tty` (JSON auto-force) bypasses only the *stdout*-is-a-tty requirement, so an interactive user whose stdout is captured by a JSON consumer still gets a PTY.
- Explicit `--no-tty` now wins over the JSON auto-force.

### 2. `--default-user-env-probe` rejected the spec's camelCase values
The flag only accepted clap's derived kebab-case (`interactive-shell`), but the spec, the upstream devcontainer CLI, the `userEnvProbe` config field, and **this flag's own `--help` description** all use camelCase (`interactiveShell`, `loginInteractiveShell`, `loginShell`). camelCase is now the canonical, displayed value, with kebab-case retained as an alias for back-compat.

## Tests
- `compute_should_use_tty` unit test rewritten to lock in the new semantics (force_tty cannot conjure a PTY without a stdin terminal; `--no-tty` wins).
- Existing probe-mode mapping + parity tests stay green.

Found via `examples/exec/non-interactive-streaming` (bug 1) and `examples/exec/user-env-probe-modes` (bug 2). The example/fixture-side fixes and `CANARY_STATUS.md` flips follow in a separate `docs(examples):` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)