### PR TITLE
fix(install): strip macOS quarantine in the curl installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -230,6 +230,26 @@ extract_archive() {
     esac
 }
 
+# Strip macOS quarantine so Gatekeeper doesn't block an unsigned binary.
+#
+# Browser/Finder downloads tag files with com.apple.quarantine, which makes
+# Gatekeeper refuse to run an un-notarized binary ("Apple could not verify
+# 'deacon' is free of malware"). curl/wget downloads are NOT quarantined, so
+# for a piped install this is usually a no-op — but it's cheap insurance and
+# covers binaries that arrived via a quarantining path.
+strip_quarantine() {
+    local path="$1"
+    local os="$2"
+
+    [[ "$os" == "macos" ]] || return 0
+    has_cmd xattr || return 0
+
+    if xattr -p com.apple.quarantine "$path" >/dev/null 2>&1; then
+        xattr -d com.apple.quarantine "$path" 2>/dev/null || true
+        info "Removed macOS quarantine attribute"
+    fi
+}
+
 # Get default installation directory
 get_default_install_dir() {
     # Prefer ~/.local/bin if it exists or can be created
@@ -365,6 +385,7 @@ main() {
     info "Installing binary to: $binary_path"
     cp "$src_binary" "$binary_path"
     chmod +x "$binary_path"
+    strip_quarantine "$binary_path" "$os"
 
     echo ""
     success "Deacon $version has been installed successfully!"


### PR DESCRIPTION
## Problem
Mac users who install a release see: *"Apple could not verify 'deacon' is free of malware that may harm your Mac or compromise your privacy."* Our release binaries are unsigned/un-notarized, so macOS **Gatekeeper** blocks them whenever they carry the `com.apple.quarantine` attribute (set by browser/Finder downloads).

## Fix (curl-installer side)
`install.sh` now removes `com.apple.quarantine` from the installed binary on macOS (after `chmod +x`).

- `curl`/`wget` downloads are **not** quarantined, so for the piped `curl … | bash` flow this is usually a no-op — it's belt-and-suspenders that also covers binaries that arrived via a quarantining path.
- Double-guarded: runs only when `os == macos` **and** `xattr` exists, so Linux/Windows installs are unaffected.
- The `deploy-pages` job copies `scripts/install.sh` verbatim, so this ships with the next release.

Validated with `bash -n`. Function is a no-op on this Linux box (no `xattr`).

## Not included (follow-ups, by design)
- This does **not** help users who download the archive in a browser and double-click it — only true notarization (Apple Developer ID, $99/yr) removes the prompt for that path.
- The hosted installer still needs a release to run for the Pages site to go live (the `enablement:true` fix is on `main` but no release has run since).
- Optional: add the `xattr -d com.apple.quarantine ./deacon` one-liner to the release-notes "Install" section / README for manual-download users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)