### PR TITLE
fix(compose): runServices unset defaults to all services

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -942,10 +942,14 @@ impl ComposeManager {
         gpu_mode: crate::gpu::GpuMode,
     ) -> Result<()> {
         let command = self.get_command(project);
-        let services = project.get_all_services();
+        // Per spec, `runServices` defaults to all services: an empty selection
+        // means we pass no service names to `compose up`, so Compose starts
+        // every service. An explicit `runServices` scopes the up to
+        // primary ∪ runServices.
+        let services = project.up_service_selection();
 
         debug!(
-            "Starting compose project {} with services: {:?}, gpu_mode: {:?}",
+            "Starting compose project {} with services: {:?} (empty = all), gpu_mode: {:?}",
             project.name, services, gpu_mode
         );
 
@@ -1222,6 +1226,23 @@ impl ComposeProject {
         let mut services = vec![self.service.clone()];
         services.extend(self.run_services.clone());
         services
+    }
+
+    /// Service names to pass to `docker compose up`.
+    ///
+    /// Per the containers.dev spec, `runServices` *"defaults to all services"*.
+    /// When `run_services` is empty (unset) we return an empty list so that
+    /// Compose brings up **all** services in the project — this mirrors the
+    /// reference `@devcontainers/cli`, which omits service arguments to `up`
+    /// when `runServices` is undefined. When `run_services` is set we scope to
+    /// the explicit selection (primary service ∪ `runServices`) via
+    /// [`Self::get_all_services`].
+    pub fn up_service_selection(&self) -> Vec<String> {
+        if self.run_services.is_empty() {
+            Vec::new()
+        } else {
+            self.get_all_services()
+        }
     }
 
     /// Generate inline compose override YAML for mount/env injection.


### PR DESCRIPTION
## Summary

Per the containers.dev spec, `runServices` **"defaults to all services"**. Deacon was bringing up only the primary `service` when `runServices` was unset, because `start_project` passed `get_all_services()` (which returns `[service]` when `run_services` is empty) as the explicit service list to `docker compose up`.

## Decision (spec vs reference)

The user directed: adhere to the published spec; if it diverges from the reference, capture a follow-up note. I confirmed **no divergence** here:
- **Spec** (containers.dev json_reference): *"An array of services... Defaults to all services."*
- **Reference `@devcontainers/cli`**: when `runServices` is undefined it omits service arguments to `docker compose up`, so Compose starts all services.

Both agree → deacon was wrong; this PR aligns it with both. No divergence file needed.

## Change

- Add `ComposeProject::up_service_selection()`:
  - **unset** `run_services` → empty list → `docker compose up` receives no service args → Compose starts **all** services (mirrors the reference).
  - **set** `run_services` → `primary ∪ runServices`.
- `start_project` now uses `up_service_selection()` instead of `get_all_services()`.
- `down`/`stop` are already project-wide, so for the unset case `up`/`down`/`stop` all scope to "all" and match.

## Tests / canary

- Unit test `test_up_service_selection_unset_means_all` (hermetic).
- Dropped the now-unnecessary `runServices: ["db"]` from `examples/compose/multiservice-down/`, so that canary now regression-guards the default: if only `app` came up, its "both running" assertion fails.

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)