### PR TITLE
feat(ports): support appPort arrays and share build-config resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # MVP-only build: excludes non-MVP subcommands (build, features, templates, doctor, outdated, etc.)
 
 jobs:
   verify:
@@ -39,9 +38,9 @@ jobs:
             ${{ runner.os }}-verify-
       - name: Fmt check
         run: cargo fmt --all -- --check
-      - name: Clippy (deny warnings, MVP features)
+      - name: Clippy (deny warnings)
         run: cargo clippy --all-targets -- -D warnings
-      - name: Unit tests (MVP features only, no Docker-dependent tests)
+      - name: Unit tests (no Docker-dependent tests)
         run: cargo test --workspace --lib -- --test-threads=1
 
   create-release:

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -139,6 +139,34 @@ impl PortSpec {
     }
 }
 
+/// Application port(s) to publish for the container.
+///
+/// Per the containers.dev spec, `appPort` may be a single port (number or
+/// `HOST:CONTAINER` string) or an array of ports. Both shapes are accepted and
+/// normalized via [`AppPort::specs`]; serialization round-trips the original
+/// shape (a single value stays a scalar, an array stays an array).
+///
+/// Reference: [Port Configuration - appPort](https://containers.dev/implementors/json_reference/#app-port)
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AppPort {
+    /// A single port (number or `HOST:CONTAINER` string).
+    Single(PortSpec),
+    /// A list of ports.
+    Multiple(Vec<PortSpec>),
+}
+
+impl AppPort {
+    /// View the configured port(s) as a slice, regardless of whether the source
+    /// JSON was a single value or an array.
+    pub fn specs(&self) -> &[PortSpec] {
+        match self {
+            AppPort::Single(spec) => std::slice::from_ref(spec),
+            AppPort::Multiple(specs) => specs.as_slice(),
+        }
+    }
+}
+
 /// Action to take when a port is auto-forwarded.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -529,7 +557,7 @@ pub struct DevContainerConfig {
     /// Primary application port.
     ///
     /// Reference: [Port Configuration - appPort](https://containers.dev/implementors/json_reference/#app-port)
-    pub app_port: Option<PortSpec>,
+    pub app_port: Option<AppPort>,
 
     /// Attributes for specific ports.
     ///
@@ -2694,13 +2722,15 @@ impl ConfigLoader {
             valid_ports.insert(port_spec.as_string());
         }
 
-        // Add app_port if specified
+        // Add app_port if specified (single value or array)
         if let Some(app_port) = &config.app_port {
-            if let Some(port_num) = app_port.primary_port() {
-                valid_ports.insert(port_num.to_string());
-                valid_ports.insert(format!("{}/tcp", port_num));
+            for port_spec in app_port.specs() {
+                if let Some(port_num) = port_spec.primary_port() {
+                    valid_ports.insert(port_num.to_string());
+                    valid_ports.insert(format!("{}/tcp", port_num));
+                }
+                valid_ports.insert(port_spec.as_string());
             }
-            valid_ports.insert(app_port.as_string());
         }
 
         // Check each port attribute reference
@@ -3671,6 +3701,69 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_app_port_deserialize_single_and_array() {
+        // Single number
+        let single_num: AppPort = serde_json::from_str("3000").unwrap();
+        assert_eq!(single_num, AppPort::Single(PortSpec::Number(3000)));
+        assert_eq!(single_num.specs(), &[PortSpec::Number(3000)]);
+
+        // Single string mapping
+        let single_str: AppPort = serde_json::from_str("\"8080:80\"").unwrap();
+        assert_eq!(
+            single_str,
+            AppPort::Single(PortSpec::String("8080:80".to_string()))
+        );
+
+        // Array of mixed numbers and strings
+        let multi: AppPort = serde_json::from_str(r#"[3000, "8080:80"]"#).unwrap();
+        assert_eq!(
+            multi,
+            AppPort::Multiple(vec![
+                PortSpec::Number(3000),
+                PortSpec::String("8080:80".to_string()),
+            ])
+        );
+        assert_eq!(
+            multi.specs(),
+            &[
+                PortSpec::Number(3000),
+                PortSpec::String("8080:80".to_string())
+            ]
+        );
+
+        // Serialization round-trips the original shape (scalar stays scalar,
+        // array stays array).
+        assert_eq!(serde_json::to_string(&single_num).unwrap(), "3000");
+        assert_eq!(
+            serde_json::to_string(&multi).unwrap(),
+            r#"[3000,"8080:80"]"#
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_with_app_port_array() -> anyhow::Result<()> {
+        let config_content = r#"{
+            "image": "node:18",
+            "appPort": [3000, "8080:80"]
+        }"#;
+
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(config_content.as_bytes())?;
+
+        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+
+        assert_eq!(
+            config.app_port,
+            Some(AppPort::Multiple(vec![
+                PortSpec::Number(3000),
+                PortSpec::String("8080:80".to_string()),
+            ]))
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_config_with_ports_and_attributes() -> anyhow::Result<()> {
         let config_content = r#"{
@@ -3702,7 +3795,10 @@ mod tests {
 
         assert_eq!(config.name, Some("Test Container".to_string()));
         assert_eq!(config.forward_ports.len(), 2);
-        assert_eq!(config.app_port, Some(PortSpec::Number(3000)));
+        assert_eq!(
+            config.app_port,
+            Some(AppPort::Single(PortSpec::Number(3000)))
+        );
 
         // Check port attributes
         assert_eq!(config.ports_attributes.len(), 2);

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -432,6 +432,58 @@ pub fn derive_container_workspace_folder(mounts: &[Mount]) -> Option<String> {
     longest_bind_mount.map(|mount| mount.destination.clone())
 }
 
+/// Convert a single port specification into a docker `-p` value.
+///
+/// A bare port number (or numeric string) publishes to the same port on the
+/// host (`N` -> `N:N`); an explicit `HOST:CONTAINER` string is passed through
+/// unchanged. Returns `None` for an unparseable spec (logged and skipped),
+/// matching the fail-soft behavior of upstream port handling.
+fn port_spec_to_publish_arg(port_spec: &crate::config::PortSpec, source: &str) -> Option<String> {
+    match port_spec {
+        crate::config::PortSpec::Number(port) => Some(format!("{}:{}", port, port)),
+        crate::config::PortSpec::String(spec) => {
+            if spec.contains(':') {
+                // Already has host:container mapping
+                Some(spec.clone())
+            } else {
+                // Single port string, map to same port
+                match spec.parse::<u16>() {
+                    Ok(port) => Some(format!("{}:{}", port, port)),
+                    Err(_) => {
+                        warn!("Invalid port specification in {}: {}", source, spec);
+                        None
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Build the ordered list of docker `run` arguments that publish ports from a
+/// config's `forwardPorts` and `appPort` fields.
+///
+/// Both fields publish host bindings via `-p`; `forwardPorts` entries come
+/// first (in declaration order) followed by `appPort`. Invalid specs are
+/// skipped. Reference: containers.dev `forwardPorts` / `appPort`.
+fn port_publish_args(config: &DevContainerConfig) -> Vec<String> {
+    let mut args = Vec::new();
+    for port_spec in &config.forward_ports {
+        if let Some(port_arg) = port_spec_to_publish_arg(port_spec, "forwardPorts") {
+            args.push("-p".to_string());
+            args.push(port_arg);
+        }
+    }
+    if let Some(app_port) = &config.app_port {
+        for port_spec in app_port.specs() {
+            if let Some(port_arg) = port_spec_to_publish_arg(port_spec, "appPort") {
+                args.push("-p".to_string());
+                args.push(port_arg);
+            }
+        }
+    }
+    args
+}
+
 /// Configuration for executing commands in containers
 
 #[derive(Debug, Clone)]
@@ -1830,33 +1882,10 @@ impl ContainerOps for CliRuntime {
             }
         }
 
-        // Add port forwarding from forwardPorts configuration
-        for port_spec in &config.forward_ports {
-            let port_arg = match port_spec {
-                crate::config::PortSpec::Number(port) => {
-                    // Simple port number - forward to same port on host
-                    format!("{}:{}", port, port)
-                }
-                crate::config::PortSpec::String(spec) => {
-                    // Port string should be validated already, but handle edge cases
-                    if spec.contains(':') {
-                        // Already has host:container mapping
-                        spec.clone()
-                    } else {
-                        // Single port string, map to same port
-                        match spec.parse::<u16>() {
-                            Ok(port) => format!("{}:{}", port, port),
-                            Err(_) => {
-                                warn!("Invalid port specification in forwardPorts: {}", spec);
-                                continue;
-                            }
-                        }
-                    }
-                }
-            };
-            args.push("-p".to_string());
-            args.push(port_arg);
-        }
+        // Add published ports from forwardPorts and appPort configuration.
+        // Both map to docker `-p host:container` bindings; a bare port number
+        // publishes to the same port on the host.
+        args.extend(port_publish_args(config));
 
         // Add GPU flags based on GPU mode
         // Note: GpuMode::Detect is resolved to All or None by the caller (e.g., in up.rs)
@@ -3797,5 +3826,94 @@ mod tests {
         // SIGKILL = 9
         let status = std::process::ExitStatus::from_raw(9);
         assert_eq!(resolve_exit_code(status), 137);
+    }
+
+    #[test]
+    fn test_port_spec_to_publish_arg_variants() {
+        use crate::config::PortSpec;
+
+        // Bare number publishes to the same host port.
+        assert_eq!(
+            port_spec_to_publish_arg(&PortSpec::Number(3000), "forwardPorts"),
+            Some("3000:3000".to_string())
+        );
+        // Numeric string behaves like a bare number.
+        assert_eq!(
+            port_spec_to_publish_arg(&PortSpec::String("8080".to_string()), "appPort"),
+            Some("8080:8080".to_string())
+        );
+        // Explicit host:container mapping passes through unchanged.
+        assert_eq!(
+            port_spec_to_publish_arg(&PortSpec::String("8080:80".to_string()), "forwardPorts"),
+            Some("8080:80".to_string())
+        );
+        // Unparseable spec is skipped.
+        assert_eq!(
+            port_spec_to_publish_arg(&PortSpec::String("nope".to_string()), "appPort"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_port_publish_args_includes_app_port() {
+        use crate::config::{AppPort, PortSpec};
+
+        let config = DevContainerConfig {
+            forward_ports: vec![
+                PortSpec::Number(3000),
+                PortSpec::String("9000:90".to_string()),
+            ],
+            app_port: Some(AppPort::Single(PortSpec::Number(8080))),
+            ..Default::default()
+        };
+
+        // forwardPorts entries come first (in order), then appPort.
+        assert_eq!(
+            port_publish_args(&config),
+            vec![
+                "-p",
+                "3000:3000", //
+                "-p",
+                "9000:90", //
+                "-p",
+                "8080:8080",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_port_publish_args_app_port_only() {
+        use crate::config::{AppPort, PortSpec};
+
+        let config = DevContainerConfig {
+            app_port: Some(AppPort::Single(PortSpec::String("5000:5001".to_string()))),
+            ..Default::default()
+        };
+
+        assert_eq!(port_publish_args(&config), vec!["-p", "5000:5001"]);
+    }
+
+    #[test]
+    fn test_port_publish_args_app_port_array() {
+        use crate::config::{AppPort, PortSpec};
+
+        let config = DevContainerConfig {
+            app_port: Some(AppPort::Multiple(vec![
+                PortSpec::Number(8080),
+                PortSpec::String("9000:90".to_string()),
+            ])),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            port_publish_args(&config),
+            vec!["-p", "8080:8080", "-p", "9000:90"]
+        );
+    }
+
+    #[test]
+    fn test_port_publish_args_empty_when_no_ports() {
+        let config = DevContainerConfig::default();
+        assert!(port_publish_args(&config).is_empty());
     }
 }

--- a/crates/core/src/ports.rs
+++ b/crates/core/src/ports.rs
@@ -118,10 +118,12 @@ impl PortForwardingManager {
             }
         }
 
-        // Add appPort if specified
+        // Add appPort if specified (single value or array)
         if let Some(app_port) = &config.app_port {
-            if let Some(port_num) = app_port.primary_port() {
-                ports.insert(port_num, app_port);
+            for port_spec in app_port.specs() {
+                if let Some(port_num) = port_spec.primary_port() {
+                    ports.insert(port_num, port_spec);
+                }
             }
         }
 
@@ -336,6 +338,7 @@ impl PortForwardingManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::AppPort;
     use std::collections::HashMap;
 
     #[test]
@@ -346,7 +349,7 @@ mod tests {
             PortSpec::Number(3000),
             PortSpec::String("8080:8080".to_string()),
         ];
-        config.app_port = Some(PortSpec::Number(4000));
+        config.app_port = Some(AppPort::Single(PortSpec::Number(4000)));
 
         let ports = PortForwardingManager::collect_configured_ports(&config);
 

--- a/crates/core/tests/integration_ports.rs
+++ b/crates/core/tests/integration_ports.rs
@@ -3,7 +3,7 @@
 //! Tests the complete workflow of port configuration, Docker container inspection,
 //! and port event emission with attribute resolution.
 
-use deacon_core::config::{DevContainerConfig, OnAutoForward, PortAttributes, PortSpec};
+use deacon_core::config::{AppPort, DevContainerConfig, OnAutoForward, PortAttributes, PortSpec};
 use deacon_core::docker::{ContainerInfo, ExposedPort, PortMapping};
 use deacon_core::ports::{PortEvent, PortForwardingManager};
 use std::collections::HashMap;
@@ -45,7 +45,7 @@ fn test_port_event_generation_with_attributes() {
         PortSpec::Number(3000),
         PortSpec::String("8080:8080".to_string()),
     ];
-    config.app_port = Some(PortSpec::Number(4000));
+    config.app_port = Some(AppPort::Single(PortSpec::Number(4000)));
     config.ports_attributes = ports_attributes;
     config.other_ports_attributes = Some(PortAttributes {
         label: Some("Default Service".to_string()),

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -6,6 +6,7 @@
 pub mod result;
 
 use crate::cli::{BuildKitOption, OutputFormat};
+use crate::commands::shared::build_resolution::resolve_devcontainer_build_config;
 use crate::commands::shared::{ConfigLoadArgs, TerminalDimensions, load_config};
 use anyhow::{Context, Result, anyhow};
 use deacon_core::config::DevContainerConfig;
@@ -325,10 +326,14 @@ impl BuildSecret {
 /// Build configuration extracted from DevContainer config
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BuildConfig {
-    /// Dockerfile path (relative to context)
+    /// Dockerfile path as specified by config
     pub dockerfile: String,
+    /// Resolved Dockerfile path
+    pub dockerfile_path: PathBuf,
     /// Build context path
     pub context: String,
+    /// Directory containing the active devcontainer config
+    pub context_folder: PathBuf,
     /// Build target (optional)
     pub target: Option<String>,
     /// Build options/args
@@ -630,7 +635,7 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
     }
 
     // Extract build configuration
-    let build_config = extract_build_config(&config, &workspace_folder)?;
+    let build_config = extract_build_config(&config, &config_path)?;
     debug!("Build config: {:?}", build_config);
 
     // Calculate configuration hash for caching
@@ -827,10 +832,9 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
 }
 
 /// Extract build configuration from DevContainer config
-fn extract_build_config(
-    config: &DevContainerConfig,
-    workspace_folder: &Path,
-) -> Result<BuildConfig> {
+fn extract_build_config(config: &DevContainerConfig, config_path: &Path) -> Result<BuildConfig> {
+    let config_folder = config_path.parent().unwrap_or_else(|| Path::new("."));
+
     // Check if this is a compose-based configuration
     if config.uses_compose() {
         // For compose mode, we use the service name as a placeholder
@@ -843,86 +847,36 @@ fn extract_build_config(
 
         return Ok(BuildConfig {
             dockerfile: format!("compose-service-{}", service),
+            dockerfile_path: config_folder.join(format!("compose-service-{}", service)),
             context: ".".to_string(),
+            context_folder: config_folder.to_path_buf(),
             target: None,
             options: HashMap::new(),
         });
     }
-    // Resolve the Dockerfile from either the top-level `dockerFile` field or the
-    // canonical nested `build.dockerfile` field (containers.dev json_reference).
-    // `up` already honors both (see commands/up/image_build.rs); mirror that here.
-    let build_dockerfile = config
-        .build
-        .as_ref()
-        .and_then(|v| v.as_object())
-        .and_then(|o| o.get("dockerfile"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-    let dockerfile_opt = config.dockerfile.clone().or(build_dockerfile);
 
-    // Check if we have a dockerfile specified
-    if let Some(dockerfile) = &dockerfile_opt {
-        let dockerfile_path = workspace_folder.join(dockerfile);
-        if !dockerfile_path.exists() {
-            return Err(
-                DeaconError::Config(deacon_core::errors::ConfigError::NotFound {
-                    path: dockerfile_path.to_string_lossy().to_string(),
-                })
-                .into(),
-            );
-        }
+    if let Some(resolved) = resolve_devcontainer_build_config(config, config_path)? {
+        return Ok(BuildConfig {
+            dockerfile: resolved.dockerfile,
+            dockerfile_path: resolved.dockerfile_path,
+            context: resolved.context,
+            context_folder: resolved.context_folder,
+            target: resolved.target,
+            options: resolved.options,
+        });
+    }
 
-        let mut build_config = BuildConfig {
-            dockerfile: dockerfile.clone(),
-            context: ".".to_string(),
-            target: None,
-            options: HashMap::new(),
-        };
-
-        // Parse build configuration if present
-        if let Some(build_value) = &config.build {
-            if let Some(build_obj) = build_value.as_object() {
-                // Extract context
-                if let Some(context) = build_obj.get("context").and_then(|v| v.as_str()) {
-                    build_config.context = context.to_string();
-                }
-
-                // Extract target
-                if let Some(target) = build_obj.get("target").and_then(|v| v.as_str()) {
-                    build_config.target = Some(target.to_string());
-                }
-
-                // Extract build options/args
-                if let Some(options) = build_obj.get("options").and_then(|v| v.as_object()) {
-                    for (key, value) in options {
-                        let val_str = value
-                            .as_str()
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| value.to_string());
-                        build_config.options.insert(key.clone(), val_str);
-                    }
-                }
-
-                // Extract build args (upstream-compatible: build.args)
-                if let Some(args_obj) = build_obj.get("args").and_then(|v| v.as_object()) {
-                    for (key, value) in args_obj {
-                        let val_str = value
-                            .as_str()
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| value.to_string());
-                        build_config.options.insert(key.clone(), val_str);
-                    }
-                }
-            }
-        }
-
-        Ok(build_config)
-    } else if let Some(image) = &config.image {
+    if let Some(image) = &config.image {
         // For image-reference mode, create a build config that will generate a Dockerfile
         // Actual image-reference build will be handled by execute_image_reference_build
         Ok(BuildConfig {
             dockerfile: format!("image-reference-{}", image.replace([':', '/'], "-")),
+            dockerfile_path: config_folder.join(format!(
+                "image-reference-{}",
+                image.replace([':', '/'], "-")
+            )),
             context: ".".to_string(),
+            context_folder: config_folder.to_path_buf(),
             target: None,
             options: HashMap::new(),
         })
@@ -938,7 +892,7 @@ fn extract_build_config(
 }
 
 /// Calculate configuration hash for caching
-fn calculate_config_hash(build_config: &BuildConfig, workspace_folder: &Path) -> Result<String> {
+fn calculate_config_hash(build_config: &BuildConfig, _workspace_folder: &Path) -> Result<String> {
     use sha2::{Digest, Sha256};
 
     let mut hasher = Sha256::new();
@@ -959,16 +913,14 @@ fn calculate_config_hash(build_config: &BuildConfig, workspace_folder: &Path) ->
     }
 
     // Hash dockerfile content
-    let dockerfile_path = workspace_folder
-        .join(&build_config.context)
-        .join(&build_config.dockerfile);
+    let dockerfile_path = build_config.dockerfile_path.clone();
     if dockerfile_path.exists() {
         let dockerfile_content = std::fs::read_to_string(&dockerfile_path)?;
         hasher.update(dockerfile_content.as_bytes());
     }
 
     // Hash selected build context files (limit count for performance)
-    let context_path = workspace_folder.join(&build_config.context);
+    let context_path = build_config.context_folder.join(&build_config.context);
     if context_path.exists() {
         let mut build_affecting_files = Vec::new();
 
@@ -990,7 +942,7 @@ fn calculate_config_hash(build_config: &BuildConfig, workspace_folder: &Path) ->
                             if !is_non_build_affecting_file(file_name) {
                                 if let Ok(metadata) = std::fs::metadata(&path) {
                                     build_affecting_files.push((
-                                        path.strip_prefix(workspace_folder)
+                                        path.strip_prefix(&context_path)
                                             .unwrap_or(&path)
                                             .to_string_lossy()
                                             .to_string(),
@@ -1206,7 +1158,9 @@ fn create_build_inputs(result: &BuildResult, _workspace_folder: &Path) -> Result
         feature_set_digest: None, // TODO: Implement when features are integrated
         build_config: BuildConfig {
             dockerfile: "Dockerfile".to_string(), // Would be extracted from actual config
+            dockerfile_path: PathBuf::from("Dockerfile"),
             context: ".".to_string(),
+            context_folder: PathBuf::from("."),
             target: None,
             options: HashMap::new(),
         },
@@ -1479,7 +1433,9 @@ async fn execute_image_reference_build(
     // Create a BuildConfig for this temporary Dockerfile
     let build_config = BuildConfig {
         dockerfile: "Dockerfile".to_string(),
-        context: temp_dir.to_string_lossy().to_string(),
+        dockerfile_path,
+        context: ".".to_string(),
+        context_folder: temp_dir.to_path_buf(),
         target: None,
         options: HashMap::new(),
     };
@@ -1664,8 +1620,8 @@ async fn execute_docker_build(
         debug!("Building Docker image");
 
         // Prepare build context
-        let context_path = workspace_folder.join(&build_config.context);
-        let dockerfile_path = context_path.join(&build_config.dockerfile);
+        let context_path = build_config.context_folder.join(&build_config.context);
+        let dockerfile_path = build_config.dockerfile_path.clone();
 
         // Prepare docker build arguments
         let mut build_args = vec!["build".to_string()];
@@ -2294,8 +2250,9 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let dockerfile_path = temp_dir.path().join("Dockerfile");
         std::fs::write(&dockerfile_path, "FROM alpine:3.19\nLABEL test=1\n").unwrap();
+        let config_path = temp_dir.path().join("devcontainer.json");
 
-        let result = extract_build_config(&config, temp_dir.path());
+        let result = extract_build_config(&config, &config_path);
         assert!(result.is_ok());
         let build_config = result.unwrap();
         assert_eq!(build_config.dockerfile, "Dockerfile");
@@ -2310,7 +2267,7 @@ mod tests {
             }
         }));
 
-        let result = extract_build_config(&config, temp_dir.path());
+        let result = extract_build_config(&config, &config_path);
         assert!(result.is_ok());
         let build_config = result.unwrap();
         assert_eq!(build_config.context, "docker");
@@ -2331,6 +2288,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let dockerfile_path = temp_dir.path().join("Dockerfile");
         std::fs::write(&dockerfile_path, "FROM alpine:3.19\nLABEL test=1\n").unwrap();
+        let config_path = temp_dir.path().join("devcontainer.json");
 
         let mut config = DevContainerConfig::default();
         config.name = Some("test".to_string());
@@ -2341,7 +2299,7 @@ mod tests {
             "args": { "FOO": "bar" }
         }));
 
-        let result = extract_build_config(&config, temp_dir.path());
+        let result = extract_build_config(&config, &config_path);
         assert!(
             result.is_ok(),
             "build.dockerfile should be recognized: {:?}",
@@ -2351,6 +2309,29 @@ mod tests {
         assert_eq!(build_config.dockerfile, "Dockerfile");
         assert_eq!(build_config.context, ".");
         assert_eq!(build_config.options.get("FOO"), Some(&"bar".to_string()));
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn test_build_config_resolves_dockerfile_relative_to_config_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_dir = temp_dir.path().join(".devcontainer");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("Dockerfile"), "FROM alpine:3.19\n").unwrap();
+        std::fs::write(temp_dir.path().join("Dockerfile"), "FROM busybox:1.36\n").unwrap();
+        let config_path = config_dir.join("devcontainer.json");
+
+        let mut config = DevContainerConfig::default();
+        config.name = Some("test".to_string());
+        config.build = Some(serde_json::json!({
+            "dockerfile": "Dockerfile",
+            "context": ".."
+        }));
+
+        let build_config = extract_build_config(&config, &config_path).unwrap();
+        assert_eq!(build_config.dockerfile_path, config_dir.join("Dockerfile"));
+        assert_eq!(build_config.context_folder, config_dir);
+        assert_eq!(build_config.context, "..");
     }
 
     #[test]
@@ -2376,9 +2357,12 @@ mod tests {
 
     #[test]
     fn test_config_hash_calculation() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let build_config = BuildConfig {
             dockerfile: "Dockerfile".to_string(),
+            dockerfile_path: temp_dir.path().join("Dockerfile"),
             context: ".".to_string(),
+            context_folder: temp_dir.path().to_path_buf(),
             target: Some("dev".to_string()),
             options: {
                 let mut map = HashMap::new();
@@ -2388,7 +2372,6 @@ mod tests {
             },
         };
 
-        let temp_dir = tempfile::tempdir().unwrap();
         let dockerfile_path = temp_dir.path().join("Dockerfile");
         std::fs::write(&dockerfile_path, "FROM alpine:3.19\n").unwrap();
 
@@ -2842,14 +2825,15 @@ mod tests {
 
     #[test]
     fn test_config_hash_with_context_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let build_config = BuildConfig {
             dockerfile: "Dockerfile".to_string(),
+            dockerfile_path: temp_dir.path().join("Dockerfile"),
             context: ".".to_string(),
+            context_folder: temp_dir.path().to_path_buf(),
             target: None,
             options: HashMap::new(),
         };
-
-        let temp_dir = tempfile::tempdir().unwrap();
 
         // Create Dockerfile
         std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.19\n").unwrap();
@@ -2883,14 +2867,15 @@ mod tests {
 
     #[test]
     fn test_config_hash_recursive_directory_traversal() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let build_config = BuildConfig {
             dockerfile: "Dockerfile".to_string(),
+            dockerfile_path: temp_dir.path().join("Dockerfile"),
             context: ".".to_string(),
+            context_folder: temp_dir.path().to_path_buf(),
             target: None,
             options: HashMap::new(),
         };
-
-        let temp_dir = tempfile::tempdir().unwrap();
 
         // Create Dockerfile
         std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.19\n").unwrap();
@@ -2922,14 +2907,15 @@ mod tests {
 
     #[test]
     fn test_config_hash_excludes_devcontainer_directory() {
+        let temp_dir = tempfile::tempdir().unwrap();
         let build_config = BuildConfig {
             dockerfile: "Dockerfile".to_string(),
+            dockerfile_path: temp_dir.path().join("Dockerfile"),
             context: ".".to_string(),
+            context_folder: temp_dir.path().to_path_buf(),
             target: None,
             options: HashMap::new(),
         };
-
-        let temp_dir = tempfile::tempdir().unwrap();
 
         // Create Dockerfile
         std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.19\n").unwrap();
@@ -2991,7 +2977,9 @@ mod tests {
             feature_set_digest: Some("features_hash".to_string()),
             build_config: BuildConfig {
                 dockerfile: "Dockerfile".to_string(),
+                dockerfile_path: PathBuf::from("Dockerfile"),
                 context: ".".to_string(),
+                context_folder: PathBuf::from("."),
                 target: None,
                 options: HashMap::new(),
             },

--- a/crates/deacon/src/commands/shared/build_resolution.rs
+++ b/crates/deacon/src/commands/shared/build_resolution.rs
@@ -1,0 +1,168 @@
+//! Shared build configuration resolution for devcontainer Dockerfile builds.
+
+use anyhow::Result;
+use deacon_core::config::DevContainerConfig;
+use deacon_core::errors::{ConfigError, DeaconError};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Build configuration resolved from a devcontainer configuration.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedBuildConfig {
+    pub dockerfile: String,
+    pub dockerfile_path: PathBuf,
+    pub context: String,
+    pub context_folder: PathBuf,
+    pub target: Option<String>,
+    pub options: HashMap<String, String>,
+}
+
+/// Resolve a devcontainer Dockerfile build configuration.
+///
+/// Dev Container `dockerFile` and `build.dockerfile` paths are resolved
+/// relative to the directory containing the active config file. The build
+/// context is also interpreted relative to that config directory by callers.
+pub(crate) fn resolve_devcontainer_build_config(
+    config: &DevContainerConfig,
+    config_path: &Path,
+) -> Result<Option<ResolvedBuildConfig>> {
+    if config.image.is_some() {
+        return Ok(None);
+    }
+
+    let config_folder = config_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut context = ".".to_string();
+    let mut target = None;
+    let mut options = HashMap::new();
+
+    let build_dockerfile = if let Some(build_value) = &config.build {
+        let build_obj = build_value.as_object().ok_or_else(|| {
+            DeaconError::Config(ConfigError::Validation {
+                message: "build field must be an object".to_string(),
+            })
+        })?;
+
+        if let Some(build_context) = build_obj.get("context").and_then(|v| v.as_str()) {
+            context = build_context.to_string();
+        }
+
+        if let Some(build_target) = build_obj.get("target").and_then(|v| v.as_str()) {
+            target = Some(build_target.to_string());
+        }
+
+        if let Some(options_obj) = build_obj.get("options").and_then(|v| v.as_object()) {
+            insert_stringified_values(&mut options, options_obj);
+        }
+
+        if let Some(args_obj) = build_obj.get("args").and_then(|v| v.as_object()) {
+            insert_stringified_values(&mut options, args_obj);
+        }
+
+        build_obj
+            .get("dockerfile")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    } else {
+        None
+    };
+
+    let dockerfile = config.dockerfile.clone().or(build_dockerfile);
+
+    match dockerfile {
+        Some(dockerfile) => {
+            let dockerfile_path = config_folder.join(&dockerfile);
+            if !dockerfile_path.exists() {
+                return Err(DeaconError::Config(ConfigError::NotFound {
+                    path: dockerfile_path.to_string_lossy().to_string(),
+                })
+                .into());
+            }
+
+            Ok(Some(ResolvedBuildConfig {
+                dockerfile,
+                dockerfile_path,
+                context,
+                context_folder: config_folder.to_path_buf(),
+                target,
+                options,
+            }))
+        }
+        None if config.build.is_some() => Err(DeaconError::Config(ConfigError::Validation {
+            message: "build.dockerfile is required when using build object".to_string(),
+        })
+        .into()),
+        None => Ok(None),
+    }
+}
+
+fn insert_stringified_values(
+    options: &mut HashMap<String, String>,
+    values: &serde_json::Map<String, serde_json::Value>,
+) {
+    for (key, value) in values {
+        let val_str = value
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| value.to_string());
+        options.insert(key.clone(), val_str);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn resolves_top_level_dockerfile_relative_to_config_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_dir = temp_dir.path().join(".devcontainer");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("Dockerfile"), "FROM alpine:3.19\n").unwrap();
+        std::fs::write(temp_dir.path().join("Dockerfile"), "FROM busybox:1.36\n").unwrap();
+        let config_path = config_dir.join("devcontainer.json");
+
+        let mut config = DevContainerConfig::default();
+        config.dockerfile = Some("Dockerfile".to_string());
+
+        let resolved = resolve_devcontainer_build_config(&config, &config_path)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.dockerfile, "Dockerfile");
+        assert_eq!(resolved.dockerfile_path, config_dir.join("Dockerfile"));
+        assert_eq!(resolved.context_folder, config_dir);
+    }
+
+    #[test]
+    #[allow(clippy::field_reassign_with_default)]
+    fn resolves_build_object_fields() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_dir = temp_dir.path().join(".devcontainer");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("Containerfile"), "FROM alpine:3.19\n").unwrap();
+        let config_path = config_dir.join("devcontainer.json");
+
+        let mut config = DevContainerConfig::default();
+        config.build = Some(serde_json::json!({
+            "dockerfile": "Containerfile",
+            "context": "..",
+            "target": "dev",
+            "args": { "FOO": "bar" },
+            "options": { "BUILDKIT_INLINE_CACHE": "1" }
+        }));
+
+        let resolved = resolve_devcontainer_build_config(&config, &config_path)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(resolved.dockerfile_path, config_dir.join("Containerfile"));
+        assert_eq!(resolved.context, "..");
+        assert_eq!(resolved.target, Some("dev".to_string()));
+        assert_eq!(resolved.options.get("FOO"), Some(&"bar".to_string()));
+        assert_eq!(
+            resolved.options.get("BUILDKIT_INLINE_CACHE"),
+            Some(&"1".to_string())
+        );
+    }
+}

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -1,5 +1,6 @@
 //! Shared helpers for command implementations.
 
+pub(crate) mod build_resolution;
 pub mod config_loader;
 pub mod env_user;
 pub mod feature_resolver;

--- a/crates/deacon/src/commands/up/image_build.rs
+++ b/crates/deacon/src/commands/up/image_build.rs
@@ -5,12 +5,13 @@
 //! - `extract_build_config_from_devcontainer` - Extract build config from devcontainer.json
 //! - `build_image_from_config` - Build Docker image from build configuration
 
+use crate::commands::shared::build_resolution::resolve_devcontainer_build_config;
 use anyhow::{Context, Result};
 use deacon_core::build::BuildOptions;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::errors::{DeaconError, DockerError};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tracing::{debug, info, instrument};
 
 /// Build configuration extracted from DevContainerConfig
@@ -26,125 +27,28 @@ pub(crate) struct BuildConfig {
 /// Extract build configuration from DevContainerConfig.build object
 pub(crate) fn extract_build_config_from_devcontainer(
     config: &DevContainerConfig,
-    workspace_folder: &Path,
+    config_path: &std::path::Path,
 ) -> Result<Option<BuildConfig>> {
-    // If image is specified, no build needed
-    if config.image.is_some() {
-        return Ok(None);
-    }
-
-    // Determine config folder (where devcontainer.json is located)
-    // Typically .devcontainer/ or workspace root
-    let config_folder = workspace_folder.join(".devcontainer");
-    let config_folder = if config_folder.exists() {
-        config_folder
-    } else {
-        workspace_folder.to_path_buf()
+    let resolved = match resolve_devcontainer_build_config(config, config_path)? {
+        Some(resolved) => resolved,
+        None => return Ok(None),
     };
 
-    // Check for build object with dockerfile field
-    let build_value = match &config.build {
-        Some(v) => v,
-        None => {
-            // Check for top-level dockerFile field
-            if let Some(dockerfile) = &config.dockerfile {
-                let dockerfile_path = config_folder.join(dockerfile);
-                if !dockerfile_path.exists() {
-                    return Err(
-                        DeaconError::Config(deacon_core::errors::ConfigError::NotFound {
-                            path: dockerfile_path.to_string_lossy().to_string(),
-                        })
-                        .into(),
-                    );
-                }
-
-                return Ok(Some(BuildConfig {
-                    dockerfile: dockerfile.clone(),
-                    context: ".".to_string(),
-                    context_folder: config_folder.clone(),
-                    target: None,
-                    options: HashMap::new(),
-                }));
-            }
-            return Ok(None);
-        }
-    };
-
-    let build_obj = build_value.as_object().ok_or_else(|| {
-        DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-            message: "build field must be an object".to_string(),
-        })
-    })?;
-
-    // Extract dockerfile from build object
-    let dockerfile = build_obj
-        .get("dockerfile")
-        .and_then(|v| v.as_str())
+    let dockerfile = resolved
+        .dockerfile_path
+        .to_str()
         .ok_or_else(|| {
-            DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-                message: "build.dockerfile is required when using build object".to_string(),
-            })
-        })?;
+            DeaconError::Docker(DockerError::CLIError("Invalid dockerfile path".to_string()))
+        })?
+        .to_string();
 
-    // Verify dockerfile exists - it's resolved relative to the config folder (where devcontainer.json is)
-    // The context is used at build time as the Docker build context, but the Dockerfile path
-    // itself is relative to the devcontainer.json location
-    let dockerfile_path = config_folder.join(dockerfile);
-    if !dockerfile_path.exists() {
-        return Err(
-            DeaconError::Config(deacon_core::errors::ConfigError::NotFound {
-                path: dockerfile_path.to_string_lossy().to_string(),
-            })
-            .into(),
-        );
-    }
-
-    let mut build_config = BuildConfig {
-        dockerfile: dockerfile_path
-            .to_str()
-            .ok_or_else(|| {
-                DeaconError::Docker(DockerError::CLIError("Invalid dockerfile path".to_string()))
-            })?
-            .to_string(),
-        context: ".".to_string(),
-        context_folder: config_folder.clone(),
-        target: None,
-        options: HashMap::new(),
-    };
-
-    // Extract context
-    if let Some(context) = build_obj.get("context").and_then(|v| v.as_str()) {
-        build_config.context = context.to_string();
-    }
-
-    // Extract target
-    if let Some(target) = build_obj.get("target").and_then(|v| v.as_str()) {
-        build_config.target = Some(target.to_string());
-    }
-
-    // Extract build options/args
-    if let Some(options) = build_obj.get("options").and_then(|v| v.as_object()) {
-        for (key, value) in options {
-            let val_str = value
-                .as_str()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| value.to_string());
-            build_config.options.insert(key.clone(), val_str);
-        }
-    }
-
-    // Extract build args (upstream-compatible: build.args)
-    if let Some(args_obj) = build_obj.get("args").and_then(|v| v.as_object()) {
-        for (key, value) in args_obj {
-            let val_str = value
-                .as_str()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| value.to_string());
-            build_config.options.insert(key.clone(), val_str);
-        }
-    }
-
-    Ok(Some(build_config))
+    Ok(Some(BuildConfig {
+        dockerfile,
+        context: resolved.context,
+        context_folder: resolved.context_folder,
+        target: resolved.target,
+        options: resolved.options,
+    }))
 }
 
 /// Build Docker image from build configuration

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -460,9 +460,7 @@ pub(crate) async fn execute_up_with_runtime(
     // Build image from Dockerfile if needed (when no image specified but build object present)
     // T007: Pass build_options to apply cache-from/cache-to/buildx settings
     if config.image.is_none() && !config.uses_compose() {
-        if let Some(build_config) =
-            extract_build_config_from_devcontainer(&config, &workspace_folder)?
-        {
+        if let Some(build_config) = extract_build_config_from_devcontainer(&config, &config_path)? {
             info!("Building image from Dockerfile configuration");
             let built_image_id = build_image_from_config(&build_config, &build_options).await?;
 

--- a/crates/deacon/tests/integration_build.rs
+++ b/crates/deacon/tests/integration_build.rs
@@ -17,7 +17,13 @@ LABEL deacon.test=integration
 RUN echo "Building test image"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     // Create a devcontainer.json configuration
     let devcontainer_config = r#"{
@@ -32,7 +38,7 @@ RUN echo "Building test image"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -82,7 +88,7 @@ fn test_build_with_missing_dockerfile() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -112,7 +118,7 @@ fn test_build_with_image_config() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -152,7 +158,7 @@ fn test_build_with_image_config() {
 fn test_build_image_reference_with_features_tags_final_image() {
     let temp_dir = TempDir::new().unwrap();
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
 
     // Local feature (resolved relative to the config dir) that drops a marker
     // file during install.
@@ -232,7 +238,13 @@ fn test_build_command_flags() {
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Build Container",
@@ -240,7 +252,7 @@ fn test_build_command_flags() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -286,7 +298,13 @@ fn test_build_command_advanced_flags() {
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Build Container Advanced",
@@ -294,7 +312,7 @@ fn test_build_command_advanced_flags() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -359,7 +377,13 @@ LABEL test=cache_test
 RUN echo "Building with cache test"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     // Create a devcontainer.json configuration
     let devcontainer_config = r#"{
@@ -372,7 +396,7 @@ RUN echo "Building with cache test"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -471,7 +495,13 @@ LABEL test=force_test
 RUN echo "Testing force flag"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Force Test Container",
@@ -479,7 +509,7 @@ RUN echo "Testing force flag"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -552,7 +582,13 @@ fn test_build_with_non_affecting_file_changes() {
 RUN echo "Testing non-affecting changes"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Non-Affecting Changes Test",
@@ -560,7 +596,7 @@ RUN echo "Testing non-affecting changes"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -632,7 +668,13 @@ COPY main.py /app/
 RUN echo "Testing affecting changes"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Affecting Changes Test",
@@ -640,7 +682,7 @@ RUN echo "Testing affecting changes"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -709,7 +751,13 @@ RUN --mount=type=secret,id=mytoken \
     echo "Secret was accessed successfully"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     // Create a secret file
     let secret_file = temp_dir.path().join("token.txt");
@@ -725,7 +773,7 @@ RUN --mount=type=secret,id=mytoken \
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -786,7 +834,13 @@ RUN --mount=type=secret,id=envtoken \
     echo "Secret from env was mounted"
 "#;
 
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Env Secret Container",
@@ -797,7 +851,7 @@ RUN --mount=type=secret,id=envtoken \
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -838,7 +892,13 @@ RUN --mount=type=secret,id=envtoken \
 fn test_build_secret_validation_duplicate_id() {
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let secret_file = temp_dir.path().join("token.txt");
     fs::write(&secret_file, "secret1\n").unwrap();
@@ -849,7 +909,7 @@ fn test_build_secret_validation_duplicate_id() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -877,7 +937,13 @@ fn test_build_secret_validation_duplicate_id() {
 fn test_build_secret_validation_missing_file() {
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Missing Secret File",
@@ -885,7 +951,7 @@ fn test_build_secret_validation_missing_file() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -911,7 +977,13 @@ fn test_build_secret_validation_missing_file() {
 fn test_build_secret_requires_buildkit() {
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let secret_file = temp_dir.path().join("token.txt");
     fs::write(&secret_file, "secret\n").unwrap();
@@ -922,7 +994,7 @@ fn test_build_secret_requires_buildkit() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -951,7 +1023,13 @@ fn test_push_and_output_mutual_exclusivity() {
     // Create a temporary directory with a simple Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Mutual Exclusivity",
@@ -959,7 +1037,7 @@ fn test_push_and_output_mutual_exclusivity() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -987,7 +1065,13 @@ fn test_push_requires_buildkit() {
     // Create a temporary directory with a simple Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Push Requires BuildKit",
@@ -995,7 +1079,7 @@ fn test_push_requires_buildkit() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -1035,7 +1119,13 @@ fn test_output_requires_buildkit() {
     // Create a temporary directory with a simple Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Output Requires BuildKit",
@@ -1043,7 +1133,7 @@ fn test_output_requires_buildkit() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -1081,7 +1171,13 @@ fn test_platform_requires_buildkit() {
     // Create a temporary directory with a simple Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Platform Requires BuildKit",
@@ -1089,7 +1185,7 @@ fn test_platform_requires_buildkit() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -1135,7 +1231,13 @@ fn test_cache_to_requires_buildkit() {
     // Create a temporary directory with a simple Dockerfile
     let temp_dir = TempDir::new().unwrap();
     let dockerfile_content = "FROM alpine:3.19\nLABEL test=1\n";
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile resolves relative to the devcontainer.json location
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Test Cache-To Requires BuildKit",
@@ -1143,7 +1245,7 @@ fn test_cache_to_requires_buildkit() {
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,

--- a/crates/deacon/tests/integration_progress.rs
+++ b/crates/deacon/tests/integration_progress.rs
@@ -26,8 +26,9 @@ fn test_progress_json_output() {
     .unwrap();
 
     // Create a simple Dockerfile
+    // dockerFile resolves relative to the devcontainer.json location
     std::fs::write(
-        workspace_path.join("Dockerfile"),
+        devcontainer_dir.join("Dockerfile"),
         "FROM ubuntu:20.04\nRUN echo 'Hello from test build'\n",
     )
     .unwrap();

--- a/crates/deacon/tests/smoke_basic.rs
+++ b/crates/deacon/tests/smoke_basic.rs
@@ -46,14 +46,20 @@ fn smoke_build_json_then_text() {
 LABEL test=smoke
 RUN echo "Smoke test image"
 "#;
-    fs::write(tmp.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile is resolved relative to the devcontainer.json location, so the
+    // Dockerfile lives alongside the config under .devcontainer/.
+    fs::create_dir(tmp.path().join(".devcontainer")).unwrap();
+    fs::write(
+        tmp.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     let devcontainer_config = r#"{
     "name": "Smoke Build Test",
     "dockerFile": "Dockerfile"
 }
 "#;
-    fs::create_dir(tmp.path().join(".devcontainer")).unwrap();
     fs::write(
         tmp.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,
@@ -311,16 +317,22 @@ LABEL environment=$BUILD_ENV
 LABEL deacon.test=smoke
 RUN echo "Building with version: $BUILD_VERSION, env: $BUILD_ENV"
 "#;
-    fs::write(temp_dir.path().join("Dockerfile"), dockerfile_content).unwrap();
+    // dockerFile is resolved relative to the devcontainer.json location, so the
+    // Dockerfile lives alongside the config under .devcontainer/.
+    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(
+        temp_dir.path().join(".devcontainer/Dockerfile"),
+        dockerfile_content,
+    )
+    .unwrap();
 
     // Create devcontainer.json with dockerFile
     let devcontainer_config = r#"{
-    "name": "Build Args Test Container", 
+    "name": "Build Args Test Container",
     "dockerFile": "Dockerfile"
 }
 "#;
 
-    fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
     fs::write(
         temp_dir.path().join(".devcontainer/devcontainer.json"),
         devcontainer_config,


### PR DESCRIPTION
## Summary

Two related changes that were sitting uncommitted in the working tree, plus a small CI cleanup.

### 1. `appPort` array support (spec parity)
- New `AppPort` untagged enum (`Single(PortSpec)` | `Multiple(Vec<PortSpec>)`) replacing `app_port: Option<PortSpec>`. Per the containers.dev spec, `appPort` may be a single value **or** an array; previously only a scalar was accepted. Serialization round-trips the original shape.
- `ports.rs` and `config.rs` iterate `app_port.specs()` everywhere.
- `docker.rs` now publishes `appPort` (single or array) as docker `-p` bindings alongside `forwardPorts`, with publish-arg construction extracted into tested `port_spec_to_publish_arg` / `port_publish_args` helpers (ordering preserved: `forwardPorts` first, then `appPort`).

### 2. Shared build-config resolution (refactor)
- New `commands/shared/build_resolution.rs::resolve_devcontainer_build_config()` resolving `dockerFile` / `build.dockerfile` **relative to the config dir** (per the config-relative path rule).
- `build/mod.rs` and `up/image_build.rs` both call it instead of duplicating extraction; `up` now passes `config_path` rather than `workspace_folder`. Net reduction of duplicated logic.

### 3. CI cleanup
- Drops stale "MVP-only" comments from `release.yml` left over after the MVP/full feature gate was removed (#165).

## Testing
Local gate is green:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --doc --workspace` (130 passed)
- `cargo nextest run --profile dev-fast` (2455 passed, 31 skipped)
- `cargo deny check` (advisories/bans/licenses/sources ok)
- New unit tests for `AppPort` (de)serialization, port publish args, and build-config resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)