### PR TITLE
docs(examples): fix up/configuration-output, lifecycle-hooks, dotfiles fixtures

### DIFF
--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -81,15 +81,15 @@ Last broad sweep: **2026-05-29** (against `main` including PRs #129/#131/#132/
 | up/basic-image | ✅ pass | 2026-05-29 | |
 | up/compose-basic | ✅ pass | 2026-05-29 | |
 | up/compose-profiles | ✅ pass | 2026-05-29 | |
-| up/configuration-output | ⚠️ fixture | 2026-05-29 | alpine + git feature needs bash → exit 127 |
+| up/configuration-output | ✅ pass | 2026-05-29 | base switched alpine→debian:bookworm-slim (git feature needs bash) (#151) |
 | up/container-user-vs-remote-user | ✅ pass | 2026-05-29 | |
 | up/dockerfile-build | ✅ pass | 2026-05-29 | |
-| up/dotfiles-integration | ⚠️ fixture | 2026-05-29 | clones a GitHub repo → needs network/auth |
+| up/dotfiles-integration | ✅ pass | 2026-05-29 | repo URL `codespaces/dotfiles` (404)→`holman/dotfiles` (#151); `~` target-path expansion (#150) |
 | up/gpu-modes | ✅ pass | 2026-05-29 | GPU `all` failure expected on non-GPU hosts (tolerated) |
 | up/id-labels-reconnect | ✅ pass | 2026-05-29 | full-ID on reconnect (#143) |
 | up/image-metadata-merge | ✅ pass | 2026-05-29 | |
 | up/initialize-command | ✅ pass | 2026-05-29 | |
-| up/lifecycle-hooks | ⚠️ fixture | 2026-05-29 | `remoteUser: devuser` runs `apt-get` → permission denied |
+| up/lifecycle-hooks | ✅ pass | 2026-05-29 | non-existent `devuser`→root (apt needs root); array hooks→argv `["bash","-c",…]` (#151) |
 | up/override-command | ✅ pass | 2026-05-29 | |
 | up/ports-config | ✅ pass | 2026-05-29 | |
 | up/prebuild-mode | ✅ pass | 2026-05-29 | keep-alive PATH fix (#145) |

--- a/examples/up/configuration-output/.devcontainer/devcontainer.json
+++ b/examples/up/configuration-output/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "Configuration Output Example",
-	"image": "alpine:3.18",
+	"image": "debian:bookworm-slim",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
 	"remoteEnv": {

--- a/examples/up/configuration-output/README.md
+++ b/examples/up/configuration-output/README.md
@@ -49,7 +49,7 @@ Output:
   "remoteWorkspaceFolder": "/workspace",
   "configuration": {
     "name": "Configuration Output Example",
-    "image": "alpine:3.18",
+    "image": "debian:bookworm-slim",
     "remoteUser": "root",
     "workspaceFolder": "/workspace",
     "remoteEnv": {

--- a/examples/up/dotfiles-integration/exec.sh
+++ b/examples/up/dotfiles-integration/exec.sh
@@ -38,27 +38,27 @@ cd "$SCRIPT_DIR"
 
 echo "== Basic Dotfiles Integration (default repository) ==" >&2
 out_basic="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container \
-	--dotfiles-repository "https://github.com/codespaces/dotfiles" \
+	--dotfiles-repository "https://github.com/holman/dotfiles" \
 	"$@")"
 cleanup_container "$(extract_container_id "$out_basic")"
 
 echo "== Custom Install Command ==" >&2
 out_custom_install="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container \
-	--dotfiles-repository "https://github.com/codespaces/dotfiles" \
+	--dotfiles-repository "https://github.com/holman/dotfiles" \
 	--dotfiles-install-command "echo 'custom install command executed'" \
 	"$@")"
 cleanup_container "$(extract_container_id "$out_custom_install")"
 
 echo "== Custom Target Path ==" >&2
 out_custom_target="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container \
-	--dotfiles-repository "https://github.com/codespaces/dotfiles" \
+	--dotfiles-repository "https://github.com/holman/dotfiles" \
 	--dotfiles-target-path "~/.config/dotfiles-custom" \
 	"$@")"
 cleanup_container "$(extract_container_id "$out_custom_target")"
 
 echo "== All Options Combined ==" >&2
 out_all="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container \
-	--dotfiles-repository "https://github.com/codespaces/dotfiles" \
+	--dotfiles-repository "https://github.com/holman/dotfiles" \
 	--dotfiles-install-command "echo 'custom install command executed'" \
 	--dotfiles-target-path "~/.config/dotfiles-custom" \
 	"$@")"

--- a/examples/up/lifecycle-hooks/.devcontainer/devcontainer.json
+++ b/examples/up/lifecycle-hooks/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Lifecycle Hooks Example",
 	"image": "ubuntu:22.04",
-	"remoteUser": "devuser",
+	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
 	
 	"onCreateCommand": {
@@ -10,9 +10,9 @@
 	},
 	
 	"updateContentCommand": [
-		"echo 'Updating content...'",
-		"mkdir -p /tmp/updates",
-		"date > /tmp/updates/last-update.txt"
+		"bash",
+		"-c",
+		"echo 'Updating content...' && mkdir -p /tmp/updates && date > /tmp/updates/last-update.txt"
 	],
 	
 	"postCreateCommand": "echo 'Setup directory structure' && mkdir -p /workspace/{src,tests,docs}",
@@ -23,9 +23,9 @@
 	},
 	
 	"postAttachCommand": [
-		"echo 'Welcome to the dev container!'",
-		"echo 'Workspace: /workspace'",
-		"echo 'User: $(whoami)'"
+		"bash",
+		"-c",
+		"echo 'Welcome to the dev container!' && echo 'Workspace: /workspace' && echo \"User: $(whoami)\""
 	],
 	
 	"remoteEnv": {

--- a/examples/up/lifecycle-hooks/README.md
+++ b/examples/up/lifecycle-hooks/README.md
@@ -20,14 +20,17 @@ This example demonstrates all available lifecycle hooks in the Dev Container spe
 
 ### 2. updateContentCommand
 **When**: Runs after onCreate and on every subsequent container start
-**Format**: Array of commands (runs sequentially)
+**Format**: Array (exec/argv form — the array is a single command with
+arguments and is **not** run through a shell). To chain multiple shell
+commands, invoke a shell explicitly (`["bash", "-c", "… && …"]`) or use the
+string form.
 **Use Case**: Update cached content, refresh dependencies
 
 ```json
 "updateContentCommand": [
-  "echo 'Updating content...'",
-  "mkdir -p /tmp/updates",
-  "date > /tmp/updates/last-update.txt"
+  "bash",
+  "-c",
+  "echo 'Updating content...' && mkdir -p /tmp/updates && date > /tmp/updates/last-update.txt"
 ]
 ```
 
@@ -54,13 +57,16 @@ This example demonstrates all available lifecycle hooks in the Dev Container spe
 
 ### 5. postAttachCommand
 **When**: Runs every time a tool attaches to the container
-**Format**: Array of commands (runs sequentially)
+**Format**: Array (exec/argv form — a single command with arguments, not run
+through a shell; use `["bash", "-c", "…"]` for shell features such as
+`$(whoami)`)
 **Use Case**: Display welcome messages, show environment info
 
 ```json
 "postAttachCommand": [
-  "echo 'Welcome!'",
-  "echo 'User: $(whoami)'"
+  "bash",
+  "-c",
+  "echo 'Welcome!' && echo \"User: $(whoami)\""
 ]
 ```
 
@@ -68,11 +74,11 @@ This example demonstrates all available lifecycle hooks in the Dev Container spe
 
 ```
 Container Creation (first time):
-  1. onCreateCommand    (parallel execution)
-  2. updateContentCommand  (sequential execution)
-  3. postCreateCommand
-  4. postStartCommand   (parallel execution)
-  5. postAttachCommand  (sequential execution)
+  1. onCreateCommand    (object form → named commands run in parallel)
+  2. updateContentCommand  (array → single exec/argv command)
+  3. postCreateCommand     (string → run in a shell)
+  4. postStartCommand   (object form → named commands run in parallel)
+  5. postAttachCommand  (array → single exec/argv command)
 
 Container Restart (subsequent starts):
   1. updateContentCommand
@@ -142,7 +148,7 @@ docker exec <container-id> curl --version
 {
   "outcome": "success",
   "containerId": "<container-id>",
-  "remoteUser": "devuser",
+  "remoteUser": "root",
   "remoteWorkspaceFolder": "/workspace"
 }
 ```


### PR DESCRIPTION
## Summary

Three `up/*` canaries (the remaining `⚠️ fixture` rows) failed for fixture reasons, not deacon bugs. Fixes + `CANARY_STATUS.md` flips to ✅.

### up/configuration-output
Base was `alpine:3.18`, but the `ghcr.io/devcontainers/features/git` install.sh has a `#!/usr/bin/env bash` shebang and alpine ships no bash → `exit 127`. Switched to `debian:bookworm-slim`. README config snippet updated.

### up/lifecycle-hooks
Two layered fixture bugs:
1. `remoteUser: devuser` references a user that doesn't exist in bare `ubuntu:22.04`, and `onCreateCommand`'s `apt-get install` needs root → changed to run lifecycle as **root** (the textbook onCreate-installs-deps pattern; user demos live in `container-user-vs-remote-user/`).
2. `updateContentCommand` / `postAttachCommand` were written as **arrays of shell commands**, but the spec treats an array as a single **exec/argv** command (not a shell, not a sequence). deacon correctly tried to exec a program literally named `echo 'Updating content...'` → 127. Rewrote them as `["bash", "-c", "… && …"]` and corrected the README's array-form documentation (it claimed "runs sequentially").

### up/dotfiles-integration
`--dotfiles-repository https://github.com/codespaces/dotfiles` is a **404** — git then prompts for credentials and fails (`could not read Username`). Network itself is fine. Pointed at the stable, public `holman/dotfiles` (no root `install.sh`/`setup.sh`, so deacon clones cleanly without running an installer).

## Dependency

up/dotfiles-integration also needs the `~` target-path expansion code fix in **#150** (merge first). The other two rows are fixture-only. All three verified green locally with the release binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)