### PR TITLE
fix(user-mapping): don't chown the workspace to root (corrupts host repo)

### DIFF
--- a/crates/core/src/user_mapping.rs
+++ b/crates/core/src/user_mapping.rs
@@ -367,21 +367,36 @@ impl<T: UserMapper> UserMappingService<T> {
             result.home_created = true;
         }
 
-        // Set workspace ownership if specified
+        // Set workspace ownership if specified.
+        //
+        // Skip when the target user is root (uid 0): chowning the workspace to
+        // root is a no-op for access (root can already read/write everything)
+        // and, because the workspace is a bind mount of a host directory,
+        // `chown 0:0` inside the container rewrites the HOST directory's owner
+        // to root — corrupting the developer's workspace (e.g. `remoteUser:
+        // root` fixtures flipping the repo to root:root). Only adjust ownership
+        // for a real, non-root target user.
         if let Some(ref workspace_path) = config.workspace_path {
-            debug!(
-                "Setting workspace ownership: {} -> {}:{}",
-                workspace_path, result.user_info.uid, result.user_info.gid
-            );
-            self.user_mapper
-                .set_workspace_ownership(
-                    container_id,
-                    workspace_path,
-                    result.user_info.uid,
-                    result.user_info.gid,
-                )
-                .await?;
-            result.workspace_ownership_adjusted = true;
+            if result.user_info.uid == 0 {
+                debug!(
+                    "Skipping workspace ownership adjustment for {}: target user is root (uid 0)",
+                    workspace_path
+                );
+            } else {
+                debug!(
+                    "Setting workspace ownership: {} -> {}:{}",
+                    workspace_path, result.user_info.uid, result.user_info.gid
+                );
+                self.user_mapper
+                    .set_workspace_ownership(
+                        container_id,
+                        workspace_path,
+                        result.user_info.uid,
+                        result.user_info.gid,
+                    )
+                    .await?;
+                result.workspace_ownership_adjusted = true;
+            }
         }
 
         debug!(
@@ -1152,6 +1167,65 @@ mod tests {
         assert!(!result.home_created);
         assert!(!result.workspace_ownership_adjusted);
         assert_eq!(result.user_info.username, "root");
+    }
+
+    #[tokio::test]
+    async fn test_workspace_ownership_skipped_for_root() {
+        // remoteUser: root resolves to uid 0. The workspace must NOT be chowned:
+        // on a bind mount, `chown 0:0 <workspace>` rewrites the host directory
+        // to root:root (e.g. flipping the repo workspace to root ownership).
+        let root_user = UserInfo::new(
+            "root".to_string(),
+            0,
+            0,
+            "/root".to_string(),
+            "/bin/bash".to_string(),
+        );
+        let mapper = MockUserMapper::new().with_user(root_user);
+        let service = UserMappingService::new(mapper);
+
+        let config = UserMappingConfig::new(Some("root".to_string()), None, false)
+            .with_workspace_path("/workspace".to_string());
+
+        let result = service
+            .apply_user_mapping("container123", &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.user_info.uid, 0);
+        assert!(
+            !result.workspace_ownership_adjusted,
+            "workspace ownership must not be adjusted for a root target user"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_ownership_adjusted_for_nonroot() {
+        // A real, non-root remote user still gets the workspace ownership
+        // adjustment (the legitimate use case the guard preserves).
+        let dev_user = UserInfo::new(
+            "devuser".to_string(),
+            1000,
+            1000,
+            "/home/devuser".to_string(),
+            "/bin/bash".to_string(),
+        );
+        let mapper = MockUserMapper::new().with_user(dev_user);
+        let service = UserMappingService::new(mapper);
+
+        let config = UserMappingConfig::new(Some("devuser".to_string()), None, false)
+            .with_workspace_path("/workspace".to_string());
+
+        let result = service
+            .apply_user_mapping("container123", &config)
+            .await
+            .unwrap();
+
+        assert_eq!(result.user_info.uid, 1000);
+        assert!(
+            result.workspace_ownership_adjusted,
+            "workspace ownership should be adjusted for a non-root target user"
+        );
     }
 
     #[tokio::test]

--- a/crates/deacon/tests/up_dotfiles.rs
+++ b/crates/deacon/tests/up_dotfiles.rs
@@ -51,28 +51,49 @@ fn can_run_dotfiles_tests() -> bool {
     is_docker_available() && is_network_available()
 }
 
-/// Helper to get the fixture path for feature-and-dotfiles
-fn feature_dotfiles_fixture() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+/// Copy a `fixtures/devcontainer-up/<name>` fixture into a fresh TempDir.
+///
+/// These tests run a real `deacon up`. If the workspace folder lived inside
+/// this repo, `up` would walk to the git root and bind-mount `/workspaces/...`
+/// into the container — container-side writes (and historically a `chown` for
+/// `remoteUser: root`) would then corrupt the host repo's ownership. Running
+/// from a TempDir outside the repo keeps the workspace fully hermetic.
+fn copy_fixture_to_temp(name: &str) -> tempfile::TempDir {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
         .join("fixtures")
         .join("devcontainer-up")
-        .join("feature-and-dotfiles")
+        .join(name);
+    let temp = tempfile::TempDir::new().unwrap();
+    copy_dir_contents(&src, temp.path());
+    temp
 }
 
-/// Helper to get the single-container fixture path
-fn single_container_fixture() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("fixtures")
-        .join("devcontainer-up")
-        .join("single-container")
+/// Recursively copy the contents of `src` into `dest`.
+fn copy_dir_contents(src: &std::path::Path, dest: &std::path::Path) {
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let target = dest.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            std::fs::create_dir_all(&target).unwrap();
+            copy_dir_contents(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+/// Helper to get a hermetic (TempDir-backed) feature-and-dotfiles fixture.
+fn feature_dotfiles_fixture() -> tempfile::TempDir {
+    copy_fixture_to_temp("feature-and-dotfiles")
+}
+
+/// Helper to get a hermetic (TempDir-backed) single-container fixture.
+fn single_container_fixture() -> tempfile::TempDir {
+    copy_fixture_to_temp("single-container")
 }
 
 #[test]
@@ -88,17 +109,11 @@ fn test_dotfiles_installation_with_custom_command() {
     // Verify that dotfiles are cloned and custom install command is executed
     // Uses fixture with features to ensure dotfiles run in correct lifecycle order
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
-
-    // Clean up any existing state to ensure fresh lifecycle execution
-    // The workspace resolves to the git root, so clean markers there
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let git_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let state_dir = git_root.join(".devcontainer-state");
-    if state_dir.exists() {
-        let _ = std::fs::remove_dir_all(&state_dir);
-    }
+    // The TempDir workspace is always fresh, so no pre-existing lifecycle
+    // markers need clearing.
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
     cmd.arg("up")
@@ -131,7 +146,8 @@ fn test_dotfiles_idempotency_on_rerun() {
     // Verify that running up again with same dotfiles config does not fail
     // Even if dotfiles target directory already exists from previous run
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     // First run: install dotfiles
@@ -179,7 +195,8 @@ fn test_dotfiles_auto_detected_install_script() {
     // Verify that install script is auto-detected when no custom command provided
     // Should detect and run install.sh or setup.sh from dotfiles repo
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -210,7 +227,8 @@ fn test_dotfiles_custom_target_path() {
     // Verify that --dotfiles-target-path is respected
     // Dotfiles should be cloned to specified path instead of default
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -245,7 +263,8 @@ fn test_dotfiles_invalid_repository_error() {
 
     // Verify that invalid dotfiles repository URL produces clear error JSON
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -279,7 +298,8 @@ fn test_dotfiles_install_script_failure_error() {
     // Verify that dotfiles install script failure produces error JSON
     // Uses custom install command that intentionally fails
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -312,7 +332,8 @@ fn test_dotfiles_without_features() {
     // Verify dotfiles work on simple fixture without features
     // Ensures dotfiles module is not dependent on features module
 
-    let fixture_path = single_container_fixture();
+    let _fixture = single_container_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -344,7 +365,8 @@ fn test_dotfiles_with_prebuild_mode() {
     // Dotfiles should NOT be installed during prebuild (CI image creation)
     // Only features and updateContent run in prebuild
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();

--- a/crates/deacon/tests/up_prebuild.rs
+++ b/crates/deacon/tests/up_prebuild.rs
@@ -25,16 +25,44 @@ fn is_docker_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Helper to get the fixture path for feature-and-dotfiles
-fn feature_dotfiles_fixture() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+/// Copy a `fixtures/devcontainer-up/<name>` fixture into a fresh TempDir.
+///
+/// These tests run a real `deacon up`. If the workspace folder lived inside
+/// this repo, `up` would walk to the git root and bind-mount `/workspaces/...`
+/// into the container — container-side writes (and historically a `chown` for
+/// `remoteUser: root`) would then corrupt the host repo's ownership. Running
+/// from a TempDir outside the repo keeps the workspace fully hermetic.
+fn copy_fixture_to_temp(name: &str) -> tempfile::TempDir {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
         .parent()
         .unwrap()
         .join("fixtures")
         .join("devcontainer-up")
-        .join("feature-and-dotfiles")
+        .join(name);
+    let temp = tempfile::TempDir::new().unwrap();
+    copy_dir_contents(&src, temp.path());
+    temp
+}
+
+/// Recursively copy the contents of `src` into `dest`.
+fn copy_dir_contents(src: &std::path::Path, dest: &std::path::Path) {
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let target = dest.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            std::fs::create_dir_all(&target).unwrap();
+            copy_dir_contents(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), &target).unwrap();
+        }
+    }
+}
+
+/// Helper to get a hermetic (TempDir-backed) feature-and-dotfiles fixture.
+fn feature_dotfiles_fixture() -> tempfile::TempDir {
+    copy_fixture_to_temp("feature-and-dotfiles")
 }
 
 #[test]
@@ -50,7 +78,8 @@ fn test_prebuild_stops_after_update_content() {
     // 3. Stops execution (does NOT run postCreateCommand)
     // 4. Emits success JSON with containerId
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
 
     let config_path = fixture_path.join("devcontainer.json");
 
@@ -84,7 +113,8 @@ fn test_prebuild_rerun_executes_update_content_again() {
     // 2. DOES rerun updateContentCommand
     // 3. Still stops before postCreate
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     // First prebuild run
@@ -125,7 +155,8 @@ fn test_prebuild_does_not_run_post_create() {
 
     // This test verifies lifecycle boundary: prebuild must NOT run postCreateCommand
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -157,7 +188,8 @@ fn test_prebuild_skip_post_attach_honored() {
     // Verify that prebuild implies skip-post-attach behavior
     // (postAttach should never run during prebuild, even if specified)
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -185,7 +217,8 @@ fn test_prebuild_with_features_metadata_merge() {
     // Verify that features are installed and metadata is merged before updateContent
     // in prebuild mode, and that the merged config includes feature metadata
 
-    let fixture_path = feature_dotfiles_fixture();
+    let _fixture = feature_dotfiles_fixture();
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();
@@ -216,14 +249,8 @@ fn test_prebuild_without_update_content_command() {
     // does not define updateContentCommand (no-op lifecycle hook)
 
     // Use single-container fixture which has no updateContentCommand
-    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("fixtures")
-        .join("devcontainer-up")
-        .join("single-container");
+    let _fixture = copy_fixture_to_temp("single-container");
+    let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
     let mut cmd = Command::cargo_bin("deacon").unwrap();


### PR DESCRIPTION
## Problem
Running the test suite kept flipping `/workspaces/deacon` to `root:root` ownership, and it came back after every fix.

## Root cause
`deacon up` bind-mounts the host workspace into the container. Per the git-root mount default, an in-repo workspace folder resolves to the **git root** (`/workspaces/deacon`), so the whole repo gets mounted. Then `user_mapping::set_workspace_ownership` runs `chown <uid>:<gid> <workspaceFolder>` **as root inside the container** whenever a `remoteUser` is set (`needs_user_mapping()` = `remote_user.is_some()`). The `feature-and-dotfiles` / `single-container` fixtures set `"remoteUser": "root"`, so it did `chown 0:0 /workspace` — which, on a bind mount, rewrites the **host** repo dir to `root:root`. The `up_prebuild` tests run for real in the docker integration job, so it recurred every run.

## Fix (two layers)
1. **Production guard** (`crates/core/src/user_mapping.rs`): skip the workspace ownership adjustment when the target user is **root (uid 0)** — chowning to root is pointless (root already has full access) and actively corrupts host ownership on bind mounts. Non-root users still get the adjustment. Adds `test_workspace_ownership_skipped_for_root` and `test_workspace_ownership_adjusted_for_nonroot`. This protects real users and canaries, not just tests.
2. **Hermetic tests** (`up_prebuild.rs`, `up_dotfiles.rs`): copy fixtures into a `TempDir` outside the repo and run `up` there, so the git root is never mounted regardless. Drops the now-obsolete git-root `.devcontainer-state` cleanup.

`integration_up_with_features.rs` already passed `--mount-workspace-git-root=false`; no other in-repo `up` tests were unguarded.

## Verification
- `cargo test -p deacon-core --lib user_mapping` — 17 passed (incl. both new tests).
- `cargo nextest run -E 'binary(=up_prebuild)'` — 8 passed; **no root-owned artifacts created** in `/tmp` or the repo during the run (TempDirs were created and cleaned by the unprivileged test user, proving no chown fired).
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

Note: the repo dir is currently still `root:root` from earlier (pre-fix) runs; a one-time `sudo chown -R vscode:vscode /workspaces/deacon` is needed, after which it will stay correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)