### PR TITLE
docs(examples): add Tier 1-3 compatibility canaries

### DIFF
--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -23,9 +23,13 @@ pass, so they don't have to be re-evaluated from scratch every session.
 Last broad sweep: **2026-05-29** (against `main` including PRs #129/#131/#132/
 #134/#139/#143/#144/#145 and this session's #147/#148/#149/#150/#151). Every
 row is currently ✅ — the last `❓`/`⚠️` rows (`down/basic`, the `exec/*` and
-`up/*` fixtures) were unblocked by those five PRs. The four top-level runners
-(`build/`, `exec/`, `read-configuration/`, `up/`) just iterate their children
-and aren't listed.
+`up/*` fixtures) were unblocked by those five PRs. A later pass added Tier 1–3
+**coverage** canaries (compose `down`, feature dependency ordering, local /
+contributed-option features, lockfile, `outdated`/`upgrade`, `config
+substitute`, `doctor`, `runServices`, workspace-trust) — one of which surfaced
+the compose-`stopCompose` fix (#153). The four top-level runners (`build/`,
+`exec/`, `read-configuration/`, `up/`) just iterate their children and aren't
+listed.
 
 | Canary | Status | Verified | Notes |
 |---|---|---|---|
@@ -48,8 +52,13 @@ and aren't listed.
 | build/secrets-and-ssh | ✅ pass | 2026-05-29 | ssh needs `SSH_AUTH_SOCK` (allow-fail) |
 | build/unwritable-output | ✅ pass | 2026-05-29 | asserts error |
 | compose/multiple-compose-files | ✅ pass | 2026-05-29 | |
+| compose/multiservice-down | ✅ pass | 2026-05-29 | compose `down`/`stopCompose` + `--remove`/`--volumes`; needs the `stop_project` fix (#153) |
+| compose/run-services | ✅ pass | 2026-05-29 | `runServices` selectivity (app+worker up, idle down) (new) |
 | configuration/extends-chain-cycle | ✅ pass | 2026-05-29 | asserts cycle errors |
 | configuration/secrets-declarative | ✅ pass | 2026-05-29 | |
+| configuration/substitute | ✅ pass | 2026-05-29 | `config substitute`: localEnv/localWorkspaceFolderBasename, `--dry-run` (new) |
+| configuration/workspace-trust | ✅ pass | 2026-05-29 | host `initializeCommand` trust gate: `DEACON_NO_PROMPT` denies, `--trust-workspace` allows (new) |
+| doctor/diagnostics | ✅ pass | 2026-05-29 | plain `doctor`, `--json`, `--bundle` (new) |
 | doctor/gpu-host-requirements | ✅ pass | 2026-05-29 | |
 | doctor/host-requirements-failure | ✅ pass | 2026-05-29 | |
 | down/basic | ✅ pass | 2026-05-29 | `--all` now sweeps by `devcontainer.local_folder` + idempotent down on gone container (#147) |
@@ -62,11 +71,16 @@ and aren't listed.
 | exec/remote-user-execution | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
 | exec/user-env-probe-modes | ✅ pass | 2026-05-29 | camelCase `--default-user-env-probe` values (#148); git-root flag (#149) |
 | exec/workspace-folder-discovery | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
+| features/contributed-options | ✅ pass | 2026-05-29 | feature-contributed mount/entrypoint/init/capAdd reach the container (new) |
+| features/dependency-ordering | ✅ pass | 2026-05-29 | auto install order via `installsAfter`+`dependsOn` (no override) (new) |
 | features/feature-contributed-lifecycle | ✅ pass | 2026-05-29 | |
 | features/feature-env-injection | ✅ pass | 2026-05-29 | |
+| features/local-feature | ✅ pass | 2026-05-29 | local `./` feature install + option override (new) |
+| features/lockfile | ✅ pass | 2026-05-29 | lockfile generate / `--frozen-lockfile` pass + mismatch fail; needs ghcr (new) |
 | features/oci-digest-pin | ✅ pass | 2026-05-29 | `name:tag@digest` parsing (#131) |
 | features/option-sanitization | ✅ pass | 2026-05-29 | |
 | features/override-install-order | ✅ pass | 2026-05-29 | |
+| outdated/basic | ✅ pass | 2026-05-29 | `outdated --output json` + `--fail-on-outdated`; needs ghcr (new) |
 | read-configuration/basic | ✅ pass | 2026-05-29 | |
 | read-configuration/compose | ✅ pass | 2026-05-29 | |
 | read-configuration/extends-chain | ✅ pass | 2026-05-29 | |
@@ -105,3 +119,4 @@ and aren't listed.
 | up/wait-for | ✅ pass | 2026-05-29 | |
 | up/with-features | ✅ pass | 2026-05-29 | canary python fix (#144) |
 | up/workspace-mount | ✅ pass | 2026-05-29 | |
+| upgrade/basic | ✅ pass | 2026-05-29 | `upgrade --dry-run` + lockfile write; needs ghcr (new) |

--- a/examples/compose/multiservice-down/.devcontainer.json
+++ b/examples/compose/multiservice-down/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "Compose multiservice down",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"runServices": ["db"],
+	"workspaceFolder": "/",
+	"shutdownAction": "stopCompose",
+	"overrideCommand": false
+}

--- a/examples/compose/multiservice-down/README.md
+++ b/examples/compose/multiservice-down/README.md
@@ -1,0 +1,27 @@
+# Compose: Multi-Service Teardown (`down` / `stopCompose`)
+
+`down/basic/` covers single-container teardown; this is its Compose
+counterpart. It brings up a two-service Compose project (`app` + `db`) and
+exercises `deacon down` against it, including the `shutdownAction:
+stopCompose` default and the `--remove` / `--volumes` flags.
+
+## Files
+
+- `docker-compose.yml` — two `alpine` services (`app`, `db`); `db` has a named
+  volume `msdown-data`. Both carry the label `canary.group=msdown` so the
+  script can find them without knowing deacon's derived project name.
+- `.devcontainer.json` — `dockerComposeFile` + `service: app`,
+  `runServices: ["db"]` (so both services come up — deacon starts the primary
+  `service` plus `runServices`), `shutdownAction: stopCompose`.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Up** starts both services (2 running).
+2. **`down`** (default `stopCompose`) stops both but leaves them present.
+3. **`down --remove`** deletes the project's containers.
+4. **`down --remove --volumes`** also drops the named volume.
+
+## Spec references
+
+- `shutdownAction` (`stopCompose`):
+  <https://containers.dev/implementors/json_reference/>

--- a/examples/compose/multiservice-down/docker-compose.yml
+++ b/examples/compose/multiservice-down/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  app:
+    image: alpine:3.18
+    command: sleep infinity
+    labels:
+      - "canary.group=msdown"
+  db:
+    image: alpine:3.18
+    command: sleep infinity
+    labels:
+      - "canary.group=msdown"
+    volumes:
+      - msdown-data:/data
+
+volumes:
+  msdown-data:

--- a/examples/compose/multiservice-down/exec.sh
+++ b/examples/compose/multiservice-down/exec.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+LABEL="canary.group=msdown"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+# All services in docker-compose.yml carry label canary.group=msdown, so we can
+# find them regardless of deacon's derived compose project name.
+service_ids() {
+	docker ps -a --filter "label=${LABEL}" --format '{{.ID}}'
+}
+running_count() {
+	docker ps --filter "label=${LABEL}" --filter "status=running" -q | wc -l | tr -d ' '
+}
+present_count() {
+	docker ps -a --filter "label=${LABEL}" -q | wc -l | tr -d ' '
+}
+
+cleanup() {
+	service_ids | xargs -r docker rm -f >/dev/null 2>&1 || true
+	docker volume ls -q | grep -i msdown-data | xargs -r docker volume rm >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+
+up() {
+	run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" "$@" >/dev/null
+}
+
+# Scenario 1: up starts both services.
+echo "== Scenario 1: up brings up app + db ==" >&2
+up
+[ "$(running_count)" -eq 2 ] || { echo "FAIL: expected 2 running services, got $(running_count)" >&2; exit 1; }
+echo "  ok: 2 services running" >&2
+
+# Scenario 2: shutdownAction=stopCompose -> plain `down` stops but keeps them.
+echo "== Scenario 2: down (stopCompose) stops but does not remove ==" >&2
+run "$DEACON_BIN" down --workspace-folder "$SCRIPT_DIR"
+[ "$(running_count)" -eq 0 ] || { echo "FAIL: services still running after down" >&2; exit 1; }
+[ "$(present_count)" -eq 2 ] || { echo "FAIL: expected 2 stopped services to remain, got $(present_count)" >&2; exit 1; }
+echo "  ok: services stopped, still present" >&2
+
+# Scenario 3: down --remove deletes the project's containers.
+echo "== Scenario 3: down --remove removes containers ==" >&2
+up
+run "$DEACON_BIN" down --workspace-folder "$SCRIPT_DIR" --remove
+[ "$(present_count)" -eq 0 ] || { echo "FAIL: containers remain after down --remove, got $(present_count)" >&2; exit 1; }
+echo "  ok: containers removed" >&2
+
+# Scenario 4: down --remove --volumes also drops the named volume.
+echo "== Scenario 4: down --remove --volumes drops the volume ==" >&2
+up
+run "$DEACON_BIN" down --workspace-folder "$SCRIPT_DIR" --remove --volumes
+[ "$(present_count)" -eq 0 ] || { echo "FAIL: containers remain after down --remove --volumes" >&2; exit 1; }
+vols="$(docker volume ls -q | grep -ic msdown-data || true)"
+[ "$vols" -eq 0 ] || { echo "FAIL: msdown-data volume(s) still present (${vols})" >&2; exit 1; }
+echo "  ok: containers and volume removed" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/compose/run-services/.devcontainer.json
+++ b/examples/compose/run-services/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "Compose runServices",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"runServices": ["worker"],
+	"workspaceFolder": "/",
+	"overrideCommand": false
+}

--- a/examples/compose/run-services/README.md
+++ b/examples/compose/run-services/README.md
@@ -1,0 +1,20 @@
+# Compose: `runServices` Selectivity
+
+`runServices` lists the Compose services deacon should start/stop alongside the
+primary `service`. When set, services *not* in `service` ∪ `runServices` should
+stay down. This canary verifies that selectivity.
+
+## Files
+
+- `docker-compose.yml` — three `alpine` services: `app`, `worker`, `idle`
+  (each labeled `canary.svc=<name>`).
+- `.devcontainer.json` — `service: app`, `runServices: ["worker"]`.
+
+## Scenario exercised by `exec.sh`
+
+After `up`: `app` (primary) and `worker` (runServices) are running, while
+`idle` — listed in the compose file but not selected — stays down.
+
+## Spec references
+
+- `runServices`: <https://containers.dev/implementors/json_reference/>

--- a/examples/compose/run-services/docker-compose.yml
+++ b/examples/compose/run-services/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  app:
+    image: alpine:3.18
+    command: sleep infinity
+    labels:
+      - "canary.group=runsvc"
+      - "canary.svc=app"
+  worker:
+    image: alpine:3.18
+    command: sleep infinity
+    labels:
+      - "canary.group=runsvc"
+      - "canary.svc=worker"
+  idle:
+    image: alpine:3.18
+    command: sleep infinity
+    labels:
+      - "canary.group=runsvc"
+      - "canary.svc=idle"

--- a/examples/compose/run-services/exec.sh
+++ b/examples/compose/run-services/exec.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+svc_running() {
+	# 1 if the given compose service is running, else 0.
+	docker ps --filter "label=canary.svc=$1" --filter "status=running" -q | grep -q . && echo 1 || echo 0
+}
+
+cleanup() {
+	docker ps -a --filter "label=canary.group=runsvc" -q | xargs -r docker rm -f >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+
+echo "== Bring up with service=app, runServices=[worker] ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@" >/dev/null
+
+echo "== Scenario: only app + worker start; idle stays down ==" >&2
+app="$(svc_running app)"; worker="$(svc_running worker)"; idle="$(svc_running idle)"
+echo "  app=${app} worker=${worker} idle=${idle}" >&2
+[ "$app" = "1" ]    || { echo "FAIL: primary service 'app' not running" >&2; exit 1; }
+[ "$worker" = "1" ] || { echo "FAIL: runServices entry 'worker' not running" >&2; exit 1; }
+[ "$idle" = "0" ]   || { echo "FAIL: 'idle' should NOT start (not in service/runServices)" >&2; exit 1; }
+echo "  ok: runServices selectivity honored" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/configuration/substitute/.devcontainer.json
+++ b/examples/configuration/substitute/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "subst-${localEnv:CANARY_TOKEN}",
+	"image": "alpine:3.18",
+	"workspaceFolder": "/wf/${localWorkspaceFolderBasename}",
+	"containerEnv": {
+		"GREETING": "hi-${localEnv:CANARY_TOKEN}"
+	}
+}

--- a/examples/configuration/substitute/README.md
+++ b/examples/configuration/substitute/README.md
@@ -1,0 +1,29 @@
+# Configuration: `config substitute`
+
+`deacon config substitute` loads a `devcontainer.json`, applies `${...}`
+variable substitution, and prints the resolved configuration — without
+touching Docker. Useful for debugging what a config resolves to before an
+`up`.
+
+## Files
+
+- `.devcontainer.json` — uses `${localEnv:CANARY_TOKEN}` and
+  `${localWorkspaceFolderBasename}` in the name, `workspaceFolder`, and
+  `containerEnv`.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Substitution** — with `CANARY_TOKEN=zzz`, the output contains `subst-zzz`,
+   `hi-zzz`, and `/wf/substitute` (this directory's basename).
+2. **`--dry-run`** previews successfully.
+3. **Valid JSON** (when `python3` is present) — the output parses and the
+   resolved config is under `.configuration` with `name == "subst-zzz"`.
+
+> `config substitute` resolves host-side variables (`localEnv`,
+> `localWorkspaceFolder*`). `${containerWorkspaceFolder}` is only known once a
+> container exists, so it is left for the `up`/`read-configuration` flow.
+
+## Spec references
+
+- Variable interpolation:
+  <https://containers.dev/implementors/json_reference/#variables-in-devcontainerjson>

--- a/examples/configuration/substitute/exec.sh
+++ b/examples/configuration/substitute/exec.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cd "$SCRIPT_DIR"
+
+# `config substitute` is a no-Docker command: it loads the config, applies
+# ${...} variable substitution, and prints the resolved config to stdout.
+echo "== Scenario 1: variables are substituted in the output ==" >&2
+out="$(CANARY_TOKEN=zzz run "$DEACON_BIN" config substitute --workspace-folder "$SCRIPT_DIR")"
+echo "$out" | sed 's/^/  | /' >&2
+
+# localEnv:CANARY_TOKEN -> zzz
+echo "$out" | grep -q 'subst-zzz' \
+	|| { echo "FAIL: \${localEnv:CANARY_TOKEN} not substituted" >&2; exit 1; }
+echo "$out" | grep -q 'hi-zzz' \
+	|| { echo "FAIL: \${localEnv} inside containerEnv not substituted" >&2; exit 1; }
+# localWorkspaceFolderBasename -> substitute (this dir's name)
+echo "$out" | grep -q '/wf/substitute' \
+	|| { echo "FAIL: \${localWorkspaceFolderBasename} not substituted" >&2; exit 1; }
+echo "  ok: localEnv and localWorkspaceFolderBasename resolved" >&2
+
+echo "== Scenario 2: --dry-run previews without error ==" >&2
+CANARY_TOKEN=zzz run "$DEACON_BIN" config substitute --workspace-folder "$SCRIPT_DIR" --dry-run >/dev/null
+echo "  ok: --dry-run succeeded" >&2
+
+# Optional stricter assertion if python is available: output is valid JSON.
+if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+	echo "== Scenario 3: output is valid JSON with substituted name ==" >&2
+	# `config substitute` wraps the resolved config under `.configuration`.
+	name="$(printf '%s' "$out" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["configuration"]["name"])' 2>/dev/null || true)"
+	[ "$name" = "subst-zzz" ] \
+		|| { echo "FAIL: parsed .configuration.name was '${name}', expected 'subst-zzz'" >&2; exit 1; }
+	echo "  ok: JSON parses, .configuration.name=subst-zzz" >&2
+fi
+
+echo "All scenarios passed." >&2

--- a/examples/configuration/workspace-trust/.devcontainer.json
+++ b/examples/configuration/workspace-trust/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "Workspace trust gate",
+	"image": "alpine:3.18",
+	"workspaceFolder": "/workspace",
+	"initializeCommand": "touch ./initialize-ran.marker"
+}

--- a/examples/configuration/workspace-trust/README.md
+++ b/examples/configuration/workspace-trust/README.md
@@ -1,0 +1,26 @@
+# Configuration: Workspace-Trust Gate for `initializeCommand`
+
+`initializeCommand` runs on the **developer's host** before any container
+sandboxing. deacon gates any host-side exec sourced from the workspace behind
+a workspace-trust check (see `SECURITY.md`). This canary verifies both ends of
+that gate.
+
+## Files
+
+- `.devcontainer.json` — an `initializeCommand` that writes
+  `./initialize-ran.marker` on the host.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Denied.** `DEACON_NO_PROMPT=1 deacon up …` fails closed: the command
+   errors with a workspace-trust message and the host marker is **not**
+   written (CI-safe default).
+2. **Allowed.** `deacon up --trust-workspace …` runs the host
+   `initializeCommand`, so the marker appears.
+
+`exec.sh` removes the marker and container on exit.
+
+## Spec / security references
+
+- This gate is deacon-specific (not mandated by containers.dev). See
+  `SECURITY.md` and the "Workspace-Trust Gate" section of `CLAUDE.md`.

--- a/examples/configuration/workspace-trust/exec.sh
+++ b/examples/configuration/workspace-trust/exec.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+MARKER="${SCRIPT_DIR}/initialize-ran.marker"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+container_id() {
+	docker ps -a --filter "label=devcontainer.source=deacon" --filter "label=devcontainer.name=Workspace trust gate" --format '{{.ID}}' | head -n1
+}
+
+cleanup() {
+	local cid
+	cid="$(container_id || true)"
+	if [ -n "${cid:-}" ]; then
+		docker rm -f "$cid" >/dev/null 2>&1 || true
+	fi
+	rm -f "$MARKER"
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+rm -f "$MARKER"
+
+# `initializeCommand` runs on the HOST before any container sandboxing, so it
+# is gated by deacon's workspace-trust check.
+
+echo "== Scenario 1: untrusted (DEACON_NO_PROMPT=1) denies host initializeCommand ==" >&2
+set +e
+DEACON_NO_PROMPT=1 "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@" >/dev/null 2>"${SCRIPT_DIR}/deny.log"
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+	echo "FAIL: up unexpectedly succeeded under DEACON_NO_PROMPT=1" >&2
+	rm -f "${SCRIPT_DIR}/deny.log"; exit 1
+fi
+if [ -f "$MARKER" ]; then
+	echo "FAIL: initializeCommand ran despite being untrusted" >&2
+	rm -f "${SCRIPT_DIR}/deny.log"; exit 1
+fi
+if ! grep -qiE "trust|untrusted" "${SCRIPT_DIR}/deny.log"; then
+	echo "FAIL: error did not mention workspace trust" >&2
+	cat "${SCRIPT_DIR}/deny.log" >&2; rm -f "${SCRIPT_DIR}/deny.log"; exit 1
+fi
+rm -f "${SCRIPT_DIR}/deny.log"
+echo "  ok: denied, initializeCommand did not run" >&2
+
+echo "== Scenario 2: --trust-workspace allows host initializeCommand ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --trust-workspace "$@" >/dev/null
+[ -f "$MARKER" ] || { echo "FAIL: initializeCommand did not run under --trust-workspace" >&2; exit 1; }
+echo "  ok: trusted, initializeCommand ran" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/doctor/diagnostics/README.md
+++ b/examples/doctor/diagnostics/README.md
@@ -1,0 +1,21 @@
+# Doctor: Environment Diagnostics & Support Bundle
+
+`deacon doctor` reports environment diagnostics (runtime versions, Docker
+availability, etc.). The existing `doctor/*` canaries focus on host-requirement
+evaluation; this one covers the plain diagnostics output, the `--json`
+contract, and `--bundle`.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Text** — `deacon doctor` emits human-readable diagnostics.
+2. **JSON** — `deacon doctor --json` emits a single parseable JSON document on
+   stdout.
+3. **Bundle** — `deacon doctor --bundle <path>` writes a support-bundle
+   artifact.
+
+`exec.sh` removes the bundle on exit. No `devcontainer.json` is needed.
+
+## Output streams
+
+Per the output contract, `--json` writes the JSON document to stdout and all
+logs to stderr.

--- a/examples/doctor/diagnostics/exec.sh
+++ b/examples/doctor/diagnostics/exec.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+BUNDLE="${SCRIPT_DIR}/support-bundle"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cleanup() {
+	rm -rf "$BUNDLE" "${BUNDLE}.zip" "${BUNDLE}.tar.gz"
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+
+# `doctor` collects environment diagnostics; it needs no devcontainer config.
+echo "== Scenario 1: text diagnostics run ==" >&2
+out="$(run "$DEACON_BIN" doctor 2>/dev/null || true)"
+[ -n "$out" ] || { echo "FAIL: doctor produced no output" >&2; exit 1; }
+echo "$out" | sed 's/^/  | /' | head -n 20 >&2
+echo "  ok: doctor emitted diagnostics" >&2
+
+echo "== Scenario 2: --json emits parseable JSON ==" >&2
+json="$(run "$DEACON_BIN" doctor --json 2>/dev/null)"
+if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+	printf '%s' "$json" | "$PYTHON_BIN" -c 'import json,sys; json.load(sys.stdin)' \
+		|| { echo "FAIL: doctor --json did not emit valid JSON" >&2; exit 1; }
+	echo "  ok: valid JSON" >&2
+else
+	printf '%s' "$json" | grep -q '{' || { echo "FAIL: no JSON object" >&2; exit 1; }
+	echo "  ok: JSON-ish output (no python to fully validate)" >&2
+fi
+
+echo "== Scenario 3: --bundle writes a support bundle ==" >&2
+rm -rf "$BUNDLE" "${BUNDLE}.zip" "${BUNDLE}.tar.gz"
+run "$DEACON_BIN" doctor --bundle "$BUNDLE" >/dev/null 2>&1
+# Accept a directory or an archive artifact at/near the requested path.
+if [ -e "$BUNDLE" ] || [ -e "${BUNDLE}.zip" ] || [ -e "${BUNDLE}.tar.gz" ] || ls "${BUNDLE}"* >/dev/null 2>&1; then
+	echo "  ok: support bundle created" >&2
+else
+	echo "FAIL: no support bundle artifact at ${BUNDLE}*" >&2
+	exit 1
+fi
+
+echo "All scenarios passed." >&2

--- a/examples/down/basic/README.md
+++ b/examples/down/basic/README.md
@@ -54,5 +54,5 @@ deacon down --workspace-folder . --all --remove
 
 - `shutdownAction`: <https://containers.dev/implementors/json_reference/>
 - Compose teardown (`stopCompose`) is covered by
-  `examples/compose/multiservice-basic/` and is the natural follow-up to
+  `examples/compose/multiservice-down/` and is the natural follow-up to
   this single-container example.

--- a/examples/features/contributed-options/README.md
+++ b/examples/features/contributed-options/README.md
@@ -1,0 +1,33 @@
+# Features: Feature-Contributed Container Options
+
+A Feature's `devcontainer-feature.json` can contribute container-level options
+beyond install scripts: `mounts`, `entrypoint`, `init`, `privileged`,
+`capAdd`, and `securityOpt`. deacon merges these into the container it creates.
+This example verifies four of them actually reach the running container (the
+existing `feature-env-injection/` and `feature-contributed-lifecycle/`
+canaries cover `containerEnv` and lifecycle hooks respectively).
+
+## The feature (`./probe-feature`)
+
+Declares:
+- `mounts` — a named volume mounted at `/contrib-data`
+- `entrypoint` — `/usr/local/share/contrib/entrypoint.sh` (created by
+  `install.sh`); deacon chains it ahead of the container command, and it ends
+  with `exec "$@"`. On start it writes `/tmp/contrib-entrypoint-ran`.
+- `init` — request the tini init process
+- `capAdd` — `SYS_PTRACE`
+
+## Scenarios exercised by `exec.sh`
+
+1. **Mount** — `docker inspect` shows `/contrib-data` mounted.
+2. **Capability** — `HostConfig.CapAdd` contains `SYS_PTRACE`.
+3. **Init** — `HostConfig.Init` is `true`.
+4. **Entrypoint** — the marker the chained entrypoint writes exists in the
+   container.
+
+`exec.sh` removes the named volume on exit.
+
+## Spec references
+
+- Feature contribution properties:
+  <https://containers.dev/implementors/features/#devcontainer-feature-json-properties>

--- a/examples/features/contributed-options/devcontainer.json
+++ b/examples/features/contributed-options/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "Feature-contributed container options",
+	"image": "alpine:3.18",
+	"remoteUser": "root",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"./probe-feature": {}
+	}
+}

--- a/examples/features/contributed-options/exec.sh
+++ b/examples/features/contributed-options/exec.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+VOLUME_NAME="deacon-contrib-vol"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+container_id() {
+	docker ps -a --filter "label=devcontainer.source=deacon" --filter "label=devcontainer.name=Feature-contributed container options" --format '{{.ID}}' | head -n1
+}
+
+cleanup() {
+	local cid
+	cid="$(container_id || true)"
+	if [ -n "${cid:-}" ]; then
+		docker rm -f "$cid" >/dev/null 2>&1 || true
+	fi
+	docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
+	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
+}
+trap cleanup EXIT
+
+chmod +x "$SCRIPT_DIR"/probe-feature/install.sh
+
+cd "$SCRIPT_DIR"
+
+echo "== Bring container up (feature contributes mount/entrypoint/init/capAdd) ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --config "$SCRIPT_DIR/devcontainer.json" --remove-existing-container "$@" >/dev/null
+cid="$(container_id)"
+[ -n "$cid" ] || { echo "FAIL: container not found after up" >&2; exit 1; }
+
+echo "== Scenario 1: feature-contributed mount is attached ==" >&2
+mounts="$(docker inspect -f '{{range .Mounts}}{{.Destination}} {{end}}' "$cid")"
+echo "  mounts: ${mounts}" >&2
+case " $mounts " in
+	*" /contrib-data "*) echo "  ok: /contrib-data mounted" >&2 ;;
+	*) echo "FAIL: feature mount /contrib-data not present" >&2; exit 1 ;;
+esac
+
+echo "== Scenario 2: feature-contributed capability (SYS_PTRACE) applied ==" >&2
+caps="$(docker inspect -f '{{json .HostConfig.CapAdd}}' "$cid")"
+echo "  CapAdd: ${caps}" >&2
+case "$caps" in
+	*SYS_PTRACE*) echo "  ok: SYS_PTRACE added" >&2 ;;
+	*) echo "FAIL: SYS_PTRACE capability not added" >&2; exit 1 ;;
+esac
+
+echo "== Scenario 3: feature requested init (tini) ==" >&2
+init="$(docker inspect -f '{{.HostConfig.Init}}' "$cid")"
+echo "  Init: ${init}" >&2
+[ "$init" = "true" ] || { echo "FAIL: HostConfig.Init expected true" >&2; exit 1; }
+echo "  ok: init enabled" >&2
+
+echo "== Scenario 4: feature-contributed entrypoint actually ran ==" >&2
+ran="$(docker exec "$cid" cat /tmp/contrib-entrypoint-ran 2>/dev/null || true)"
+echo "  marker: ${ran}" >&2
+[ -n "$ran" ] || { echo "FAIL: feature entrypoint did not run (marker missing)" >&2; exit 1; }
+echo "  ok: entrypoint chained and ran" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/features/contributed-options/probe-feature/devcontainer-feature.json
+++ b/examples/features/contributed-options/probe-feature/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+	"id": "probe",
+	"version": "1.0.0",
+	"name": "Probe (contributes container options)",
+	"description": "A local feature that contributes a mount, an entrypoint, init, and an added Linux capability — to verify they reach the running container.",
+	"mounts": [
+		{
+			"source": "deacon-contrib-vol",
+			"target": "/contrib-data",
+			"type": "volume"
+		}
+	],
+	"entrypoint": "/usr/local/share/contrib/entrypoint.sh",
+	"init": true,
+	"capAdd": ["SYS_PTRACE"]
+}

--- a/examples/features/contributed-options/probe-feature/install.sh
+++ b/examples/features/contributed-options/probe-feature/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+# Install the entrypoint the feature declares. deacon chains feature
+# entrypoints ahead of the container command, so this must end with `exec "$@"`.
+mkdir -p /usr/local/share/contrib
+cat > /usr/local/share/contrib/entrypoint.sh <<'EOF'
+#!/bin/sh
+# Marker proving the feature-contributed entrypoint actually ran at start.
+echo "contrib entrypoint ran" > /tmp/contrib-entrypoint-ran
+# The feature-contributed volume is mounted here; record into it too.
+[ -d /contrib-data ] && echo started > /contrib-data/started 2>/dev/null || true
+exec "$@"
+EOF
+chmod +x /usr/local/share/contrib/entrypoint.sh

--- a/examples/features/dependency-ordering/README.md
+++ b/examples/features/dependency-ordering/README.md
@@ -1,0 +1,34 @@
+# Features: Dependency-Driven Install Order
+
+Distinct from `override-install-order/` (which uses the explicit
+`overrideFeatureInstallOrder` array), this example proves that deacon resolves
+install order **automatically** from feature dependency metadata —
+`installsAfter` (soft) and `dependsOn` (hard) — with no manual override.
+
+## The setup
+
+Three local features whose **declaration / alphabetical** order would be
+`app, base, lib`:
+
+- `feature-base` (id `base`) — no dependencies
+- `feature-lib` (id `lib`) — `"installsAfter": ["base"]`
+- `feature-app` (id `app`) — `"dependsOn": { "lib": {} }`
+
+Each `install.sh` appends its name to `/usr/local/share/feature-order/log`.
+
+The dependency graph (`lib` after `base`, `app` after `lib`) forces a
+**different** order: `base → lib → app`.
+
+> Note: `installsAfter` and `dependsOn` reference a sibling feature by its
+> metadata `id` (here `base` / `lib`), which deacon maps onto the local
+> `./feature-*` path during resolution.
+
+## Scenario exercised by `exec.sh`
+
+After `up`, the recorded install order is exactly `base,lib,app` — confirming
+the dependency graph (not declaration order) drove installation.
+
+## Spec references
+
+- Feature install order / `installsAfter` / `dependsOn`:
+  <https://containers.dev/implementors/features/#installation-order>

--- a/examples/features/dependency-ordering/devcontainer.json
+++ b/examples/features/dependency-ordering/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "Feature dependency ordering",
+	"image": "alpine:3.18",
+	"remoteUser": "root",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"./feature-app": {},
+		"./feature-base": {},
+		"./feature-lib": {}
+	}
+}

--- a/examples/features/dependency-ordering/exec.sh
+++ b/examples/features/dependency-ordering/exec.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+container_id() {
+	docker ps -a --filter "label=devcontainer.source=deacon" --filter "label=devcontainer.name=Feature dependency ordering" --format '{{.ID}}' | head -n1
+}
+
+cleanup() {
+	local cid
+	cid="$(container_id || true)"
+	if [ -n "${cid:-}" ]; then
+		docker rm -f "$cid" >/dev/null 2>&1 || true
+	fi
+	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
+}
+trap cleanup EXIT
+
+chmod +x "$SCRIPT_DIR"/feature-*/install.sh
+
+cd "$SCRIPT_DIR"
+
+# Top-level devcontainer.json so the `./feature-*` paths resolve against the
+# config dir; point deacon at it explicitly.
+echo "== Bring container up (no overrideFeatureInstallOrder; deps decide order) ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --config "$SCRIPT_DIR/devcontainer.json" --remove-existing-container "$@" >/dev/null
+cid="$(container_id)"
+[ -n "$cid" ] || { echo "FAIL: container not found after up" >&2; exit 1; }
+
+echo "== Scenario: installsAfter + dependsOn drive the install order ==" >&2
+# Declaration/alphabetical default would be app,base,lib. The dependency graph
+# (lib installsAfter base; app dependsOn lib) forces base -> lib -> app.
+actual="$(docker exec "$cid" cat /usr/local/share/feature-order/log 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
+expected="base,lib,app"
+echo "  expected: ${expected}" >&2
+echo "  actual:   ${actual}" >&2
+[ "$actual" = "$expected" ] \
+	|| { echo "FAIL: dependency-driven install order not honored" >&2; exit 1; }
+echo "  ok: dependsOn/installsAfter honored" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/features/dependency-ordering/feature-app/devcontainer-feature.json
+++ b/examples/features/dependency-ordering/feature-app/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+	"id": "app",
+	"version": "1.0.0",
+	"name": "App",
+	"description": "Hard-depends on lib via dependsOn.",
+	"dependsOn": {
+		"lib": {}
+	}
+}

--- a/examples/features/dependency-ordering/feature-app/install.sh
+++ b/examples/features/dependency-ordering/feature-app/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+mkdir -p /usr/local/share/feature-order
+echo "app" >> /usr/local/share/feature-order/log

--- a/examples/features/dependency-ordering/feature-base/devcontainer-feature.json
+++ b/examples/features/dependency-ordering/feature-base/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+	"id": "base",
+	"version": "1.0.0",
+	"name": "Base",
+	"description": "No dependencies."
+}

--- a/examples/features/dependency-ordering/feature-base/install.sh
+++ b/examples/features/dependency-ordering/feature-base/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+mkdir -p /usr/local/share/feature-order
+echo "base" >> /usr/local/share/feature-order/log

--- a/examples/features/dependency-ordering/feature-lib/devcontainer-feature.json
+++ b/examples/features/dependency-ordering/feature-lib/devcontainer-feature.json
@@ -1,0 +1,7 @@
+{
+	"id": "lib",
+	"version": "1.0.0",
+	"name": "Lib",
+	"description": "Soft-depends on base via installsAfter.",
+	"installsAfter": ["base"]
+}

--- a/examples/features/dependency-ordering/feature-lib/install.sh
+++ b/examples/features/dependency-ordering/feature-lib/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+mkdir -p /usr/local/share/feature-order
+echo "lib" >> /usr/local/share/feature-order/log

--- a/examples/features/local-feature/README.md
+++ b/examples/features/local-feature/README.md
@@ -1,0 +1,30 @@
+# Features: Local (`./path`) Feature Install
+
+Features can be referenced three ways in `devcontainer.json`: an OCI registry
+ref (`ghcr.io/owner/repo/feat:1`), a direct HTTPS tarball, or a **local
+relative path** (`./my-feature`). This example exercises the local-path form —
+the only one that needs no network and the one whose dispatch (`./`, `../`,
+absolute) is easy to regress.
+
+## Files
+
+- `devcontainer.json` — references `./hello-feature` with an option override.
+- `hello-feature/devcontainer-feature.json` — feature metadata with one
+  `greeting` option (default `hello`).
+- `hello-feature/install.sh` — writes `${GREETING} from local feature v1.0.0`
+  to `/usr/local/share/local-feature/marker`.
+
+Local feature paths resolve relative to the **config directory**. Because the
+config is kept at the example root (`devcontainer.json`, not under
+`.devcontainer/`), `exec.sh` points deacon at it with `--config`.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Local feature runs.** After `up`, the marker file exists in the image.
+2. **Option override applied.** The marker reads `bonjour …`, proving the
+   `greeting=bonjour` option from `devcontainer.json` reached the install
+   script (default would be `hello`).
+
+## Spec references
+
+- Feature reference formats: <https://containers.dev/implementors/features/>

--- a/examples/features/local-feature/devcontainer.json
+++ b/examples/features/local-feature/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "Local feature install",
+	"image": "alpine:3.18",
+	"remoteUser": "root",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"./hello-feature": {
+			"greeting": "bonjour"
+		}
+	}
+}

--- a/examples/features/local-feature/exec.sh
+++ b/examples/features/local-feature/exec.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+container_id() {
+	docker ps -a --filter "label=devcontainer.source=deacon" --filter "label=devcontainer.name=Local feature install" --format '{{.ID}}' | head -n1
+}
+
+cleanup() {
+	local cid
+	cid="$(container_id || true)"
+	if [ -n "${cid:-}" ]; then
+		docker rm -f "$cid" >/dev/null 2>&1 || true
+	fi
+	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
+}
+trap cleanup EXIT
+
+chmod +x "$SCRIPT_DIR"/hello-feature/install.sh
+
+cd "$SCRIPT_DIR"
+
+# Top-level devcontainer.json so the relative `./hello-feature` path resolves
+# against the config dir; point deacon at it explicitly.
+echo "== Bring container up (installs a local ./hello-feature) ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --config "$SCRIPT_DIR/devcontainer.json" --remove-existing-container "$@" >/dev/null
+cid="$(container_id)"
+[ -n "$cid" ] || { echo "FAIL: container not found after up" >&2; exit 1; }
+
+echo "== Scenario 1: the local feature's marker is baked into the image ==" >&2
+marker="$(docker exec "$cid" cat /usr/local/share/local-feature/marker 2>/dev/null || true)"
+echo "  marker: ${marker}" >&2
+[ -n "$marker" ] || { echo "FAIL: local feature did not run (marker missing)" >&2; exit 1; }
+echo "  ok: local feature installed" >&2
+
+echo "== Scenario 2: the feature option (greeting=bonjour) was applied ==" >&2
+case "$marker" in
+	"bonjour from local feature v1.0.0")
+		echo "  ok: option override honored" >&2
+		;;
+	*)
+		echo "FAIL: expected greeting 'bonjour', got: ${marker}" >&2
+		exit 1
+		;;
+esac
+
+echo "All scenarios passed." >&2

--- a/examples/features/local-feature/hello-feature/devcontainer-feature.json
+++ b/examples/features/local-feature/hello-feature/devcontainer-feature.json
@@ -1,0 +1,13 @@
+{
+	"id": "hello",
+	"version": "1.0.0",
+	"name": "Hello (local)",
+	"description": "A local (./path) feature that writes a marker and honors an option, proving the local-feature install path (not OCI).",
+	"options": {
+		"greeting": {
+			"type": "string",
+			"default": "hello",
+			"description": "Greeting word baked into the marker file"
+		}
+	}
+}

--- a/examples/features/local-feature/hello-feature/install.sh
+++ b/examples/features/local-feature/hello-feature/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Feature options are exported as uppercased env vars during install:
+# `greeting` -> $GREETING (default "hello" from devcontainer-feature.json).
+mkdir -p /usr/local/share/local-feature
+echo "${GREETING} from local feature v1.0.0" > /usr/local/share/local-feature/marker

--- a/examples/features/lockfile/.devcontainer/devcontainer.json
+++ b/examples/features/lockfile/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "Feature lockfile lifecycle",
+	"image": "mcr.microsoft.com/devcontainers/base:debian",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/examples/features/lockfile/README.md
+++ b/examples/features/lockfile/README.md
@@ -1,0 +1,25 @@
+# Features: Lockfile Lifecycle (`--frozen-lockfile`)
+
+When a config declares OCI Features, deacon resolves them to content digests
+and records them in `devcontainer-lock.json` so later builds are reproducible.
+This canary exercises generation and the `--frozen-lockfile` gate.
+
+## Files
+
+- `.devcontainer/devcontainer.json` — one OCI feature
+  (`ghcr.io/devcontainers/features/git:1`). The lockfile is generated/removed
+  by the script.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Generate** — a plain `up` writes `devcontainer-lock.json` with a pinned
+   `sha256:` digest.
+2. **Frozen passes** — `up --frozen-lockfile` succeeds when the lockfile
+   matches the resolved Features.
+3. **Frozen fails closed** — after tampering the pinned digest,
+   `up --frozen-lockfile` exits non-zero rather than silently re-resolving.
+
+## Notes
+
+Depends on Docker **and** the public `ghcr.io` registry. An unreachable
+registry is environmental, not a deacon defect.

--- a/examples/features/lockfile/exec.sh
+++ b/examples/features/lockfile/exec.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+LOCKFILE="${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+container_id() {
+	docker ps -a --filter "label=devcontainer.source=deacon" --filter "label=devcontainer.name=Feature lockfile lifecycle" --format '{{.ID}}' | head -n1
+}
+
+cleanup() {
+	local cid
+	cid="$(container_id || true)"
+	if [ -n "${cid:-}" ]; then
+		docker rm -f "$cid" >/dev/null 2>&1 || true
+	fi
+	rm -f "$LOCKFILE"
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+rm -f "$LOCKFILE"
+
+# Scenario 1: a plain `up` resolves the OCI feature and writes a lockfile that
+# pins it to a content digest.
+echo "== Scenario 1: up generates devcontainer-lock.json ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@" >/dev/null
+[ -f "$LOCKFILE" ] || { echo "FAIL: lockfile not generated at ${LOCKFILE}" >&2; exit 1; }
+grep -q 'sha256:' "$LOCKFILE" || { echo "FAIL: lockfile has no pinned digest" >&2; exit 1; }
+echo "  ok: lockfile written with a digest" >&2
+
+# Scenario 2: --frozen-lockfile succeeds when the lockfile already matches.
+echo "== Scenario 2: up --frozen-lockfile passes when lock matches ==" >&2
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --frozen-lockfile "$@" >/dev/null
+echo "  ok: frozen up succeeded against a matching lock" >&2
+
+# Scenario 3: tamper the pinned digest -> --frozen-lockfile must fail closed.
+echo "== Scenario 3: --frozen-lockfile fails on a mismatched lock ==" >&2
+# Flip the resolved digest to a bogus one.
+sed -i 's/sha256:[0-9a-f]\{64\}/sha256:0000000000000000000000000000000000000000000000000000000000000000/' "$LOCKFILE"
+set +e
+run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container --frozen-lockfile "$@" >/dev/null 2>"${SCRIPT_DIR}/frozen.log"
+code=$?
+set -e
+echo "  exit code: ${code}" >&2
+if [ "$code" -eq 0 ]; then
+	echo "FAIL: --frozen-lockfile accepted a tampered lockfile" >&2
+	rm -f "${SCRIPT_DIR}/frozen.log"; exit 1
+fi
+rm -f "${SCRIPT_DIR}/frozen.log"
+echo "  ok: frozen up rejected the mismatched lock" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/outdated/basic/.devcontainer/devcontainer.json
+++ b/examples/outdated/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "Outdated report",
+	"image": "mcr.microsoft.com/devcontainers/base:debian",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.0.0": {}
+	}
+}

--- a/examples/outdated/basic/README.md
+++ b/examples/outdated/basic/README.md
@@ -1,0 +1,28 @@
+# Outdated: Feature Version Drift Report
+
+`deacon outdated` resolves the Features in a config against their registry and
+reports `current | wanted | latest`, so you can see which Features have newer
+versions available. It needs network access to the feature registry
+(`ghcr.io`) but does **not** start a container.
+
+## Files
+
+- `.devcontainer/devcontainer.json` — pins
+  `ghcr.io/devcontainers/features/git:1.0.0` (deliberately old) so it shows as
+  outdated.
+
+## Scenarios exercised by `exec.sh`
+
+1. **Report** — `outdated --output json` emits a non-empty JSON object that
+   includes the `git` feature.
+2. **CI gate** — `outdated --fail-on-outdated` exits non-zero because the
+   pinned version is behind `latest`.
+
+## Output streams
+
+`--output json` writes the JSON report to stdout; all logs go to stderr.
+
+## Notes
+
+This canary depends on the public `ghcr.io` registry. If the registry is
+unreachable it cannot pass (environmental, not a deacon defect).

--- a/examples/outdated/basic/exec.sh
+++ b/examples/outdated/basic/exec.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cd "$SCRIPT_DIR"
+
+# `outdated` resolves the configured Features against their registry and reports
+# current | wanted | latest. It needs network to ghcr.io but no Docker daemon.
+# The config pins git to an old version so it is reported as outdated.
+
+echo "== Scenario 1: outdated --output json emits a report ==" >&2
+out="$(run "$DEACON_BIN" outdated --workspace-folder "$SCRIPT_DIR" --output json 2>/dev/null)"
+echo "$out" | sed 's/^/  | /' | head -n 20 >&2
+echo "$out" | grep -q 'git' || { echo "FAIL: git feature missing from outdated report" >&2; exit 1; }
+
+if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+	printf '%s' "$out" | "$PYTHON_BIN" -c 'import json,sys; d=json.load(sys.stdin); assert isinstance(d, dict) and d, "empty report"' \
+		|| { echo "FAIL: outdated --output json was not a non-empty JSON object" >&2; exit 1; }
+fi
+echo "  ok: JSON report includes the git feature" >&2
+
+echo "== Scenario 2: --fail-on-outdated gates CI with a non-zero exit ==" >&2
+set +e
+run "$DEACON_BIN" outdated --workspace-folder "$SCRIPT_DIR" --output json --fail-on-outdated >/dev/null 2>&1
+code=$?
+set -e
+echo "  exit code: ${code}" >&2
+# git:1.0.0 should be behind latest, so --fail-on-outdated must signal non-zero.
+[ "$code" -ne 0 ] || { echo "FAIL: --fail-on-outdated returned 0 despite an outdated feature" >&2; exit 1; }
+echo "  ok: non-zero exit when outdated" >&2
+
+echo "All scenarios passed." >&2

--- a/examples/upgrade/basic/.devcontainer/devcontainer.json
+++ b/examples/upgrade/basic/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "Upgrade lockfile",
+	"image": "mcr.microsoft.com/devcontainers/base:debian",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/examples/upgrade/basic/README.md
+++ b/examples/upgrade/basic/README.md
@@ -1,0 +1,23 @@
+# Upgrade: Regenerate the Feature Lockfile
+
+`deacon upgrade` re-resolves the Features declared in a config and (re)writes
+`devcontainer-lock.json`, pinning each Feature to a content digest. It needs
+network access to the feature registry (`ghcr.io`) but does not start a
+container. `--dry-run` prints the lockfile JSON to stdout instead of writing it.
+
+## Files
+
+- `.devcontainer/devcontainer-lock.json` is generated/removed by the script.
+- `.devcontainer/devcontainer.json` — one OCI feature
+  (`ghcr.io/devcontainers/features/git:1`).
+
+## Scenarios exercised by `exec.sh`
+
+1. **`--dry-run`** prints a resolved, digest-pinned (`sha256:`) lockfile to
+   stdout as valid JSON and does **not** write to disk.
+2. **`upgrade`** (no flag) writes `devcontainer-lock.json` with a pinned digest.
+
+## Notes
+
+Depends on the public `ghcr.io` registry; unreachable registry → environmental
+failure, not a deacon defect.

--- a/examples/upgrade/basic/exec.sh
+++ b/examples/upgrade/basic/exec.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+LOCKFILE="${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cleanup() {
+	rm -f "$LOCKFILE"
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+rm -f "$LOCKFILE"
+
+# `upgrade` re-resolves the configured Features and (re)writes the lockfile.
+# It needs network to ghcr.io but no Docker daemon. `--dry-run` prints the
+# lockfile JSON to stdout instead of writing it.
+
+echo "== Scenario 1: upgrade --dry-run prints a resolved lockfile ==" >&2
+out="$(run "$DEACON_BIN" upgrade --workspace-folder "$SCRIPT_DIR" --dry-run 2>/dev/null)"
+echo "$out" | sed 's/^/  | /' | head -n 25 >&2
+echo "$out" | grep -q 'git' || { echo "FAIL: git feature missing from lockfile output" >&2; exit 1; }
+echo "$out" | grep -q 'sha256:' || { echo "FAIL: no resolved digest (sha256:) in lockfile output" >&2; exit 1; }
+if command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+	printf '%s' "$out" | "$PYTHON_BIN" -c 'import json,sys; json.load(sys.stdin)' \
+		|| { echo "FAIL: --dry-run output was not valid JSON" >&2; exit 1; }
+fi
+echo "  ok: dry-run produced a resolved, digest-pinned lockfile" >&2
+[ -f "$LOCKFILE" ] && { echo "FAIL: --dry-run must not write the lockfile to disk" >&2; exit 1; }
+echo "  ok: --dry-run did not touch disk" >&2
+
+echo "== Scenario 2: upgrade (no --dry-run) writes devcontainer-lock.json ==" >&2
+run "$DEACON_BIN" upgrade --workspace-folder "$SCRIPT_DIR" >/dev/null 2>&1
+[ -f "$LOCKFILE" ] || { echo "FAIL: lockfile not written at ${LOCKFILE}" >&2; exit 1; }
+grep -q 'sha256:' "$LOCKFILE" || { echo "FAIL: written lockfile has no digest" >&2; exit 1; }
+echo "  ok: lockfile written with a pinned digest" >&2
+
+echo "All scenarios passed." >&2


### PR DESCRIPTION
## Summary

Adds **11 canaries** closing coverage gaps found by auditing our canary set against the containers.dev spec + the reference CLI. Each has a README and an `exec.sh` that asserts behavior and cleans up; all verified green locally with the release binary.

### Tier 1 — core spec behavior, previously untested
- **compose/multiservice-down** — `down`/`stopCompose` on a Compose project + `--remove`/`--volumes`. *(Surfaced the `stop_project` bug fixed in #153 — merge that first.)*
- **features/dependency-ordering** — automatic install order from `installsAfter` + `dependsOn` (distinct from `overrideFeatureInstallOrder`).
- **features/local-feature** — local `./` feature install + option override.
- **features/contributed-options** — feature-contributed `mounts`/`entrypoint`/`init`/`capAdd` reach the container.

### Tier 2
- **configuration/workspace-trust** — host `initializeCommand` trust gate (`DEACON_NO_PROMPT` denies, `--trust-workspace` allows).
- **features/lockfile** — lockfile generation, `--frozen-lockfile` pass + fail on a tampered digest.
- **outdated/basic** — `outdated --output json` + `--fail-on-outdated`.
- **upgrade/basic** — `upgrade --dry-run` + lockfile write.

### Tier 3
- **configuration/substitute** — `config substitute` variable resolution.
- **doctor/diagnostics** — plain `doctor`, `--json`, `--bundle`.
- **compose/run-services** — `runServices` selectivity.

Also fixes the dangling `examples/compose/multiservice-basic/` reference in `down/basic`'s README and records all rows in `CANARY_STATUS.md`.

## Dependency

`compose/multiservice-down` needs the compose-`stopCompose` fix in **#153** (merge first). The network-backed canaries (`outdated`, `upgrade`, `features/lockfile`) require `ghcr.io`. `features/https-tarball` was intentionally **not** added — there's no stable public HTTPS feature tarball to point at without hosting one; recommend deferring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)