### PR TITLE
fix(features): resolve dependsOn/installsAfter by features-object ref form

### DIFF
--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -763,6 +763,31 @@ impl InstallationPlan {
     }
 }
 
+/// Strip a trailing OCI version/tag (`:tag`) from a feature reference, if present.
+///
+/// Used for tag-insensitive matching of `dependsOn`/`installsAfter` keys against
+/// resolved feature ids/sources. Only the LAST `:`-separated segment is treated as
+/// a tag, and only when it does not contain a `/` (so a registry port such as
+/// `localhost:5000/owner/feat` is not mistaken for a tag). The `:tag` separator
+/// also must come after the final `/` in the reference. Strings without a tag are
+/// returned unchanged.
+fn strip_oci_tag(reference: &str) -> &str {
+    match reference.rfind(':') {
+        Some(colon) => {
+            let tag = &reference[colon + 1..];
+            let after_last_slash = reference.rfind('/').map(|s| colon > s).unwrap_or(true);
+            // A tag never contains '/'; the colon must be after the last path
+            // separator to be a tag rather than a registry-port delimiter.
+            if !tag.is_empty() && !tag.contains('/') && after_last_slash {
+                &reference[..colon]
+            } else {
+                reference
+            }
+        }
+        None => reference,
+    }
+}
+
 /// Feature dependency resolver that builds DAG and performs topological sort
 #[derive(Debug)]
 pub struct FeatureDependencyResolver {
@@ -873,12 +898,57 @@ impl FeatureDependencyResolver {
             }
         }
 
+        // Per spec (https://containers.dev/implementors/features/#installation-order),
+        // `dependsOn`/`installsAfter` keys use "the same syntax as the `features`
+        // object". That means besides the canonical `id` and the metadata-`id`
+        // alias, a key may be the *features-object reference form* that was used to
+        // fetch the feature — i.e. `ResolvedFeature.source`. This covers:
+        //   * local relative/absolute paths (`./feature-lib`, `../x`, `/abs`), and
+        //   * full/partial OCI refs (`ghcr.io/owner/repo/feat:1`).
+        //
+        // For OCI refs we also match tag-insensitively: a key without a version/tag
+        // should match a candidate whose only difference is the trailing `:tag`
+        // (and vice versa). Local paths are compared as exact strings since they use
+        // identical syntax on both sides.
+
+        // Map each candidate `source` (and its tag-stripped form) to a canonical id.
+        let mut source_to_canonical: HashMap<String, String> = HashMap::new();
+        let mut source_notag_to_canonical: HashMap<String, String> = HashMap::new();
+        for feature in features {
+            source_to_canonical
+                .entry(feature.source.clone())
+                .or_insert_with(|| feature.id.clone());
+            let src_notag = strip_oci_tag(&feature.source);
+            source_notag_to_canonical
+                .entry(src_notag.to_string())
+                .or_insert_with(|| feature.id.clone());
+            // Also index the canonical id without its tag so a tagless dep key can
+            // match an `id` that carries a tag.
+            let id_notag = strip_oci_tag(&feature.id);
+            source_notag_to_canonical
+                .entry(id_notag.to_string())
+                .or_insert_with(|| feature.id.clone());
+        }
+
         let resolve_dep = |dep_id: &str| -> Option<String> {
+            // 1. Exact canonical id.
             if feature_ids.contains(dep_id) {
-                Some(dep_id.to_string())
-            } else {
-                alias_to_canonical.get(dep_id).cloned()
+                return Some(dep_id.to_string());
             }
+            // 2. Metadata-id alias.
+            if let Some(canonical) = alias_to_canonical.get(dep_id) {
+                return Some(canonical.clone());
+            }
+            // 3. Exact features-object reference (source) form.
+            if let Some(canonical) = source_to_canonical.get(dep_id) {
+                return Some(canonical.clone());
+            }
+            // 4. Tag-insensitive OCI ref match (key and/or candidate without tag).
+            let dep_notag = strip_oci_tag(dep_id);
+            if let Some(canonical) = source_notag_to_canonical.get(dep_notag) {
+                return Some(canonical.clone());
+            }
+            None
         };
 
         // Initialize graph with all feature IDs
@@ -913,17 +983,23 @@ impl FeatureDependencyResolver {
                 }
             }
 
-            // Add dependsOn dependencies (simplified - just extract string keys)
+            // Add dependsOn dependencies. `dependsOn` is a HARD dependency: per
+            // spec the referenced feature MUST be installed. An unresolvable key
+            // is therefore a hard error (no silent fallback) rather than a warn.
             for depend_id in feature.metadata.depends_on.keys() {
                 match resolve_dep(depend_id) {
                     Some(canonical) => {
                         dependencies.insert(canonical);
                     }
                     None => {
-                        warn!(
-                            "Feature '{}' depends on '{}' which is not in the feature set",
-                            feature.id, depend_id
-                        );
+                        return Err(FeatureError::DependencyResolution {
+                            message: format!(
+                                "Feature '{}' has a 'dependsOn' entry '{}' that does not \
+                                 resolve to any feature in the set (checked canonical id, \
+                                 metadata id, and features-object reference form)",
+                                feature.id, depend_id
+                            ),
+                        });
                     }
                 }
             }
@@ -2423,10 +2499,129 @@ mod tests {
         let resolver = FeatureDependencyResolver::new(None);
         let plan = resolver.resolve(&features).unwrap();
 
-        // Should succeed but warn about missing dependency
+        // Should succeed but warn about missing dependency (installsAfter is soft).
         let mut ids = plan.feature_ids();
         ids.sort(); // Make test deterministic
         assert_eq!(ids, vec!["feature-a", "feature-b"]);
+    }
+
+    #[test]
+    fn test_depends_on_resolves_by_local_path_source() {
+        // Author writes the dependsOn key using the *features-object reference
+        // form* (a local relative path) rather than the canonical local: id.
+        // The dependency must still resolve via `ResolvedFeature.source`. Per #155.
+        let mut depends_on_app = HashMap::new();
+        depends_on_app.insert("./feature-lib".to_string(), serde_json::Value::Bool(true));
+
+        // lib: canonical id `local:/abs/feature-lib`, source `./feature-lib`.
+        let lib = ResolvedFeature {
+            id: "local:/abs/feature-lib".to_string(),
+            source: "./feature-lib".to_string(),
+            metadata: FeatureMetadata {
+                id: "lib".to_string(),
+                ..Default::default()
+            },
+            options: HashMap::new(),
+        };
+        // app depends on lib by its local path reference.
+        let app = ResolvedFeature {
+            id: "local:/abs/feature-app".to_string(),
+            source: "./feature-app".to_string(),
+            metadata: FeatureMetadata {
+                id: "app".to_string(),
+                depends_on: depends_on_app,
+                ..Default::default()
+            },
+            options: HashMap::new(),
+        };
+
+        let resolver = FeatureDependencyResolver::new(None);
+        let graph = resolver
+            .build_dependency_graph(&[lib.clone(), app.clone()])
+            .expect("graph builds");
+
+        // An edge from app -> lib (canonical id) must exist.
+        let app_deps = graph
+            .get("local:/abs/feature-app")
+            .expect("app node present");
+        assert!(
+            app_deps.contains("local:/abs/feature-lib"),
+            "expected app to depend on lib via local-path source, got {:?}",
+            app_deps
+        );
+
+        // And the full resolve must order lib before app.
+        let order = resolver.resolve(&[app, lib]).unwrap().feature_ids();
+        let pos_lib = order
+            .iter()
+            .position(|x| x == "local:/abs/feature-lib")
+            .unwrap();
+        let pos_app = order
+            .iter()
+            .position(|x| x == "local:/abs/feature-app")
+            .unwrap();
+        assert!(pos_app > pos_lib);
+    }
+
+    #[test]
+    fn test_unresolvable_depends_on_is_hard_error() {
+        // A dependsOn key that matches no feature (by id, metadata id, or
+        // features-object reference form) must be a HARD error. Per #155.
+        let mut depends_on = HashMap::new();
+        depends_on.insert(
+            "./does-not-exist".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let app = ResolvedFeature {
+            id: "local:/abs/feature-app".to_string(),
+            source: "./feature-app".to_string(),
+            metadata: FeatureMetadata {
+                id: "app".to_string(),
+                depends_on,
+                ..Default::default()
+            },
+            options: HashMap::new(),
+        };
+
+        let resolver = FeatureDependencyResolver::new(None);
+        let err = resolver
+            .build_dependency_graph(&[app])
+            .expect_err("unresolvable dependsOn must error");
+        match err {
+            FeatureError::DependencyResolution { message } => {
+                assert!(
+                    message.contains("dependsOn") && message.contains("./does-not-exist"),
+                    "unexpected error message: {message}"
+                );
+            }
+            other => panic!("expected DependencyResolution error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_unresolvable_installs_after_is_soft_skip() {
+        // installsAfter is a SOFT dependency: an unresolvable entry is warned and
+        // skipped, not an error. Per #155.
+        let app = ResolvedFeature {
+            id: "local:/abs/feature-app".to_string(),
+            source: "./feature-app".to_string(),
+            metadata: FeatureMetadata {
+                id: "app".to_string(),
+                installs_after: vec!["./does-not-exist".to_string()],
+                ..Default::default()
+            },
+            options: HashMap::new(),
+        };
+
+        let resolver = FeatureDependencyResolver::new(None);
+        let graph = resolver
+            .build_dependency_graph(&[app])
+            .expect("unresolvable installsAfter must not error");
+        let deps = graph.get("local:/abs/feature-app").expect("app present");
+        assert!(
+            deps.is_empty(),
+            "expected no edge for skipped installsAfter"
+        );
     }
 
     #[test]

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -555,7 +555,16 @@ async fn resolve_and_stage_features(
 
         resolved_features.push(ResolvedFeature {
             id: canonical_id.clone(),
-            source: reference.clone(),
+            // Record the features-object reference AS WRITTEN (e.g. `./feature-lib`
+            // for locals, or the OCI ref string) so dependency resolution can match
+            // `dependsOn`/`installsAfter` keys that use the features-object syntax
+            // (issue #155). Local features carry a synthetic empty FeatureRef whose
+            // `reference()` is NOT the user path, so prefer the user-facing id and
+            // fall back to the normalized reference only when it's unavailable.
+            source: user_id_by_canonical
+                .get(canonical_id)
+                .cloned()
+                .unwrap_or_else(|| reference.clone()),
             options,
             metadata: downloaded.metadata.clone(),
         });

--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -52,7 +52,7 @@ listed.
 | build/secrets-and-ssh | ✅ pass | 2026-05-29 | ssh needs `SSH_AUTH_SOCK` (allow-fail) |
 | build/unwritable-output | ✅ pass | 2026-05-29 | asserts error |
 | compose/multiple-compose-files | ✅ pass | 2026-05-29 | |
-| compose/multiservice-down | ✅ pass | 2026-05-29 | compose `down`/`stopCompose` + `--remove`/`--volumes`; needs the `stop_project` fix (#153) |
+| compose/multiservice-down | ✅ pass | 2026-05-29 `f29a1a3` | compose `down`/`stopCompose` + `--remove`/`--volumes`; needs the `stop_project` fix (#153). `runServices` dropped — unset now brings up ALL services (#156, PR #157) |
 | compose/run-services | ✅ pass | 2026-05-29 | `runServices` selectivity (app+worker up, idle down) (new) |
 | configuration/extends-chain-cycle | ✅ pass | 2026-05-29 | asserts cycle errors |
 | configuration/secrets-declarative | ✅ pass | 2026-05-29 | |
@@ -72,7 +72,7 @@ listed.
 | exec/user-env-probe-modes | ✅ pass | 2026-05-29 | camelCase `--default-user-env-probe` values (#148); git-root flag (#149) |
 | exec/workspace-folder-discovery | ✅ pass | 2026-05-29 | git-root mount flag (#149) |
 | features/contributed-options | ✅ pass | 2026-05-29 | feature-contributed mount/entrypoint/init/capAdd reach the container (new) |
-| features/dependency-ordering | ✅ pass | 2026-05-29 | auto install order via `installsAfter`+`dependsOn` (no override) (new) |
+| features/dependency-ordering | ✅ pass | 2026-05-29 `f29a1a3` | auto install order via `installsAfter`+`dependsOn` (no override); now uses local-path `dependsOn` form `./feature-lib` (#155, PR #158) |
 | features/feature-contributed-lifecycle | ✅ pass | 2026-05-29 | |
 | features/feature-env-injection | ✅ pass | 2026-05-29 | |
 | features/local-feature | ✅ pass | 2026-05-29 | local `./` feature install + option override (new) |

--- a/examples/features/dependency-ordering/feature-app/devcontainer-feature.json
+++ b/examples/features/dependency-ordering/feature-app/devcontainer-feature.json
@@ -4,6 +4,6 @@
 	"name": "App",
 	"description": "Hard-depends on lib via dependsOn.",
 	"dependsOn": {
-		"lib": {}
+		"./feature-lib": {}
 	}
 }


### PR DESCRIPTION
## Summary

Per the containers.dev spec, `dependsOn`/`installsAfter` keys use **"the same syntax as the `features` object"** — a local `./path` or a full/partial OCI ref. `FeatureDependencyResolver::build_dependency_graph` previously matched only the resolved canonical `id` or the metadata-`id` alias, so the reference form silently `warn!`ed and produced no edge.

## Change

- Match dependency keys against each feature's `ResolvedFeature.source` (the features-object reference exactly as written), both exact and — for OCI refs — tag-insensitively (new `strip_oci_tag` helper, which guards against registry-port false positives like `localhost:5000/...`). Existing canonical-id and metadata-id matching are preserved.
- A hard `dependsOn` that resolves to nothing is now a **hard error** (`FeatureError::DependencyResolution`) instead of a `warn!`, per spec semantics for hard dependencies. `installsAfter` (soft) keeps warn+skip.
- Flip `examples/features/dependency-ordering/` so feature-app's `dependsOn` key is the local path form `./feature-lib` (matching the `features` object key), regression-guarding path-form resolution. Install order stays `base,lib,app`.

## Tests

New unit tests (all green): path-form resolves to an edge; unresolvable `dependsOn` is a hard error; unresolvable `installsAfter` is a soft skip; metadata-id form still works.

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)