### PR TITLE
docs(examples): make exec canaries monorepo-robust and portable

### DIFF
--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -50,15 +50,15 @@ Last broad sweep: **2026-05-29** (against `main` including PRs #129/#131/#132/
 | doctor/gpu-host-requirements | ✅ pass | 2026-05-29 | |
 | doctor/host-requirements-failure | ✅ pass | 2026-05-29 | |
 | down/basic | ✅ pass | 2026-05-29 | `--all` now sweeps by `devcontainer.local_folder` + idempotent down on gone container (#147) |
-| exec/container-id-targeting | ⚠️ fixture | 2026-05-29 | git-root mount: `/workspace/test-script.sh` lands under `/workspace/examples/...`; pass with `--mount-workspace-git-root false` |
-| exec/exit-code-handling | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/*.sh`) |
-| exec/id-label-targeting | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/app.py`) |
+| exec/container-id-targeting | ✅ pass | 2026-05-29 | baked `--mount-workspace-git-root false` into the example's `up` (#149) |
+| exec/exit-code-handling | ✅ pass | 2026-05-29 | baked `--mount-workspace-git-root false` (#149) |
+| exec/id-label-targeting | ✅ pass | 2026-05-29 | non-spec `containerLabels`→`runArgs --label`; git-root mount flag (#149) |
 | exec/interactive-pty | ✅ pass | 2026-05-29 | |
-| exec/non-interactive-streaming | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/generate-output.sh`) |
-| exec/remote-env-variables | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/check-env.sh`) |
-| exec/remote-user-execution | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/user-check.sh`) |
-| exec/user-env-probe-modes | ⚠️ fixture | 2026-05-29 | git-root mount (`/workspace/probe-test.sh`) |
-| exec/workspace-folder-discovery | ⚠️ fixture | 2026-05-29 | `node --version` passthrough fixed (#132); `/workspace/src/main.js` still hits git-root mount |
+| exec/non-interactive-streaming | ✅ pass | 2026-05-29 | PTY-on-non-tty + JSON stream fixes (#148); `xxd`→`od`, git-root flag (#149) |
+| exec/remote-env-variables | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
+| exec/remote-user-execution | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
+| exec/user-env-probe-modes | ✅ pass | 2026-05-29 | camelCase `--default-user-env-probe` values (#148); git-root flag (#149) |
+| exec/workspace-folder-discovery | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
 | features/feature-contributed-lifecycle | ✅ pass | 2026-05-29 | |
 | features/feature-env-injection | ✅ pass | 2026-05-29 | |
 | features/oci-digest-pin | ✅ pass | 2026-05-29 | `name:tag@digest` parsing (#131) |

--- a/examples/exec/container-id-targeting/exec.sh
+++ b/examples/exec/container-id-targeting/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: step 1) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 CID="$(container_id)"
 if [ -z "$CID" ]; then

--- a/examples/exec/exit-code-handling/exec.sh
+++ b/examples/exec/exit-code-handling/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Success (Exit 0) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" true

--- a/examples/exec/id-label-targeting/.devcontainer.json
+++ b/examples/exec/id-label-targeting/.devcontainer.json
@@ -2,11 +2,11 @@
   "name": "Exec ID Label Example",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "remoteUser": "vscode",
-  "containerLabels": {
-    "app.name": "exec-example",
-    "app.environment": "development",
-    "app.version": "1.0"
-  },
+  "runArgs": [
+    "--label", "app.name=exec-example",
+    "--label", "app.environment=development",
+    "--label", "app.version=1.0"
+  ],
   "remoteEnv": {
     "APP_NAME": "exec-label-demo"
   },

--- a/examples/exec/id-label-targeting/README.md
+++ b/examples/exec/id-label-targeting/README.md
@@ -63,5 +63,7 @@ Labels must follow the format `name=value`:
 ## Notes
 
 - The `devcontainer.local_folder` label uses absolute paths
-- Custom labels defined in `containerLabels` are also searchable
+- Custom labels added via `runArgs` (`--label key=value`) are also searchable
+  (the spec has no `containerLabels` property; `runArgs` is the supported way
+  to attach arbitrary container labels)
 - Labels are more stable than container IDs across recreations

--- a/examples/exec/id-label-targeting/exec.sh
+++ b/examples/exec/id-label-targeting/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: step 1) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Execute using workspace label (README: step 2) ==" >&2
 run "$DEACON_BIN" exec --id-label "devcontainer.local_folder=${SCRIPT_DIR}" python3 /workspace/app.py

--- a/examples/exec/non-interactive-streaming/README.md
+++ b/examples/exec/non-interactive-streaming/README.md
@@ -48,7 +48,7 @@ deacon exec --workspace-folder . bash /workspace/generate-output.sh \
 ```bash
 # Read binary file and pipe through exec without corruption
 deacon exec --workspace-folder . cat /workspace/data/sample.bin \
-  | xxd | head -n 5
+  | od -An -tx1 | head -n 5
 ```
 
 ### Process Substitution
@@ -66,9 +66,10 @@ EXIT_CODE=$?
 echo "Build exit code: $EXIT_CODE"
 ```
 
-### JSON Output (Forces PTY but streams continuously)
+### JSON Output (streams continuously; non-PTY when non-interactive)
 ```bash
-# Even with JSON, output streams continuously
+# Even with JSON, output streams continuously. A PTY is only allocated when
+# stdin is an interactive terminal — piped/redirected stdin streams without one.
 deacon exec --workspace-folder . --log-format json \
   bash /workspace/generate-output.sh
 ```

--- a/examples/exec/non-interactive-streaming/binary-test.sh
+++ b/examples/exec/non-interactive-streaming/binary-test.sh
@@ -10,7 +10,7 @@ if [ -f /workspace/data/sample.bin ]; then
     
     # Output first 16 bytes in hex
     echo "First 16 bytes (hex):" >&2
-    xxd -l 16 /workspace/data/sample.bin >&2
+    od -An -tx1 -N 16 /workspace/data/sample.bin >&2
 fi
 
 # Test 2: Generate and output binary data

--- a/examples/exec/non-interactive-streaming/exec.sh
+++ b/examples/exec/non-interactive-streaming/exec.sh
@@ -27,7 +27,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Separate stdout/stderr to files (README: Separate Streams) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash /workspace/generate-output.sh \
@@ -43,7 +43,7 @@ run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash /workspace/generate
 
 echo "== Binary-safe operation (README: Binary-Safe Operation) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" cat /workspace/data/sample.bin \
-	| xxd | head -n 5
+	| od -An -tx1 | head -n 5
 
 echo "== Process substitution (README: Process Substitution) ==" >&2
 cat <(run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash /workspace/generate-output.sh)
@@ -56,8 +56,11 @@ set -e
 echo "Build exit code: $EXIT_CODE" >&2
 
 echo "== JSON output streaming (README: JSON Output) ==" >&2
+# No `| head` here: with a non-terminal stdin the command streams without a
+# PTY, and truncating a live stream with `head` would SIGPIPE the producer
+# (exit 141) under `set -o pipefail`. Matches the README's JSON example.
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" --log-format json \
-	bash /workspace/generate-output.sh | head -n 5
+	bash /workspace/generate-output.sh
 
 echo "== Large output streaming (README: Large Output Streaming) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash -c 'for i in {1..50}; do echo "Line $i"; done' | wc -l

--- a/examples/exec/remote-env-variables/exec.sh
+++ b/examples/exec/remote-env-variables/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: step 1) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Default environment from config (README: step 2) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash /workspace/check-env.sh

--- a/examples/exec/remote-user-execution/exec.sh
+++ b/examples/exec/remote-user-execution/exec.sh
@@ -27,7 +27,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: Basic User Verification) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Verify user (whoami) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" whoami

--- a/examples/exec/user-env-probe-modes/exec.sh
+++ b/examples/exec/user-env-probe-modes/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: Prerequisites) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Default probe: loginInteractiveShell (README: Test Default Probe) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" bash /workspace/probe-test.sh

--- a/examples/exec/workspace-folder-discovery/exec.sh
+++ b/examples/exec/workspace-folder-discovery/exec.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 cd "$SCRIPT_DIR"
 
 echo "== Start dev container (README: step 1) ==" >&2
-run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@"
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --mount-workspace-git-root false "$@"
 
 echo "== Execute with workspace discovery (README: step 2) ==" >&2
 run "$DEACON_BIN" exec --workspace-folder "$SCRIPT_DIR" node --version


### PR DESCRIPTION
## Summary

Fixture/portability fixes for the `exec/*` canaries (the `⚠️ fixture` rows in `CANARY_STATUS.md`), plus the manifest flips to ✅.

- **Git-root mount**: bake `--mount-workspace-git-root false` into every exec example's `up` invocation. Run inside this monorepo the git root is mounted, so `/workspace/<file>` references land under `/workspace/examples/...`; the flag mounts the example folder directly. Harmless standalone.
- **id-label-targeting**: `containerLabels` is **not** a devcontainer.json spec property (confirmed against containers.dev) — deacon correctly ignores it, so `exec --id-label app.name=…` found no container. Replaced with the spec-compliant `runArgs: ["--label", "key=value", …]`. README note updated.
- **non-interactive-streaming**: host `xxd` isn't always installed → use coreutils `od -An -tx1`. Dropped the `| head -n 5` on the JSON-streaming step (it SIGPIPE-killed the producer — exit 141 — under `set -o pipefail`; this is correct `exec` passthrough, not a deacon bug) to match the README, and corrected the README's "Forces PTY" wording.

## Dependency

The exec canaries also needed two **code** fixes (PTY-without-terminal, camelCase env-probe values) — those are in **#148** and should merge first. With #148 + this PR at `main`, all nine `exec/*` rows run green end-to-end (verified locally with the release binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)