### PR TITLE
fix(oci): verify content digests and harden dotfiles host-exec gates

### DIFF
--- a/crates/core/src/dotfiles.rs
+++ b/crates/core/src/dotfiles.rs
@@ -94,13 +94,50 @@ async fn check_git_available() -> Result<()> {
     }
 }
 
+/// Validate a dotfiles repository URL before handing it to `git clone`.
+///
+/// Guards against argument/transport injection: a URL beginning with `-` would
+/// be parsed by git as an option, and the `ext::` transport runs an arbitrary
+/// command as the remote helper. We reject both rather than relying on the
+/// ambient `GIT_ALLOW_PROTOCOL` environment. This matters today only for the
+/// user-supplied `--dotfiles-repository` flag, but keeps the path safe if a
+/// future change ever sources the URL from workspace config.
+fn validate_repo_url(repo_url: &str) -> Result<()> {
+    let trimmed = repo_url.trim();
+    if trimmed.is_empty() {
+        return Err(GitError::InvalidUrl("repository URL is empty".to_string()).into());
+    }
+    if trimmed.starts_with('-') {
+        return Err(GitError::InvalidUrl(format!(
+            "repository URL must not begin with '-': {}",
+            trimmed
+        ))
+        .into());
+    }
+    // Detect a `scheme::` transport prefix (e.g. `ext::`, `fd::`).
+    if let Some((scheme, _)) = trimmed.split_once("::") {
+        if scheme.eq_ignore_ascii_case("ext") {
+            return Err(GitError::InvalidUrl(format!(
+                "unsupported git transport '{}::' in repository URL",
+                scheme
+            ))
+            .into());
+        }
+    }
+    Ok(())
+}
+
 /// Clone a git repository to the target directory
 #[instrument]
 async fn clone_repository(repo_url: &str, target: &Path, _options: &DotfilesOptions) -> Result<()> {
     info!("Starting to clone dotfiles repository: {}", repo_url);
 
+    validate_repo_url(repo_url)?;
+
     let output = Command::new("git")
         .arg("clone")
+        // `--` terminates option parsing so a URL can never be treated as a flag.
+        .arg("--")
         .arg(repo_url)
         .arg(target)
         .output()
@@ -432,19 +469,25 @@ pub async fn execute_dotfiles_phase(config: &DotfilesPhaseConfig) -> Result<Dotf
         target.display()
     );
 
+    // If the dotfiles source is workspace-resident, require an explicit trust
+    // opt-in BEFORE we clone and exec any host shell from it. This gates every
+    // host-side exec path uniformly: the auto-detected install.sh/setup.sh run
+    // inside apply_dotfiles AND a custom install command below. (Gating here
+    // rather than per-exec-site avoids the asymmetry where an auto-detected
+    // script could run ungated — see HostTrustSource.)
+    if let HostTrustSource::WorkspaceSourced { workspace, policy } = &config.host_trust {
+        let decision = check_workspace_trust(workspace, policy.clone()).await?;
+        decision_to_result(decision)?;
+    }
+
     // Execute dotfiles with custom install command if provided
     let options = DotfilesOptions::default();
     let result = apply_dotfiles(&repository, target, &options).await?;
 
-    // If custom install command was provided and no script was auto-detected,
-    // execute the custom command (gated by workspace trust when the command
-    // came from a workspace-resident source — see HostTrustSource).
+    // If a custom install command was provided and no script was auto-detected,
+    // execute the custom command (trust already enforced above).
     if let Some(ref custom_cmd) = config.install_command {
         if !result.script_executed {
-            if let HostTrustSource::WorkspaceSourced { workspace, policy } = &config.host_trust {
-                let decision = check_workspace_trust(workspace, policy.clone()).await?;
-                decision_to_result(decision)?;
-            }
             info!("Executing custom dotfiles install command: {}", custom_cmd);
             execute_custom_install_command(target, custom_cmd).await?;
         }
@@ -457,11 +500,11 @@ pub async fn execute_dotfiles_phase(config: &DotfilesPhaseConfig) -> Result<Dotf
 ///
 /// Trust boundary note: `command` is interpreted as shell by `bash -c`,
 /// which is the design intent (it accepts pipelines, redirects, etc.).
-/// The trust gate is the *source* of the command — currently
-/// `--dotfiles-install-command` (CLI, user opt-in) — not this exec
-/// layer. If a future caller plumbs through devcontainer.json's
-/// dotfiles config, that path needs the workspace-trust check (audit
-/// gap #3 / spec §12) before reaching here.
+/// The trust gate is the *source* of the command, enforced by the caller
+/// (`execute_dotfiles_phase`) before any host shell runs: `UserCliFlag`
+/// sources are pre-trusted, while `WorkspaceSourced` sources go through
+/// [`check_workspace_trust`]. This exec layer assumes that gate has
+/// already passed.
 ///
 /// `target` is passed through `current_dir`, which is a syscall argument
 /// (not a shell interpolation), so no quoting is needed for the path.
@@ -790,6 +833,34 @@ mod tests {
         // Check that files were cloned
         let cloned_bashrc = target_path.join(".bashrc");
         assert!(cloned_bashrc.exists());
+    }
+
+    #[test]
+    fn test_validate_repo_url_accepts_common_forms() {
+        assert!(validate_repo_url("https://github.com/user/dotfiles").is_ok());
+        assert!(validate_repo_url("git@github.com:user/dotfiles.git").is_ok());
+        assert!(validate_repo_url("ssh://git@github.com/user/dotfiles.git").is_ok());
+        assert!(validate_repo_url("git://github.com/user/dotfiles.git").is_ok());
+    }
+
+    #[test]
+    fn test_validate_repo_url_rejects_leading_dash() {
+        // Would be parsed by git as an option (e.g. --upload-pack=...).
+        assert!(validate_repo_url("--upload-pack=touch /tmp/pwned").is_err());
+        assert!(validate_repo_url("-oProxyCommand=evil").is_err());
+    }
+
+    #[test]
+    fn test_validate_repo_url_rejects_ext_transport() {
+        // The ext:: transport executes an arbitrary command as the remote helper.
+        assert!(validate_repo_url("ext::sh -c 'touch /tmp/pwned'").is_err());
+        assert!(validate_repo_url("EXT::sh -c whoami").is_err());
+    }
+
+    #[test]
+    fn test_validate_repo_url_rejects_empty() {
+        assert!(validate_repo_url("").is_err());
+        assert!(validate_repo_url("   ").is_err());
     }
 
     #[test]

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -124,9 +124,21 @@ pub enum FeatureError {
     #[error("Feature download error: {message}")]
     Download { message: String },
 
-    /// Feature extraction error  
+    /// Feature extraction error
     #[error("Feature extraction error: {message}")]
     Extraction { message: String },
+
+    /// Content integrity verification failed
+    ///
+    /// Raised when downloaded bytes (a manifest or layer blob) do not hash to
+    /// the digest declared in the manifest, a digest-pinned reference, or the
+    /// lockfile. Fail closed: never trust content that fails this check.
+    #[error("Integrity verification failed for {context}: expected {expected}, computed {actual}")]
+    IntegrityMismatch {
+        context: String,
+        expected: String,
+        actual: String,
+    },
 
     /// Feature installation error (generic installation failure)
     #[error("Feature installation error: {message}")]

--- a/crates/core/src/oci/fetcher.rs
+++ b/crates/core/src/oci/fetcher.rs
@@ -20,7 +20,7 @@ use super::types::{
     DownloadedFeature, DownloadedTemplate, FeatureRef, Manifest, PublishResult, TagList,
     TemplateRef,
 };
-use super::utils::{classify_network_error, get_features_cache_dir};
+use super::utils::{classify_network_error, get_features_cache_dir, verify_content_digest};
 
 /// Feature fetcher for OCI registries
 pub struct FeatureFetcher<C: HttpClient> {
@@ -349,6 +349,21 @@ impl<C: HttpClient> FeatureFetcher<C> {
         let mut hasher = Sha256::new();
         hasher.update(&manifest_data);
         let digest = format!("{:x}", hasher.finalize());
+
+        // If the reference is digest-pinned (e.g. `feature@sha256:...`, surfaced
+        // here as the tag), the returned manifest MUST hash to that digest.
+        // Otherwise the registry could serve a different manifest than the one
+        // the caller pinned.
+        if let Some(expected_hex) = feature_ref.tag().strip_prefix("sha256:") {
+            if !digest.eq_ignore_ascii_case(expected_hex) {
+                return Err(FeatureError::IntegrityMismatch {
+                    context: format!("manifest for {}", feature_ref.reference()),
+                    expected: format!("sha256:{}", expected_hex),
+                    actual: format!("sha256:{}", digest),
+                }
+                .into());
+            }
+        }
 
         // Parse the manifest JSON
         let manifest: serde_json::Value =
@@ -964,6 +979,10 @@ impl<C: HttpClient> FeatureFetcher<C> {
         )
         .await?;
 
+        // Verify the downloaded blob hashes to the manifest's declared digest
+        // before extraction (see download_layer for rationale).
+        verify_content_digest(&layer_data, digest, &format!("layer blob {}", blob_url))?;
+
         Ok(layer_data)
     }
 
@@ -1018,6 +1037,11 @@ impl<C: HttpClient> FeatureFetcher<C> {
             classify_network_error,
         )
         .await?;
+
+        // Verify the downloaded blob hashes to the digest declared in the
+        // manifest before we extract and execute its contents. The registry is
+        // not trusted to return correct bytes for a digest-addressed URL.
+        verify_content_digest(&layer_data, digest, &format!("layer blob {}", blob_url))?;
 
         Ok(layer_data)
     }

--- a/crates/core/src/oci/utils.rs
+++ b/crates/core/src/oci/utils.rs
@@ -21,6 +21,9 @@ pub(crate) fn classify_network_error(error: &FeatureError) -> RetryDecision {
         FeatureError::Parsing { .. }
         | FeatureError::Validation { .. }
         | FeatureError::Extraction { .. }
+        // Integrity failures are deterministic for given bytes; retrying the
+        // same registry response cannot help, so fail fast.
+        | FeatureError::IntegrityMismatch { .. }
         | FeatureError::Installation { .. }
         | FeatureError::InstallationFailed { .. }
         | FeatureError::NotFound { .. }
@@ -94,6 +97,53 @@ pub fn canonical_id(manifest: &Manifest) -> Result<String> {
     let mut hasher = Sha256::new();
     hasher.update(&manifest_json);
     Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+/// Verify that the SHA256 digest of `data` matches the `expected` OCI digest.
+///
+/// `expected` is an OCI content descriptor digest in `algorithm:hex` form
+/// (e.g. `sha256:<64 hex chars>`). Only `sha256` is supported; any other
+/// algorithm is rejected rather than silently accepted (no silent fallback per
+/// the project's fail-fast principle). The hex comparison is case-insensitive.
+///
+/// On any mismatch — malformed digest, unsupported algorithm, or content that
+/// does not hash to the expected value — returns [`FeatureError::IntegrityMismatch`]
+/// so callers fail closed before trusting downloaded bytes. `context` is a short
+/// human-readable description of what is being verified (e.g. the blob URL or
+/// reference) for diagnostics.
+pub(crate) fn verify_content_digest(data: &[u8], expected: &str, context: &str) -> Result<()> {
+    let (algorithm, expected_hex) =
+        expected
+            .split_once(':')
+            .ok_or_else(|| FeatureError::IntegrityMismatch {
+                context: context.to_string(),
+                expected: expected.to_string(),
+                actual: "<malformed digest: missing 'algorithm:' prefix>".to_string(),
+            })?;
+
+    if !algorithm.eq_ignore_ascii_case("sha256") {
+        return Err(FeatureError::IntegrityMismatch {
+            context: context.to_string(),
+            expected: expected.to_string(),
+            actual: format!("<unsupported digest algorithm: {}>", algorithm),
+        }
+        .into());
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let actual_hex = format!("{:x}", hasher.finalize());
+
+    if !actual_hex.eq_ignore_ascii_case(expected_hex) {
+        return Err(FeatureError::IntegrityMismatch {
+            context: context.to_string(),
+            expected: expected.to_string(),
+            actual: format!("sha256:{}", actual_hex),
+        }
+        .into());
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -215,6 +265,56 @@ mod tests {
         let result = retry_async(&config, op, classify_network_error).await;
         assert_eq!(result.unwrap(), 42);
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn verify_content_digest_accepts_matching_sha256() {
+        // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+        let data = b"hello world";
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        assert!(verify_content_digest(data, expected, "test blob").is_ok());
+    }
+
+    #[test]
+    fn verify_content_digest_is_case_insensitive_on_hex() {
+        let data = b"hello world";
+        let expected = "sha256:B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9";
+        assert!(verify_content_digest(data, expected, "test blob").is_ok());
+    }
+
+    #[test]
+    fn verify_content_digest_rejects_tampered_content() {
+        let data = b"tampered payload";
+        let expected = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        let err = verify_content_digest(data, expected, "test blob").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::errors::DeaconError::Feature(FeatureError::IntegrityMismatch { .. })
+            ),
+            "expected IntegrityMismatch, got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn verify_content_digest_rejects_unsupported_algorithm() {
+        let data = b"hello world";
+        let err = verify_content_digest(data, "sha512:deadbeef", "test blob").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::errors::DeaconError::Feature(FeatureError::IntegrityMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn verify_content_digest_rejects_malformed_digest() {
+        let data = b"hello world";
+        let err = verify_content_digest(data, "no-prefix-here", "test blob").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::errors::DeaconError::Feature(FeatureError::IntegrityMismatch { .. })
+        ));
     }
 
     /// Sanity: classifier returns the expected decisions for boundary cases.

--- a/crates/core/tests/integration_oci.rs
+++ b/crates/core/tests/integration_oci.rs
@@ -61,7 +61,15 @@ echo "Test feature installed successfully"
 async fn test_oci_feature_fetch_with_mock_client() {
     // Create test data
     let tar_data = create_test_feature_tar();
-    let layer_digest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+    // The layer digest MUST be the real sha256 of the blob bytes — the fetcher
+    // now verifies downloaded content against the manifest's declared digest,
+    // so a placeholder digest would (correctly) be rejected.
+    let layer_digest = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&tar_data);
+        format!("sha256:{:x}", hasher.finalize())
+    };
 
     // Create the manifest JSON
     let manifest_json = format!(
@@ -133,6 +141,64 @@ async fn test_oci_feature_fetch_with_mock_client() {
     let cached_feature = fetcher.fetch_feature(&feature_ref).await.unwrap();
     assert_eq!(cached_feature.metadata.id, "test-feature");
     assert_eq!(cached_feature.path, downloaded_feature.path);
+}
+
+/// Security regression: a registry that serves blob bytes which do not match
+/// the manifest's declared layer digest must be rejected, not extracted and
+/// executed. Guards the content-integrity verification in `download_layer`.
+#[tokio::test]
+async fn test_oci_feature_fetch_rejects_tampered_blob() {
+    let tar_data = create_test_feature_tar();
+
+    // Manifest claims a digest the served bytes will NOT hash to.
+    let claimed_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    let manifest_json = format!(
+        r#"{{
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "layers": [
+                {{
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                    "size": {},
+                    "digest": "{}"
+                }}
+            ]
+        }}"#,
+        tar_data.len(),
+        claimed_digest
+    );
+
+    let feature_ref = FeatureRef::new(
+        "ghcr.io".to_string(),
+        "test".to_string(),
+        "feature".to_string(),
+        Some("1.0.0".to_string()),
+    );
+
+    let temp_dir = TempDir::new().unwrap();
+    let mock_client = MockHttpClient::new();
+    let fetcher = FeatureFetcher::with_cache_dir(mock_client, temp_dir.path().to_path_buf());
+
+    let manifest_url = "https://ghcr.io/v2/test/feature/manifests/1.0.0";
+    let blob_url = format!("https://ghcr.io/v2/test/feature/blobs/{}", claimed_digest);
+
+    fetcher
+        .client()
+        .add_response(manifest_url.to_string(), Bytes::from(manifest_json))
+        .await;
+    // Serve the (mismatched) tar bytes at the claimed-digest URL.
+    fetcher
+        .client()
+        .add_response(blob_url, Bytes::from(tar_data))
+        .await;
+
+    let result = fetcher.fetch_feature(&feature_ref).await;
+    let err = result.expect_err("tampered blob must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Integrity verification failed"),
+        "expected integrity error, got: {msg}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Addresses three security findings from a project security review (one HIGH integrity gap, two LOW host-exec hardening gaps). All consumer-side; no spec deviation.

### 1. OCI content-digest verification (HIGH)
Downloaded layer blobs and manifests were never re-hashed against their expected digests, so `@sha256:` pinning and lockfile `integrity` provided **no actual integrity guarantee**. A malicious or compromised registry (or a poisoned pull-through mirror) could serve a tampered feature layer in response to a digest-pinned request; its `install.sh` then executes with build/container privileges.

- New `FeatureError::IntegrityMismatch { context, expected, actual }` (fails closed; classified non-retryable).
- New `verify_content_digest()` in `oci/utils.rs` — `algorithm:hex` parse, **sha256-only** (no silent fallback), case-insensitive hex compare.
- `download_layer` / `download_layer_template` verify downloaded bytes against the manifest's declared layer digest **before** extraction.
- `get_manifest_with_digest` rejects a manifest that doesn't hash to a digest-pinned (`@sha256:…`) reference.
- Because a feature's lockfile `integrity` *is* its layer digest, this also closes the lockfile-integrity loop.

### 2. git argument/transport injection in dotfiles clone (LOW)
`git clone <url>` had no `--` separator and no scheme validation. Added `validate_repo_url()` (rejects leading `-` and the `ext::` transport) plus a `--` separator. Self-inflicted today (`--dotfiles-repository` is a trusted CLI flag), but keeps the path safe if a future change ever sources the URL from workspace config.

### 3. Dotfiles trust-gate asymmetry (LOW)
The auto-detected `install.sh`/`setup.sh` ran ungated while only the custom install command was trust-checked. Moved the `WorkspaceSourced` trust check to the top of `execute_dotfiles_phase` so it uniformly gates every host-side exec path (clone → auto-script → custom command).

## Tests
- Fixed `test_oci_feature_fetch_with_mock_client` — it used a placeholder layer digest that didn't match the tar bytes (exactly the unrealistic mock that masked this gap); now computes the real digest.
- Added `test_oci_feature_fetch_rejects_tampered_blob` (regression: mismatched content must be rejected).
- New unit tests for `verify_content_digest` (match / case-insensitive / tampered / unsupported-algo / malformed) and `validate_repo_url` (common forms / leading-dash / `ext::` / empty).
- Full suite green: `make test-nextest-fast` → 2161 passed; fmt + clippy `--all-targets --all-features` clean.

## Note on scope
Layer blobs are verified against the **manifest's** declared digest. The manifest is itself authenticated when the reference is digest-pinned; tag-based pulls still rely on registry TLS for manifest authenticity, matching upstream behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)