### PR TITLE
chore: align workspace with Rust best practices (edition 2024, MSRV CI, deps, profiles)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
-[build]
-rustflags = ["-C", "debuginfo=1"]
+# Dev build tuning lives in [profile.dev] in the workspace Cargo.toml (debug = 1
+# for faster incremental links). Keeping it profile-scoped avoids emitting debug
+# info into release builds, which the release profile then strips anyway.
 
 [term]
 quiet = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,42 @@ jobs:
       run: cargo check --workspace --all-targets
 
     - name: Run clippy
-      run: cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: Run doctests
       run: cargo test --doc --workspace
+
+  msrv:
+    name: MSRV (cargo check)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    # Pin to the declared MSRV (rust-version in [workspace.package]). If this
+    # job fails, either fix the offending code or bump rust-version in lockstep.
+    - name: Install MSRV toolchain (1.85)
+      uses: dtolnay/rust-toolchain@1.85
+
+    - name: Cache cargo registry and target
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-msrv-
+          ${{ runner.os }}-cargo-
+
+    - name: Check on MSRV
+      run: cargo check --workspace --all-targets --all-features --locked
 
   test-fast:
     name: Test (MVP fast) (${{ matrix.os }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,9 +224,9 @@ jobs:
       - name: Prepare packaging files (Unix)
         if: runner.os != 'Windows'
         run: |
+          # The binary is already stripped by `strip = true` in [profile.release]
+          # (rustc's built-in, cross-platform stripping), so no shell `strip` here.
           cp README.md LICENSE target/${{ matrix.target }}/release/
-          # Attempt to strip (ignore failures on unsupported formats)
-          strip target/${{ matrix.target }}/release/deacon || true
       - name: Prepare packaging files (Windows)
         if: runner.os == 'Windows'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "sha2",
  "shell-words",
  "tar",
+ "temp-env",
  "tempfile",
  "testcontainers",
  "tokio",
@@ -718,6 +719,7 @@ dependencies = [
  "shell-words",
  "sysinfo",
  "tar",
+ "temp-env",
  "tempfile",
  "testcontainers",
  "thiserror 2.0.18",
@@ -1625,6 +1627,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1903,29 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "parse-display"
@@ -2212,6 +2246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,6 +2477,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -2740,6 +2789,16 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "futures",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,25 @@ members = [
     "crates/deacon",
     "crates/core"
 ]
-resolver = "2"
+# resolver "3" enables the MSRV-aware dependency resolver (Rust 1.84+), so
+# `cargo update` will not select dependency versions whose own rust-version
+# exceeds our declared MSRV below.
+resolver = "3"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
+# Not published to crates.io (consumer CLI distributed as prebuilt binaries);
+# see each crate's `publish = false`. Point docs at the repo rather than docs.rs.
 license = "MIT"
 authors = ["get2knowio <dev@get2know.io>"]
 repository = "https://github.com/get2knowio/deacon"
 homepage = "https://github.com/get2knowio/deacon"
-documentation = "https://docs.rs/deacon-core"
+documentation = "https://github.com/get2knowio/deacon"
 keywords = ["devcontainer", "containers", "docker", "development", "cli"]
 categories = ["command-line-utilities", "development-tools"]
-rust-version = "1.82"
+# Minimum Supported Rust Version. Verified in CI by a dedicated job pinned to
+# this exact toolchain. edition 2024 requires >= 1.85.
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
@@ -28,6 +35,42 @@ tracing-error = "0.2"
 color-eyre = "0.6"
 once_cell = "1.21"
 shell-words = "1.1"
+# Shared across both member crates — declared once here to prevent version
+# drift. tokio carries the union of the features each crate needs.
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "process", "macros", "fs", "io-std", "io-util"] }
+futures = "0.3"
+tar = "0.4"
+sha2 = "0.10"
+regex = "1.10"
+zip = "2.4"
+# Shared dev-dependencies.
+tempfile = "3.12"
+assert_cmd = "2.0"
+testcontainers = "0.27"
+# Scoped, serialized env-var mutation for tests (sets vars for a closure/future
+# then restores them). Encapsulates the edition-2024 `unsafe` env calls behind a
+# safe API and serializes via an internal lock, so test code stays unsafe-free.
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+# `deny` (not `forbid`) so the rare, reviewed exceptions mandated by edition
+# 2024 — wrapping std::env::set_var/remove_var in test code — can opt in via a
+# scoped `#[allow(unsafe_code)]`. Production code remains unsafe-free; `deny`
+# still turns any unguarded `unsafe` into a compile error.
+unsafe_code = "deny"
+
+[profile.dev]
+# Lighter debug info than the default (2) for faster incremental links. Was
+# previously a global `-C debuginfo=1` rustflag in .cargo/config.toml, which
+# also applied to release builds; scoping it here keeps release lean.
+debug = 1
+
+[profile.release]
+# Distributed CLI binary: optimize size and runtime over compile time.
+# `strip = true` uses rustc's cross-platform stripping (replaces the fragile
+# per-target shell `strip || true` in the release workflow).
+lto = "thin"
+codegen-units = 1
+strip = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 description = "Core library for deacon — DevContainer configuration resolution, OCI feature/template fetching, container runtime abstraction (Docker/Podman), lifecycle execution, and lockfile management."
 
 [dependencies]
@@ -17,16 +18,16 @@ anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde.workspace = true
+serde_json.workspace = true
 jsonc-parser = { version = "0.32", default-features = false, features = ["preserve_order"] }
-regex = "1.0"
-tokio = { version = "1.0", features = ["rt", "process", "macros", "io-util", "io-std", "fs"] }
+regex.workspace = true
+tokio.workspace = true
 once_cell.workspace = true
 # Use rustls for a pure-Rust TLS stack to simplify cross-compilation (musl, aarch64) and avoid OpenSSL toolchain requirements.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tar = "0.4"
-sha2 = "0.10"
+tar.workspace = true
+sha2.workspace = true
 bytes = "1.0"
 async-trait = "0.1"
 linked-hash-map = "0.5"
@@ -54,6 +55,7 @@ assert_cmd = "2.0"
 tokio-test = "0.4"
 wiremock = "0.6"
 testcontainers = "0.27"
+temp-env.workspace = true
 
 [lints]
 workspace = true

--- a/crates/core/src/cache/disk.rs
+++ b/crates/core/src/cache/disk.rs
@@ -1,6 +1,6 @@
 //! Disk-based cache implementation with TTL support
 
-use super::{hash_key, Cache, CacheStats, Result, TtlEntry};
+use super::{Cache, CacheStats, Result, TtlEntry, hash_key};
 use crate::errors::CacheError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -350,7 +350,9 @@ impl ComposeCommand {
             }
             crate::gpu::GpuMode::Detect => {
                 // This should never happen - Detect mode should be resolved upstream
-                warn!("GpuMode::Detect passed to compose.rs - this indicates a bug. Skipping GPU flags.");
+                warn!(
+                    "GpuMode::Detect passed to compose.rs - this indicates a bug. Skipping GPU flags."
+                );
             }
         }
 
@@ -391,7 +393,9 @@ impl ComposeCommand {
                 );
             }
 
-            warn!("Security options from devcontainer.json cannot be applied dynamically to Docker Compose services.");
+            warn!(
+                "Security options from devcontainer.json cannot be applied dynamically to Docker Compose services."
+            );
             warn!("Please add these options to your docker-compose.yml service definition.");
         }
 
@@ -1560,13 +1564,11 @@ fn derive_project_name(base_path: &Path) -> String {
         .to_string();
 
     // Ensure first character is a lowercase letter or number
-    let final_name = match sanitized.chars().next() {
+    match sanitized.chars().next() {
         Some(c) if c.is_ascii_lowercase() || c.is_ascii_digit() => sanitized,
         Some(_) => format!("d{}", sanitized),
         None => FALLBACK.to_string(),
-    };
-
-    final_name
+    }
 }
 
 #[cfg(test)]
@@ -2106,8 +2108,11 @@ mod tests {
             .expect("override command should produce override yaml even with no env/mounts");
 
         assert!(override_yaml.contains("services:\n  app:\n"));
-        assert!(override_yaml
-            .contains("command: [\"/bin/sh\", \"-c\", \"sleep infinity || tail -f /dev/null\"]"));
+        assert!(
+            override_yaml.contains(
+                "command: [\"/bin/sh\", \"-c\", \"sleep infinity || tail -f /dev/null\"]"
+            )
+        );
     }
 
     #[test]
@@ -2157,8 +2162,11 @@ mod tests {
 
         let override_yaml = project.generate_injection_override().unwrap();
 
-        assert!(override_yaml
-            .contains("command: [\"/bin/sh\", \"-c\", \"sleep infinity || tail -f /dev/null\"]"));
+        assert!(
+            override_yaml.contains(
+                "command: [\"/bin/sh\", \"-c\", \"sleep infinity || tail -f /dev/null\"]"
+            )
+        );
         assert!(override_yaml.contains("environment:"));
         assert!(override_yaml.contains("FOO: \"bar\""));
         // command must appear before environment (matches struct field order in yaml)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -376,7 +376,7 @@ fn parse_resource_string(s: &str) -> Result<u64> {
             return Err(ConfigError::Validation {
                 message: format!("Unknown unit: {}", unit),
             }
-            .into())
+            .into());
         }
     };
 
@@ -2639,7 +2639,9 @@ impl ConfigLoader {
                 }));
             }
             (None, None) => {
-                debug!("Neither 'image' nor 'dockerFile' specified - this may be intended for extends or compose configurations");
+                debug!(
+                    "Neither 'image' nor 'dockerFile' specified - this may be intended for extends or compose configurations"
+                );
             }
             _ => {
                 // Valid: exactly one is specified
@@ -3468,11 +3470,13 @@ mod tests {
         }
 
         // Check container env substitution
-        assert!(config
-            .container_env
-            .get("WORKSPACE_ROOT")
-            .unwrap()
-            .starts_with(workspace_canonical_str));
+        assert!(
+            config
+                .container_env
+                .get("WORKSPACE_ROOT")
+                .unwrap()
+                .starts_with(workspace_canonical_str)
+        );
 
         // Check mounts substitution
         if !config.mounts.is_empty() {

--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -447,7 +447,7 @@ impl ContainerEnvironmentProber {
                     crate::errors::InternalError::Generic {
                         message: "None mode should be handled earlier".to_string(),
                     },
-                ))
+                ));
             }
             ContainerProbeMode::LoginShell => "-lc",
             ContainerProbeMode::InteractiveShell => "-ic",

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -7,7 +7,7 @@ use crate::docker::{CliDocker, Docker, ExecConfig};
 use crate::errors::{ConfigError, DeaconError, Result};
 use crate::lifecycle::LifecyclePhase;
 use crate::progress::{ProgressEvent, ProgressTracker};
-use crate::redaction::{redact_if_enabled, RedactionConfig};
+use crate::redaction::{RedactionConfig, redact_if_enabled};
 use crate::state::record_phase_executed_with_config_hash;
 use crate::variable::{SubstitutionContext, SubstitutionReport, VariableSubstitution};
 use indexmap::IndexMap;
@@ -173,14 +173,12 @@ impl LifecycleCommandValue {
                                 match elem {
                                     serde_json::Value::String(s) => strings.push(s.clone()),
                                     _ => {
-                                        return Err(DeaconError::Config(
-                                            ConfigError::Validation {
-                                                message: format!(
-                                                    "Lifecycle command object entry '{}' contains array with non-string element at index {}",
-                                                    key, idx
-                                                ),
-                                            },
-                                        ));
+                                        return Err(DeaconError::Config(ConfigError::Validation {
+                                            message: format!(
+                                                "Lifecycle command object entry '{}' contains array with non-string element at index {}",
+                                                key, idx
+                                            ),
+                                        }));
                                     }
                                 }
                             }

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1820,13 +1820,11 @@ impl ContainerOps for CliRuntime {
             crate::features::EntrypointChain::None => {
                 // Use image default entrypoint
             }
-            crate::features::EntrypointChain::Single(ref path) => {
+            crate::features::EntrypointChain::Single(path) => {
                 args.push("--entrypoint".to_string());
                 args.push(path.clone());
             }
-            crate::features::EntrypointChain::Chained {
-                ref wrapper_path, ..
-            } => {
+            crate::features::EntrypointChain::Chained { wrapper_path, .. } => {
                 args.push("--entrypoint".to_string());
                 args.push(wrapper_path.clone());
             }
@@ -1873,7 +1871,9 @@ impl ContainerOps for CliRuntime {
             }
             crate::gpu::GpuMode::Detect => {
                 // This should never happen - Detect mode should be resolved upstream
-                warn!("GpuMode::Detect passed to docker.rs - this indicates a bug. Skipping GPU flags.");
+                warn!(
+                    "GpuMode::Detect passed to docker.rs - this indicates a bug. Skipping GPU flags."
+                );
             }
         }
 
@@ -3022,14 +3022,18 @@ mod tests {
 
         // Check exposed ports
         assert_eq!(container.exposed_ports.len(), 2);
-        assert!(container
-            .exposed_ports
-            .iter()
-            .any(|p| p.port == 3000 && p.protocol == "tcp"));
-        assert!(container
-            .exposed_ports
-            .iter()
-            .any(|p| p.port == 8080 && p.protocol == "tcp"));
+        assert!(
+            container
+                .exposed_ports
+                .iter()
+                .any(|p| p.port == 3000 && p.protocol == "tcp")
+        );
+        assert!(
+            container
+                .exposed_ports
+                .iter()
+                .any(|p| p.port == 8080 && p.protocol == "tcp")
+        );
 
         // Check port mappings
         assert_eq!(container.port_mappings.len(), 2);
@@ -3744,9 +3748,11 @@ mod tests {
         let image_pos = args.iter().position(|a| a == "ubuntu:22.04").unwrap();
         assert!(image_pos > 0, "Image should not be the first argument");
         // No runArgs-related strings should be present
-        assert!(!args
-            .iter()
-            .any(|a| a.starts_with("--memory") || a.starts_with("--cpus")));
+        assert!(
+            !args
+                .iter()
+                .any(|a| a.starts_with("--memory") || a.starts_with("--cpus"))
+        );
     }
 
     /// BEAD-6-T01: a normal exit code is passed through verbatim.

--- a/crates/core/src/docker_retry.rs
+++ b/crates/core/src/docker_retry.rs
@@ -32,7 +32,7 @@ use std::process::Output;
 use thiserror::Error;
 
 use crate::errors::{DockerError, Result};
-use crate::retry::{retry_async, RetryConfig, RetryDecision};
+use crate::retry::{RetryConfig, RetryDecision, retry_async};
 
 /// Classification of a failed `docker build` / `docker buildx build` invocation.
 ///
@@ -239,9 +239,16 @@ pub fn classify_retry_decision(error: &DockerSubprocessError) -> RetryDecision {
 /// failure so a single test run can observe both the failure and recovery
 /// branches.
 ///
-/// Production code paths never set this variable. Mirrors the env-var-driven
-/// fail-N-times approach referenced in issue #17.
-pub const DEACON_TEST_DOCKER_FAIL_N: &str = "DEACON_TEST_DOCKER_FAIL_N";
+/// Test-only seam: the number of synthetic transient failures the next
+/// `run_build_with_retry` should inject before letting the real subprocess
+/// run. Replaces the former `DEACON_TEST_DOCKER_FAIL_N` env var so the hook no
+/// longer mutates the process environment (which is `unsafe` and racy under
+/// edition 2024). Production builds never reference it — `take_forced_failure`
+/// is compiled to a no-op outside `cfg(test)`. Mirrors the fail-N-times
+/// approach referenced in issue #17.
+#[cfg(test)]
+pub(crate) static FORCED_TRANSIENT_FAILURES: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
 
 /// Run a `docker` subprocess (typically `docker buildx build ...`) with
 /// retry-on-transient. The caller passes the runtime binary path and the
@@ -295,21 +302,37 @@ pub async fn run_build_with_retry(runtime_path: &Path, args: &[String]) -> Resul
 }
 
 /// Pull-and-decrement the test-hook counter. Returns `Some(stderr)` if a
-/// forced failure should be injected, else `None`. Always `None` outside
-/// tests because production code does not set the env var.
+/// forced failure should be injected, else `None`. Compiled to an
+/// unconditional `None` outside `cfg(test)`, so production code never injects.
 fn take_forced_failure() -> Option<String> {
-    let raw = std::env::var(DEACON_TEST_DOCKER_FAIL_N).ok()?;
-    let n: u32 = raw.parse().ok()?;
-    if n == 0 {
-        return None;
+    #[cfg(test)]
+    {
+        use std::sync::atomic::Ordering;
+        // Atomically claim one synthetic failure if any remain. Lock-free CAS
+        // loop so concurrent attempts can't double-consume the counter.
+        let mut remaining = FORCED_TRANSIENT_FAILURES.load(Ordering::SeqCst);
+        while remaining > 0 {
+            match FORCED_TRANSIENT_FAILURES.compare_exchange_weak(
+                remaining,
+                remaining - 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => {
+                    return Some(format!(
+                        "synthetic transient failure: TLS handshake timeout (remaining was {})",
+                        remaining
+                    ));
+                }
+                Err(actual) => remaining = actual,
+            }
+        }
+        None
     }
-    // Decrement so the next attempt proceeds normally once we've consumed
-    // the configured failure count.
-    std::env::set_var(DEACON_TEST_DOCKER_FAIL_N, (n - 1).to_string());
-    Some(format!(
-        "synthetic transient failure: TLS handshake timeout (DEACON_TEST_DOCKER_FAIL_N={})",
-        n
-    ))
+    #[cfg(not(test))]
+    {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -504,24 +527,25 @@ mod tests {
     // run_build_with_retry — integration-style tests
     //
     // These exercise the retry loop end-to-end using the
-    // DEACON_TEST_DOCKER_FAIL_N env-var hook so we can simulate transient
+    // FORCED_TRANSIENT_FAILURES atomic hook so we can simulate transient
     // failures without needing a real Docker daemon. They mirror the
-    // env-var-driven fail-N-times pattern referenced in issue #17 and the
-    // shape of the existing OCI retry tests in oci/utils.rs.
+    // fail-N-times pattern referenced in issue #17 and the shape of the
+    // existing OCI retry tests in oci/utils.rs.
     //
-    // Tests serialize on the global env var via a mutex.
+    // Tests serialize on the global counter via a mutex.
     // ------------------------------------------------------------------
 
+    use std::sync::atomic::Ordering;
     use tokio::sync::Mutex;
 
     // tokio Mutex is async-aware: holding the guard across `.await` is safe
     // (sidesteps `clippy::await_holding_lock`). We serialize on the global
-    // env var via this lock because tests in this module mutate
-    // `DEACON_TEST_DOCKER_FAIL_N` and observe its post-state.
-    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+    // counter via this lock because tests in this module mutate
+    // `FORCED_TRANSIENT_FAILURES` and observe its post-state.
+    static HOOK_LOCK: Mutex<()> = Mutex::const_new(());
 
     fn clear_fail_hook() {
-        std::env::remove_var(DEACON_TEST_DOCKER_FAIL_N);
+        FORCED_TRANSIENT_FAILURES.store(0, Ordering::SeqCst);
     }
 
     /// The retry loop recovers once the synthetic transient failure counter
@@ -530,10 +554,10 @@ mod tests {
     /// subprocess succeeds on the recovery attempt (no Docker daemon required).
     #[tokio::test]
     async fn run_build_recovers_after_transient_failures() {
-        let _guard = ENV_LOCK.lock().await;
+        let _guard = HOOK_LOCK.lock().await;
         clear_fail_hook();
         // Two synthetic transient failures, then real subprocess succeeds.
-        std::env::set_var(DEACON_TEST_DOCKER_FAIL_N, "2");
+        FORCED_TRANSIENT_FAILURES.store(2, Ordering::SeqCst);
 
         let result =
             run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
@@ -544,10 +568,7 @@ mod tests {
             result
         );
         // Counter should be drained.
-        assert_eq!(
-            std::env::var(DEACON_TEST_DOCKER_FAIL_N).ok().as_deref(),
-            Some("0")
-        );
+        assert_eq!(FORCED_TRANSIENT_FAILURES.load(Ordering::SeqCst), 0);
         clear_fail_hook();
     }
 
@@ -555,11 +576,11 @@ mod tests {
     /// up and surfaces a `DockerError::CLIError` with the last stderr.
     #[tokio::test]
     async fn run_build_gives_up_after_exhausting_retries() {
-        let _guard = ENV_LOCK.lock().await;
+        let _guard = HOOK_LOCK.lock().await;
         clear_fail_hook();
         // Network profile is 3 retries (4 attempts total). 10 forced failures
         // guarantees exhaustion.
-        std::env::set_var(DEACON_TEST_DOCKER_FAIL_N, "10");
+        FORCED_TRANSIENT_FAILURES.store(10, Ordering::SeqCst);
 
         let result =
             run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
@@ -576,17 +597,14 @@ mod tests {
             err
         );
         // After 4 attempts (initial + 3 retries) the counter should be 10-4 = 6.
-        assert_eq!(
-            std::env::var(DEACON_TEST_DOCKER_FAIL_N).ok().as_deref(),
-            Some("6")
-        );
+        assert_eq!(FORCED_TRANSIENT_FAILURES.load(Ordering::SeqCst), 6);
         clear_fail_hook();
     }
 
     /// First attempt succeeds (no failures injected) — no retries, no env hook.
     #[tokio::test]
     async fn run_build_succeeds_on_first_attempt_without_hook() {
-        let _guard = ENV_LOCK.lock().await;
+        let _guard = HOOK_LOCK.lock().await;
         clear_fail_hook();
 
         let result =

--- a/crates/core/src/dockerfile_generator.rs
+++ b/crates/core/src/dockerfile_generator.rs
@@ -544,8 +544,10 @@ mod tests {
         let dockerfile = generator.generate(&plan).unwrap();
 
         assert!(dockerfile.contains("ARG _DEV_CONTAINERS_BASE_IMAGE=ubuntu:22.04"));
-        assert!(dockerfile
-            .contains("FROM ${_DEV_CONTAINERS_BASE_IMAGE} AS dev_containers_target_stage"));
+        assert!(
+            dockerfile
+                .contains("FROM ${_DEV_CONTAINERS_BASE_IMAGE} AS dev_containers_target_stage")
+        );
         assert!(dockerfile.contains("RUN mkdir -p /tmp/dev-container-features"));
         assert!(dockerfile.contains("RUN --mount=type=bind"));
         assert!(dockerfile.contains("VERSION=\"20\""));

--- a/crates/core/src/doctor.rs
+++ b/crates/core/src/doctor.rs
@@ -14,12 +14,12 @@ use tracing::{debug, info, warn};
 
 /// Macro for printing redacted output
 macro_rules! println_redacted {
-    ($config:expr, $fmt:expr) => {
+    ($config:expr_2021, $fmt:expr_2021) => {
         let output = format!($fmt);
         let redacted = crate::redaction::redact_if_enabled(&output, $config);
         println!("{}", redacted);
     };
-    ($config:expr, $fmt:expr, $($arg:tt)*) => {
+    ($config:expr_2021, $fmt:expr_2021, $($arg:tt)*) => {
         let output = format!($fmt, $($arg)*);
         let redacted = crate::redaction::redact_if_enabled(&output, $config);
         println!("{}", redacted);

--- a/crates/core/src/dotfiles.rs
+++ b/crates/core/src/dotfiles.rs
@@ -41,7 +41,7 @@
 //! ```
 
 use crate::errors::{GitError, Result};
-use crate::trust::{check_workspace_trust, decision_to_result, WorkspaceTrustPolicy};
+use crate::trust::{WorkspaceTrustPolicy, check_workspace_trust, decision_to_result};
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, info, instrument, warn};

--- a/crates/core/src/env_probe.rs
+++ b/crates/core/src/env_probe.rs
@@ -288,9 +288,9 @@ impl EnvironmentProber {
         mut cmd: Command,
         timeout: Duration,
     ) -> std::io::Result<std::process::Output> {
+        use std::sync::Arc;
         use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::mpsc;
-        use std::sync::Arc;
         use std::thread;
 
         let (tx, rx) = mpsc::channel();

--- a/crates/core/src/errors.rs
+++ b/crates/core/src/errors.rs
@@ -333,7 +333,9 @@ pub enum ContainerSelectorError {
     InvalidLabelFormat,
 
     /// At least one selector is required (container_id, id_labels, or workspace_folder)
-    #[error("Missing required argument: One of --container-id, --id-label or --workspace-folder is required.")]
+    #[error(
+        "Missing required argument: One of --container-id, --id-label or --workspace-folder is required."
+    )]
     NoSelector,
 }
 
@@ -597,9 +599,11 @@ mod tests {
         };
         // thiserror automatically provides the conversion
         let anyhow_error = anyhow::Error::from(config_error);
-        assert!(anyhow_error
-            .to_string()
-            .contains("Failed to parse configuration file"));
+        assert!(
+            anyhow_error
+                .to_string()
+                .contains("Failed to parse configuration file")
+        );
 
         let deacon_error = DeaconError::Docker(DockerError::NotInstalled);
         let anyhow_error = anyhow::Error::from(deacon_error);

--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -1050,7 +1050,7 @@ impl FeatureDependencyResolver {
         let mut queue: VecDeque<String> = VecDeque::new();
         let mut zero_degree_nodes: Vec<String> = in_degree
             .iter()
-            .filter(|(_, &degree)| degree == 0)
+            .filter(|&(_, &degree)| degree == 0)
             .map(|(node, _)| node.clone())
             .collect();
         zero_degree_nodes.sort(); // Lexicographic ordering for determinism - tie-breaks independent features
@@ -1145,7 +1145,7 @@ impl FeatureDependencyResolver {
             // Find all nodes with zero in-degree (can be processed in parallel)
             let mut current_level: Vec<String> = in_degree
                 .iter()
-                .filter(|(_, &degree)| degree == 0)
+                .filter(|&(_, &degree)| degree == 0)
                 .map(|(node, _)| node.clone())
                 .collect();
 
@@ -2006,12 +2006,16 @@ mod tests {
             default: Some(true),
             description: None,
         };
-        assert!(bool_option
-            .validate_value(&OptionValue::Boolean(false))
-            .is_ok());
-        assert!(bool_option
-            .validate_value(&OptionValue::String("test".to_string()))
-            .is_err());
+        assert!(
+            bool_option
+                .validate_value(&OptionValue::Boolean(false))
+                .is_ok()
+        );
+        assert!(
+            bool_option
+                .validate_value(&OptionValue::String("test".to_string()))
+                .is_err()
+        );
 
         let enum_option = FeatureOption::String {
             default: None,
@@ -2019,12 +2023,16 @@ mod tests {
             r#enum: Some(vec!["value1".to_string(), "value2".to_string()]),
             proposals: None,
         };
-        assert!(enum_option
-            .validate_value(&OptionValue::String("value1".to_string()))
-            .is_ok());
-        assert!(enum_option
-            .validate_value(&OptionValue::String("invalid".to_string()))
-            .is_err());
+        assert!(
+            enum_option
+                .validate_value(&OptionValue::String("value1".to_string()))
+                .is_ok()
+        );
+        assert!(
+            enum_option
+                .validate_value(&OptionValue::String("invalid".to_string()))
+                .is_err()
+        );
     }
 
     #[test]
@@ -2037,15 +2045,21 @@ mod tests {
         };
 
         // Pass-through types should be accepted even for Boolean option
-        assert!(bool_option
-            .validate_value(&OptionValue::Number(serde_json::Number::from(42)))
-            .is_ok());
-        assert!(bool_option
-            .validate_value(&OptionValue::Array(vec![]))
-            .is_ok());
-        assert!(bool_option
-            .validate_value(&OptionValue::Object(serde_json::Map::new()))
-            .is_ok());
+        assert!(
+            bool_option
+                .validate_value(&OptionValue::Number(serde_json::Number::from(42)))
+                .is_ok()
+        );
+        assert!(
+            bool_option
+                .validate_value(&OptionValue::Array(vec![]))
+                .is_ok()
+        );
+        assert!(
+            bool_option
+                .validate_value(&OptionValue::Object(serde_json::Map::new()))
+                .is_ok()
+        );
         assert!(bool_option.validate_value(&OptionValue::Null).is_ok());
 
         let string_option = FeatureOption::String {
@@ -2056,15 +2070,21 @@ mod tests {
         };
 
         // Pass-through types should also be accepted for String option
-        assert!(string_option
-            .validate_value(&OptionValue::Number(serde_json::Number::from(42)))
-            .is_ok());
-        assert!(string_option
-            .validate_value(&OptionValue::Array(vec![]))
-            .is_ok());
-        assert!(string_option
-            .validate_value(&OptionValue::Object(serde_json::Map::new()))
-            .is_ok());
+        assert!(
+            string_option
+                .validate_value(&OptionValue::Number(serde_json::Number::from(42)))
+                .is_ok()
+        );
+        assert!(
+            string_option
+                .validate_value(&OptionValue::Array(vec![]))
+                .is_ok()
+        );
+        assert!(
+            string_option
+                .validate_value(&OptionValue::Object(serde_json::Map::new()))
+                .is_ok()
+        );
         assert!(string_option.validate_value(&OptionValue::Null).is_ok());
     }
 

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -322,10 +322,12 @@ mod tests {
         let result = detect_gpu_capability("nonexistent-docker-binary-xyz").await;
         assert!(!result.available);
         assert!(result.probe_error.is_some());
-        assert!(result
-            .probe_error
-            .unwrap()
-            .contains("Failed to execute runtime info command"));
+        assert!(
+            result
+                .probe_error
+                .unwrap()
+                .contains("Failed to execute runtime info command")
+        );
     }
 
     // Note: Integration tests with real Docker commands should be in

--- a/crates/core/src/host_requirements.rs
+++ b/crates/core/src/host_requirements.rs
@@ -803,10 +803,12 @@ mod tests {
             evaluator.evaluate_requirements_with_gpu_availability(&requirements, None, Some(true));
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Expected 'optional'"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Expected 'optional'")
+        );
     }
 
     #[test]
@@ -844,7 +846,10 @@ mod tests {
             }
             Err(e) => {
                 // In some test environments, this might fail, which is acceptable
-                eprintln!("Real disk space check failed for temp dir (expected in some test environments): {}", e);
+                eprintln!(
+                    "Real disk space check failed for temp dir (expected in some test environments): {}",
+                    e
+                );
             }
         }
     }

--- a/crates/core/src/jsonc.rs
+++ b/crates/core/src/jsonc.rs
@@ -13,7 +13,7 @@
 //! `Map` itself is also order-preserving.
 
 use crate::errors::{ConfigError, DeaconError, Result};
-use jsonc_parser::{parse_to_value, JsonValue, ParseOptions};
+use jsonc_parser::{JsonValue, ParseOptions, parse_to_value};
 use serde_json::{Map, Number, Value};
 
 /// Parse a JSONC string into a `serde_json::Value`.

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -7,7 +7,7 @@
 //! References: subcommand-specs/*/SPEC.md "Container Lifecycle Management"
 
 use crate::errors::{ConfigError, DeaconError, Result};
-use crate::redaction::{redact_if_enabled, RedactionConfig};
+use crate::redaction::{RedactionConfig, redact_if_enabled};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -1585,9 +1585,10 @@ mod tests {
 
         // Prebuild skips postCreate, dotfiles, postStart, postAttach
         assert!(ctx.should_skip_phase(LifecyclePhase::OnCreate).is_none());
-        assert!(ctx
-            .should_skip_phase(LifecyclePhase::UpdateContent)
-            .is_none());
+        assert!(
+            ctx.should_skip_phase(LifecyclePhase::UpdateContent)
+                .is_none()
+        );
         assert_eq!(
             ctx.should_skip_phase(LifecyclePhase::PostCreate),
             Some("prebuild mode")
@@ -1614,9 +1615,10 @@ mod tests {
 
         // skip-post-create skips postCreate, dotfiles, postStart, postAttach
         assert!(ctx.should_skip_phase(LifecyclePhase::OnCreate).is_none());
-        assert!(ctx
-            .should_skip_phase(LifecyclePhase::UpdateContent)
-            .is_none());
+        assert!(
+            ctx.should_skip_phase(LifecyclePhase::UpdateContent)
+                .is_none()
+        );
         assert_eq!(
             ctx.should_skip_phase(LifecyclePhase::PostCreate),
             Some("--skip-post-create flag")

--- a/crates/core/src/lockfile.rs
+++ b/crates/core/src/lockfile.rs
@@ -243,7 +243,7 @@ pub async fn read_lockfile(path: &Path) -> Result<Option<Lockfile>> {
             return Err(LockfileError::Io {
                 path: path.to_path_buf(),
                 source,
-            })
+            });
         }
     };
 
@@ -1095,25 +1095,33 @@ mod tests {
 
     #[test]
     fn test_validate_sha256_digest() {
-        assert!(validate_sha256_digest(
-            "sha256:1111111111111111111111111111111111111111111111111111111111111111"
-        )
-        .is_ok());
-        assert!(validate_sha256_digest(
-            "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
-        )
-        .is_ok());
+        assert!(
+            validate_sha256_digest(
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_sha256_digest(
+                "sha256:abc123def456abc123def456abc123def456abc123def456abc123def456abcd"
+            )
+            .is_ok()
+        );
 
         assert!(validate_sha256_digest("no-prefix").is_err());
         assert!(validate_sha256_digest("sha256:tooshort").is_err());
-        assert!(validate_sha256_digest(
-            "sha256:1111111111111111111111111111111111111111111111111111111111111111111"
-        )
-        .is_err()); // too long
-        assert!(validate_sha256_digest(
-            "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
-        )
-        .is_err()); // invalid hex
+        assert!(
+            validate_sha256_digest(
+                "sha256:1111111111111111111111111111111111111111111111111111111111111111111"
+            )
+            .is_err()
+        ); // too long
+        assert!(
+            validate_sha256_digest(
+                "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+            )
+            .is_err()
+        ); // invalid hex
     }
 
     #[test]

--- a/crates/core/src/logging/mod.rs
+++ b/crates/core/src/logging/mod.rs
@@ -9,7 +9,7 @@
 use crate::redaction::RedactionConfig;
 use anyhow::Result;
 use std::sync::Once;
-use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 pub mod redaction_layer;
 
@@ -70,9 +70,24 @@ pub fn init_with_redaction(
     format: Option<&str>,
     redaction_config: Option<RedactionConfig>,
 ) -> Result<()> {
+    init_with_redaction_and_directive(format, redaction_config, None)
+}
+
+/// Initialize logging like [`init_with_redaction`], but with an explicit
+/// default filter directive.
+///
+/// `default_directive` is the env-filter spec (e.g. `"deacon=info,deacon_core=info"`)
+/// applied only when neither `DEACON_LOG` nor `RUST_LOG` is set in the
+/// environment. This lets callers supply a computed default without mutating
+/// the process environment (which is `unsafe` under edition 2024).
+pub fn init_with_redaction_and_directive(
+    format: Option<&str>,
+    redaction_config: Option<RedactionConfig>,
+    default_directive: Option<&str>,
+) -> Result<()> {
     let redaction_config = redaction_config.unwrap_or_default();
     INIT.call_once(|| {
-        let filter = create_env_filter(None);
+        let filter = create_env_filter(default_directive);
 
         // Determine format from parameter or environment variable
         let env_format = std::env::var("DEACON_LOG_FORMAT").ok();
@@ -129,8 +144,11 @@ pub fn init(format: Option<&str>) -> Result<()> {
     init_with_redaction(format, None)
 }
 
-/// Create an EnvFilter based on environment variables
-fn create_env_filter(_logging_spec: Option<&str>) -> EnvFilter {
+/// Create an EnvFilter from environment variables, falling back to a caller-
+/// supplied default directive.
+///
+/// Precedence: `DEACON_LOG` > `RUST_LOG` > `default_directive` > `"info"`.
+fn create_env_filter(default_directive: Option<&str>) -> EnvFilter {
     if let Ok(deacon_log) = std::env::var("DEACON_LOG") {
         // Use DEACON_LOG environment variable
         EnvFilter::try_new(&deacon_log).unwrap_or_else(|_| {
@@ -140,9 +158,14 @@ fn create_env_filter(_logging_spec: Option<&str>) -> EnvFilter {
             );
             EnvFilter::new("info")
         })
-    } else {
-        // Fall back to standard RUST_LOG or default (info)
+    } else if std::env::var_os("RUST_LOG").is_some() {
+        // Honor a user-set RUST_LOG.
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+    } else if let Some(directive) = default_directive {
+        // Caller-computed default (no env override present).
+        EnvFilter::try_new(directive).unwrap_or_else(|_| EnvFilter::new("info"))
+    } else {
+        EnvFilter::new("info")
     }
 }
 
@@ -225,14 +248,14 @@ mod tests {
     #[test]
     fn test_env_filter_with_env_vars() {
         // Test with DEACON_LOG environment variable
-        std::env::set_var("DEACON_LOG", "trace");
-        let _filter = create_env_filter(None);
-        std::env::remove_var("DEACON_LOG");
+        temp_env::with_var("DEACON_LOG", Some("trace"), || {
+            let _filter = create_env_filter(None);
+        });
 
         // Test with RUST_LOG fallback
-        std::env::set_var("RUST_LOG", "warn");
-        let _filter = create_env_filter(None);
-        std::env::remove_var("RUST_LOG");
+        temp_env::with_var("RUST_LOG", Some("warn"), || {
+            let _filter = create_env_filter(None);
+        });
     }
 
     #[test]

--- a/crates/core/src/mount.rs
+++ b/crates/core/src/mount.rs
@@ -1497,12 +1497,16 @@ mod merge_mounts_tests {
 
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 2);
-        assert!(result
-            .mounts
-            .contains(&"type=bind,source=/host/data,target=/data".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=cache,target=/cache".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=bind,source=/host/data,target=/data".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=cache,target=/cache".to_string())
+        );
     }
 
     #[test]
@@ -1522,12 +1526,16 @@ mod merge_mounts_tests {
 
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 2);
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol1,target=/vol1".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol2,target=/vol2".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol1,target=/vol1".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol2,target=/vol2".to_string())
+        );
     }
 
     #[test]
@@ -1543,12 +1551,16 @@ mod merge_mounts_tests {
 
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 2);
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=cache,target=/cache".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=bind,source=/host/data,target=/data".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=cache,target=/cache".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=bind,source=/host/data,target=/data".to_string())
+        );
     }
 
     // ==================== Precedence Tests ====================
@@ -1616,15 +1628,21 @@ mod merge_mounts_tests {
 
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 3);
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol1,target=/vol1".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol2,target=/vol2".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=override-shared,target=/shared".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol1,target=/vol1".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol2,target=/vol2".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=override-shared,target=/shared".to_string())
+        );
     }
 
     #[test]
@@ -1758,15 +1776,21 @@ mod merge_mounts_tests {
 
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 3);
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol1,target=/vol1".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol2,target=/vol2".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=tmpfs,target=/tmp".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol1,target=/vol1".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol2,target=/vol2".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=tmpfs,target=/tmp".to_string())
+        );
     }
 
     #[test]
@@ -1831,20 +1855,28 @@ mod merge_mounts_tests {
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 4);
         // Config mounts should be present
-        assert!(result
-            .mounts
-            .contains(&"type=bind,source=/host/workspace,target=/workspace".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=bind,source=/host/override,target=/data".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=bind,source=/host/workspace,target=/workspace".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=bind,source=/host/override,target=/data".to_string())
+        );
         // Feature2's cache should override feature1's cache
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=cache2,target=/cache".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=cache2,target=/cache".to_string())
+        );
         // Feature2's tmpfs should be present
-        assert!(result
-            .mounts
-            .contains(&"type=tmpfs,target=/tmp".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=tmpfs,target=/tmp".to_string())
+        );
     }
 
     // ==================== Error Handling Tests ====================
@@ -2114,15 +2146,21 @@ mod merge_mounts_tests {
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 3);
         // The exact order may vary based on implementation, but all should be present
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol1,target=/vol1".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol2,target=/vol2".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol3,target=/vol3".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol1,target=/vol1".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol2,target=/vol2".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol3,target=/vol3".to_string())
+        );
     }
 
     #[test]
@@ -2141,14 +2179,20 @@ mod merge_mounts_tests {
         let result = merge_mounts(&config_mounts, &features, None).unwrap();
         assert_eq!(result.mounts.len(), 3);
         // All mounts should be present
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol1,target=/vol1".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol2,target=/vol2".to_string()));
-        assert!(result
-            .mounts
-            .contains(&"type=volume,source=vol3,target=/vol3".to_string()));
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol1,target=/vol1".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol2,target=/vol2".to_string())
+        );
+        assert!(
+            result
+                .mounts
+                .contains(&"type=volume,source=vol3,target=/vol3".to_string())
+        );
     }
 }

--- a/crates/core/src/observability.rs
+++ b/crates/core/src/observability.rs
@@ -8,7 +8,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
 use std::time::Instant;
-use tracing::{span, Span};
+use tracing::{Span, span};
 
 /// Canonical span names for core workflows
 pub mod spans {
@@ -209,7 +209,7 @@ impl TimedSpan {
 /// Macro to create and enter a standardized span with automatic timing
 #[macro_export]
 macro_rules! timed_span {
-    ($span_fn:expr) => {{
+    ($span_fn:expr_2021) => {{
         let span = $span_fn;
         $crate::observability::TimedSpan::new(span)
     }};

--- a/crates/core/src/oci/fetcher.rs
+++ b/crates/core/src/oci/fetcher.rs
@@ -11,9 +11,9 @@ use tokio::sync::Mutex;
 use tracing::{debug, info, instrument, warn};
 
 use crate::errors::{FeatureError, Result};
-use crate::features::{parse_feature_metadata, FeatureMetadata};
+use crate::features::{FeatureMetadata, parse_feature_metadata};
 use crate::progress::{ProgressEvent, ProgressTracker};
-use crate::retry::{retry_async, RetryConfig};
+use crate::retry::{RetryConfig, retry_async};
 
 use super::client::{HttpClient, ReqwestClient};
 use super::types::{

--- a/crates/core/src/oci/mod.rs
+++ b/crates/core/src/oci/mod.rs
@@ -44,7 +44,7 @@ mod utils;
 // Re-export public types
 pub use auth::{RegistryAuth, RegistryCredentials};
 pub use client::{HttpClient, MockHttpClient, ReqwestClient};
-pub use fetcher::{default_fetcher, default_fetcher_with_config, FeatureFetcher};
+pub use fetcher::{FeatureFetcher, default_fetcher, default_fetcher_with_config};
 pub use types::{
     CollectionFeature, CollectionMetadata, CollectionSourceInfo, CollectionTemplate,
     DownloadedFeature, DownloadedTemplate, FeatureRef, HttpResponse, Layer, Manifest,
@@ -220,8 +220,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_integration_with_manifest_fetch() {
-        use std::sync::atomic::{AtomicU32, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
         // Mock client that fails first N attempts
         #[derive(Debug, Clone)]
@@ -371,8 +371,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_retry_gives_up_after_max_attempts() {
-        use std::sync::atomic::{AtomicU32, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
         // Mock client that always fails
         #[derive(Debug, Clone)]
@@ -700,8 +700,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_publish_collection_metadata_upload_failure() {
-        use std::sync::atomic::{AtomicU32, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
         // Mock client that always fails PUT requests for blob upload
         #[derive(Debug, Clone)]
@@ -814,8 +814,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_publish_collection_metadata_retry_success() {
-        use std::sync::atomic::{AtomicU32, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
         // Mock client that fails first 2 attempts then succeeds
         #[derive(Debug, Clone)]
@@ -940,8 +940,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_publish_collection_metadata_authentication_error() {
-        use std::sync::atomic::{AtomicBool, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
 
         // Mock client that returns authentication error
         #[derive(Debug, Clone)]

--- a/crates/core/src/oci/utils.rs
+++ b/crates/core/src/oci/utils.rs
@@ -149,9 +149,9 @@ pub(crate) fn verify_content_digest(data: &[u8], expected: &str, context: &str) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::retry::{retry_async, JitterStrategy, RetryConfig, RetryDecision};
-    use std::sync::atomic::{AtomicU32, Ordering};
+    use crate::retry::{JitterStrategy, RetryConfig, RetryDecision, retry_async};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
     /// Tight test profile: same classifier behavior, but with millisecond delays

--- a/crates/core/src/outdated.rs
+++ b/crates/core/src/outdated.rs
@@ -5,7 +5,7 @@
 //! for Dev Container Features.
 
 use crate::lockfile;
-use crate::oci::{default_fetcher, FeatureRef};
+use crate::oci::{FeatureRef, default_fetcher};
 use crate::semver_utils;
 use semver::Version;
 

--- a/crates/core/src/plugins.rs
+++ b/crates/core/src/plugins.rs
@@ -397,8 +397,8 @@ impl Plugin for NoOpPlugin {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     /// Test plugin that tracks initialization order
     #[derive(Debug)]

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -228,8 +228,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     #[test]
     fn test_retry_config_default() {

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -687,33 +687,35 @@ mod tests {
     #[test]
     fn test_detect_runtime_default() {
         // Clear environment variable for test
-        std::env::remove_var("DEACON_RUNTIME");
-        assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
+        temp_env::with_var_unset("DEACON_RUNTIME", || {
+            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
+        });
     }
 
     #[test]
     fn test_detect_runtime_cli_precedence() {
-        std::env::set_var("DEACON_RUNTIME", "podman");
-        assert_eq!(
-            RuntimeFactory::detect_runtime(Some(RuntimeKind::Docker)),
-            RuntimeKind::Docker
-        );
-        std::env::remove_var("DEACON_RUNTIME");
+        temp_env::with_var("DEACON_RUNTIME", Some("podman"), || {
+            assert_eq!(
+                RuntimeFactory::detect_runtime(Some(RuntimeKind::Docker)),
+                RuntimeKind::Docker
+            );
+        });
     }
 
     #[test]
     fn test_detect_runtime_env_var() {
-        std::env::set_var("DEACON_RUNTIME", "podman");
-        assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Podman);
+        temp_env::with_var("DEACON_RUNTIME", Some("podman"), || {
+            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Podman);
+        });
 
-        std::env::set_var("DEACON_RUNTIME", "docker");
-        assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
+        temp_env::with_var("DEACON_RUNTIME", Some("docker"), || {
+            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
+        });
 
         // Invalid env var should fall back to default
-        std::env::set_var("DEACON_RUNTIME", "invalid");
-        assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
-
-        std::env::remove_var("DEACON_RUNTIME");
+        temp_env::with_var("DEACON_RUNTIME", Some("invalid"), || {
+            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
+        });
     }
 
     #[test]

--- a/crates/core/src/security.rs
+++ b/crates/core/src/security.rs
@@ -498,9 +498,11 @@ mod tests {
             security.conflicts[0].conflict_type,
             SecurityConflictType::PrivilegedConflict
         );
-        assert!(security.conflicts[0]
-            .description
-            .contains("conflicting-feature"));
+        assert!(
+            security.conflicts[0]
+                .description
+                .contains("conflicting-feature")
+        );
     }
 
     #[test]
@@ -550,9 +552,11 @@ mod tests {
             SecurityConflictType::SecurityOptConflict
         );
         assert!(security.conflicts[0].description.contains("seccomp"));
-        assert!(security.conflicts[0]
-            .description
-            .contains("feature-with-seccomp"));
+        assert!(
+            security.conflicts[0]
+                .description
+                .contains("feature-with-seccomp")
+        );
     }
 
     #[test]

--- a/crates/core/src/user_mapping.rs
+++ b/crates/core/src/user_mapping.rs
@@ -154,7 +154,9 @@ pub enum UserMappingError {
     #[error("Insufficient permissions to create user '{username}' - container must run as root")]
     InsufficientPermissions { username: String },
 
-    #[error("User '{username}' already exists with different UID {existing_uid}, cannot update to {target_uid}")]
+    #[error(
+        "User '{username}' already exists with different UID {existing_uid}, cannot update to {target_uid}"
+    )]
     UserExistsWithDifferentUid {
         username: String,
         existing_uid: u32,

--- a/crates/core/src/variable.rs
+++ b/crates/core/src/variable.rs
@@ -626,7 +626,6 @@ impl VariableSubstitution {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use tempfile::TempDir;
 
     #[test]
@@ -635,9 +634,11 @@ mod tests {
         let context = SubstitutionContext::new(temp_dir.path())?;
 
         // Should have canonical path
-        assert!(context
-            .local_workspace_folder
-            .contains(temp_dir.path().file_name().unwrap().to_str().unwrap()));
+        assert!(
+            context
+                .local_workspace_folder
+                .contains(temp_dir.path().file_name().unwrap().to_str().unwrap())
+        );
 
         // Should have environment variables
         assert!(!context.local_env.is_empty());
@@ -689,20 +690,18 @@ mod tests {
     fn test_local_env_substitution() -> anyhow::Result<()> {
         // Use a unique env var to avoid interference with other tests running in parallel.
         const VAR: &str = "DEACON_TEST_LOCAL_ENV_SUBST";
-        env::set_var(VAR, "test_value");
+        temp_env::with_var(VAR, Some("test_value"), || -> anyhow::Result<()> {
+            let temp_dir = TempDir::new()?;
+            let context = SubstitutionContext::new(temp_dir.path())?;
+            let mut report = SubstitutionReport::new();
 
-        let temp_dir = TempDir::new()?;
-        let context = SubstitutionContext::new(temp_dir.path())?;
-        let mut report = SubstitutionReport::new();
+            let input = &format!("Value: ${{localEnv:{VAR}}}");
+            let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
-        let input = &format!("Value: ${{localEnv:{VAR}}}");
-        let result = VariableSubstitution::substitute_string(input, &context, &mut report);
-
-        assert_eq!(result, "Value: test_value");
-        assert!(report.replacements.contains_key(&format!("localEnv:{VAR}")));
-
-        env::remove_var(VAR);
-        Ok(())
+            assert_eq!(result, "Value: test_value");
+            assert!(report.replacements.contains_key(&format!("localEnv:{VAR}")));
+            Ok(())
+        })
     }
 
     #[test]
@@ -734,21 +733,20 @@ mod tests {
     fn test_env_alias_for_local_env() -> anyhow::Result<()> {
         // `${env:VAR}` is the upstream-aligned alias for `${localEnv:VAR}`.
         const VAR: &str = "DEACON_TEST_ENV_ALIAS";
-        env::set_var(VAR, "from-env-alias");
+        temp_env::with_var(VAR, Some("from-env-alias"), || -> anyhow::Result<()> {
+            let temp_dir = TempDir::new()?;
+            let context = SubstitutionContext::new(temp_dir.path())?;
+            let mut report = SubstitutionReport::new();
 
-        let temp_dir = TempDir::new()?;
-        let context = SubstitutionContext::new(temp_dir.path())?;
-        let mut report = SubstitutionReport::new();
+            let result = VariableSubstitution::substitute_string(
+                &format!("${{env:{VAR}}}"),
+                &context,
+                &mut report,
+            );
 
-        let result = VariableSubstitution::substitute_string(
-            &format!("${{env:{VAR}}}"),
-            &context,
-            &mut report,
-        );
-
-        assert_eq!(result, "from-env-alias");
-        env::remove_var(VAR);
-        Ok(())
+            assert_eq!(result, "from-env-alias");
+            Ok(())
+        })
     }
 
     #[test]
@@ -807,31 +805,31 @@ mod tests {
         let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
         assert_eq!(result, "Value: ${unknownVariable}");
-        assert!(report
-            .unknown_variables
-            .contains(&"unknownVariable".to_string()));
+        assert!(
+            report
+                .unknown_variables
+                .contains(&"unknownVariable".to_string())
+        );
 
         Ok(())
     }
 
     #[test]
     fn test_multiple_variables_in_string() -> anyhow::Result<()> {
-        env::set_var("TEST_VAR", "test");
+        temp_env::with_var("TEST_VAR", Some("test"), || -> anyhow::Result<()> {
+            let temp_dir = TempDir::new()?;
+            let context = SubstitutionContext::new(temp_dir.path())?;
+            let mut report = SubstitutionReport::new();
 
-        let temp_dir = TempDir::new()?;
-        let context = SubstitutionContext::new(temp_dir.path())?;
-        let mut report = SubstitutionReport::new();
+            let input = "${localWorkspaceFolder}/src/${localEnv:TEST_VAR}/${devcontainerId}";
+            let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
-        let input = "${localWorkspaceFolder}/src/${localEnv:TEST_VAR}/${devcontainerId}";
-        let result = VariableSubstitution::substitute_string(input, &context, &mut report);
-
-        assert!(result.contains(&context.local_workspace_folder));
-        assert!(result.contains("test"));
-        assert!(result.contains(&context.devcontainer_id));
-        assert_eq!(report.replacements.len(), 3);
-
-        env::remove_var("TEST_VAR");
-        Ok(())
+            assert!(result.contains(&context.local_workspace_folder));
+            assert!(result.contains("test"));
+            assert!(result.contains(&context.devcontainer_id));
+            assert_eq!(report.replacements.len(), 3);
+            Ok(())
+        })
     }
 
     #[test]
@@ -887,9 +885,11 @@ mod tests {
 
         // Should be left unchanged because the regex will match "${localWorkspaceFolder${invalid" which is unknown
         assert_eq!(result, input);
-        assert!(report
-            .unknown_variables
-            .contains(&"localWorkspaceFolder${invalid".to_string()));
+        assert!(
+            report
+                .unknown_variables
+                .contains(&"localWorkspaceFolder${invalid".to_string())
+        );
 
         Ok(())
     }
@@ -926,10 +926,12 @@ mod tests {
         assert_eq!(context1.devcontainer_id.len(), 12);
 
         // ID should be hexadecimal
-        assert!(context1
-            .devcontainer_id
-            .chars()
-            .all(|c| c.is_ascii_hexdigit()));
+        assert!(
+            context1
+                .devcontainer_id
+                .chars()
+                .all(|c| c.is_ascii_hexdigit())
+        );
 
         Ok(())
     }
@@ -961,9 +963,11 @@ mod tests {
 
         // Should be left unchanged when container workspace folder is not available
         assert_eq!(result, "${containerWorkspaceFolder}/src");
-        assert!(report
-            .unknown_variables
-            .contains(&"containerWorkspaceFolder".to_string()));
+        assert!(
+            report
+                .unknown_variables
+                .contains(&"containerWorkspaceFolder".to_string())
+        );
 
         Ok(())
     }
@@ -1034,54 +1038,60 @@ mod tests {
     /// pass 1 still resolves the local-side tokens.
     #[test]
     fn test_container_env_three_pass_composition() -> anyhow::Result<()> {
-        env::set_var("BEAD8_LOCAL", "from-local");
-        let temp_dir = TempDir::new()?;
+        temp_env::with_var(
+            "BEAD8_LOCAL",
+            Some("from-local"),
+            || -> anyhow::Result<()> {
+                let temp_dir = TempDir::new()?;
 
-        // Pass 1: container_env is None
-        let pass1_ctx = SubstitutionContext::new(temp_dir.path())?;
-        let mut report1 = SubstitutionReport::new();
-        let input = "${localEnv:BEAD8_LOCAL}/${containerEnv:NODE_ENV}";
-        let after_pass1 = VariableSubstitution::substitute_string(input, &pass1_ctx, &mut report1);
-        assert_eq!(after_pass1, "from-local/${containerEnv:NODE_ENV}");
+                // Pass 1: container_env is None
+                let pass1_ctx = SubstitutionContext::new(temp_dir.path())?;
+                let mut report1 = SubstitutionReport::new();
+                let input = "${localEnv:BEAD8_LOCAL}/${containerEnv:NODE_ENV}";
+                let after_pass1 =
+                    VariableSubstitution::substitute_string(input, &pass1_ctx, &mut report1);
+                assert_eq!(after_pass1, "from-local/${containerEnv:NODE_ENV}");
 
-        // Pass 3: container_env populated
-        let mut container_env = HashMap::new();
-        container_env.insert("NODE_ENV".to_string(), "production".to_string());
-        let pass3_ctx =
-            SubstitutionContext::new(temp_dir.path())?.with_container_env(container_env);
-        let mut report3 = SubstitutionReport::new();
-        let after_pass3 =
-            VariableSubstitution::substitute_string(&after_pass1, &pass3_ctx, &mut report3);
-        assert_eq!(after_pass3, "from-local/production");
-
-        env::remove_var("BEAD8_LOCAL");
-        Ok(())
+                // Pass 3: container_env populated
+                let mut container_env = HashMap::new();
+                container_env.insert("NODE_ENV".to_string(), "production".to_string());
+                let pass3_ctx =
+                    SubstitutionContext::new(temp_dir.path())?.with_container_env(container_env);
+                let mut report3 = SubstitutionReport::new();
+                let after_pass3 =
+                    VariableSubstitution::substitute_string(&after_pass1, &pass3_ctx, &mut report3);
+                assert_eq!(after_pass3, "from-local/production");
+                Ok(())
+            },
+        )
     }
 
     #[test]
     fn test_mixed_container_and_local_variables() -> anyhow::Result<()> {
-        env::set_var("TEST_LOCAL", "local_value");
+        temp_env::with_var(
+            "TEST_LOCAL",
+            Some("local_value"),
+            || -> anyhow::Result<()> {
+                let temp_dir = TempDir::new()?;
+                let mut container_env = HashMap::new();
+                container_env.insert("TEST_CONTAINER".to_string(), "container_value".to_string());
 
-        let temp_dir = TempDir::new()?;
-        let mut container_env = HashMap::new();
-        container_env.insert("TEST_CONTAINER".to_string(), "container_value".to_string());
+                let context = SubstitutionContext::new(temp_dir.path())?
+                    .with_container_workspace_folder("/workspaces/test".to_string())
+                    .with_container_env(container_env);
+                let mut report = SubstitutionReport::new();
 
-        let context = SubstitutionContext::new(temp_dir.path())?
-            .with_container_workspace_folder("/workspaces/test".to_string())
-            .with_container_env(container_env);
-        let mut report = SubstitutionReport::new();
+                let input = "${localWorkspaceFolder} -> ${containerWorkspaceFolder}, ${localEnv:TEST_LOCAL} vs ${containerEnv:TEST_CONTAINER}";
+                let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
-        let input = "${localWorkspaceFolder} -> ${containerWorkspaceFolder}, ${localEnv:TEST_LOCAL} vs ${containerEnv:TEST_CONTAINER}";
-        let result = VariableSubstitution::substitute_string(input, &context, &mut report);
-
-        assert!(result.contains(&context.local_workspace_folder));
-        assert!(result.contains("/workspaces/test"));
-        assert!(result.contains("local_value"));
-        assert!(result.contains("container_value"));
-        assert_eq!(report.replacements.len(), 4);
-
-        env::remove_var("TEST_LOCAL");
-        Ok(())
+                assert!(result.contains(&context.local_workspace_folder));
+                assert!(result.contains("/workspaces/test"));
+                assert!(result.contains("local_value"));
+                assert!(result.contains("container_value"));
+                assert_eq!(report.replacements.len(), 4);
+                Ok(())
+            },
+        )
     }
 
     #[test]
@@ -1142,34 +1152,37 @@ mod tests {
 
     #[test]
     fn test_nested_variable_substitution() -> anyhow::Result<()> {
-        let temp_dir = TempDir::new()?;
-        env::set_var("NESTED_TEST_VAR", "localWorkspaceFolder");
+        temp_env::with_var(
+            "NESTED_TEST_VAR",
+            Some("localWorkspaceFolder"),
+            || -> anyhow::Result<()> {
+                let temp_dir = TempDir::new()?;
 
-        let mut context = SubstitutionContext::new(temp_dir.path())?;
-        context.add_feature_var(
-            "dynamicVar".to_string(),
-            "${localEnv:NESTED_TEST_VAR}".to_string(),
-        );
+                let mut context = SubstitutionContext::new(temp_dir.path())?;
+                context.add_feature_var(
+                    "dynamicVar".to_string(),
+                    "${localEnv:NESTED_TEST_VAR}".to_string(),
+                );
 
-        let mut report = SubstitutionReport::new();
-        let options = SubstitutionOptions::default();
+                let mut report = SubstitutionReport::new();
+                let options = SubstitutionOptions::default();
 
-        // This should resolve ${feature:dynamicVar} -> ${localEnv:NESTED_TEST_VAR} -> localWorkspaceFolder -> actual path
-        let input = "${feature:dynamicVar}/src";
-        let result = VariableSubstitution::substitute_string_advanced(
-            input,
-            &context,
-            &options,
-            &mut report,
-        )?;
+                // This should resolve ${feature:dynamicVar} -> ${localEnv:NESTED_TEST_VAR} -> localWorkspaceFolder -> actual path
+                let input = "${feature:dynamicVar}/src";
+                let result = VariableSubstitution::substitute_string_advanced(
+                    input,
+                    &context,
+                    &options,
+                    &mut report,
+                )?;
 
-        // Should resolve to the literal string "localWorkspaceFolder/src" since the nested resolution
-        // would resolve to the variable name, not the value
-        assert_eq!(result, "localWorkspaceFolder/src");
-        assert!(report.passes > 1);
-
-        env::remove_var("NESTED_TEST_VAR");
-        Ok(())
+                // Should resolve to the literal string "localWorkspaceFolder/src" since the nested resolution
+                // would resolve to the variable name, not the value
+                assert_eq!(result, "localWorkspaceFolder/src");
+                assert!(report.passes > 1);
+                Ok(())
+            },
+        )
     }
 
     #[test]
@@ -1280,9 +1293,11 @@ mod tests {
         let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
         assert_eq!(result, "Path: ${feature:unknownVar}");
-        assert!(report
-            .unknown_variables
-            .contains(&"feature:unknownVar".to_string()));
+        assert!(
+            report
+                .unknown_variables
+                .contains(&"feature:unknownVar".to_string())
+        );
 
         Ok(())
     }
@@ -1325,10 +1340,12 @@ mod tests {
 
         if let Some(paths) = result["paths"].as_array() {
             assert_eq!(paths.len(), 2);
-            assert!(paths[0]
-                .as_str()
-                .unwrap()
-                .starts_with(&context.local_workspace_folder));
+            assert!(
+                paths[0]
+                    .as_str()
+                    .unwrap()
+                    .starts_with(&context.local_workspace_folder)
+            );
         }
 
         if let Some(config) = result["config"].as_object() {
@@ -1369,10 +1386,12 @@ mod tests {
 
         // Should hit max depth and generate warning
         assert!(report.has_cycles());
-        assert!(report
-            .cycle_warnings
-            .iter()
-            .any(|w| w.contains("maximum depth")));
+        assert!(
+            report
+                .cycle_warnings
+                .iter()
+                .any(|w| w.contains("maximum depth"))
+        );
 
         Ok(())
     }

--- a/crates/core/tests/integration_container_lifecycle.rs
+++ b/crates/core/tests/integration_container_lifecycle.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle, ContainerLifecycleCommands, ContainerLifecycleConfig,
+    ContainerLifecycleCommands, ContainerLifecycleConfig, execute_container_lifecycle,
 };
 use deacon_core::variable::SubstitutionContext;
 use std::collections::HashMap;

--- a/crates/core/tests/integration_features.rs
+++ b/crates/core/tests/integration_features.rs
@@ -1,6 +1,6 @@
 //! Integration tests for feature metadata parsing
 
-use deacon_core::features::{parse_feature_metadata, FeatureOption, OptionValue};
+use deacon_core::features::{FeatureOption, OptionValue, parse_feature_metadata};
 use std::path::Path;
 
 #[test]
@@ -97,20 +97,28 @@ fn test_option_value_validation_with_fixtures() {
     let version_option = metadata.options.get("version").unwrap();
 
     // Valid value should pass
-    assert!(version_option
-        .validate_value(&OptionValue::String("stable".to_string()))
-        .is_ok());
-    assert!(version_option
-        .validate_value(&OptionValue::String("latest".to_string()))
-        .is_ok());
+    assert!(
+        version_option
+            .validate_value(&OptionValue::String("stable".to_string()))
+            .is_ok()
+    );
+    assert!(
+        version_option
+            .validate_value(&OptionValue::String("latest".to_string()))
+            .is_ok()
+    );
 
     // Invalid value should fail
-    assert!(version_option
-        .validate_value(&OptionValue::String("invalid".to_string()))
-        .is_err());
+    assert!(
+        version_option
+            .validate_value(&OptionValue::String("invalid".to_string()))
+            .is_err()
+    );
 
     // Type mismatch should fail
-    assert!(version_option
-        .validate_value(&OptionValue::Boolean(true))
-        .is_err());
+    assert!(
+        version_option
+            .validate_value(&OptionValue::Boolean(true))
+            .is_err()
+    );
 }

--- a/crates/core/tests/integration_gpu_detection.rs
+++ b/crates/core/tests/integration_gpu_detection.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify that GPU detection works correctly with real Docker runtime.
 
-use deacon_core::gpu::{detect_gpu_capability, HostGpuCapability};
+use deacon_core::gpu::{HostGpuCapability, detect_gpu_capability};
 
 /// Test GPU detection with Docker runtime.
 ///

--- a/crates/core/tests/integration_lifecycle.rs
+++ b/crates/core/tests/integration_lifecycle.rs
@@ -6,7 +6,7 @@
 //! Note: These tests use Unix-specific APIs and are only compiled on Unix systems.
 #![cfg(unix)]
 
-use deacon_core::lifecycle::{run_phase, ExecutionContext, LifecycleCommands, LifecyclePhase};
+use deacon_core::lifecycle::{ExecutionContext, LifecycleCommands, LifecyclePhase, run_phase};
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;

--- a/crates/core/tests/integration_lockfile.rs
+++ b/crates/core/tests/integration_lockfile.rs
@@ -4,8 +4,8 @@
 //! reading, writing, and merging lockfiles in real filesystem scenarios.
 
 use deacon_core::lockfile::{
-    get_lockfile_path, merge_lockfile_features, read_lockfile, write_lockfile, Lockfile,
-    LockfileFeature,
+    Lockfile, LockfileFeature, get_lockfile_path, merge_lockfile_features, read_lockfile,
+    write_lockfile,
 };
 use std::collections::HashMap;
 use tempfile::TempDir;
@@ -445,13 +445,19 @@ async fn test_real_world_scenario() {
         .expect("Lockfile should exist");
 
     assert_eq!(read_lockfile.features.len(), 3);
-    assert!(read_lockfile
-        .features
-        .contains_key("ghcr.io/devcontainers/features/node"));
-    assert!(read_lockfile
-        .features
-        .contains_key("ghcr.io/devcontainers/features/docker-in-docker"));
-    assert!(read_lockfile
-        .features
-        .contains_key("ghcr.io/devcontainers/features/git"));
+    assert!(
+        read_lockfile
+            .features
+            .contains_key("ghcr.io/devcontainers/features/node")
+    );
+    assert!(
+        read_lockfile
+            .features
+            .contains_key("ghcr.io/devcontainers/features/docker-in-docker")
+    );
+    assert!(
+        read_lockfile
+            .features
+            .contains_key("ghcr.io/devcontainers/features/git")
+    );
 }

--- a/crates/core/tests/integration_logging.rs
+++ b/crates/core/tests/integration_logging.rs
@@ -58,14 +58,11 @@ fn test_integration_cli_debug_logging() {
 #[test]
 fn test_deacon_log_environment_variable() {
     // Test that DEACON_LOG environment variable is respected
-    std::env::set_var("DEACON_LOG", "trace");
-
-    // Initialize logging without explicit spec - should use DEACON_LOG
-    let result = logging::init(None);
-    assert!(result.is_ok());
-
-    // Clean up
-    std::env::remove_var("DEACON_LOG");
+    temp_env::with_var("DEACON_LOG", Some("trace"), || {
+        // Initialize logging without explicit spec - should use DEACON_LOG
+        let result = logging::init(None);
+        assert!(result.is_ok());
+    });
 }
 
 #[test]

--- a/crates/core/tests/integration_mock_runtime.rs
+++ b/crates/core/tests/integration_mock_runtime.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_docker, ContainerLifecycleCommands, ContainerLifecycleConfig,
+    ContainerLifecycleCommands, ContainerLifecycleConfig, execute_container_lifecycle_with_docker,
 };
 use deacon_core::docker::mock::{MockContainer, MockDocker, MockDockerConfig, MockExecResponse};
 use deacon_core::docker::{Docker, ExecConfig};

--- a/crates/core/tests/integration_mount.rs
+++ b/crates/core/tests/integration_mount.rs
@@ -57,11 +57,13 @@ fn test_mount_parsing_from_config() {
     // Verify fourth mount (with variable substitution placeholder)
     let mount4 = &mounts[3];
     assert_eq!(mount4.mount_type, MountType::Bind);
-    assert!(mount4
-        .source
-        .as_ref()
-        .unwrap()
-        .contains("${localWorkspaceFolder}"));
+    assert!(
+        mount4
+            .source
+            .as_ref()
+            .unwrap()
+            .contains("${localWorkspaceFolder}")
+    );
     assert_eq!(mount4.target, "/workspaces/src");
 }
 
@@ -283,11 +285,13 @@ async fn test_mount_from_fixture_config() {
 
     let mount = &mounts[0];
     assert_eq!(mount.mount_type, MountType::Bind);
-    assert!(mount
-        .source
-        .as_ref()
-        .unwrap()
-        .contains("${localWorkspaceFolder}"));
+    assert!(
+        mount
+            .source
+            .as_ref()
+            .unwrap()
+            .contains("${localWorkspaceFolder}")
+    );
     assert_eq!(mount.target, "/usr/local/cargo");
     assert_eq!(mount.consistency, Some(MountConsistency::Cached));
 }

--- a/crates/core/tests/integration_non_blocking_lifecycle.rs
+++ b/crates/core/tests/integration_non_blocking_lifecycle.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_docker, ContainerLifecycleCommands, ContainerLifecycleConfig,
-    LifecycleCommandValue,
+    ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandValue,
+    execute_container_lifecycle_with_docker,
 };
 use deacon_core::docker::mock::{MockDocker, MockDockerConfig, MockExecResponse};
 use deacon_core::variable::SubstitutionContext;
@@ -497,14 +497,18 @@ async fn test_non_blocking_phase_timeout_handling() {
 
     // Verify that timeout errors are properly aggregated
     assert_eq!(final_result.background_errors.len(), 1); // postStart should timeout
-    assert!(final_result
-        .background_errors
-        .iter()
-        .any(|err| err.contains("timed out")));
-    assert!(final_result
-        .background_errors
-        .iter()
-        .any(|err| err.contains("postStart")));
+    assert!(
+        final_result
+            .background_errors
+            .iter()
+            .any(|err| err.contains("timed out"))
+    );
+    assert!(
+        final_result
+            .background_errors
+            .iter()
+            .any(|err| err.contains("postStart"))
+    );
 
     println!("✓ Non-blocking phase timeouts are properly handled");
     println!(

--- a/crates/core/tests/integration_oci.rs
+++ b/crates/core/tests/integration_oci.rs
@@ -131,10 +131,12 @@ async fn test_oci_feature_fetch_with_mock_client() {
         Some("1.0.0".to_string())
     );
     assert!(downloaded_feature.path.exists());
-    assert!(downloaded_feature
-        .path
-        .join("devcontainer-feature.json")
-        .exists());
+    assert!(
+        downloaded_feature
+            .path
+            .join("devcontainer-feature.json")
+            .exists()
+    );
     assert!(downloaded_feature.path.join("install.sh").exists());
 
     // Test caching - fetch the same feature again

--- a/crates/core/tests/integration_oci_auth.rs
+++ b/crates/core/tests/integration_oci_auth.rs
@@ -9,7 +9,6 @@ use deacon_core::oci::{
     ReqwestClient,
 };
 use std::collections::HashMap;
-use std::env;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
@@ -374,83 +373,78 @@ async fn test_auth_failure_permanent() {
 
 #[tokio::test]
 async fn test_environment_variable_auth() {
-    // Clean up any existing environment variables first
-    env::remove_var("DEACON_REGISTRY_TOKEN");
-    env::remove_var("DEACON_REGISTRY_USER");
-    env::remove_var("DEACON_REGISTRY_PASS");
+    // Clean baseline: TOKEN absent; USER/PASS present during the awaited body.
+    temp_env::async_with_vars(
+        [
+            ("DEACON_REGISTRY_TOKEN", None),
+            ("DEACON_REGISTRY_USER", Some("env_user")),
+            ("DEACON_REGISTRY_PASS", Some("env_pass")),
+        ],
+        async {
+            // Create authentication config manually to avoid environment variable interference
+            let mut auth = RegistryAuth::new();
+            auth.set_default_credentials(RegistryCredentials::Basic {
+                username: "env_user".to_string(),
+                password: "env_pass".to_string(),
+            });
 
-    // Test that authentication is loaded from environment variables
-    env::set_var("DEACON_REGISTRY_USER", "env_user");
-    env::set_var("DEACON_REGISTRY_PASS", "env_pass");
+            // Create a client with explicit auth config
+            let client_result = ReqwestClient::with_auth_config(auth);
+            assert!(client_result.is_ok(), "Client creation should succeed");
 
-    // Create authentication config manually to avoid environment variable interference
-    let mut auth = RegistryAuth::new();
-    auth.set_default_credentials(RegistryCredentials::Basic {
-        username: "env_user".to_string(),
-        password: "env_pass".to_string(),
-    });
+            let client = client_result.unwrap();
 
-    // Create a client with explicit auth config
-    let client_result = ReqwestClient::with_auth_config(auth);
-    assert!(client_result.is_ok(), "Client creation should succeed");
-
-    let client = client_result.unwrap();
-
-    // Verify that the credentials were loaded
-    let creds = client.auth().get_credentials("any.registry");
-    match creds {
-        RegistryCredentials::Basic { username, password } => {
-            assert_eq!(username, "env_user");
-            assert_eq!(password, "env_pass");
-        }
-        _ => panic!("Expected basic credentials from authentication config"),
-    }
-
-    // Clean up environment
-    env::remove_var("DEACON_REGISTRY_USER");
-    env::remove_var("DEACON_REGISTRY_PASS");
+            // Verify that the credentials were loaded
+            let creds = client.auth().get_credentials("any.registry");
+            match creds {
+                RegistryCredentials::Basic { username, password } => {
+                    assert_eq!(username, "env_user");
+                    assert_eq!(password, "env_pass");
+                }
+                _ => panic!("Expected basic credentials from authentication config"),
+            }
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn test_environment_variable_token_auth() {
-    // Clean up any existing environment variables first
-    env::remove_var("DEACON_REGISTRY_TOKEN");
-    env::remove_var("DEACON_REGISTRY_USER");
-    env::remove_var("DEACON_REGISTRY_PASS");
+    // Clean baseline: USER/PASS absent; TOKEN present during the awaited body.
+    temp_env::async_with_vars(
+        [
+            ("DEACON_REGISTRY_TOKEN", Some("env_token_123")),
+            ("DEACON_REGISTRY_USER", None),
+            ("DEACON_REGISTRY_PASS", None),
+        ],
+        async {
+            // Create authentication config manually to avoid environment variable interference
+            let mut auth = RegistryAuth::new();
+            auth.set_default_credentials(RegistryCredentials::Bearer {
+                token: "env_token_123".to_string(),
+            });
 
-    // Test that token authentication is loaded from environment variables
-    env::set_var("DEACON_REGISTRY_TOKEN", "env_token_123");
+            // Create a client with explicit auth config
+            let client_result = ReqwestClient::with_auth_config(auth);
+            assert!(client_result.is_ok(), "Client creation should succeed");
 
-    // Create authentication config manually to avoid environment variable interference
-    let mut auth = RegistryAuth::new();
-    auth.set_default_credentials(RegistryCredentials::Bearer {
-        token: "env_token_123".to_string(),
-    });
+            let client = client_result.unwrap();
 
-    // Create a client with explicit auth config
-    let client_result = ReqwestClient::with_auth_config(auth);
-    assert!(client_result.is_ok(), "Client creation should succeed");
-
-    let client = client_result.unwrap();
-
-    // Verify that the token credentials were loaded
-    let creds = client.auth().get_credentials("any.registry");
-    match creds {
-        RegistryCredentials::Bearer { token } => {
-            assert_eq!(token, "env_token_123");
-        }
-        _ => panic!("Expected bearer credentials from authentication config"),
-    }
-
-    // Clean up environment
-    env::remove_var("DEACON_REGISTRY_TOKEN");
+            // Verify that the token credentials were loaded
+            let creds = client.auth().get_credentials("any.registry");
+            match creds {
+                RegistryCredentials::Bearer { token } => {
+                    assert_eq!(token, "env_token_123");
+                }
+                _ => panic!("Expected bearer credentials from authentication config"),
+            }
+        },
+    )
+    .await;
 }
 
 #[tokio::test]
 async fn test_custom_ca_bundle() {
-    // Clean up any existing environment variables first
-    env::remove_var("DEACON_CUSTOM_CA_BUNDLE");
-
     // Create a temporary CA bundle file
     let temp_dir = TempDir::new().unwrap();
     let ca_bundle_path = temp_dir.path().join("ca-bundle.pem");
@@ -465,28 +459,29 @@ async fn test_custom_ca_bundle() {
                    -----END CERTIFICATE-----\n";
     std::fs::write(&ca_bundle_path, dummy_ca).unwrap();
 
-    // Set environment variable
-    env::set_var("DEACON_CUSTOM_CA_BUNDLE", &ca_bundle_path);
+    // Set environment variable for the duration of the client creation.
+    temp_env::async_with_vars(
+        [("DEACON_CUSTOM_CA_BUNDLE", Some(ca_bundle_path.as_os_str()))],
+        async {
+            // Note: We can't easily test the actual CA loading without setting up a real HTTPS server
+            // with a custom CA, but we can test that the client creation succeeds when the file exists
+            let client_result = ReqwestClient::new();
 
-    // Note: We can't easily test the actual CA loading without setting up a real HTTPS server
-    // with a custom CA, but we can test that the client creation succeeds when the file exists
-    let client_result = ReqwestClient::new();
-
-    // Always clean up environment variable
-    env::remove_var("DEACON_CUSTOM_CA_BUNDLE");
-
-    // The client creation might fail due to invalid cert format, but it should at least
-    // attempt to read the file (which means our code path is working)
-    if let Err(e) = client_result {
-        let error_msg = e.to_string();
-        assert!(
-            error_msg.contains("certificate")
-                || error_msg.contains("pem")
-                || error_msg.contains("builder"),
-            "Error should be related to certificate parsing or client building: {}",
-            error_msg
-        );
-    }
+            // The client creation might fail due to invalid cert format, but it should at least
+            // attempt to read the file (which means our code path is working)
+            if let Err(e) = client_result {
+                let error_msg = e.to_string();
+                assert!(
+                    error_msg.contains("certificate")
+                        || error_msg.contains("pem")
+                        || error_msg.contains("builder"),
+                    "Error should be related to certificate parsing or client building: {}",
+                    error_msg
+                );
+            }
+        },
+    )
+    .await;
 }
 
 /// Helper wrapper to use AuthMockHttpClient with the FeatureFetcher

--- a/crates/core/tests/integration_oci_enhancements.rs
+++ b/crates/core/tests/integration_oci_enhancements.rs
@@ -6,8 +6,8 @@
 use bytes::Bytes;
 use deacon_core::features::FeatureMetadata;
 use deacon_core::oci::{
-    semver_utils, CollectionFeature, CollectionMetadata, CollectionSourceInfo, FeatureFetcher,
-    FeatureRef, MockHttpClient, TagList,
+    CollectionFeature, CollectionMetadata, CollectionSourceInfo, FeatureFetcher, FeatureRef,
+    MockHttpClient, TagList, semver_utils,
 };
 use std::collections::HashMap;
 use tempfile::TempDir;

--- a/crates/core/tests/integration_override_secrets.rs
+++ b/crates/core/tests/integration_override_secrets.rs
@@ -103,15 +103,21 @@ UNUSED_SECRET=ignored-value
     );
 
     // Verify substitution report shows the secret substitutions
-    assert!(substitution_report
-        .replacements
-        .contains_key("localEnv:DB_PASSWORD"));
-    assert!(substitution_report
-        .replacements
-        .contains_key("localEnv:API_URL"));
-    assert!(substitution_report
-        .replacements
-        .contains_key("localEnv:SECRET_TOKEN"));
+    assert!(
+        substitution_report
+            .replacements
+            .contains_key("localEnv:DB_PASSWORD")
+    );
+    assert!(
+        substitution_report
+            .replacements
+            .contains_key("localEnv:API_URL")
+    );
+    assert!(
+        substitution_report
+            .replacements
+            .contains_key("localEnv:SECRET_TOKEN")
+    );
 
     // Verify redaction works
     let registry = secrets.redaction_registry();

--- a/crates/core/tests/integration_parallel_feature_installation.rs
+++ b/crates/core/tests/integration_parallel_feature_installation.rs
@@ -164,22 +164,20 @@ fn test_resource_conflict_detection() {
 #[test]
 fn test_concurrency_limit_env_var() {
     // Test that environment variable is respected
-    std::env::set_var("DEACON_FEATURE_INSTALL_CONCURRENCY", "4");
+    temp_env::with_var("DEACON_FEATURE_INSTALL_CONCURRENCY", Some("4"), || {
+        // Create features that would use the concurrency limit
+        let features = vec![
+            create_test_feature("feature-1", vec![]),
+            create_test_feature("feature-2", vec![]),
+        ];
 
-    // Create features that would use the concurrency limit
-    let features = vec![
-        create_test_feature("feature-1", vec![]),
-        create_test_feature("feature-2", vec![]),
-    ];
+        let resolver = FeatureDependencyResolver::new(None);
+        let plan = resolver.resolve(&features).unwrap();
 
-    let resolver = FeatureDependencyResolver::new(None);
-    let plan = resolver.resolve(&features).unwrap();
-
-    // Features should be able to run in parallel (same level)
-    assert_eq!(plan.levels.len(), 1);
-    assert_eq!(plan.levels[0].len(), 2);
-
-    std::env::remove_var("DEACON_FEATURE_INSTALL_CONCURRENCY");
+        // Features should be able to run in parallel (same level)
+        assert_eq!(plan.levels.len(), 1);
+        assert_eq!(plan.levels[0].len(), 2);
+    });
 }
 
 #[test]

--- a/crates/core/tests/integration_per_command_events.rs
+++ b/crates/core/tests/integration_per_command_events.rs
@@ -6,8 +6,8 @@
 mod common;
 
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_progress_callback, ContainerLifecycleCommands,
-    ContainerLifecycleConfig,
+    ContainerLifecycleCommands, ContainerLifecycleConfig,
+    execute_container_lifecycle_with_progress_callback,
 };
 use deacon_core::progress::{ProgressEvent, ProgressTracker};
 use deacon_core::variable::SubstitutionContext;

--- a/crates/core/tests/integration_ports.rs
+++ b/crates/core/tests/integration_ports.rs
@@ -364,16 +364,20 @@ fn test_port_event_redaction() {
 
     assert_eq!(events.len(), 1);
     let event = &events[0];
-    assert!(event
-        .label
-        .as_ref()
-        .unwrap()
-        .contains("secret-port-token-123"));
-    assert!(event
-        .description
-        .as_ref()
-        .unwrap()
-        .contains("secret-port-token-123"));
+    assert!(
+        event
+            .label
+            .as_ref()
+            .unwrap()
+            .contains("secret-port-token-123")
+    );
+    assert!(
+        event
+            .description
+            .as_ref()
+            .unwrap()
+            .contains("secret-port-token-123")
+    );
 
     // The actual redaction test would require capturing stdout from emit_port_event
     // which is complex in unit tests. The functionality is tested through the

--- a/crates/core/tests/integration_redaction.rs
+++ b/crates/core/tests/integration_redaction.rs
@@ -5,10 +5,10 @@
 
 use assert_cmd::Command;
 use deacon_core::{
-    lifecycle::{run_phase, ExecutionContext, LifecycleCommands, LifecyclePhase},
+    lifecycle::{ExecutionContext, LifecycleCommands, LifecyclePhase, run_phase},
     redaction::{
-        add_global_secret, global_registry, redact_if_enabled, RedactingWriter, RedactionConfig,
-        SecretRegistry,
+        RedactingWriter, RedactionConfig, SecretRegistry, add_global_secret, global_registry,
+        redact_if_enabled,
     },
 };
 use serde_json::json;

--- a/crates/core/tests/integration_spans.rs
+++ b/crates/core/tests/integration_spans.rs
@@ -98,7 +98,8 @@ fn test_config_resolve_span_json_logging() {
                 .is_some()
     });
 
-    assert!(has_duration,
+    assert!(
+        has_duration,
         "Expected duration timing in config.resolve span (time.busy or duration_ms). Config spans: {:?}",
         config_resolve_spans
     );

--- a/crates/core/tests/integration_templates.rs
+++ b/crates/core/tests/integration_templates.rs
@@ -2,7 +2,7 @@
 
 use deacon_core::features::FeatureOption;
 use deacon_core::templates::{
-    apply_template, parse_template_metadata, ApplyOptions, PlannedAction,
+    ApplyOptions, PlannedAction, apply_template, parse_template_metadata,
 };
 use std::fs;
 use std::path::Path;

--- a/crates/core/tests/integration_variable_substitution.rs
+++ b/crates/core/tests/integration_variable_substitution.rs
@@ -195,32 +195,33 @@ async fn test_config_discovery_order() -> anyhow::Result<()> {
 #[test]
 fn test_env_variable_substitution() -> anyhow::Result<()> {
     // Set a test environment variable
-    env::set_var("DEACON_TEST_VAR", "test_value_123");
+    temp_env::with_var(
+        "DEACON_TEST_VAR",
+        Some("test_value_123"),
+        || -> anyhow::Result<()> {
+            let temp_workspace = TempDir::new()?;
+            let workspace = temp_workspace.path();
+            let context = SubstitutionContext::new(workspace)?;
 
-    let temp_workspace = TempDir::new()?;
-    let workspace = temp_workspace.path();
-    let context = SubstitutionContext::new(workspace)?;
+            // Test localEnv substitution
+            let input = "Value: ${localEnv:DEACON_TEST_VAR}";
+            let mut report = deacon_core::variable::SubstitutionReport::new();
+            let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
-    // Test localEnv substitution
-    let input = "Value: ${localEnv:DEACON_TEST_VAR}";
-    let mut report = deacon_core::variable::SubstitutionReport::new();
-    let result = VariableSubstitution::substitute_string(input, &context, &mut report);
+            assert_eq!(result, "Value: test_value_123");
+            assert!(report.replacements.contains_key("localEnv:DEACON_TEST_VAR"));
 
-    assert_eq!(result, "Value: test_value_123");
-    assert!(report.replacements.contains_key("localEnv:DEACON_TEST_VAR"));
+            // Test missing environment variable
+            let input = "Missing: ${localEnv:NONEXISTENT_VAR}";
+            let mut report = deacon_core::variable::SubstitutionReport::new();
+            let result = VariableSubstitution::substitute_string(input, &context, &mut report);
 
-    // Test missing environment variable
-    let input = "Missing: ${localEnv:NONEXISTENT_VAR}";
-    let mut report = deacon_core::variable::SubstitutionReport::new();
-    let result = VariableSubstitution::substitute_string(input, &context, &mut report);
+            assert_eq!(result, "Missing: ");
+            assert!(report.replacements.contains_key("localEnv:NONEXISTENT_VAR"));
 
-    assert_eq!(result, "Missing: ");
-    assert!(report.replacements.contains_key("localEnv:NONEXISTENT_VAR"));
+            println!("✅ Environment variable substitution test passed");
 
-    // Clean up
-    env::remove_var("DEACON_TEST_VAR");
-
-    println!("✅ Environment variable substitution test passed");
-
-    Ok(())
+            Ok(())
+        },
+    )
 }

--- a/crates/core/tests/test_aggregate_lifecycle_commands.rs
+++ b/crates/core/tests/test_aggregate_lifecycle_commands.rs
@@ -5,7 +5,7 @@
 
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    aggregate_lifecycle_commands, LifecycleCommandSource, LifecycleCommandValue,
+    LifecycleCommandSource, LifecycleCommandValue, aggregate_lifecycle_commands,
 };
 use deacon_core::features::{FeatureMetadata, ResolvedFeature};
 use deacon_core::lifecycle::LifecyclePhase;

--- a/crates/core/tests/test_lifecycle_formats.rs
+++ b/crates/core/tests/test_lifecycle_formats.rs
@@ -408,8 +408,8 @@ async fn test_parallel_execution_is_concurrent_async() {
 /// results" semantics in both host-side (JoinSet) and container-side (join_all).
 #[tokio::test]
 async fn test_parallel_execution_waits_for_all_on_failure() {
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
     use tokio::task::JoinSet;
 
@@ -459,8 +459,8 @@ async fn test_parallel_execution_waits_for_all_on_failure() {
 /// pattern (container-side execution path).
 #[tokio::test]
 async fn test_parallel_async_execution_waits_for_all_on_failure() {
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     let slow_task_completed = Arc::new(AtomicBool::new(false));

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -10,40 +10,45 @@ documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
+publish = false
 description = "Rust implementation of the Development Containers CLI (containers.dev). Consumer-side commands: up, down, exec, build, read-configuration, run-user-commands, set-up, upgrade, templates apply, doctor."
 readme = "../../README.md"
 
 [features]
 default = ["full"]
-# Full CLI with all subcommands (build, features, templates, doctor, outdated, etc.)
+# `full` is a compile-gate marker, not a dependency toggle: it carries no
+# optional deps, it only flips `#[cfg(feature = "full")]` blocks in cli.rs /
+# main.rs that register the non-MVP subcommands (build, features, templates,
+# doctor, outdated, …). Building with `--no-default-features` yields the MVP
+# surface (up, exec, down, read-configuration); the test/release workflows use
+# that to validate the MVP build.
 full = []
-# MVP: only up, exec, down, read-configuration subcommands
 
 [dependencies]
 deacon-core.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "fs", "io-std", "io-util"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
-tempfile = "3.12"
-sha2 = "0.10"
-tar = "0.4"
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+sha2.workspace = true
+tar.workspace = true
 flate2 = "1"
 shell-words.workspace = true
 indicatif = "0.18"
 console = "0.16"
-futures = "0.3"
-regex = "1.10"
+futures.workspace = true
+regex.workspace = true
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-assert_cmd = "2.0"
+assert_cmd.workspace = true
 predicates = "3.1"
-tempfile = "3.12"
-zip = "2.4"
-serde_json = { version = "1.0", features = ["preserve_order"] }
-testcontainers = "0.27"
+zip.workspace = true
+serde_json.workspace = true
+testcontainers.workspace = true
+temp-env.workspace = true

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -1046,17 +1046,25 @@ impl Cli {
             && stderr_is_tty
             && !json_format;
 
-        // Set environment variable for log level before initializing logging
-        if std::env::var_os("DEACON_LOG").is_none() && std::env::var_os("RUST_LOG").is_none() {
-            // In spinner sessions, prefer quieter default unless user overrode via flag/env
-            if spinner_eligible {
-                log_level = "warn";
-            }
-            std::env::set_var(
-                "RUST_LOG",
-                format!("deacon={},deacon_core={}", log_level, log_level),
-            );
-        }
+        // Compute the default log directive used only when the user has set
+        // neither DEACON_LOG nor RUST_LOG. We pass it directly to the logging
+        // initializer rather than mutating the process environment: env
+        // mutation is `unsafe` under edition 2024 and unsound once the async
+        // runtime's worker threads exist.
+        let default_log_directive =
+            if std::env::var_os("DEACON_LOG").is_none() && std::env::var_os("RUST_LOG").is_none() {
+                // In spinner sessions, prefer a quieter default unless the user
+                // overrode it via flag/env.
+                if spinner_eligible {
+                    log_level = "warn";
+                }
+                Some(format!(
+                    "deacon={level},deacon_core={level}",
+                    level = log_level
+                ))
+            } else {
+                None
+            };
         // Create redaction configuration from CLI flags so it can be threaded into the
         // logging initializer below. The redaction layer needs to be wired up at init
         // time — otherwise registered secrets can still leak into tracing output.
@@ -1066,7 +1074,11 @@ impl Cli {
             deacon_core::redaction::RedactionConfig::default()
         };
 
-        deacon_core::logging::init_with_redaction(log_format, Some(redaction_config.clone()))?;
+        deacon_core::logging::init_with_redaction_and_directive(
+            log_format,
+            Some(redaction_config.clone()),
+            default_log_directive.as_deref(),
+        )?;
 
         // Emit logs to help with testing and log-level verification
         tracing::debug!("CLI initialized with log level: {}", log_level);
@@ -1074,7 +1086,9 @@ impl Cli {
 
         // Warn if redaction is disabled
         if self.no_redact {
-            tracing::warn!("Secret redaction is DISABLED via --no-redact flag. This may expose sensitive information in logs and output. Use only for debugging purposes!");
+            tracing::warn!(
+                "Secret redaction is DISABLED via --no-redact flag. This may expose sensitive information in logs and output. Use only for debugging purposes!"
+            );
         }
 
         // Get global secret registry
@@ -1086,8 +1100,8 @@ impl Cli {
         // Prefer spinner emitter in eligible sessions; otherwise fall back to core helper
         let progress_tracker = if spinner_eligible {
             // Build a tracker with SpinnerEmitter
-            use deacon_core::progress::get_cache_dir;
             use deacon_core::progress::ProgressTracker;
+            use deacon_core::progress::get_cache_dir;
             let cache_dir = get_cache_dir()?;
             let emitter: Box<dyn deacon_core::progress::ProgressEmitter> =
                 Box::new(SpinnerEmitter::new());
@@ -1148,7 +1162,7 @@ impl Cli {
                 ignore_host_requirements,
                 env_file,
             }) => {
-                use crate::commands::up::{execute_up, UpArgs};
+                use crate::commands::up::{UpArgs, execute_up};
 
                 // Mutual exclusivity check (mirrors devcontainers/cli).
                 if no_lockfile && frozen_lockfile {
@@ -1316,7 +1330,7 @@ impl Cli {
                 no_lockfile,
                 frozen_lockfile,
             }) => {
-                use crate::commands::build::{execute_build, BuildArgs};
+                use crate::commands::build::{BuildArgs, execute_build};
 
                 // Mutual exclusivity check (mirrors devcontainers/cli).
                 if no_lockfile && frozen_lockfile {
@@ -1376,7 +1390,7 @@ impl Cli {
                 default_user_env_probe,
                 command,
             }) => {
-                use crate::commands::exec::{execute_exec, ExecArgs};
+                use crate::commands::exec::{ExecArgs, execute_exec};
 
                 // Exec attaches to an interactive shell. If a spinner-based progress tracker
                 // was initialized earlier (eligible session), drop it now to avoid the spinner
@@ -1428,7 +1442,7 @@ impl Cli {
                 user_data_folder,
             }) => {
                 use crate::commands::read_configuration::{
-                    execute_read_configuration, ReadConfigurationArgs,
+                    ReadConfigurationArgs, execute_read_configuration,
                 };
 
                 let args = ReadConfigurationArgs {
@@ -1457,7 +1471,7 @@ impl Cli {
             }
             #[cfg(feature = "full")]
             Some(Commands::Config { command }) => {
-                use crate::commands::config::{execute_config, ConfigArgs};
+                use crate::commands::config::{ConfigArgs, execute_config};
 
                 let args = ConfigArgs {
                     command,
@@ -1472,7 +1486,7 @@ impl Cli {
             }
             #[cfg(feature = "full")]
             Some(Commands::Templates { command }) => {
-                use crate::commands::templates::{execute_templates, TemplatesArgs};
+                use crate::commands::templates::{TemplatesArgs, execute_templates};
 
                 let args = TemplatesArgs {
                     command,
@@ -1490,7 +1504,7 @@ impl Cli {
                 feature,
                 target_version,
             }) => {
-                use crate::commands::upgrade::{execute_upgrade, UpgradeArgs};
+                use crate::commands::upgrade::{UpgradeArgs, execute_upgrade};
 
                 let args = UpgradeArgs {
                     workspace_folder: self.workspace_folder,
@@ -1515,7 +1529,7 @@ impl Cli {
                 id_label,
             }) => {
                 use crate::commands::run_user_commands::{
-                    execute_run_user_commands, RunUserCommandsArgs,
+                    RunUserCommandsArgs, execute_run_user_commands,
                 };
 
                 let args = RunUserCommandsArgs {
@@ -1552,7 +1566,7 @@ impl Cli {
                 container_data_folder,
                 container_system_data_folder,
             }) => {
-                use crate::commands::set_up::{execute_set_up, SetUpArgs};
+                use crate::commands::set_up::{SetUpArgs, execute_set_up};
 
                 let args = SetUpArgs {
                     container_id,
@@ -1583,7 +1597,7 @@ impl Cli {
                 force,
                 timeout,
             }) => {
-                use crate::commands::down::{execute_down, DownArgs};
+                use crate::commands::down::{DownArgs, execute_down};
 
                 let args = DownArgs {
                     remove,
@@ -1625,7 +1639,7 @@ impl Cli {
                 output,
                 fail_on_outdated,
             }) => {
-                use crate::commands::outdated::{run as run_outdated, OutdatedArgs};
+                use crate::commands::outdated::{OutdatedArgs, run as run_outdated};
 
                 // Determine workspace folder precedence: explicit flag -> global flag -> current_dir
                 let wf = if let Some(wf) = workspace_folder {
@@ -1693,9 +1707,9 @@ mod tests {
         let cli = Cli::parse_from(["deacon", "--log-format", "json"]);
         assert!(cli.is_json_log_format());
         assert!(!cli.force_tty_if_json); // user didn't pass the explicit flag
-                                         // The dispatch site ORs these two together; the test of that wiring
-                                         // is here at the source of truth (cli.is_json_log_format()) since
-                                         // dispatch is async and harder to unit-test in isolation.
+        // The dispatch site ORs these two together; the test of that wiring
+        // is here at the source of truth (cli.is_json_log_format()) since
+        // dispatch is async and harder to unit-test in isolation.
         let effective_force_tty = cli.force_tty_if_json || cli.is_json_log_format();
         assert!(effective_force_tty);
     }

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -6,8 +6,8 @@
 pub mod result;
 
 use crate::cli::{BuildKitOption, OutputFormat};
-use crate::commands::shared::{load_config, ConfigLoadArgs, TerminalDimensions};
-use anyhow::{anyhow, Context, Result};
+use crate::commands::shared::{ConfigLoadArgs, TerminalDimensions, load_config};
+use anyhow::{Context, Result, anyhow};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::errors::{DeaconError, DockerError};
 use deacon_core::features::{FeatureMergeConfig, FeatureMerger};
@@ -592,7 +592,9 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
                 if evaluation.requirements_met {
                     debug!("Host requirements validation passed");
                 } else if args.ignore_host_requirements {
-                    warn!("Host requirements not met, but proceeding due to --ignore-host-requirements flag");
+                    warn!(
+                        "Host requirements not met, but proceeding due to --ignore-host-requirements flag"
+                    );
                 }
                 debug!("Host evaluation: {:?}", evaluation);
             }
@@ -2448,24 +2450,28 @@ mod tests {
 
         // Verify advanced args are structured correctly
         assert_eq!(args.cache_from.len(), 2);
-        assert!(args
-            .cache_from
-            .contains(&"registry://example.com/cache".to_string()));
-        assert!(args
-            .cache_from
-            .contains(&"type=local,src=/tmp/cache".to_string()));
+        assert!(
+            args.cache_from
+                .contains(&"registry://example.com/cache".to_string())
+        );
+        assert!(
+            args.cache_from
+                .contains(&"type=local,src=/tmp/cache".to_string())
+        );
 
         assert_eq!(args.cache_to.len(), 1);
-        assert!(args
-            .cache_to
-            .contains(&"registry://example.com/cache:latest".to_string()));
+        assert!(
+            args.cache_to
+                .contains(&"registry://example.com/cache:latest".to_string())
+        );
 
         assert_eq!(args.buildkit, Some(BuildKitOption::Auto));
 
         assert_eq!(args.secret.len(), 2);
-        assert!(args
-            .secret
-            .contains(&"id=mypassword,src=./password.txt".to_string()));
+        assert!(
+            args.secret
+                .contains(&"id=mypassword,src=./password.txt".to_string())
+        );
         assert!(args.secret.contains(&"id=mykey,env=SSH_KEY".to_string()));
 
         // SSH defaults currently only contain explicitly provided entries
@@ -2476,38 +2482,43 @@ mod tests {
     #[test]
     fn test_buildkit_detection() {
         // Test BuildKit Auto mode with DOCKER_BUILDKIT=1
-        std::env::set_var("DOCKER_BUILDKIT", "1");
-        assert!(should_use_buildkit(Some(&BuildKitOption::Auto)));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("1"), || {
+            assert!(should_use_buildkit(Some(&BuildKitOption::Auto)));
+        });
 
         // Test BuildKit Auto mode with DOCKER_BUILDKIT=true
-        std::env::set_var("DOCKER_BUILDKIT", "true");
-        assert!(should_use_buildkit(Some(&BuildKitOption::Auto)));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("true"), || {
+            assert!(should_use_buildkit(Some(&BuildKitOption::Auto)));
+        });
 
         // Test BuildKit Auto mode with DOCKER_BUILDKIT=0
-        std::env::set_var("DOCKER_BUILDKIT", "0");
-        assert!(!should_use_buildkit(Some(&BuildKitOption::Auto)));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("0"), || {
+            assert!(!should_use_buildkit(Some(&BuildKitOption::Auto)));
+        });
 
         // Test BuildKit Auto mode with DOCKER_BUILDKIT=false
-        std::env::set_var("DOCKER_BUILDKIT", "false");
-        assert!(!should_use_buildkit(Some(&BuildKitOption::Auto)));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("false"), || {
+            assert!(!should_use_buildkit(Some(&BuildKitOption::Auto)));
+        });
 
         // Test BuildKit Never mode (should always be false)
-        std::env::set_var("DOCKER_BUILDKIT", "1");
-        assert!(!should_use_buildkit(Some(&BuildKitOption::Never)));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("1"), || {
+            assert!(!should_use_buildkit(Some(&BuildKitOption::Never)));
+        });
 
         // Test None (default) mode - should respect env var
-        std::env::set_var("DOCKER_BUILDKIT", "1");
-        assert!(should_use_buildkit(None));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("1"), || {
+            assert!(should_use_buildkit(None));
+        });
 
-        std::env::set_var("DOCKER_BUILDKIT", "0");
-        assert!(!should_use_buildkit(None));
+        temp_env::with_var("DOCKER_BUILDKIT", Some("0"), || {
+            assert!(!should_use_buildkit(None));
+        });
 
         // Test None with no env var (should default to false)
-        std::env::remove_var("DOCKER_BUILDKIT");
-        assert!(!should_use_buildkit(None));
-
-        // Clean up
-        std::env::remove_var("DOCKER_BUILDKIT");
+        temp_env::with_var_unset("DOCKER_BUILDKIT", || {
+            assert!(!should_use_buildkit(None));
+        });
     }
 
     #[test]
@@ -2758,42 +2769,44 @@ mod tests {
         assert_eq!(args_with_ssh.buildkit, None);
 
         // Test behavior with DOCKER_BUILDKIT unset (should default to false)
-        std::env::remove_var("DOCKER_BUILDKIT");
-        assert!(
-            !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
-            "should_use_buildkit should return false when DOCKER_BUILDKIT is unset and buildkit is None"
-        );
+        temp_env::with_var_unset("DOCKER_BUILDKIT", || {
+            assert!(
+                !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
+                "should_use_buildkit should return false when DOCKER_BUILDKIT is unset and buildkit is None"
+            );
+        });
 
         // Test behavior with DOCKER_BUILDKIT=1 (should return true)
-        std::env::set_var("DOCKER_BUILDKIT", "1");
-        assert!(
-            should_use_buildkit(args_with_ssh.buildkit.as_ref()),
-            "should_use_buildkit should return true when DOCKER_BUILDKIT=1 and buildkit is None"
-        );
+        temp_env::with_var("DOCKER_BUILDKIT", Some("1"), || {
+            assert!(
+                should_use_buildkit(args_with_ssh.buildkit.as_ref()),
+                "should_use_buildkit should return true when DOCKER_BUILDKIT=1 and buildkit is None"
+            );
+        });
 
         // Test behavior with DOCKER_BUILDKIT=true (should return true)
-        std::env::set_var("DOCKER_BUILDKIT", "true");
-        assert!(
-            should_use_buildkit(args_with_ssh.buildkit.as_ref()),
-            "should_use_buildkit should return true when DOCKER_BUILDKIT=true and buildkit is None"
-        );
+        temp_env::with_var("DOCKER_BUILDKIT", Some("true"), || {
+            assert!(
+                should_use_buildkit(args_with_ssh.buildkit.as_ref()),
+                "should_use_buildkit should return true when DOCKER_BUILDKIT=true and buildkit is None"
+            );
+        });
 
         // Test behavior with DOCKER_BUILDKIT=0 (should return false)
-        std::env::set_var("DOCKER_BUILDKIT", "0");
-        assert!(
-            !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
-            "should_use_buildkit should return false when DOCKER_BUILDKIT=0 and buildkit is None"
-        );
+        temp_env::with_var("DOCKER_BUILDKIT", Some("0"), || {
+            assert!(
+                !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
+                "should_use_buildkit should return false when DOCKER_BUILDKIT=0 and buildkit is None"
+            );
+        });
 
         // Test behavior with DOCKER_BUILDKIT=false (should return false)
-        std::env::set_var("DOCKER_BUILDKIT", "false");
-        assert!(
-            !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
-            "should_use_buildkit should return false when DOCKER_BUILDKIT=false and buildkit is None"
-        );
-
-        // Clean up - remove the env var
-        std::env::remove_var("DOCKER_BUILDKIT");
+        temp_env::with_var("DOCKER_BUILDKIT", Some("false"), || {
+            assert!(
+                !should_use_buildkit(args_with_ssh.buildkit.as_ref()),
+                "should_use_buildkit should return false when DOCKER_BUILDKIT=false and buildkit is None"
+            );
+        });
 
         // Test explicit Never option with SSH
         let args_ssh_never = BuildArgs {
@@ -3129,10 +3142,12 @@ mod tests {
         let spec = "id=test,stdin,src=/path/to/file";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot specify 'value-stdin' or 'stdin' flag with 'src' or 'env'"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot specify 'value-stdin' or 'stdin' flag with 'src' or 'env'")
+        );
     }
 
     #[test]
@@ -3140,10 +3155,12 @@ mod tests {
         let spec = "id=test,value-stdin,env=MY_VAR";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot specify 'value-stdin' or 'stdin' flag with 'src' or 'env'"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot specify 'value-stdin' or 'stdin' flag with 'src' or 'env'")
+        );
     }
 
     #[test]
@@ -3151,10 +3168,12 @@ mod tests {
         let spec = "src=/path/to/file";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("must specify 'id'"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("must specify 'id'")
+        );
     }
 
     #[test]
@@ -3170,10 +3189,12 @@ mod tests {
         let spec = "id=test,src=/path,env=VAR";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("cannot specify both"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot specify both")
+        );
     }
 
     #[test]
@@ -3181,10 +3202,12 @@ mod tests {
         let spec = "id=test,unknown=value";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown build secret parameter"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unknown build secret parameter")
+        );
     }
 
     #[test]
@@ -3192,10 +3215,12 @@ mod tests {
         let spec = "id=test,invalid";
         let result = BuildSecret::parse(spec);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unknown build secret parameter"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unknown build secret parameter")
+        );
     }
 
     #[test]
@@ -3212,14 +3237,15 @@ mod tests {
     #[test]
     fn test_build_secret_validate_missing_env() {
         // Make sure this env var doesn't exist
-        std::env::remove_var("NONEXISTENT_SECRET_VAR_12345");
-        let secret = BuildSecret {
-            id: "test".to_string(),
-            source: BuildSecretSource::Env("NONEXISTENT_SECRET_VAR_12345".to_string()),
-        };
-        let result = secret.validate();
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("is not set"));
+        temp_env::with_var_unset("NONEXISTENT_SECRET_VAR_12345", || {
+            let secret = BuildSecret {
+                id: "test".to_string(),
+                source: BuildSecretSource::Env("NONEXISTENT_SECRET_VAR_12345".to_string()),
+            };
+            let result = secret.validate();
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("is not set"));
+        });
     }
 
     #[test]
@@ -3245,14 +3271,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_secret_read_from_env() {
-        std::env::set_var("TEST_BUILD_SECRET_12345", "secret_value_here");
-        let secret = BuildSecret {
-            id: "test".to_string(),
-            source: BuildSecretSource::Env("TEST_BUILD_SECRET_12345".to_string()),
-        };
-        let value = secret.read_value().await.unwrap();
-        assert_eq!(value, "secret_value_here");
-        std::env::remove_var("TEST_BUILD_SECRET_12345");
+        temp_env::async_with_vars(
+            [("TEST_BUILD_SECRET_12345", Some("secret_value_here"))],
+            async {
+                let secret = BuildSecret {
+                    id: "test".to_string(),
+                    source: BuildSecretSource::Env("TEST_BUILD_SECRET_12345".to_string()),
+                };
+                let value = secret.read_value().await.unwrap();
+                assert_eq!(value, "secret_value_here");
+            },
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/deacon/src/commands/config.rs
+++ b/crates/deacon/src/commands/config.rs
@@ -10,8 +10,8 @@ use tracing::{debug, info};
 
 use deacon_core::config::{ConfigLoader, DiscoveryResult};
 use deacon_core::errors::{ConfigError, DeaconError};
-use deacon_core::observability::{config_resolve_span, TimedSpan};
-use deacon_core::redaction::{redact_if_enabled, RedactionConfig};
+use deacon_core::observability::{TimedSpan, config_resolve_span};
+use deacon_core::redaction::{RedactionConfig, redact_if_enabled};
 use deacon_core::secrets::SecretsCollection;
 use deacon_core::variable::{SubstitutionContext, SubstitutionOptions};
 

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -4,17 +4,17 @@
 //! for the exec command, targeting the correct workspace container.
 
 use crate::commands::shared::{
-    load_config, resolve_env_and_user, ConfigLoadArgs, ConfigLoadResult, NormalizedRemoteEnv,
-    TerminalDimensions,
+    ConfigLoadArgs, ConfigLoadResult, NormalizedRemoteEnv, TerminalDimensions, load_config,
+    resolve_env_and_user,
 };
 use anyhow::{Context, Result};
+use deacon_core::IndexMap;
 use deacon_core::compose::{ComposeManager, ComposeProject};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
 use deacon_core::container_env_probe::ContainerProbeMode;
 use deacon_core::docker::{CliDocker, Docker, TerminalSize};
 use deacon_core::errors::{ConfigError, DeaconError};
-use deacon_core::IndexMap;
 use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -524,7 +524,7 @@ where
         // 3. Workspace-based resolution (default)
         let container_id = if args.container_id.is_some() || !args.id_label.is_empty() {
             // Use ContainerSelector for direct ID or label-based lookup and validate format early
-            use deacon_core::container::{resolve_container, ContainerSelector};
+            use deacon_core::container::{ContainerSelector, resolve_container};
 
             let selector = ContainerSelector::new(
                 args.container_id.clone(),
@@ -948,10 +948,12 @@ mod tests {
         let result = resolve_target_container_by_labels(&mock_docker, &search_labels).await;
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("No running container found matching labels"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No running container found matching labels")
+        );
     }
 
     #[tokio::test]

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -6,7 +6,7 @@
 //! Spec: docs/subcommand-specs/read-configuration/SPEC.md
 //! Implementation: specs/001-read-config-parity/spec.md
 
-use crate::commands::shared::{load_config, ConfigLoadArgs, TerminalDimensions};
+use crate::commands::shared::{ConfigLoadArgs, TerminalDimensions, load_config};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerSelector;
@@ -15,7 +15,7 @@ use deacon_core::features::{
     FeatureDependencyResolver, FeatureMergeConfig, FeatureMerger, OptionValue, ResolvedFeature,
 };
 use deacon_core::io::Output;
-use deacon_core::oci::{default_fetcher_with_config, FeatureRef};
+use deacon_core::oci::{FeatureRef, default_fetcher_with_config};
 use deacon_core::redaction::{RedactionConfig, SecretRegistry};
 use deacon_core::registry_parser::parse_registry_reference;
 use deacon_core::secrets::SecretsCollection;
@@ -1260,13 +1260,15 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
                 // If merged configuration is requested, we need container metadata, so fail
                 if args.include_merged_configuration {
                     return Err(anyhow::anyhow!(
-                            "Dev container not found. Container ID or labels did not match any running containers. \
+                        "Dev container not found. Container ID or labels did not match any running containers. \
                              Cannot compute merged configuration without container metadata."
-                        ));
+                    ));
                 }
 
                 // Otherwise, succeed with devcontainerId substituted but no container-specific variables
-                debug!("Proceeding without container-specific substitutions (merged config not requested)");
+                debug!(
+                    "Proceeding without container-specific substitutions (merged config not requested)"
+                );
                 (config_after_before, Some(id_labels), None, None, None)
             }
         }
@@ -3121,10 +3123,12 @@ API_KEY=another-secret
 
         let result = execute_read_configuration(args).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Failed to parse --additional-features JSON"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Failed to parse --additional-features JSON")
+        );
     }
 
     #[tokio::test]
@@ -3163,10 +3167,12 @@ API_KEY=another-secret
 
         let result = execute_read_configuration(args).await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("--additional-features must be a JSON object"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("--additional-features must be a JSON object")
+        );
     }
 
     #[tokio::test]

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -3,14 +3,14 @@
 //! This module provides execution of lifecycle commands in an existing container
 //! without going through the full `up` workflow.
 
-use crate::commands::shared::{load_config, ConfigLoadArgs, ConfigLoadResult};
+use crate::commands::shared::{ConfigLoadArgs, ConfigLoadResult, load_config};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback,
     ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandList,
+    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback,
 };
-use deacon_core::lifecycle::{should_queue_phase_for_wait_for, wait_for_phase, LifecyclePhase};
+use deacon_core::lifecycle::{LifecyclePhase, should_queue_phase_for_wait_for, wait_for_phase};
 use deacon_core::variable::SubstitutionContext;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -70,7 +70,7 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
         // 2. --id-label (label-based lookup)
         // 3. workspace-based discovery
         if args.container_id.is_some() || !args.id_label.is_empty() {
-            use deacon_core::container::{resolve_container, ContainerSelector};
+            use deacon_core::container::{ContainerSelector, resolve_container};
 
             let selector = ContainerSelector::new(
                 args.container_id.clone(),

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -35,9 +35,9 @@
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    execute_container_lifecycle_with_progress_callback, AggregatedLifecycleCommand,
-    ContainerLifecycleCommands, ContainerLifecycleConfig, DotfilesConfig, LifecycleCommandList,
-    LifecycleCommandSource, LifecycleCommandValue,
+    AggregatedLifecycleCommand, ContainerLifecycleCommands, ContainerLifecycleConfig,
+    DotfilesConfig, LifecycleCommandList, LifecycleCommandSource, LifecycleCommandValue,
+    execute_container_lifecycle_with_progress_callback,
 };
 use deacon_core::docker::{CliDocker, ContainerInfo, Docker, ExecConfig};
 use deacon_core::variable::SubstitutionContext;

--- a/crates/deacon/src/commands/shared/env_user.rs
+++ b/crates/deacon/src/commands/shared/env_user.rs
@@ -1,6 +1,6 @@
+use deacon_core::IndexMap;
 use deacon_core::container_env_probe::{ContainerEnvironmentProber, ContainerProbeMode};
 use deacon_core::docker::Docker;
-use deacon_core::IndexMap;
 use std::collections::HashMap;
 use tracing::warn;
 

--- a/crates/deacon/src/commands/shared/feature_resolver.rs
+++ b/crates/deacon/src/commands/shared/feature_resolver.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use deacon_core::config::DevContainerConfig;
 use deacon_core::features::{
-    parse_feature_metadata, FeatureDependencyResolver, OptionValue, ResolvedFeature,
+    FeatureDependencyResolver, OptionValue, ResolvedFeature, parse_feature_metadata,
 };
 use deacon_core::oci::{FeatureFetcher, FeatureRef, HttpClient};
 use deacon_core::registry_parser::parse_registry_reference;
@@ -27,6 +27,9 @@ use deacon_core::registry_parser::parse_registry_reference;
 /// - **Fails fast**: any unresolvable feature (missing local path, missing
 ///   `devcontainer-feature.json`, OCI fetch error, dependency cycle) is
 ///   propagated with context rather than silently dropped.
+// Only reachable through `full`-gated CLI dispatch (e.g. run-user-commands), so
+// it is dead code in a `--no-default-features` MVP build; tests still exercise it.
+#[cfg_attr(not(feature = "full"), allow(dead_code))]
 pub(crate) async fn resolve_features_ordered<C: HttpClient>(
     config: &DevContainerConfig,
     config_dir: &Path,

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -8,7 +8,7 @@ pub mod remote_env;
 pub mod terminal;
 pub mod workspace;
 
-pub use config_loader::{load_config, ConfigLoadArgs, ConfigLoadResult};
+pub use config_loader::{ConfigLoadArgs, ConfigLoadResult, load_config};
 pub use env_user::resolve_env_and_user;
 pub use remote_env::NormalizedRemoteEnv;
 pub use terminal::TerminalDimensions;

--- a/crates/deacon/src/commands/templates.rs
+++ b/crates/deacon/src/commands/templates.rs
@@ -5,7 +5,7 @@
 
 use crate::cli::TemplateCommands;
 use anyhow::Result;
-use deacon_core::oci::{default_fetcher, TemplateRef};
+use deacon_core::oci::{TemplateRef, default_fetcher};
 use deacon_core::registry_parser::parse_registry_reference;
 use std::path::PathBuf;
 use tracing::{debug, info, instrument, warn};
@@ -97,7 +97,7 @@ async fn execute_templates_apply(
     dry_run: bool,
 ) -> Result<()> {
     use deacon_core::features::OptionValue;
-    use deacon_core::templates::{apply_template, parse_template_metadata, ApplyOptions};
+    use deacon_core::templates::{ApplyOptions, apply_template, parse_template_metadata};
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
@@ -183,9 +183,10 @@ async fn execute_templates_apply(
                         "false" => OptionValue::Boolean(false),
                         _ => {
                             return Err(anyhow::anyhow!(
-                            "Invalid boolean value '{}' for option '{}'. Use 'true' or 'false'.",
-                            value, key
-                        ))
+                                "Invalid boolean value '{}' for option '{}'. Use 'true' or 'false'.",
+                                value,
+                                key
+                            ));
                         }
                     }
                 }

--- a/crates/deacon/src/commands/up/args.rs
+++ b/crates/deacon/src/commands/up/args.rs
@@ -83,7 +83,7 @@ impl NormalizedMount {
                                 ),
                             },
                         )
-                        .into())
+                        .into());
                     }
                 }
             } else {
@@ -149,7 +149,7 @@ impl NormalizedMount {
                         ),
                     })
                     .into(),
-                )
+                );
             }
         };
 
@@ -157,17 +157,15 @@ impl NormalizedMount {
         let external_flag = match external {
             Some("true") => true,
             Some("false") | None => false,
-            Some(val) => {
-                return Err(
-                    DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-                        message: format!(
+            Some(val) => return Err(DeaconError::Config(
+                deacon_core::errors::ConfigError::Validation {
+                    message: format!(
                         "Invalid mount format: '{}'. external must be 'true' or 'false', got: '{}'",
                         mount_str, val
                     ),
-                    })
-                    .into(),
-                )
-            }
+                },
+            )
+            .into()),
         };
 
         let read_only = match read_only_flag {

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -5,19 +5,20 @@
 //! - `execute_compose_post_create` - Post-create lifecycle for compose
 //! - `handle_compose_shutdown` - Shutdown handling for compose
 
+use super::ENV_LOG_FORMAT;
 use super::args::{MountType, NormalizedMount, UpArgs};
 use super::features_build::{
-    build_image_with_features, build_image_with_features_from_dockerfile, FeatureBuildOutput,
+    FeatureBuildOutput, build_image_with_features, build_image_with_features_from_dockerfile,
 };
 use super::helpers::handle_lockfile_post_build;
-use super::lifecycle::{execute_initialize_command, resolve_force_pty, HostTrustArgs};
+use super::lifecycle::{HostTrustArgs, execute_initialize_command, resolve_force_pty};
 use super::merged_config::{
     build_merged_configuration_with_options, inspect_for_merged_configuration,
 };
 use super::ports::handle_port_events;
 use super::result::{EffectiveMount, UpContainerInfo};
-use super::ENV_LOG_FORMAT;
 use anyhow::{Context, Result};
+use deacon_core::IndexMap;
 use deacon_core::compose::{ComposeCommand, ComposeManager, ComposeProject, ServiceShape};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
@@ -26,7 +27,6 @@ use deacon_core::docker::ExecConfig;
 use deacon_core::errors::{DeaconError, DockerError};
 use deacon_core::runtime::ContainerRuntimeImpl;
 use deacon_core::state::{ComposeState, StateManager};
-use deacon_core::IndexMap;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -7,7 +7,7 @@
 use super::args::UpArgs;
 use super::features_build::build_image_with_features;
 use super::helpers::{apply_user_mapping, handle_lockfile_post_build};
-use super::lifecycle::{execute_initialize_command, execute_lifecycle_commands, HostTrustArgs};
+use super::lifecycle::{HostTrustArgs, execute_initialize_command, execute_lifecycle_commands};
 use super::merged_config::{
     build_merged_configuration_with_options, inspect_for_merged_configuration,
     merge_image_metadata_after_image_ready,
@@ -16,6 +16,7 @@ use super::ports::handle_container_port_events;
 use super::result::UpContainerInfo;
 use crate::commands::shared::resolve_env_and_user;
 use anyhow::{Context, Result};
+use deacon_core::IndexMap;
 use deacon_core::build::BuildOptions;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container::ContainerIdentity;
@@ -27,7 +28,6 @@ use deacon_core::features::{
 use deacon_core::mount::merge_mounts;
 use deacon_core::runtime::ContainerRuntimeImpl;
 use deacon_core::state::{ContainerState, StateManager};
-use deacon_core::IndexMap;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, instrument, warn};
 
@@ -407,7 +407,7 @@ pub(crate) async fn execute_container_up(
                 "No entrypoints found in features or config"
             );
         }
-        deacon_core::features::EntrypointChain::Single(ref path) => {
+        deacon_core::features::EntrypointChain::Single(path) => {
             info!(
                 entrypoint = %path,
                 feature_count = features_slice.len(),
@@ -415,8 +415,8 @@ pub(crate) async fn execute_container_up(
             );
         }
         deacon_core::features::EntrypointChain::Chained {
-            ref wrapper_path,
-            ref entrypoints,
+            wrapper_path,
+            entrypoints,
         } => {
             info!(
                 wrapper_path = %wrapper_path,

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -17,7 +17,7 @@ use deacon_core::features::{
     FeatureDependencyResolver, InstallationPlan, OptionValue, ResolvedFeature,
 };
 use deacon_core::lockfile::{Lockfile, LockfileFeature};
-use deacon_core::oci::{default_fetcher, DownloadedFeature, FeatureRef};
+use deacon_core::oci::{DownloadedFeature, FeatureRef, default_fetcher};
 use deacon_core::registry_parser::parse_registry_reference;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/deacon/src/commands/up/helpers.rs
+++ b/crates/deacon/src/commands/up/helpers.rs
@@ -9,7 +9,7 @@
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::errors::DeaconError;
-use deacon_core::lockfile::{get_lockfile_path, write_lockfile, Lockfile};
+use deacon_core::lockfile::{Lockfile, get_lockfile_path, write_lockfile};
 use std::io;
 use std::path::Path;
 use tracing::{debug, info, instrument, warn};
@@ -145,7 +145,7 @@ pub(crate) async fn apply_user_mapping<R: deacon_core::docker::Docker + Send + S
     workspace_folder: &Path,
 ) -> Result<()> {
     use deacon_core::user_mapping::{
-        get_host_user_info, DockerUserMapper, UserMappingConfig, UserMappingService,
+        DockerUserMapper, UserMappingConfig, UserMappingService, get_host_user_info,
     };
 
     debug!("Applying user mapping configuration");
@@ -460,7 +460,7 @@ fn sort_json_object(value: &mut serde_json::Value) {
 #[cfg(test)]
 mod lockfile_post_build_tests {
     use super::*;
-    use deacon_core::lockfile::{read_lockfile, LockfileFeature};
+    use deacon_core::lockfile::{LockfileFeature, read_lockfile};
     use std::collections::HashMap;
     use tempfile::TempDir;
 

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -12,18 +12,18 @@ use super::{ENV_FORCE_TTY_IF_JSON, ENV_LOG_FORMAT};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    aggregate_lifecycle_commands, AggregatedLifecycleCommand, DotfilesConfig, LifecycleCommandList,
-    LifecycleCommandSource, LifecycleCommandValue,
+    AggregatedLifecycleCommand, DotfilesConfig, LifecycleCommandList, LifecycleCommandSource,
+    LifecycleCommandValue, aggregate_lifecycle_commands,
 };
 use deacon_core::features::ResolvedFeature;
 use deacon_core::lifecycle::{
-    should_queue_phase_for_wait_for, should_run_dotfiles_for_wait_for, wait_for_phase,
     InvocationContext, InvocationFlags, LifecyclePhase, LifecyclePhaseState,
+    should_queue_phase_for_wait_for, should_run_dotfiles_for_wait_for, wait_for_phase,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tracing::{debug, info, instrument, span, warn, Level};
+use tracing::{Level, debug, info, instrument, span, warn};
 
 /// Resolve PTY preference for lifecycle commands based on flag, environment, and JSON mode
 ///
@@ -99,7 +99,10 @@ pub(crate) fn build_invocation_context(
 
     debug!(
         "Built invocation context: mode={:?}, flags={{skip_post_create={}, prebuild={}}}, prior_markers={}",
-        ctx.mode, ctx.flags.skip_post_create, ctx.flags.prebuild, ctx.prior_markers.len()
+        ctx.mode,
+        ctx.flags.skip_post_create,
+        ctx.flags.prebuild,
+        ctx.prior_markers.len()
     );
 
     ctx
@@ -147,8 +150,8 @@ pub(crate) async fn execute_lifecycle_commands(
     config_hash: Option<&str>,
 ) -> Result<()> {
     use deacon_core::container_lifecycle::{
-        execute_container_lifecycle_with_progress_callback, ContainerLifecycleCommands,
-        ContainerLifecycleConfig,
+        ContainerLifecycleCommands, ContainerLifecycleConfig,
+        execute_container_lifecycle_with_progress_callback,
     };
     use deacon_core::variable::SubstitutionContext;
 

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -43,18 +43,18 @@ pub use result::{EffectiveMount, UpContainerInfo, UpError, UpResult, UpSuccess};
 #[allow(unused_imports)]
 pub use crate::commands::shared::NormalizedRemoteEnv;
 
-use crate::commands::shared::{load_config, ConfigLoadArgs, ConfigLoadResult};
+use crate::commands::shared::{ConfigLoadArgs, ConfigLoadResult, load_config};
 use anyhow::{Context, Result};
+use deacon_core::IndexMap;
 use deacon_core::container::{ContainerIdentity, ContainerSelector};
 use deacon_core::errors::DeaconError;
 use deacon_core::features::{FeatureMergeConfig, FeatureMerger};
 use deacon_core::lockfile::{
-    get_lockfile_path, read_lockfile, validate_lockfile_against_config, LockfileValidationResult,
+    LockfileValidationResult, get_lockfile_path, read_lockfile, validate_lockfile_against_config,
 };
 use deacon_core::runtime::{ContainerRuntimeImpl, RuntimeFactory};
 use deacon_core::secrets::SecretsCollection;
 use deacon_core::state::StateManager;
-use deacon_core::IndexMap;
 use tracing::{debug, info, instrument, warn};
 
 // Internal imports from submodules
@@ -156,7 +156,9 @@ pub async fn execute_up(args: UpArgs) -> Result<UpContainerInfo> {
                     error
                 );
             } else {
-                warn!("GPU mode 'detect' specified but no GPU runtime found. Proceeding without GPU acceleration.");
+                warn!(
+                    "GPU mode 'detect' specified but no GPU runtime found. Proceeding without GPU acceleration."
+                );
             }
             deacon_core::gpu::GpuMode::None
         }
@@ -402,7 +404,9 @@ pub(crate) async fn execute_up_with_runtime(
                 if evaluation.requirements_met {
                     debug!("Host requirements validation passed");
                 } else if args.ignore_host_requirements {
-                    warn!("Host requirements not met, but proceeding due to --ignore-host-requirements flag");
+                    warn!(
+                        "Host requirements not met, but proceeding due to --ignore-host-requirements flag"
+                    );
                 }
                 debug!("Host evaluation: {:?}", evaluation);
             }

--- a/crates/deacon/src/commands/up/tests.rs
+++ b/crates/deacon/src/commands/up/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for the up command.
 
-use super::args::{normalize_and_validate_args, MountType, NormalizedMount, UpArgs};
+use super::args::{MountType, NormalizedMount, UpArgs, normalize_and_validate_args};
 use super::result::UpResult;
 use crate::commands::shared::NormalizedRemoteEnv;
 use deacon_core::config::DevContainerConfig;

--- a/crates/deacon/src/commands/upgrade.rs
+++ b/crates/deacon/src/commands/upgrade.rs
@@ -24,14 +24,14 @@
 
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
-use deacon_core::lockfile::{get_lockfile_path, write_lockfile, Lockfile, LockfileFeature};
-use deacon_core::oci::{default_fetcher, DownloadedFeature, FeatureRef};
+use deacon_core::lockfile::{Lockfile, LockfileFeature, get_lockfile_path, write_lockfile};
+use deacon_core::oci::{DownloadedFeature, FeatureRef, default_fetcher};
 use deacon_core::registry_parser::parse_registry_reference;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tracing::{debug, info, instrument, warn};
 
-use crate::commands::shared::{load_config, ConfigLoadArgs};
+use crate::commands::shared::{ConfigLoadArgs, load_config};
 
 /// Arguments for the `upgrade` command. Mirrors the spec's CLI surface
 /// (`docs/subcommand-specs/upgrade/SPEC.md` §2).
@@ -212,12 +212,14 @@ async fn pin_feature_in_config_file(
             config_path.display()
         )),
         1 => {
-            tokio::fs::write(config_path, updated).await.with_context(|| {
-                format!(
-                    "Failed to write pinned devcontainer config to '{}'",
-                    config_path.display()
-                )
-            })?;
+            tokio::fs::write(config_path, updated)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to write pinned devcontainer config to '{}'",
+                        config_path.display()
+                    )
+                })?;
             debug!(
                 feature = %feature,
                 target_version = %target_version,
@@ -298,7 +300,7 @@ async fn resolve_lockfile_from_config(config: &DevContainerConfig) -> Result<Loc
         None => {
             return Ok(Lockfile {
                 features: HashMap::new(),
-            })
+            });
         }
     };
 
@@ -503,9 +505,10 @@ mod tests {
         // Spec §2 mandates this exact summary string so existing CI
         // scripts that grep for it keep working.
         assert!(err.to_string().contains("Invalid version 'v1'"));
-        assert!(err
-            .to_string()
-            .contains("Must be in the form of 'x', 'x.y', or 'x.y.z'"));
+        assert!(
+            err.to_string()
+                .contains("Must be in the form of 'x', 'x.y', or 'x.y.z'")
+        );
     }
 
     // =========================================================================

--- a/crates/deacon/src/ui/lifecycle_summary.rs
+++ b/crates/deacon/src/ui/lifecycle_summary.rs
@@ -737,24 +737,30 @@ mod tests {
                 .collect::<Vec<_>>(),
             false,
         );
-        assert!(all_executed
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("complete"));
-        assert!(all_executed
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("6 executed"));
-        assert!(all_executed
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("0 skipped"));
+        assert!(
+            all_executed
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("complete")
+        );
+        assert!(
+            all_executed
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("6 executed")
+        );
+        assert!(
+            all_executed
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("0 skipped")
+        );
 
         // Mixed executed and skipped
         let mixed = LifecycleSummary::from_phase_states(
@@ -791,18 +797,22 @@ mod tests {
             ],
             false,
         );
-        assert!(mixed
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("2 executed"));
-        assert!(mixed
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("4 skipped"));
+        assert!(
+            mixed
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("2 executed")
+        );
+        assert!(
+            mixed
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("4 skipped")
+        );
 
         // With failure
         let with_failure = LifecycleSummary::from_phase_states(
@@ -820,18 +830,22 @@ mod tests {
             ],
             true,
         );
-        assert!(with_failure
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("incomplete"));
-        assert!(with_failure
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("1 failed"));
+        assert!(
+            with_failure
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("incomplete")
+        );
+        assert!(
+            with_failure
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("1 failed")
+        );
     }
 
     // =========================================================================
@@ -894,12 +908,14 @@ mod tests {
 
         // Summary should reflect resumed phases
         assert_eq!(summary.summary.resumed_count, 4);
-        assert!(summary
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("resumed"));
+        assert!(
+            summary
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("resumed")
+        );
     }
 
     #[test]
@@ -964,12 +980,14 @@ mod tests {
         }
 
         assert_eq!(summary.summary.resumed_count, 0);
-        assert!(summary
-            .summary
-            .message
-            .as_ref()
-            .unwrap()
-            .contains("complete"));
+        assert!(
+            summary
+                .summary
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("complete")
+        );
     }
 
     #[test]

--- a/crates/deacon/tests/integration_build.rs
+++ b/crates/deacon/tests/integration_build.rs
@@ -778,9 +778,6 @@ RUN --mount=type=secret,id=mytoken \
 
 #[test]
 fn test_build_secret_env_source() {
-    // Set up environment variable with secret
-    std::env::set_var("TEST_BUILD_SECRET_ENV", "my-env-secret-value");
-
     // Create a temporary directory with Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = r#"# syntax=docker/dockerfile:1
@@ -812,6 +809,7 @@ RUN --mount=type=secret,id=envtoken \
     let mut cmd = Command::cargo_bin("deacon").unwrap();
     let assert = cmd
         .current_dir(&temp_dir)
+        .env("TEST_BUILD_SECRET_ENV", "my-env-secret-value")
         .arg("build")
         .arg("--build-secret")
         .arg("id=envtoken,env=TEST_BUILD_SECRET_ENV")
@@ -835,9 +833,6 @@ RUN --mount=type=secret,id=envtoken \
             "Secret value leaked in stderr!"
         );
     }
-
-    // Clean up
-    std::env::remove_var("TEST_BUILD_SECRET_ENV");
 }
 
 #[test]

--- a/crates/deacon/tests/integration_doctor.rs
+++ b/crates/deacon/tests/integration_doctor.rs
@@ -50,8 +50,7 @@ fn test_doctor_command_bundle_creation() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        stdout.contains("Support bundle created")
-            || stderr.contains("Support bundle created"),
+        stdout.contains("Support bundle created") || stderr.contains("Support bundle created"),
         "Unexpected stdout, failed var.contains(Support bundle created)\n--- stdout ---\n{}\n--- stderr ---\n{}",
         stdout,
         stderr

--- a/crates/deacon/tests/integration_e2e.rs
+++ b/crates/deacon/tests/integration_e2e.rs
@@ -470,8 +470,11 @@ fn test_e2e_plugin_customizations() {
     // This tests that the configuration is preserved correctly
     let settings = &vscode_config["settings"];
     let python_path = settings["python.defaultInterpreterPath"].as_str().unwrap();
-    assert!(python_path.contains("${localWorkspaceFolder}") || !python_path.contains("${"), 
-            "Python path should be preserved as-is since customizations variable substitution is not yet implemented: {}", python_path);
+    assert!(
+        python_path.contains("${localWorkspaceFolder}") || !python_path.contains("${"),
+        "Python path should be preserved as-is since customizations variable substitution is not yet implemented: {}",
+        python_path
+    );
 
     println!("✅ Plugin customizations test completed successfully");
 }
@@ -559,7 +562,8 @@ fn test_e2e_lifecycle_simulation() {
     assert!(
         has_config_logs || json.is_object(),
         "Should have configuration processing logs or valid JSON output. Stderr: {:?}, Stdout: {:?}",
-        stderr_content, stdout_content
+        stderr_content,
+        stdout_content
     );
 
     println!("✅ Lifecycle simulation test completed successfully");

--- a/crates/deacon/tests/integration_exec_container_state.rs
+++ b/crates/deacon/tests/integration_exec_container_state.rs
@@ -4,7 +4,7 @@
 //! which returns containers regardless of state. Exec must fail fast with
 //! "Dev container is not running." if the resolved container is stopped/exited.
 
-use deacon::commands::exec::{execute_exec_with_docker, ExecArgs};
+use deacon::commands::exec::{ExecArgs, execute_exec_with_docker};
 use deacon_core::docker::mock::{MockContainer, MockDocker};
 
 fn make_args(container_id: Option<String>, id_label: Vec<String>) -> ExecArgs {

--- a/crates/deacon/tests/integration_exec_env.rs
+++ b/crates/deacon/tests/integration_exec_env.rs
@@ -1,4 +1,4 @@
-use deacon::commands::exec::{execute_exec_with_docker, ExecArgs};
+use deacon::commands::exec::{ExecArgs, execute_exec_with_docker};
 use deacon::commands::shared::TerminalDimensions;
 use deacon_core::docker::mock::{MockContainer, MockDocker};
 

--- a/crates/deacon/tests/integration_exec_pty.rs
+++ b/crates/deacon/tests/integration_exec_pty.rs
@@ -1,4 +1,4 @@
-use deacon::commands::exec::{execute_exec_with_docker, ExecArgs};
+use deacon::commands::exec::{ExecArgs, execute_exec_with_docker};
 use deacon_core::docker::mock::{MockContainer, MockDocker, MockExecResponse};
 
 #[tokio::test]

--- a/crates/deacon/tests/integration_feature_entrypoints.rs
+++ b/crates/deacon/tests/integration_feature_entrypoints.rs
@@ -13,8 +13,8 @@
 use std::collections::HashMap;
 
 use deacon_core::features::{
-    build_entrypoint_chain, generate_wrapper_script, EntrypointChain, FeatureMetadata, OptionValue,
-    ResolvedFeature,
+    EntrypointChain, FeatureMetadata, OptionValue, ResolvedFeature, build_entrypoint_chain,
+    generate_wrapper_script,
 };
 
 /// Helper to create a ResolvedFeature with an optional entrypoint.

--- a/crates/deacon/tests/integration_feature_lifecycle.rs
+++ b/crates/deacon/tests/integration_feature_lifecycle.rs
@@ -12,7 +12,7 @@
 //! - T023: Test fail-fast behavior when feature command fails
 
 use assert_cmd::Command;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;

--- a/crates/deacon/tests/integration_feature_mounts.rs
+++ b/crates/deacon/tests/integration_feature_mounts.rs
@@ -16,7 +16,7 @@
 //! 4. Mount parsing errors are attributed to the correct feature
 
 use assert_cmd::Command;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;

--- a/crates/deacon/tests/integration_host_requirements.rs
+++ b/crates/deacon/tests/integration_host_requirements.rs
@@ -5,7 +5,7 @@
 //! Note: These tests rely on Unix-specific host detection mechanisms.
 #![cfg(unix)]
 
-use deacon::commands::up::{execute_up, UpArgs};
+use deacon::commands::up::{UpArgs, execute_up};
 use deacon_core::config::{HostRequirements, ResourceSpec};
 use deacon_core::errors::{ConfigError, DeaconError};
 use std::fs;

--- a/crates/deacon/tests/integration_progress.rs
+++ b/crates/deacon/tests/integration_progress.rs
@@ -192,7 +192,7 @@ fn test_progress_silent_mode() {
 #[test]
 fn test_audit_log_creation() {
     use deacon_core::progress::{
-        create_progress_tracker_no_redaction, get_cache_dir, ProgressFormat,
+        ProgressFormat, create_progress_tracker_no_redaction, get_cache_dir,
     };
 
     // Test that audit log is created when using progress tracker

--- a/crates/deacon/tests/integration_up_build_options.rs
+++ b/crates/deacon/tests/integration_up_build_options.rs
@@ -255,7 +255,7 @@ fn test_buildkit_options_detection_empty() {
 /// Test that require_buildkit_for_options passes when no options require BuildKit
 #[tokio::test(flavor = "current_thread")]
 async fn test_require_buildkit_for_options_passes_when_empty() {
-    use deacon_core::build::buildkit::{require_buildkit_for_options, BuildKitOptions};
+    use deacon_core::build::buildkit::{BuildKitOptions, require_buildkit_for_options};
 
     let options = BuildKitOptions::default();
     let result = require_buildkit_for_options(&options).await;

--- a/crates/deacon/tests/integration_up_with_features.rs
+++ b/crates/deacon/tests/integration_up_with_features.rs
@@ -19,10 +19,10 @@ use std::process::Command as StdCommand;
 /// Test that EnrichedMergedConfiguration includes featureMetadata when features are present.
 #[test]
 fn test_enriched_config_serializes_feature_metadata() {
+    use deacon_core::config::DevContainerConfig;
     use deacon_core::config::merge::{
         EnrichedMergedConfiguration, FeatureMetadataEntry, MergedDevContainerConfig, Provenance,
     };
-    use deacon_core::config::DevContainerConfig;
 
     // Create a base merged configuration
     let base_config = DevContainerConfig {
@@ -124,10 +124,10 @@ fn test_enriched_config_serializes_feature_metadata() {
 /// with an empty or minimal metadata placeholder so consumers see a complete list."
 #[test]
 fn test_all_features_have_metadata_entries_even_if_empty() {
+    use deacon_core::config::DevContainerConfig;
     use deacon_core::config::merge::{
         EnrichedMergedConfiguration, FeatureMetadataEntry, MergedDevContainerConfig,
     };
-    use deacon_core::config::DevContainerConfig;
 
     let base_config = DevContainerConfig {
         name: Some("minimal-test".to_string()),
@@ -272,8 +272,8 @@ fn test_feature_metadata_uses_camel_case_field_names() {
 /// Per spec: "skip_serializing_if = Option::is_none" ensures clean output.
 #[test]
 fn test_no_feature_metadata_when_empty() {
-    use deacon_core::config::merge::{EnrichedMergedConfiguration, MergedDevContainerConfig};
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::{EnrichedMergedConfiguration, MergedDevContainerConfig};
 
     let base_config = DevContainerConfig {
         name: Some("no-features".to_string()),
@@ -302,10 +302,10 @@ fn test_no_feature_metadata_when_empty() {
 /// Per spec: "Ordering from the user configuration/lockfile must be preserved."
 #[test]
 fn test_feature_metadata_preserves_declaration_order() {
+    use deacon_core::config::DevContainerConfig;
     use deacon_core::config::merge::{
         EnrichedMergedConfiguration, FeatureMetadataEntry, MergedDevContainerConfig,
     };
-    use deacon_core::config::DevContainerConfig;
 
     let base_config = DevContainerConfig {
         name: Some("ordering-test".to_string()),
@@ -369,10 +369,10 @@ fn test_feature_metadata_preserves_declaration_order() {
 /// Verifies serialization produces parseable JSON that preserves all data.
 #[test]
 fn test_enriched_config_json_roundtrip() {
+    use deacon_core::config::DevContainerConfig;
     use deacon_core::config::merge::{
         EnrichedMergedConfiguration, FeatureMetadataEntry, MergedDevContainerConfig, Provenance,
     };
-    use deacon_core::config::DevContainerConfig;
 
     let base_config = DevContainerConfig {
         name: Some("roundtrip-test".to_string()),

--- a/crates/deacon/tests/integration_vulnerability_scan.rs
+++ b/crates/deacon/tests/integration_vulnerability_scan.rs
@@ -3,7 +3,6 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -36,15 +35,14 @@ fn test_scan_without_docker_env_var() {
     )
     .unwrap();
 
-    // Ensure DEACON_SCAN_CMD is not set
-    env::remove_var("DEACON_SCAN_CMD");
-
     // Test build command with scan flags. Image reference builds are now supported,
     // so the build may succeed even without a scan command. We validate that:
     // 1. Flags are accepted (no clap parsing failure / exit code 2)
     // 2. A warning is emitted about the missing DEACON_SCAN_CMD.
+    // Ensure DEACON_SCAN_CMD is not set for the child process.
     let mut cmd = Command::cargo_bin("deacon").unwrap();
     cmd.current_dir(&temp_dir)
+        .env_remove("DEACON_SCAN_CMD")
         .arg("build")
         .arg("--scan-image")
         .arg("--fail-on-scan");

--- a/crates/deacon/tests/parity_env_probe_flag.rs
+++ b/crates/deacon/tests/parity_env_probe_flag.rs
@@ -1,8 +1,8 @@
-use deacon::commands::exec::{execute_exec_with_docker, ExecArgs};
+use deacon::commands::exec::{ExecArgs, execute_exec_with_docker};
 use deacon::commands::shared::resolve_env_and_user;
+use deacon_core::IndexMap;
 use deacon_core::container_env_probe::ContainerProbeMode;
 use deacon_core::docker::mock::{MockContainer, MockDocker};
-use deacon_core::IndexMap;
 use std::collections::HashMap;
 
 #[tokio::test]

--- a/crates/deacon/tests/parity_utils.rs
+++ b/crates/deacon/tests/parity_utils.rs
@@ -185,7 +185,7 @@ pub fn normalize_config_json(raw: &str) -> anyhow::Result<Value> {
 
 /// Extract a subset of keys that define the effective devcontainer behavior.
 fn extract_core_config(v: &Value) -> Value {
-    use serde_json::{json, Map};
+    use serde_json::{Map, json};
     let mut out = Map::new();
     let obj = match v.as_object() {
         Some(o) => o,

--- a/crates/deacon/tests/run_user_commands_prebuild.rs
+++ b/crates/deacon/tests/run_user_commands_prebuild.rs
@@ -55,13 +55,12 @@ fn find_container(name: &str) -> Option<String> {
         ])
         .output()
         .ok()?;
-    let id = String::from_utf8_lossy(&output.stdout)
+    String::from_utf8_lossy(&output.stdout)
         .lines()
         .next()
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .map(str::to_string);
-    id
+        .map(str::to_string)
 }
 
 /// Removes the named container on drop so cleanup runs even if an assertion
@@ -80,7 +79,9 @@ impl Drop for ContainerGuard {
 #[test]
 fn test_run_user_commands_prebuild_stops_after_update_content() {
     if !is_docker_available() {
-        eprintln!("Skipping test_run_user_commands_prebuild_stops_after_update_content: Docker not available");
+        eprintln!(
+            "Skipping test_run_user_commands_prebuild_stops_after_update_content: Docker not available"
+        );
         return;
     }
 

--- a/crates/deacon/tests/smoke_compose_override_command.rs
+++ b/crates/deacon/tests/smoke_compose_override_command.rs
@@ -45,11 +45,7 @@ fn compose_service_container_id(workspace: &Path, service: &str) -> Option<Strin
         return None;
     }
     let id = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if id.is_empty() {
-        None
-    } else {
-        Some(id)
-    }
+    if id.is_empty() { None } else { Some(id) }
 }
 
 fn docker_inspect_state_running(container_id: &str) -> Option<bool> {

--- a/crates/deacon/tests/smoke_doctor_text.rs
+++ b/crates/deacon/tests/smoke_doctor_text.rs
@@ -72,7 +72,8 @@ fn test_doctor_text_mode_basic() {
         assert!(
             has_host_info || has_docker_info,
             "Doctor text output should contain host or docker information. Got stdout: '{}', stderr: '{}'",
-            doctor_stdout, doctor_stderr
+            doctor_stdout,
+            doctor_stderr
         );
 
         println!("Doctor text mode basic test passed");

--- a/crates/deacon/tests/smoke_lifecycle.rs
+++ b/crates/deacon/tests/smoke_lifecycle.rs
@@ -834,7 +834,9 @@ fn test_lifecycle_phase_order_sc001() {
     println!(
         "SC-001 verification passed: All lifecycle phases executed exactly once in correct order"
     );
-    println!("Execution order verified: onCreate -> updateContent -> postCreate -> postStart -> postAttach");
+    println!(
+        "Execution order verified: onCreate -> updateContent -> postCreate -> postStart -> postAttach"
+    );
 }
 
 /// Test SC-001 with dotfiles: Verify dotfiles phase executes between postCreate and postStart
@@ -1007,9 +1009,13 @@ echo "$seq,$ts" > /tmp/lifecycle_order_dotfiles
                         assert!(
                             ts >= pc_ts && ts <= ps_ts,
                             "Dotfiles (ts={}) should execute between postCreate (ts={}) and postStart (ts={})",
-                            ts, pc_ts, ps_ts
+                            ts,
+                            pc_ts,
+                            ps_ts
                         );
-                        println!("Dotfiles executed at correct position: postCreate <= dotfiles <= postStart");
+                        println!(
+                            "Dotfiles executed at correct position: postCreate <= dotfiles <= postStart"
+                        );
                         dotfiles_executed = true;
                     }
                 }

--- a/crates/deacon/tests/testcontainers_helpers.rs
+++ b/crates/deacon/tests/testcontainers_helpers.rs
@@ -33,8 +33,8 @@ pub fn alpine_sleep_with_labels(labels: &[(&str, &str)]) -> ContainerRequest<Gen
 
 /// Start an Alpine container asynchronously.
 /// The container is automatically cleaned up when the returned handle is dropped.
-pub async fn start_alpine_container(
-) -> Result<ContainerAsync<GenericImage>, testcontainers::TestcontainersError> {
+pub async fn start_alpine_container()
+-> Result<ContainerAsync<GenericImage>, testcontainers::TestcontainersError> {
     alpine_sleep_image().start().await
 }
 

--- a/crates/deacon/tests/up_dotfiles.rs
+++ b/crates/deacon/tests/up_dotfiles.rs
@@ -79,7 +79,9 @@ fn single_container_fixture() -> PathBuf {
 #[ignore = "Dotfiles not in MVP - container-side installation incomplete"]
 fn test_dotfiles_installation_with_custom_command() {
     if !can_run_dotfiles_tests() {
-        eprintln!("Skipping test_dotfiles_installation_with_custom_command: Docker or network not available");
+        eprintln!(
+            "Skipping test_dotfiles_installation_with_custom_command: Docker or network not available"
+        );
         return;
     }
 

--- a/crates/deacon/tests/up_lockfile_frozen.rs
+++ b/crates/deacon/tests/up_lockfile_frozen.rs
@@ -12,8 +12,8 @@
 use deacon::commands::up::UpArgs;
 use deacon_core::features::{FeatureMergeConfig, FeatureMerger};
 use deacon_core::lockfile::{
-    get_lockfile_path, read_lockfile, validate_lockfile_against_config, write_lockfile, Lockfile,
-    LockfileFeature, LockfileValidationResult,
+    Lockfile, LockfileFeature, LockfileValidationResult, get_lockfile_path, read_lockfile,
+    validate_lockfile_against_config, write_lockfile,
 };
 use std::collections::HashMap;
 use std::fs;

--- a/crates/deacon/tests/up_merged_configuration.rs
+++ b/crates/deacon/tests/up_merged_configuration.rs
@@ -22,7 +22,7 @@ fn test_feature_metadata_entry_serialization_with_all_fields() {
         ),
         options: Some(serde_json::json!({"version": "20"})),
         installs_after: Some(vec![
-            "ghcr.io/devcontainers/features/common-utils:1".to_string()
+            "ghcr.io/devcontainers/features/common-utils:1".to_string(),
         ]),
         depends_on: None,
         mounts: None,
@@ -193,8 +193,8 @@ fn test_label_set_from_service() {
 /// Test that EnrichedMergedConfiguration serializes with feature metadata.
 #[test]
 fn test_enriched_merged_configuration_with_feature_metadata() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let base_merged = MergedDevContainerConfig {
         config: DevContainerConfig {
@@ -250,8 +250,8 @@ fn test_enriched_merged_configuration_with_feature_metadata() {
 /// Test that EnrichedMergedConfiguration without features has no featureMetadata field.
 #[test]
 fn test_enriched_merged_configuration_no_features() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let base_merged = MergedDevContainerConfig {
         config: DevContainerConfig {
@@ -330,8 +330,8 @@ fn test_feature_metadata_entry_json_roundtrip() {
 /// Test JSON roundtrip for EnrichedMergedConfiguration.
 #[test]
 fn test_enriched_merged_configuration_json_roundtrip() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let base_merged = MergedDevContainerConfig {
         config: DevContainerConfig {
@@ -366,8 +366,8 @@ fn test_enriched_merged_configuration_json_roundtrip() {
 /// when metadata/labels are added, without unrelated drift.
 #[test]
 fn test_enriched_differs_from_base_only_by_enrichment() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     // Create base configuration
     let base_config = DevContainerConfig {
@@ -419,8 +419,8 @@ fn test_enriched_differs_from_base_only_by_enrichment() {
 /// Per spec: JSON schema compliance including required keys.
 #[test]
 fn test_enriched_schema_compliance() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let base = DevContainerConfig {
         name: Some("schema-test".to_string()),
@@ -481,8 +481,8 @@ fn test_enriched_schema_compliance() {
 /// Per spec: deterministic ordering for stable diffs.
 #[test]
 fn test_field_ordering_consistency() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let config = DevContainerConfig {
         name: Some("ordering-test".to_string()),
@@ -571,8 +571,8 @@ fn test_camel_case_field_naming() {
 /// when serializing mergedConfiguration outputs"
 #[test]
 fn test_enriched_merged_configuration_preserves_feature_declaration_order() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     // Create config with features in non-alphabetical order
     let config = DevContainerConfig {
@@ -649,8 +649,8 @@ fn test_enriched_merged_configuration_preserves_feature_declaration_order() {
 /// Empty options should not cause features to be reordered or filtered.
 #[test]
 fn test_feature_order_with_mixed_empty_and_populated_metadata() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let config = DevContainerConfig {
         name: Some("mixed-metadata".to_string()),
@@ -715,8 +715,8 @@ fn test_feature_order_with_mixed_empty_and_populated_metadata() {
 /// Test that feature order survives JSON serialization roundtrip in EnrichedMergedConfiguration.
 #[test]
 fn test_enriched_merged_configuration_order_survives_roundtrip() {
-    use deacon_core::config::merge::MergedDevContainerConfig;
     use deacon_core::config::DevContainerConfig;
+    use deacon_core::config::merge::MergedDevContainerConfig;
 
     let config = DevContainerConfig {
         name: Some("roundtrip-test".to_string()),


### PR DESCRIPTION
Conformance pass against current Rust packaging/organization norms (Cargo Book, API guidelines, docs.rs/release tooling). Driven by a project-wide best-practices audit.

## Edition & MSRV
- Migrate both crates to **edition 2024** + `resolver = "3"` (MSRV-aware resolver), bump `rust-version` to **1.85**. Ran `cargo fix --edition` for the mechanical changes (match-ergonomics, import ordering); edition-2024 rustfmt accounts for most of the line count.
- Add an **MSRV CI job** pinned to `1.85` (`cargo check --workspace --all-targets --all-features --locked`) so the declared MSRV is actually verified instead of aspirational.

## unsafe_code: `forbid` → `deny`, with zero unsafe added
Edition 2024 makes `std::env::set_var`/`remove_var` `unsafe`. Rather than scatter `#[allow(unsafe_code)]`, the env mutation is **eliminated**:
- **Production** (the 2 sites): `cli.rs` threads the default log directive into a new `init_with_redaction_and_directive` instead of mutating `RUST_LOG`; `docker_retry.rs` replaces its env round-trip test seam with an atomic counter (also fixes a latent race).
- **Tests**: subprocess tests set env on the child `Command`; in-process tests use the **`temp-env`** crate (scoped + serialized). Result: no `unsafe` and no `#[allow(unsafe_code)]` anywhere; `deny` stays meaningful.

## Dependencies
- Hoist `serde`, `serde_json`, `tokio` (union of features), `futures`, `tar`, `sha2`, `regex`, `zip`, `tempfile`, `assert_cmd`, `testcontainers` into `[workspace.dependencies]`. Fixes the confirmed **`regex` (1.0 vs 1.10)** and **`zip` (2.1 vs 2.4)** divergences.

## Packaging / build profiles
- `publish = false` on both crates (this is a consumer CLI shipped as prebuilt binaries, not a crates.io library); `documentation` now points at the repo.
- `[profile.release]`: `lto = "thin"`, `codegen-units = 1`, `strip = true` — and drop the fragile shell `strip … || true` from the release workflow (rustc strips cross-platform now). Moved dev `debug = 1` from a global rustflag (which also bloated release) into `[profile.dev]`.

## CI / hygiene
- clippy now runs with `--all-features` (previously feature-gated `full` code was unlinted in CI).
- Standardize `codeql.yml` checkout to `actions/checkout@v6`.
- Clarify the `full = []` compile-gate feature comment.
- Silence a pre-existing dead-code warning in the `--no-default-features` MVP build (`resolve_features_ordered` is only reachable under `full`).

## Deliberately NOT changed
- `deny.toml` `multiple-versions` stays `warn`: the duplicates are transitive (`thiserror` 1/2, `getrandom`, `windows-sys`, …), not hoistable — flipping to `deny` would break CI.
- No crates.io publish step or `[package.metadata.docs.rs]` (moot under `publish = false`).

## Verification
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `make test-nextest-fast` → 2161 passed ✅
- default / `--no-default-features` MVP / `--release` builds all green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)