### PR TITLE
chore(tests): assert up error-path stdout JSON shape for v1 parity

### DIFF
--- a/crates/deacon/tests/up_json_output.rs
+++ b/crates/deacon/tests/up_json_output.rs
@@ -6,6 +6,7 @@
 //! - Error emits proper JSON with error details
 
 use assert_cmd::Command;
+use tempfile::TempDir;
 
 #[test]
 fn test_up_invalid_mount_format_fails_validation() {
@@ -95,9 +96,50 @@ fn test_up_missing_workspace_and_id_label_fails() {
 
 #[test]
 fn test_up_json_output_structure_on_missing_config() {
-    // When config is missing, we should get a proper error JSON on stdout
-    // (not testing in this simple version as it requires more complex setup)
-    // This is a placeholder for the JSON structure validation
+    // Spec contract (specs/001-up-gap-spec/contracts/up.md; up/SPEC.md §10):
+    // on error, `up` writes exactly one JSON document to STDOUT shaped
+    // `{ outcome: "error", message, description }` and exits 1. All logs go to
+    // stderr. This mirrors the reference @devcontainers/cli outcome object, so
+    // it is v1 spec-parity — not merely an exit-code check. Hermetic: the error
+    // fires during config discovery, so no Docker is required.
+    let temp_dir = TempDir::new().unwrap();
+
+    let assert = Command::cargo_bin("deacon")
+        .expect("failed to find deacon binary for tests - ensure 'cargo build' has been run")
+        .current_dir(temp_dir.path())
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .arg("--log-level")
+        .arg("error")
+        .assert()
+        .failure()
+        .code(1);
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    // stdout must be a single, parseable JSON document (not log noise).
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("up error stdout is not valid JSON ({e}): {stdout:?}"));
+
+    assert_eq!(
+        parsed["outcome"], "error",
+        "error payload must carry outcome=error: {stdout}"
+    );
+    assert!(
+        parsed
+            .get("message")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "error payload must include a non-empty string `message`: {stdout}"
+    );
+    assert!(
+        parsed
+            .get("description")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        "error payload must include a non-empty string `description`: {stdout}"
+    );
 }
 
 // Note: Full integration tests that actually create containers and verify JSON output


### PR DESCRIPTION
## Summary

Closing the last JSON v1-parity validation gap. `test_up_json_output_structure_on_missing_config` was an **empty placeholder** (comments only) even though `up_json_output.rs` documents itself as testing the error JSON contract.

The `up` error contract (up/SPEC.md §10; mirrors the reference `@devcontainers/cli` outcome object): on failure, write exactly one JSON document to **stdout** shaped `{ outcome: "error", message, description }` and exit 1, with all logs on stderr.

## Change

Implement the test: empty workspace → `up` exits 1, stdout parses as a single JSON document with `outcome == "error"` and non-empty `message`/`description`. Hermetic — the error fires during config discovery, so no Docker is required.

Verified deacon already emits exactly this shape; this locks the contract so a regression can't silently break stdout parseability for tools consuming deacon in place of the reference CLI.

## Context

The rest of the JSON-parity surface was already well covered — `up` success (`up_json_output`, `up_validation`, `smoke_basic`, `parity_up_exec`), `build` (`parity_build`, `json_output_purity`, `integration_build*`), `read-configuration` (`parity_read_configuration`, `json_output_purity`), `outdated` (`integration_outdated_json`), `exec` (`parity_exec`), and the stdout/stderr stream contract (observability/json-logs canary, #159). This was the one error-path gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)