### PR TITLE
fix(compose): stop (not remove) services on stopCompose down

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -409,6 +409,12 @@ impl ComposeCommand {
         self.execute(&["down"]).await
     }
 
+    /// Stop containers without removing them (`docker compose stop`).
+    #[instrument(skip(self))]
+    pub async fn stop(&self) -> Result<String> {
+        self.execute(&["stop"]).await
+    }
+
     /// Stop and remove containers with additional flags
     #[instrument(skip(self))]
     pub async fn down_with_flags(&self, flags: &[&str]) -> Result<String> {
@@ -961,7 +967,11 @@ impl ComposeManager {
 
         debug!("Stopping compose project {}", project.name);
 
-        command.down().await?;
+        // `docker compose stop` — stop the services but keep the containers so
+        // `down` (the default `stopCompose` action, without `--remove`) mirrors
+        // single-container `down`: stopped-but-present, resumable on next `up`.
+        // Removal is reserved for `down --remove` (-> down_project).
+        command.stop().await?;
 
         debug!("Compose project {} stopped successfully", project.name);
         Ok(())

--- a/crates/deacon/tests/smoke_compose_edges.rs
+++ b/crates/deacon/tests/smoke_compose_edges.rs
@@ -423,3 +423,137 @@ RUN echo "app service" > /tmp/app.txt
         "Build output should indicate compose service build"
     );
 }
+
+/// Regression: `down` on a Compose project with the default `stopCompose`
+/// action (no `--remove`) must STOP the services, not remove them — mirroring
+/// single-container `down`. Previously `stop_project` called
+/// `docker compose down`, deleting the containers.
+#[test]
+fn test_compose_down_stops_but_keeps_containers() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_compose_down_stops_but_keeps_containers: Docker not available");
+        return;
+    }
+    let temp_dir = TempDir::new().unwrap();
+
+    // Single service, labeled so we can find it without the project name.
+    let compose_config = r#"services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity
+    labels:
+      - "deacon.test=compose-stop"
+"#;
+    fs::write(temp_dir.path().join("docker-compose.yml"), compose_config).unwrap();
+    let devcontainer = r#"{
+  "name": "Compose Stop Test",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/",
+  "shutdownAction": "stopCompose",
+  "overrideCommand": false
+}"#;
+    fs::write(temp_dir.path().join(".devcontainer.json"), devcontainer).unwrap();
+
+    let count = |status: &str| -> usize {
+        let mut args = vec![
+            "ps".to_string(),
+            "-a".to_string(),
+            "--filter".to_string(),
+            "label=deacon.test=compose-stop".to_string(),
+            "-q".to_string(),
+        ];
+        if !status.is_empty() {
+            args.push("--filter".to_string());
+            args.push(format!("status={}", status));
+        }
+        let out = std::process::Command::new("docker")
+            .args(&args)
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count()
+    };
+    let cleanup = || {
+        let ids = std::process::Command::new("docker")
+            .args([
+                "ps",
+                "-a",
+                "--filter",
+                "label=deacon.test=compose-stop",
+                "-q",
+            ])
+            .output()
+            .unwrap();
+        for id in String::from_utf8_lossy(&ids.stdout).split_whitespace() {
+            let _ = std::process::Command::new("docker")
+                .args(["rm", "-f", id])
+                .output();
+        }
+    };
+
+    cleanup();
+
+    // deacon's workspace-state cache lives under `std::env::temp_dir()` (shared
+    // across processes). Isolate this test's state via a per-test TMPDIR so a
+    // concurrent docker test can't clobber the shared state index and make our
+    // `down` lose the saved compose project. `up` and `down` must share it.
+    let state_home = temp_dir.path().join("state-home");
+    fs::create_dir_all(&state_home).unwrap();
+
+    let up = Command::cargo_bin("deacon")
+        .unwrap()
+        .env("TMPDIR", &state_home)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .arg("--remove-existing-container")
+        .output()
+        .unwrap();
+    assert!(
+        up.status.success(),
+        "compose up failed: {}",
+        String::from_utf8_lossy(&up.stderr)
+    );
+    assert_eq!(count("running"), 1, "service should be running after up");
+
+    let down = Command::cargo_bin("deacon")
+        .unwrap()
+        .env("TMPDIR", &state_home)
+        .arg("down")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .output()
+        .unwrap();
+    let down_ok = down.status.success();
+
+    // `down` blocks until `docker compose stop` returns, but under heavy
+    // parallel docker load the container's transition to "exited" can lag the
+    // CLI return slightly — poll briefly for it to settle.
+    let mut running = count("running");
+    for _ in 0..20 {
+        if running == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        running = count("running");
+    }
+    let present = count("");
+    cleanup();
+
+    assert!(
+        down_ok,
+        "compose down failed: {}",
+        String::from_utf8_lossy(&down.stderr)
+    );
+    assert_eq!(
+        present, 1,
+        "stopCompose down (no --remove) must keep the container present"
+    );
+    assert_eq!(
+        running, 0,
+        "stopCompose down (no --remove) must stop the container"
+    );
+}


### PR DESCRIPTION
## Summary

`deacon down` on a Docker Compose project with the default `shutdownAction: stopCompose` (and no `--remove`) was **deleting** the containers instead of stopping them. `stop_project` called `ComposeCommand::down()` (`docker compose down`) despite its name/docs:

```rust
pub async fn stop_project(&self, project: &ComposeProject) -> Result<()> {
    ...
    command.down().await?;   // <- removes containers!
}
```

This diverged from single-container `down`, which only **stops** the container (leaving it present and resumable on the next `up`).

## Fix

- Add a real `ComposeCommand::stop()` that runs `docker compose stop`.
- `stop_project` now calls `stop()`. `down --remove` / `--volumes` continue to route to `down_project` / `down_project_with_volumes`.

## Test

Docker-gated regression test (`test_compose_down_stops_but_keeps_containers`): after `up` + `down` on a `stopCompose` project, the container is **present but not running**. The test isolates deacon's shared `std::env::temp_dir()/deacon-state` cache via a per-test `TMPDIR` so a concurrent docker test can't clobber the workspace-state index (which previously made this flake).

Found while building a new `examples/compose/multiservice-down/` canary (follows in a separate `docs(examples):` PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)