### PR TITLE
ci(release): auto-enable GitHub Pages in deploy step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,6 +454,10 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          # Auto-create the Pages site if it isn't enabled yet (uses the
+          # job's pages: write permission). Avoids 'Get Pages site failed'.
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
## Summary
The `v0.2.0-rc.1` release run failed only in the **Deploy Install Script to GitHub Pages** job:

> Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action.

GitHub Pages has never been enabled on this repo. This sets `enablement: true` on `actions/configure-pages@v4`, which creates the Pages site automatically using the job's existing `pages: write` permission — no manual repo settings required. Fixes the Pages job for the eventual `v0.2.0` GA release.

Note: this does not retroactively fix the `v0.2.0-rc.1` run (re-running a job uses the workflow at the tagged commit). All other rc.1 jobs — the 8-platform binaries, checksums, and SLSA provenance — succeeded and are published on the prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)