### PR TITLE
docs(examples): add observability/json-logs canary for output-streams contract

### DIFF
--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -80,6 +80,7 @@ listed.
 | features/oci-digest-pin | ✅ pass | 2026-05-29 | `name:tag@digest` parsing (#131) |
 | features/option-sanitization | ✅ pass | 2026-05-29 | |
 | features/override-install-order | ✅ pass | 2026-05-29 | |
+| observability/json-logs | ✅ pass | 2026-05-29 | Output Streams Contract: `--log-format json` stdout=1 JSON doc, stderr=JSON log lines, no log leakage to stdout; hermetic (read-configuration, no Docker) (new) |
 | outdated/basic | ✅ pass | 2026-05-29 | `outdated --output json` + `--fail-on-outdated`; needs ghcr (new) |
 | read-configuration/basic | ✅ pass | 2026-05-29 | |
 | read-configuration/compose | ✅ pass | 2026-05-29 | |

--- a/examples/observability/json-logs/README.md
+++ b/examples/observability/json-logs/README.md
@@ -1,174 +1,30 @@
-# Observability: JSON Logs Example
+# JSON Logs (observability)
 
-## What This Demonstrates
+This example shows how to enable structured JSON logging and parse it for
+fields such as `message`, `target`, and `span` data.
 
-This example shows how to use structured JSON logging for machine-readable observability. It demonstrates:
+The Deacon CLI emits structured logs to **stderr** while keeping **stdout**
+reserved for command results (e.g. JSON configuration output). This separation
+lets you parse logs and results independently.
 
-- **JSON log format**: Structured log output suitable for log aggregation tools
-- **Standardized spans**: Canonical span names like `config.resolve` for consistent tracing
-- **Structured fields**: Key fields such as `workspace_id`, `duration_ms` for filtering and analysis
-- **Runtime format selection**: Using `DEACON_LOG_FORMAT` environment variable to switch formats
+## Usage
 
-## Why This Matters
-
-JSON logging is essential for:
-- **CI/CD integration**: Machine-parseable logs for automated analysis and monitoring
-- **Log aggregation**: Integration with tools like Elasticsearch, Splunk, or CloudWatch
-- **Debugging**: Structured fields enable precise filtering and querying
-- **Observability**: Standardized spans provide consistent tracing across workflows
-
-## DevContainer Specification References
-
-This example aligns with the logging and output behavior in the Up and Read-Configuration SPECs: see ../../docs/subcommand-specs/up/SPEC.md#10-output-specifications and ../../docs/subcommand-specs/read-configuration/SPEC.md#10-output-specifications:
-
-- **Standardized Tracing Spans**: Core workflow spans (`config.resolve`, `feature.plan`, etc.)
-- **Common Fields**: Standard fields (`workspace_id`, `duration_ms`, `feature_id`, etc.)
-- **Log Format Selection**: Runtime format via `DEACON_LOG_FORMAT` environment variable
-
-## Standardized Span Names
-
-The following canonical span names are emitted during core workflows:
-
-- `config.resolve` - Configuration parsing and resolution
-- `feature.plan` - Feature dependency planning
-- `feature.install` - Feature installation execution
-- `template.apply` - Template application workflow
-- `container.build` - Container image building
-- `container.create` - Container creation
-- `lifecycle.run` - Lifecycle command execution
-- `registry.pull` - OCI registry pull operations
-- `registry.publish` - OCI registry publish operations
-
-## Common Structured Fields
-
-Spans include these standardized fields for filtering and correlation:
-
-- `workspace_id` - 8-character hash of workspace path (for correlation)
-- `duration_ms` - Operation duration in milliseconds (recorded on completion)
-- `feature_id` - Feature identifier (in feature operations)
-- `template_id` - Template identifier (in template operations)
-- `container_id` - Container identifier (in container operations)
-- `image_id` - Container image identifier (in build operations)
-- `ref` - Registry reference (in registry operations)
-
-## JSON Log Schema
-
-Each JSON log entry follows this structure:
-
-```json
-{
-  "timestamp": "2025-01-09T23:32:24.004390Z",
-  "level": "INFO",
-  "target": "deacon_core::observability",
-  "span": {
-    "name": "config.resolve",
-    "workspace_id": "a1b2c3d4"
-  },
-  "message": "Configuration resolved successfully",
-  "fields": {
-    "duration_ms": 142
-  }
-}
+```bash
+deacon --log-format json read-configuration > config.json 2> logs.jsonl
 ```
 
-## Run
+- `config.json` (stdout) is a single JSON document — the command result.
+- `logs.jsonl` (stderr) carries the structured logs, one JSON object per line.
 
-### Basic JSON Logging
+Add `--log-level debug` to increase log verbosity; stdout stays a clean,
+single JSON document regardless of how much is logged.
 
-```sh
-# Enable JSON format via environment variable
-export DEACON_LOG_FORMAT=json
-deacon read-configuration --config devcontainer.json
-```
+## Scenarios
 
-### Parse JSON Logs with jq
+`exec.sh` verifies the Output Streams Contract:
 
-```sh
-# Extract all span names
-export DEACON_LOG_FORMAT=json
-deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq -r 'select(.span != null) | .span.name' \
-  | sort -u
-
-# Filter for config.resolve spans
-export DEACON_LOG_FORMAT=json
-deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.span.name == "config.resolve")'
-
-# Extract duration metrics
-export DEACON_LOG_FORMAT=json
-deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.fields.duration_ms != null) | {span: .span.name, duration_ms: .fields.duration_ms}'
-
-# Verify workspace_id field presence
-export DEACON_LOG_FORMAT=json
-deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.span.workspace_id != null) | .span.workspace_id' \
-  | head -1
-```
-
-### Compare Text vs JSON Format
-
-```sh
-# Default text format (human-readable)
-deacon read-configuration --config devcontainer.json
-
-# JSON format (machine-readable)
-DEACON_LOG_FORMAT=json deacon read-configuration --config devcontainer.json
-```
-
-### Integration with Log Analysis Tools
-
-```sh
-# Send to file for analysis
-DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . 2> logs.jsonl
-
-# Count log entries by level
-jq -r '.level' < logs.jsonl | sort | uniq -c
-
-# Find slowest operations
-jq 'select(.fields.duration_ms != null) | {span: .span.name, duration: .fields.duration_ms}' < logs.jsonl \
-  | jq -s 'sort_by(.duration) | reverse | .[0:5]'
-
-# Extract all unique span names
-jq -r 'select(.span != null) | .span.name' < logs.jsonl | sort -u
-```
-
-## Expected Output
-
-When running with JSON logging enabled, you should see structured log entries like:
-
-```json
-{"timestamp":"2025-01-09T23:32:24.004390Z","level":"INFO","target":"deacon_core::observability","span":{"name":"config.resolve","workspace_id":"a1b2c3d4"},"message":"Starting configuration resolution"}
-{"timestamp":"2025-01-09T23:32:24.146780Z","level":"INFO","target":"deacon_core::observability","span":{"name":"config.resolve","workspace_id":"a1b2c3d4"},"fields":{"duration_ms":142},"message":"Configuration resolved successfully"}
-```
-
-## Verification
-
-To verify that JSON logs contain expected span names and fields:
-
-```sh
-# Check for config.resolve span
-DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.span.name == "config.resolve")' \
-  | grep -q "config.resolve" && echo "✓ config.resolve span found"
-
-# Check for workspace_id field
-DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.span.workspace_id != null)' \
-  | grep -q "workspace_id" && echo "✓ workspace_id field found"
-
-# Check for duration_ms field
-DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
-  | jq 'select(.fields.duration_ms != null)' \
-  | grep -q "duration_ms" && echo "✓ duration_ms field found"
-```
-
-## Notes
-
-- JSON logs are written to **stderr**, while command output goes to **stdout**
-- Use `2>&1` to capture both streams or `2>` to redirect only logs
-- The `--output-format json` flag controls command output format, not logging format
-- `DEACON_LOG_FORMAT=json` controls the logging format for observability
-- All standardized spans follow the pattern `<domain>.<action>` (e.g., `config.resolve`, `feature.install`)
-- The `workspace_id` is a deterministic 8-character hash for workspace correlation across operations
+1. `--log-format json` → stdout is one valid JSON document.
+2. `--log-format json --log-level debug` → stderr is newline-delimited JSON log
+   objects (each with a `timestamp`), and stdout stays a clean JSON document
+   (logs never leak onto stdout).
+3. Default text mode → the result is on stdout with no JSON-log leakage.

--- a/examples/observability/json-logs/README.md
+++ b/examples/observability/json-logs/README.md
@@ -1,29 +1,184 @@
-# JSON Logs (observability)
+# Observability: JSON Logs Example
 
-This example shows how to enable structured JSON logging and parse it for
-fields such as `message`, `target`, and `span` data.
+## What This Demonstrates
 
-The Deacon CLI emits structured logs to **stderr** while keeping **stdout**
-reserved for command results (e.g. JSON configuration output). This separation
-lets you parse logs and results independently.
+This example shows how to use structured JSON logging for machine-readable observability. It demonstrates:
 
-## Usage
+- **JSON log format**: Structured log output suitable for log aggregation tools
+- **Standardized spans**: Canonical span names like `config.resolve` for consistent tracing
+- **Structured fields**: Key fields such as `workspace_id`, `duration_ms` for filtering and analysis
+- **Runtime format selection**: Using `DEACON_LOG_FORMAT` environment variable to switch formats
 
-```bash
-deacon --log-format json read-configuration > config.json 2> logs.jsonl
+## Why This Matters
+
+JSON logging is essential for:
+- **CI/CD integration**: Machine-parseable logs for automated analysis and monitoring
+- **Log aggregation**: Integration with tools like Elasticsearch, Splunk, or CloudWatch
+- **Debugging**: Structured fields enable precise filtering and querying
+- **Observability**: Standardized spans provide consistent tracing across workflows
+
+## DevContainer Specification References
+
+This example aligns with the logging and output behavior in the Up and Read-Configuration SPECs: see ../../docs/subcommand-specs/up/SPEC.md#10-output-specifications and ../../docs/subcommand-specs/read-configuration/SPEC.md#10-output-specifications:
+
+- **Standardized Tracing Spans**: Core workflow spans (`config.resolve`, `feature.plan`, etc.)
+- **Common Fields**: Standard fields (`workspace_id`, `duration_ms`, `feature_id`, etc.)
+- **Log Format Selection**: Runtime format via `DEACON_LOG_FORMAT` environment variable
+
+## Standardized Span Names
+
+The following canonical span names are emitted during core workflows:
+
+- `config.resolve` - Configuration parsing and resolution
+- `feature.plan` - Feature dependency planning
+- `feature.install` - Feature installation execution
+- `template.apply` - Template application workflow
+- `container.build` - Container image building
+- `container.create` - Container creation
+- `lifecycle.run` - Lifecycle command execution
+- `registry.pull` - OCI registry pull operations
+- `registry.publish` - OCI registry publish operations
+
+## Common Structured Fields
+
+Spans include these standardized fields for filtering and correlation:
+
+- `workspace_id` - 8-character hash of workspace path (for correlation)
+- `duration_ms` - Operation duration in milliseconds (recorded on completion)
+- `feature_id` - Feature identifier (in feature operations)
+- `template_id` - Template identifier (in template operations)
+- `container_id` - Container identifier (in container operations)
+- `image_id` - Container image identifier (in build operations)
+- `ref` - Registry reference (in registry operations)
+
+## JSON Log Schema
+
+Each JSON log entry follows this structure:
+
+```json
+{
+  "timestamp": "2025-01-09T23:32:24.004390Z",
+  "level": "INFO",
+  "target": "deacon_core::observability",
+  "span": {
+    "name": "config.resolve",
+    "workspace_id": "a1b2c3d4"
+  },
+  "message": "Configuration resolved successfully",
+  "fields": {
+    "duration_ms": 142
+  }
+}
 ```
 
-- `config.json` (stdout) is a single JSON document — the command result.
-- `logs.jsonl` (stderr) carries the structured logs, one JSON object per line.
+## Run
 
-Add `--log-level debug` to increase log verbosity; stdout stays a clean,
-single JSON document regardless of how much is logged.
+### Basic JSON Logging
 
-## Scenarios
+```sh
+# Enable JSON format via environment variable
+export DEACON_LOG_FORMAT=json
+deacon read-configuration --config devcontainer.json
+```
 
-`exec.sh` verifies the Output Streams Contract:
+### Parse JSON Logs with jq
 
-1. `--log-format json` → stdout is one valid JSON document.
+```sh
+# Extract all span names
+export DEACON_LOG_FORMAT=json
+deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq -r 'select(.span != null) | .span.name' \
+  | sort -u
+
+# Filter for config.resolve spans
+export DEACON_LOG_FORMAT=json
+deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.span.name == "config.resolve")'
+
+# Extract duration metrics
+export DEACON_LOG_FORMAT=json
+deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.fields.duration_ms != null) | {span: .span.name, duration_ms: .fields.duration_ms}'
+
+# Verify workspace_id field presence
+export DEACON_LOG_FORMAT=json
+deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.span.workspace_id != null) | .span.workspace_id' \
+  | head -1
+```
+
+### Compare Text vs JSON Format
+
+```sh
+# Default text format (human-readable)
+deacon read-configuration --config devcontainer.json
+
+# JSON format (machine-readable)
+DEACON_LOG_FORMAT=json deacon read-configuration --config devcontainer.json
+```
+
+### Integration with Log Analysis Tools
+
+```sh
+# Send to file for analysis
+DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . 2> logs.jsonl
+
+# Count log entries by level
+jq -r '.level' < logs.jsonl | sort | uniq -c
+
+# Find slowest operations
+jq 'select(.fields.duration_ms != null) | {span: .span.name, duration: .fields.duration_ms}' < logs.jsonl \
+  | jq -s 'sort_by(.duration) | reverse | .[0:5]'
+
+# Extract all unique span names
+jq -r 'select(.span != null) | .span.name' < logs.jsonl | sort -u
+```
+
+## Expected Output
+
+When running with JSON logging enabled, you should see structured log entries like:
+
+```json
+{"timestamp":"2025-01-09T23:32:24.004390Z","level":"INFO","target":"deacon_core::observability","span":{"name":"config.resolve","workspace_id":"a1b2c3d4"},"message":"Starting configuration resolution"}
+{"timestamp":"2025-01-09T23:32:24.146780Z","level":"INFO","target":"deacon_core::observability","span":{"name":"config.resolve","workspace_id":"a1b2c3d4"},"fields":{"duration_ms":142},"message":"Configuration resolved successfully"}
+```
+
+## Verification
+
+To verify that JSON logs contain expected span names and fields:
+
+```sh
+# Check for config.resolve span
+DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.span.name == "config.resolve")' \
+  | grep -q "config.resolve" && echo "✓ config.resolve span found"
+
+# Check for workspace_id field
+DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.span.workspace_id != null)' \
+  | grep -q "workspace_id" && echo "✓ workspace_id field found"
+
+# Check for duration_ms field
+DEACON_LOG_FORMAT=json deacon config substitute --workspace-folder . --output-format json 2>&1 \
+  | jq 'select(.fields.duration_ms != null)' \
+  | grep -q "duration_ms" && echo "✓ duration_ms field found"
+```
+
+## Notes
+
+- JSON logs are written to **stderr**, while command output goes to **stdout**
+- Use `2>&1` to capture both streams or `2>` to redirect only logs
+- The `--output-format json` flag controls command output format, not logging format
+- `DEACON_LOG_FORMAT=json` controls the logging format for observability
+- All standardized spans follow the pattern `<domain>.<action>` (e.g., `config.resolve`, `feature.install`)
+- The `workspace_id` is a deterministic 8-character hash for workspace correlation across operations
+
+## Canary (`exec.sh`)
+
+`exec.sh` asserts the Output Streams Contract hermetically (via
+`read-configuration`, no Docker required):
+
+1. `--log-format json` → stdout is a single valid JSON document.
 2. `--log-format json --log-level debug` → stderr is newline-delimited JSON log
    objects (each with a `timestamp`), and stdout stays a clean JSON document
    (logs never leak onto stdout).

--- a/examples/observability/json-logs/exec.sh
+++ b/examples/observability/json-logs/exec.sh
@@ -10,23 +10,28 @@ set -euo pipefail
 #   Text mode (default):
 #     - stdout: the result; stderr: logs
 #   Critically, logs flowing on stderr must NEVER pollute the stdout JSON.
+#
+# NOTE: each deacon invocation is run directly (not via a `run()` helper that
+# echoes the command to stderr) — otherwise that echo would land in the
+# captured stderr log and break the "every stderr line is JSON" assertion.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEACON_BIN="${DEACON_BIN:-deacon}"
 
-run() {
-	echo "+ $*" >&2
-	"$@"
-}
-
 cd "$SCRIPT_DIR"
+
+# This example keeps its config as a plain `devcontainer.json` at the example
+# root, which is NOT a spec discovery location — so point `read-configuration`
+# at it explicitly with `--config`.
+CONFIG="$SCRIPT_DIR/devcontainer.json"
 
 # Scenario 1: JSON mode keeps stdout a single valid JSON document.
 echo "== Scenario 1: --log-format json -> stdout is one JSON document ==" >&2
-run "$DEACON_BIN" --log-format json read-configuration \
-	--workspace-folder "$SCRIPT_DIR" \
+echo "+ $DEACON_BIN --log-format json read-configuration --config <config>" >&2
+"$DEACON_BIN" --log-format json read-configuration \
+	--workspace-folder "$SCRIPT_DIR" --config "$CONFIG" \
 	>/tmp/json-logs-out.json 2>/tmp/json-logs-err.log
-python3 -c 'import json,sys; json.load(open("/tmp/json-logs-out.json"))' || {
+python3 -c 'import json; json.load(open("/tmp/json-logs-out.json"))' || {
 	echo "FAIL: stdout is not a single valid JSON document" >&2
 	head -c 400 /tmp/json-logs-out.json >&2
 	exit 1
@@ -36,16 +41,17 @@ echo "  ok: stdout parsed as JSON" >&2
 # Scenario 2: with debug logging on, stderr carries JSON log objects AND
 # stdout stays a clean single JSON document (logs must not leak to stdout).
 echo "== Scenario 2: debug logs go to stderr as JSON; stdout stays clean ==" >&2
-run "$DEACON_BIN" --log-format json --log-level debug read-configuration \
-	--workspace-folder "$SCRIPT_DIR" \
+echo "+ $DEACON_BIN --log-format json --log-level debug read-configuration --config <config>" >&2
+"$DEACON_BIN" --log-format json --log-level debug read-configuration \
+	--workspace-folder "$SCRIPT_DIR" --config "$CONFIG" \
 	>/tmp/json-logs-out2.json 2>/tmp/json-logs-err2.log
-python3 -c 'import json,sys; json.load(open("/tmp/json-logs-out2.json"))' || {
+python3 -c 'import json; json.load(open("/tmp/json-logs-out2.json"))' || {
 	echo "FAIL: stdout JSON corrupted when logs are emitted" >&2
 	head -c 400 /tmp/json-logs-out2.json >&2
 	exit 1
 }
 # Every non-blank stderr line must be a JSON object with a timestamp.
-python3 - "$@" <<'PY' || exit 1
+python3 <<'PY' || exit 1
 import json, sys
 lines = [l for l in open("/tmp/json-logs-err2.log") if l.strip()]
 if not lines:
@@ -63,18 +69,17 @@ for i, l in enumerate(lines):
 print(f"  ok: {len(lines)} JSON log lines on stderr, stdout clean", file=sys.stderr)
 PY
 
-# Scenario 3: text mode (default) — stdout is the human result, and is NOT
-# JSON-log noise. We only assert stdout is non-empty and stderr/stdout are
-# separate streams (logs never appear on stdout).
+# Scenario 3: text mode (default) — the result is on stdout, and a JSON log
+# object never leaks onto stdout.
 echo "== Scenario 3: text mode keeps result on stdout ==" >&2
-run "$DEACON_BIN" read-configuration \
-	--workspace-folder "$SCRIPT_DIR" \
+echo "+ $DEACON_BIN read-configuration --config <config>" >&2
+"$DEACON_BIN" read-configuration \
+	--workspace-folder "$SCRIPT_DIR" --config "$CONFIG" \
 	>/tmp/json-logs-text.out 2>/tmp/json-logs-text.err
 [ -s /tmp/json-logs-text.out ] || {
 	echo "FAIL: text-mode stdout was empty" >&2
 	exit 1
 }
-# A JSON log object should never appear on stdout in any mode.
 if grep -q '"timestamp"' /tmp/json-logs-text.out; then
 	echo "FAIL: JSON log leaked onto stdout in text mode" >&2
 	exit 1

--- a/examples/observability/json-logs/exec.sh
+++ b/examples/observability/json-logs/exec.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canary: the Output Streams Contract (CLAUDE.md "Output Streams Contract").
+#
+# Contract under test (hermetic — uses `read-configuration`, no Docker):
+#   JSON modes (`--log-format json`):
+#     - stdout: a SINGLE JSON document only (the command result)
+#     - stderr: all logs/diagnostics, as newline-delimited JSON objects
+#   Text mode (default):
+#     - stdout: the result; stderr: logs
+#   Critically, logs flowing on stderr must NEVER pollute the stdout JSON.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cd "$SCRIPT_DIR"
+
+# Scenario 1: JSON mode keeps stdout a single valid JSON document.
+echo "== Scenario 1: --log-format json -> stdout is one JSON document ==" >&2
+run "$DEACON_BIN" --log-format json read-configuration \
+	--workspace-folder "$SCRIPT_DIR" \
+	>/tmp/json-logs-out.json 2>/tmp/json-logs-err.log
+python3 -c 'import json,sys; json.load(open("/tmp/json-logs-out.json"))' || {
+	echo "FAIL: stdout is not a single valid JSON document" >&2
+	head -c 400 /tmp/json-logs-out.json >&2
+	exit 1
+}
+echo "  ok: stdout parsed as JSON" >&2
+
+# Scenario 2: with debug logging on, stderr carries JSON log objects AND
+# stdout stays a clean single JSON document (logs must not leak to stdout).
+echo "== Scenario 2: debug logs go to stderr as JSON; stdout stays clean ==" >&2
+run "$DEACON_BIN" --log-format json --log-level debug read-configuration \
+	--workspace-folder "$SCRIPT_DIR" \
+	>/tmp/json-logs-out2.json 2>/tmp/json-logs-err2.log
+python3 -c 'import json,sys; json.load(open("/tmp/json-logs-out2.json"))' || {
+	echo "FAIL: stdout JSON corrupted when logs are emitted" >&2
+	head -c 400 /tmp/json-logs-out2.json >&2
+	exit 1
+}
+# Every non-blank stderr line must be a JSON object with a timestamp.
+python3 - "$@" <<'PY' || exit 1
+import json, sys
+lines = [l for l in open("/tmp/json-logs-err2.log") if l.strip()]
+if not lines:
+    print("FAIL: expected JSON log lines on stderr, got none", file=sys.stderr)
+    sys.exit(1)
+for i, l in enumerate(lines):
+    try:
+        d = json.loads(l)
+    except json.JSONDecodeError:
+        print(f"FAIL: stderr line {i} is not JSON: {l!r}", file=sys.stderr)
+        sys.exit(1)
+    if "timestamp" not in d:
+        print(f"FAIL: stderr JSON log missing 'timestamp': {sorted(d)}", file=sys.stderr)
+        sys.exit(1)
+print(f"  ok: {len(lines)} JSON log lines on stderr, stdout clean", file=sys.stderr)
+PY
+
+# Scenario 3: text mode (default) — stdout is the human result, and is NOT
+# JSON-log noise. We only assert stdout is non-empty and stderr/stdout are
+# separate streams (logs never appear on stdout).
+echo "== Scenario 3: text mode keeps result on stdout ==" >&2
+run "$DEACON_BIN" read-configuration \
+	--workspace-folder "$SCRIPT_DIR" \
+	>/tmp/json-logs-text.out 2>/tmp/json-logs-text.err
+[ -s /tmp/json-logs-text.out ] || {
+	echo "FAIL: text-mode stdout was empty" >&2
+	exit 1
+}
+# A JSON log object should never appear on stdout in any mode.
+if grep -q '"timestamp"' /tmp/json-logs-text.out; then
+	echo "FAIL: JSON log leaked onto stdout in text mode" >&2
+	exit 1
+fi
+echo "  ok: result on stdout, no log leakage" >&2
+
+rm -f /tmp/json-logs-out.json /tmp/json-logs-err.log \
+	/tmp/json-logs-out2.json /tmp/json-logs-err2.log \
+	/tmp/json-logs-text.out /tmp/json-logs-text.err
+
+echo "All scenarios passed." >&2


### PR DESCRIPTION
## Summary

The **Output Streams Contract** (CLAUDE.md) — JSON command result on **stdout**, all logs/diagnostics on **stderr** — had a documented example (`examples/observability/json-logs/`) but **no executable canary** asserting it. Every in-scope subcommand otherwise has canary coverage; this was the clearest remaining gap (a core, cross-cutting invariant with zero enforcement).

## What this adds

`examples/observability/json-logs/exec.sh` — hermetic (uses `read-configuration`, **no Docker**):

1. `--log-format json` → stdout is a single valid JSON document.
2. `--log-format json --log-level debug` → stderr is newline-delimited JSON log objects (each with a `timestamp`), **and** stdout stays a clean single JSON document (logs never leak to stdout).
3. Default text mode → result on stdout, no JSON-log leakage.

Verified locally: all 3 scenarios pass (`CANARY_RC=0`; 23 JSON log lines on stderr, stdout clean).

## Also

- Fixes the example's malformed README (duplicated/garbled "Scenarios" section).
- Removes the committed `README copy.md` cruft.
- Adds the `observability/json-logs` row to `examples/CANARY_STATUS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)