### PR TITLE
chore(release): prepare v0.2.0-rc.1 prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=${{ steps.get_version.outputs.version }}
+          # Mark prerelease tags (e.g. v0.2.0-rc.1) so they are not flagged as "latest".
+          PRERELEASE_FLAG=""
+          case "$VERSION" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           # Create release if it doesn't exist
           if ! gh release view "$VERSION" >/dev/null 2>&1; then
             # Use GitHub auto-generated notes for a descriptive changelog
-            gh release create "$VERSION" -t "Release $VERSION" --generate-notes --verify-tag
+            gh release create "$VERSION" -t "Release $VERSION" --generate-notes --verify-tag $PRERELEASE_FLAG
           fi
           # Upload rustc version provenance snippet
           gh release upload "$VERSION" RUSTC_VERSION.txt --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "deacon"
-version = "0.2.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.1" }
 clap = { version = "4.5", features = ["derive", "color"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0"
+version = "0.2.0-rc.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0"
+version = "0.2.0-rc.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
Prepares the `v0.2.0-rc.1` prerelease so the release pipeline produces binaries for all platforms.

- Bump `deacon`, `deacon-core`, and the workspace `deacon-core` path-dep pin to `0.2.0-rc.1` (plus `Cargo.lock`). The release workflow's `create-release` job hard-fails unless the pushed tag equals the crate version, so the crate must be `0.2.0-rc.1` for a `v0.2.0-rc.1` tag.
- `release.yml`: mark hyphenated (semver-prerelease) tags with `--prerelease` so RC releases are not flagged as GitHub's "latest" release. Detection is automatic (`case "$VERSION" in *-*)`), so future RCs work too.

## After merge
Push the tag to trigger the 8-platform build + checksums/SBOM/provenance:
```
git tag v0.2.0-rc.1 && git push origin v0.2.0-rc.1
```
The real `v0.2.0` tag remains free for the GA release later (bump back to `0.2.0`).

## Testing
- `cargo check --workspace --all-targets` ✅
- `cargo fmt --all -- --check` ✅
- `cargo deny check` ✅ (path-dep pin still non-wildcard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)