### PR TITLE
feat(up): add --auto-forward dynamic user-space port forwarding

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -71,6 +71,14 @@ filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=r
 test-group = 'docker-exclusive'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
+# integration_auto_forward binds real host ports (static `-p` and the user-space
+# forwarder's loopback listeners), so it must NOT run concurrently with other
+# port-publishing docker tests — serialize it (docker-exclusive). Per T033.
+[[profile.default.overrides]]
+filter = 'binary(=integration_auto_forward)'
+test-group = 'docker-exclusive'
+slow-timeout = { period = "10m", terminate-after = 1 }
+
 # Build consistency tests use Docker buildx and can conflict with parallel builds
 [[profile.default.overrides]]
 filter = 'binary(=build_consistency)'
@@ -149,7 +157,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_auto_forward))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -169,6 +177,11 @@ test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path)'
+test-group = 'docker-exclusive'
+
+# integration_auto_forward binds real host ports — serialize it (see default profile).
+[[profile.dev-fast.overrides]]
+filter = 'binary(=integration_auto_forward)'
 test-group = 'docker-exclusive'
 
 # Build consistency tests use Docker buildx and can conflict with parallel builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,8 @@ RUST_LOG=debug cargo run -- up --container-data-folder /tmp/cache
 - Rust 1.70+ (Edition 2021) + okio (async runtime, JoinSet for parallel), serde/serde_json (JSON parsing), indexmap (ordered maps for object format), clap (CLI), tracing (logging) (012-fix-lifecycle-formats)
 - Rust 1.70+ (Edition 2021) + serde, tracing, thiserror, clap (existing — no new dependencies) (014-named-config-search)
 - N/A (filesystem-only config discovery) (014-named-config-search)
+- Rust, Edition 2024, MSRV 1.95 (`workspace.package` in root `Cargo.toml`); `unsafe_code = "deny"` workspace-wide. + `tokio` (rt/process/fs/io-util/net), `clap` (CLI), `serde`/`serde_json` (registry + marker JSON), `tracing` (daemon logging), `thiserror` (core domain errors), `anyhow` (binary boundary), `directories-next` (user-data folder), `libc` (already in core). **New (Unix-only):** `nix` (features `process`, `signal` — safe `setsid()`, `kill()`, `Pid`, process-liveness checks without raw `unsafe`); `fs2` (advisory `flock` on the registry, auto-released on process death). (015-auto-forward-ports)
+- Two host-side JSON files under the user-data folder (default `~/.deacon/`): a host-global `forwarded_ports.json` registry and per-container `forward_daemon_<container_id>.pid` markers; per-container `forward_daemon_<container_id>.log` log files. All writes use the temp-file + `fs::rename` atomic pattern (`crates/core/src/cache/disk.rs::save_index`). (015-auto-forward-ports)
 
 ## Recent Changes
 - 009-complete-feature-support: Added Rust 1.70+ (Edition 2021) + clap, serde, tokio, reqwest (rustls TLS), tracing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,11 +702,13 @@ dependencies = [
  "chrono",
  "directories-next",
  "fastrand",
+ "fs2",
  "futures",
  "indexmap 2.14.0",
  "jsonc-parser",
  "libc",
  "linked-hash-map",
+ "nix",
  "num_cpus",
  "once_cell",
  "postcard",
@@ -973,6 +975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1714,6 +1726,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,18 @@ shell-words = "1.1"
 # drift. tokio carries the union of the features each crate needs.
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "process", "macros", "fs", "io-std", "io-util"] }
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "process", "macros", "fs", "io-std", "io-util", "net", "signal", "time"] }
 futures = "0.3"
 tar = "0.4"
 sha2 = "0.10"
 regex = "1.10"
 zip = "2.4"
+# Unix-only safe syscall wrappers (setsid/kill/Pid) so the detached forwarder
+# daemon avoids raw `unsafe` under the workspace `unsafe_code = "deny"` policy.
+nix = { version = "0.29", features = ["process", "signal", "fs"] }
+# Advisory file locking (flock) for the host-global port registry's
+# allocate-and-bind critical section; auto-released on holder death.
+fs2 = "0.4"
 # Shared dev-dependencies.
 tempfile = "3.12"
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,35 @@ Verify installation:
 deacon --version
 ```
 
+## Auto-forward ports (`up --auto-forward`)
+
+A deacon extension (modeled on VS Code Dev Containers) that dynamically forwards
+container TCP ports to **loopback** host ports — including `127.0.0.1`-bound
+servers that static `-p` publishing cannot reach.
+
+```bash
+# Start the container and a detached forwarder, then return to the shell.
+deacon up --auto-forward
+#   stderr: Forwarding container 3000 -> http://127.0.0.1:3000 (web)
+curl http://127.0.0.1:3000        # reaches a loopback-only server in the container
+
+# Ports that start later (entrypoint / postStart / exec) are auto-detected
+# within ~1-2s; no extra flags needed. Multiple devcontainers get collision-free
+# host ports (the actual port is always reported, e.g. "(remapped; host 3000 in use)").
+
+deacon down                        # reaps the forwarder and releases its host ports
+```
+
+How it works: the forwarder polls the container's listening sockets and relays
+bytes via `docker exec` into the container's network namespace. Declared ports
+(`forwardPorts`/`appPort`/`--forward-port`) forward eagerly and are not also
+`-p` published; `portsAttributes.onAutoForward` (`ignore`/`silent`/`notify`) is
+honored; compose `"service:port"` declared ports are forwarded too.
+
+**Limits (v1):** loopback-only (never `0.0.0.0`/LAN), TCP only, Unix hosts only,
+and best-effort — if forwarding can't start you get a clear warning but `up`
+still succeeds. Forwarder logs: `~/.deacon/forward_daemon_<container_id>.log`.
+
 ## Shipped Commands
 
 | Command | Description |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,6 +86,37 @@ disk, never a partial one.
 This trust check is **deacon-specific**: the upstream
 [containers.dev spec](https://containers.dev) does not mandate it.
 
+## Dynamic port forwarding (`up --auto-forward`)
+
+`up --auto-forward` (a deacon extension; see
+`docs/subcommand-specs/up/SPEC.md` §2.1) introduces two new host-side
+surfaces, both opt-in behind the flag:
+
+- **A persistent host process** — a detached forwarder
+  (`__forward-daemon`) survives `up` and runs until the container is torn
+  down or vanishes. It is single-owner per container (pid marker), reaped
+  on `down`/replace, and self-exits when its container is gone, so it does
+  not silently accumulate. Its only privileged action is `docker exec`
+  into the user's own container — the same capability the `exec`
+  subcommand already exposes — to read `/proc/net/tcp{,6}` and run a relay
+  program. It never executes workspace-sourced host shell, so it is not a
+  new host-trust vector.
+- **Bound host ports** — for each forward the daemon binds a TCP listener.
+  These binds are **always `127.0.0.1` (loopback) only** — never
+  `0.0.0.0`/LAN — so forwarded container services are reachable only from
+  the local host, not the network. Privileged container ports (<1024)
+  always remap to an unprivileged host port, so the forwarder never needs
+  host root. Allocations are recorded in a host-global
+  `{user_data_folder}/forwarded_ports.json` registry written atomically
+  under an advisory file lock; every host port is unique file-wide.
+
+Mitigations: loopback-only binds, no host root, `docker exec` is standard
+consumer behavior, and the whole feature is off unless `--auto-forward` is
+passed. LAN/`0.0.0.0` exposure is explicitly out of scope for v1 and would
+require a separate, documented opt-in. Reviewers evaluating whether
+forwarding warrants opt-in beyond the flag itself should weigh that it
+only ever exposes the user's own container to the user's own loopback.
+
 ## Security-relevant CI gates
 
 - `cargo-deny` (advisories + bans + licenses + sources) runs on every PR

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,9 +45,13 @@ bytesize = "2.0.1"
 semver = "1.0"
 blake3 = "1"
 futures = "0.3"
+# Advisory file locking for the host-global port-forward registry (cross-platform API).
+fs2.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+# Safe wrappers for setsid/kill/Pid used by the Unix forwarder daemon.
+nix.workspace = true
 
 [dev-dependencies]
 tempfile = "3.12"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod oci;
 pub mod outdated;
 pub mod platform;
 pub mod plugins;
+pub mod port_forward;
 pub mod ports;
 pub mod progress;
 pub mod redaction;

--- a/crates/core/src/port_forward/daemon.rs
+++ b/crates/core/src/port_forward/daemon.rs
@@ -1,0 +1,714 @@
+//! The detached forwarder supervisor loop.
+//!
+//! [`run`] is the entrypoint of the re-exec'd `__forward-daemon` process. It
+//! eager-binds declared ports, polls the container's listening sockets (~1 s),
+//! reconciles detected-vs-active forwards, writes the [`DaemonMarker`], and
+//! self-exits when its container vanishes.
+//!
+//! Process detachment / signaling helpers ([`daemonize`], [`pid_alive`],
+//! [`terminate_pid`]) wrap `nix` safe syscalls on Unix; on other platforms the
+//! forwarder is unsupported and these return a clear error (Principle IV).
+//!
+//! [`DaemonMarker`]: crate::port_forward::DaemonMarker
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+use super::{
+    DaemonMarker, DetectedPort, ForwardOrigin, ForwardSpec, PortForwardError,
+    ResolvedPortAttributes, Result, detect, log_path, marker_path, registry, relay,
+};
+use crate::config::{ConfigLoader, DevContainerConfig, OnAutoForward, PortAttributes};
+use crate::docker::{CliRuntime, Docker, ExecConfig};
+use crate::ports::PortEvent;
+
+/// Fixed detection poll interval (FR-004). Not configurable in v1.
+pub const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1000);
+
+/// Default in-container dial host for the relay (the container's own loopback).
+pub const DEFAULT_DIAL_HOST: &str = "127.0.0.1";
+
+/// Configuration handed to the detached forwarder process.
+#[derive(Debug, Clone)]
+pub struct DaemonConfig {
+    /// Full id of the container to forward.
+    pub container_id: String,
+    /// Canonical workspace path of the owning devcontainer.
+    pub workspace: PathBuf,
+    /// User-data folder for registry/marker/log (default `~/.deacon`).
+    pub user_data_folder: Option<PathBuf>,
+    /// Raw declared-port specs (`PORT`, `HOST:CONTAINER`, `service:port`).
+    pub declared_ports: Vec<String>,
+    /// Path to the resolved devcontainer.json (for portsAttributes).
+    pub config_path: Option<PathBuf>,
+    /// Emit machine-readable `PORT_EVENT:` lines.
+    pub ports_events: bool,
+    /// Docker CLI path used for `exec`/`inspect`.
+    pub docker_path: String,
+}
+
+// ---------------------------------------------------------------------------
+// Process detachment / signaling (Unix)
+// ---------------------------------------------------------------------------
+
+/// Detach the current process from its controlling terminal and redirect the
+/// standard fds onto the per-container log file.
+///
+/// Calls `setsid()` (new session — a closing terminal's SIGHUP no longer kills
+/// us) then `dup2`s stdin from `/dev/null` and stdout/stderr onto `log`. Safe
+/// `nix` wrappers keep this `unsafe`-free.
+#[cfg(unix)]
+pub fn daemonize(log_path: &Path) -> Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| PortForwardError::io(format!("create log dir {}", parent.display()), e))?;
+    }
+
+    // New session: detach from the controlling terminal. Fails with EPERM only
+    // if we are already a process-group leader (we are not — we were just
+    // spawned), so a failure here is non-fatal for detachment purposes.
+    let _ = nix::unistd::setsid();
+
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .map_err(|e| PortForwardError::io(format!("open log {}", log_path.display()), e))?;
+    let devnull = std::fs::OpenOptions::new()
+        .read(true)
+        .open("/dev/null")
+        .map_err(|e| PortForwardError::io("open /dev/null", e))?;
+
+    let dup = |old: i32, new: i32, what: &str| -> Result<()> {
+        nix::unistd::dup2(old, new)
+            .map(|_| ())
+            .map_err(|e| PortForwardError::io(format!("dup2 {what}"), std::io::Error::from(e)))
+    };
+    dup(devnull.as_raw_fd(), 0, "stdin")?;
+    dup(log.as_raw_fd(), 1, "stdout")?;
+    dup(log.as_raw_fd(), 2, "stderr")?;
+    Ok(())
+}
+
+/// Non-Unix builds do not support the detached forwarder (v1 is Unix-only).
+#[cfg(not(unix))]
+pub fn daemonize(_log_path: &Path) -> Result<()> {
+    Err(PortForwardError::Docker {
+        context: "daemonize".to_string(),
+        message: "port forwarding is not supported on this platform (Unix-only in v1)".to_string(),
+    })
+}
+
+/// Whether a process id is currently alive (`kill(pid, 0)` semantics).
+#[cfg(unix)]
+pub fn pid_alive(pid: u32) -> bool {
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    // Signal `None` performs error checking without actually sending a signal.
+    // Ok(()) ⇒ alive; ESRCH ⇒ gone; EPERM ⇒ exists but not ours (still alive).
+    match kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        Err(nix::errno::Errno::EPERM) => true,
+        Err(_) => false,
+    }
+}
+
+/// Non-Unix: liveness checks are unsupported; treat as not-alive.
+#[cfg(not(unix))]
+pub fn pid_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Send `SIGTERM` to a forwarder process so it can run its own cleanup.
+#[cfg(unix)]
+pub fn terminate_pid(pid: u32) -> Result<()> {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+    match kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+        Ok(()) => Ok(()),
+        // Already gone — nothing to do.
+        Err(nix::errno::Errno::ESRCH) => Ok(()),
+        Err(e) => Err(PortForwardError::io(
+            "kill SIGTERM",
+            std::io::Error::from(e),
+        )),
+    }
+}
+
+/// Non-Unix: signaling is unsupported.
+#[cfg(not(unix))]
+pub fn terminate_pid(_pid: u32) -> Result<()> {
+    Err(PortForwardError::Docker {
+        context: "terminate_pid".to_string(),
+        message: "port forwarding is not supported on this platform (Unix-only in v1)".to_string(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Supervisor loop
+// ---------------------------------------------------------------------------
+
+/// A forward that currently has a host listener bound and a relay task running.
+struct ActiveForward {
+    spec: ForwardSpec,
+    host_port: u16,
+    task: tokio::task::JoinHandle<()>,
+}
+
+/// Build the `ExecConfig` used for silent probe execs.
+fn silent_exec() -> ExecConfig {
+    ExecConfig {
+        user: None,
+        working_dir: None,
+        env: HashMap::new(),
+        tty: false,
+        interactive: false,
+        detach: false,
+        silent: true,
+        stdout_to_stderr: false,
+        terminal_size: None,
+    }
+}
+
+/// Run the forwarder supervisor loop until the container vanishes or `SIGTERM`.
+///
+/// Eager-binds declared ports, polls listening sockets every [`POLL_INTERVAL`],
+/// reconciles auto-detected ports, and cleans up (releases ports + removes the
+/// marker) on exit (FR-002, FR-004, FR-015, FR-024).
+pub async fn run(config: DaemonConfig) -> Result<()> {
+    let udf = config.user_data_folder.as_deref();
+    let runtime = CliRuntime::with_runtime_path(config.docker_path.clone());
+
+    // Resolve port attributes from the devcontainer config (best-effort).
+    let cfg = load_config(config.config_path.as_deref()).await;
+
+    // Parse declared port specs (eager forwards).
+    let declared: Vec<ForwardSpec> = config
+        .declared_ports
+        .iter()
+        .filter_map(|s| parse_declared_spec(s, cfg.as_ref()))
+        .collect();
+    let declared_ports: HashSet<u16> = declared.iter().map(|s| s.container_port).collect();
+
+    // Determine the relay strategy up front; fail fast & loud if none (FR-019).
+    let relay_program = detect_relay_program(&runtime, &config.container_id).await?;
+
+    // Record the marker only once we know we can forward.
+    write_marker(&config)?;
+    info!(
+        container_id = %config.container_id,
+        relay = ?relay_program,
+        declared = declared.len(),
+        "forwarder ready"
+    );
+
+    let mut active: HashMap<u16, ActiveForward> = HashMap::new();
+
+    // Eager-bind declared ports (Reserved → Active once the container listens).
+    for spec in &declared {
+        if spec.attributes.on_auto_forward == OnAutoForward::Ignore {
+            continue;
+        }
+        match start_forward(spec.clone(), relay_program, &config).await {
+            Ok(af) => {
+                active.insert(spec.container_port, af);
+            }
+            Err(e) => warn!(port = spec.container_port, error = %e, "failed to bind declared port"),
+        }
+    }
+
+    // Reconcile loop with SIGTERM handling.
+    #[cfg(unix)]
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .map_err(|e| PortForwardError::io("install SIGTERM handler", e))?;
+
+    loop {
+        #[cfg(unix)]
+        {
+            tokio::select! {
+                _ = sigterm.recv() => {
+                    info!("forwarder received SIGTERM; shutting down");
+                    break;
+                }
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
+        }
+        #[cfg(not(unix))]
+        tokio::time::sleep(POLL_INTERVAL).await;
+
+        // Self-exit when the container is gone (FR-015).
+        match runtime.inspect_container(&config.container_id).await {
+            Ok(None) => {
+                info!("container gone; forwarder self-exiting");
+                break;
+            }
+            Ok(Some(_)) => {}
+            // Transient inspect failure — keep going rather than tearing down.
+            Err(e) => {
+                warn!(error = %e, "inspect failed; continuing");
+                continue;
+            }
+        }
+
+        let detected = match probe_ports(&runtime, &config.container_id).await {
+            Ok(d) => d,
+            Err(e) => {
+                warn!(error = %e, "port probe failed; continuing");
+                continue;
+            }
+        };
+
+        reconcile(
+            &mut active,
+            &detected,
+            &declared_ports,
+            cfg.as_ref(),
+            relay_program,
+            &config,
+        )
+        .await;
+    }
+
+    // Cleanup: abort relays, release this container's ports, remove the marker.
+    for (_, af) in active.drain() {
+        af.task.abort();
+    }
+    if let Err(e) = registry::release_container(udf, &config.container_id) {
+        warn!(error = %e, "failed to release registry entries on exit");
+    }
+    if let Err(e) = remove_marker(&config) {
+        warn!(error = %e, "failed to remove marker on exit");
+    }
+    Ok(())
+}
+
+/// Reconcile detected-vs-active forwards: lazily bind newly-observed undeclared
+/// ports; withdraw auto-detected forwards whose container port stopped
+/// listening (FR-004, FR-024). Declared ports stay reserved regardless.
+async fn reconcile(
+    active: &mut HashMap<u16, ActiveForward>,
+    detected: &[DetectedPort],
+    declared_ports: &HashSet<u16>,
+    cfg: Option<&DevContainerConfig>,
+    relay_program: relay::RelayProgram,
+    config: &DaemonConfig,
+) {
+    let detected_ports: HashSet<u16> = detected.iter().map(|d| d.port).collect();
+
+    // Add newly-observed undeclared ports.
+    for d in detected {
+        if active.contains_key(&d.port) || declared_ports.contains(&d.port) {
+            continue;
+        }
+        let attributes = resolve_attributes(cfg, d.port);
+        if attributes.on_auto_forward == OnAutoForward::Ignore {
+            continue;
+        }
+        let spec = ForwardSpec {
+            container_port: d.port,
+            origin: ForwardOrigin::AutoDetected,
+            service: None,
+            attributes,
+            eager: false,
+        };
+        match start_forward(spec, relay_program, config).await {
+            Ok(af) => {
+                active.insert(d.port, af);
+            }
+            Err(e) => warn!(port = d.port, error = %e, "failed to forward detected port"),
+        }
+    }
+
+    // Withdraw auto-detected forwards whose container port stopped listening.
+    let stale: Vec<u16> = active
+        .iter()
+        .filter(|(port, af)| {
+            af.spec.origin == ForwardOrigin::AutoDetected && !detected_ports.contains(port)
+        })
+        .map(|(port, _)| *port)
+        .collect();
+    for port in stale {
+        if let Some(af) = active.remove(&port) {
+            af.task.abort();
+            let udf = config.user_data_folder.as_deref();
+            if let Err(e) = registry::release_port(udf, af.host_port) {
+                warn!(error = %e, "failed to release withdrawn port");
+            }
+            report_unforward(&af, config.ports_events);
+        }
+    }
+}
+
+/// Allocate + bind a host port, start the relay task, and report the mapping.
+async fn start_forward(
+    spec: ForwardSpec,
+    relay_program: relay::RelayProgram,
+    config: &DaemonConfig,
+) -> Result<ActiveForward> {
+    let udf = config.user_data_folder.as_deref();
+    let workspace = config.workspace.display().to_string();
+    let alloc = registry::allocate(
+        udf,
+        &config.container_id,
+        spec.container_port,
+        &workspace,
+        spec.attributes.label.as_deref(),
+    )?;
+
+    alloc
+        .listener
+        .set_nonblocking(true)
+        .map_err(|e| PortForwardError::io("set listener nonblocking", e))?;
+    let listener = tokio::net::TcpListener::from_std(alloc.listener)
+        .map_err(|e| PortForwardError::io("convert listener to tokio", e))?;
+
+    let dial_host = spec
+        .service
+        .clone()
+        .unwrap_or_else(|| DEFAULT_DIAL_HOST.to_string());
+    let relay_argv = relay::relay_args(relay_program, &dial_host, spec.container_port);
+
+    let task = tokio::spawn(relay::serve(
+        listener,
+        config.docker_path.clone(),
+        config.container_id.clone(),
+        relay_argv,
+    ));
+
+    report_forward(&spec, alloc.host_port, alloc.remapped, config.ports_events);
+
+    Ok(ActiveForward {
+        spec,
+        host_port: alloc.host_port,
+        task,
+    })
+}
+
+/// Probe `/proc/net/tcp{,6}` inside the container and parse listening ports.
+async fn probe_ports(runtime: &CliRuntime, container_id: &str) -> Result<Vec<DetectedPort>> {
+    let cmd = [
+        "cat".to_string(),
+        "/proc/net/tcp".to_string(),
+        "/proc/net/tcp6".to_string(),
+    ];
+    // A missing /proc/net/tcp6 makes `cat` exit non-zero but still prints tcp;
+    // parse whatever stdout we captured rather than failing the whole probe.
+    let res = runtime
+        .exec(container_id, &cmd, silent_exec())
+        .await
+        .map_err(|e| PortForwardError::Docker {
+            context: "probe /proc/net/tcp".to_string(),
+            message: e.to_string(),
+        })?;
+    Ok(detect::parse_proc_net_tcp(&res.stdout))
+}
+
+/// Detect the best available in-container relay program (FR-019).
+async fn detect_relay_program(
+    runtime: &CliRuntime,
+    container_id: &str,
+) -> Result<relay::RelayProgram> {
+    let cmd = [
+        "sh".to_string(),
+        "-c".to_string(),
+        relay::probe_script().to_string(),
+    ];
+    let res = runtime
+        .exec(container_id, &cmd, silent_exec())
+        .await
+        .map_err(|e| PortForwardError::Docker {
+            context: "probe relay program".to_string(),
+            message: e.to_string(),
+        })?;
+    relay::select_relay_from_probe(&res.stdout)
+        .ok_or_else(|| relay::no_relay_strategy(container_id))
+}
+
+/// Load the devcontainer config for port attributes (best-effort).
+async fn load_config(config_path: Option<&Path>) -> Option<DevContainerConfig> {
+    let path = config_path?;
+    match ConfigLoader::load_with_extends(path).await {
+        Ok(cfg) => Some(cfg),
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "failed to load config for port attributes");
+            None
+        }
+    }
+}
+
+/// Parse a declared port spec (`PORT`, `HOST:CONTAINER`, or `service:port`).
+fn parse_declared_spec(spec: &str, cfg: Option<&DevContainerConfig>) -> Option<ForwardSpec> {
+    let (service, container_port) = match spec.rsplit_once(':') {
+        Some((lhs, rhs)) => {
+            let port = rhs.parse::<u16>().ok()?;
+            if lhs.is_empty() || lhs.parse::<u16>().is_ok() {
+                // "PORT:" or "HOST:CONTAINER" — forward the container port.
+                (None, port)
+            } else {
+                // "service:port" — compose service-qualified.
+                (Some(lhs.to_string()), port)
+            }
+        }
+        None => (None, spec.parse::<u16>().ok()?),
+    };
+    let attributes = resolve_attributes(cfg, container_port);
+    Some(ForwardSpec {
+        container_port,
+        origin: ForwardOrigin::Declared,
+        service,
+        attributes,
+        eager: true,
+    })
+}
+
+/// Resolve effective attributes: `portsAttributes[port]` else
+/// `otherPortsAttributes` else implicit `Notify` (FR-017).
+fn resolve_attributes(cfg: Option<&DevContainerConfig>, port: u16) -> ResolvedPortAttributes {
+    let Some(cfg) = cfg else {
+        return ResolvedPortAttributes::default();
+    };
+    let key_plain = port.to_string();
+    let key_tcp = format!("{port}/tcp");
+    if let Some(pa) = cfg
+        .ports_attributes
+        .get(&key_plain)
+        .or_else(|| cfg.ports_attributes.get(&key_tcp))
+    {
+        return to_resolved(pa);
+    }
+    if let Some(other) = &cfg.other_ports_attributes {
+        return to_resolved(other);
+    }
+    ResolvedPortAttributes::default()
+}
+
+/// Convert a [`PortAttributes`] into [`ResolvedPortAttributes`], collapsing
+/// `openBrowser`/`openPreview` to `Notify` for v1 (auto-open is deferred).
+fn to_resolved(pa: &PortAttributes) -> ResolvedPortAttributes {
+    let on_auto_forward = match pa.on_auto_forward {
+        Some(OnAutoForward::Ignore) => OnAutoForward::Ignore,
+        Some(OnAutoForward::Silent) => OnAutoForward::Silent,
+        _ => OnAutoForward::Notify,
+    };
+    ResolvedPortAttributes {
+        label: pa.label.clone(),
+        on_auto_forward,
+    }
+}
+
+/// Print the human-readable forward mapping to stderr (unless `silent`) and,
+/// when `--ports-events` is set, emit a `PORT_EVENT:` line (FR-010, FR-020).
+fn report_forward(spec: &ForwardSpec, host_port: u16, remapped: bool, ports_events: bool) {
+    if spec.attributes.on_auto_forward != OnAutoForward::Silent {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(label) = &spec.attributes.label {
+            parts.push(label.clone());
+        }
+        if remapped {
+            if spec.container_port < 1024 {
+                parts.push("remapped; privileged port".to_string());
+            } else {
+                parts.push(format!("remapped; host {} in use", spec.container_port));
+            }
+        }
+        let suffix = if parts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", parts.join("; "))
+        };
+        eprintln!(
+            "Forwarding container {} -> http://127.0.0.1:{}{}",
+            spec.container_port, host_port, suffix
+        );
+    }
+    if ports_events {
+        emit_port_event(&port_event(spec, Some(host_port), true));
+    }
+}
+
+/// Report a withdrawn forward (FR-004, FR-020).
+fn report_unforward(af: &ActiveForward, ports_events: bool) {
+    if af.spec.attributes.on_auto_forward != OnAutoForward::Silent {
+        eprintln!(
+            "Unforwarded container {} (server stopped)",
+            af.spec.container_port
+        );
+    }
+    if ports_events {
+        emit_port_event(&port_event(&af.spec, Some(af.host_port), false));
+    }
+}
+
+/// Build a [`PortEvent`] for a forward/unforward transition.
+fn port_event(spec: &ForwardSpec, host_port: Option<u16>, forwarded: bool) -> PortEvent {
+    PortEvent {
+        port: spec.container_port,
+        protocol: None,
+        label: spec.attributes.label.clone(),
+        on_auto_forward: Some(spec.attributes.on_auto_forward.clone()),
+        auto_forwarded: forwarded,
+        local_port: host_port,
+        host_ip: Some(DEFAULT_DIAL_HOST.to_string()),
+        description: None,
+        open_preview: None,
+        require_local_port: None,
+        elevate_if_needed: None,
+    }
+}
+
+/// Emit a `PORT_EVENT:` line to stdout (the daemon's stdout is its log file).
+fn emit_port_event(event: &PortEvent) {
+    match serde_json::to_string(event) {
+        Ok(json) => println!("PORT_EVENT: {json}"),
+        Err(e) => warn!(error = %e, "failed to serialize port event"),
+    }
+}
+
+/// Write the per-container marker atomically (temp file + rename).
+fn write_marker(config: &DaemonConfig) -> Result<()> {
+    let udf = config.user_data_folder.as_deref();
+    let path = marker_path(udf, &config.container_id)?;
+    let log = log_path(udf, &config.container_id)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            PortForwardError::io(format!("create marker dir {}", parent.display()), e)
+        })?;
+    }
+    let marker = DaemonMarker {
+        pid: std::process::id(),
+        container_id: config.container_id.clone(),
+        workspace: config.workspace.display().to_string(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+        log_path: log.display().to_string(),
+    };
+    let content =
+        serde_json::to_string_pretty(&marker).map_err(|e| PortForwardError::serde("marker", e))?;
+    let tmp = path.with_extension(format!("pid.tmp.{}", std::process::id()));
+    std::fs::write(&tmp, content)
+        .map_err(|e| PortForwardError::io(format!("write marker temp {}", tmp.display()), e))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| PortForwardError::io(format!("publish marker {}", path.display()), e))?;
+    Ok(())
+}
+
+/// Remove the per-container marker (idempotent).
+fn remove_marker(config: &DaemonConfig) -> Result<()> {
+    let path = marker_path(config.user_data_folder.as_deref(), &config.container_id)?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(PortForwardError::io(
+            format!("remove marker {}", path.display()),
+            e,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PortAttributes;
+
+    fn attrs(label: Option<&str>, oaf: OnAutoForward) -> PortAttributes {
+        PortAttributes {
+            label: label.map(str::to_string),
+            on_auto_forward: Some(oaf),
+            protocol: None,
+            open_preview: None,
+            require_local_port: None,
+            elevate_if_needed: None,
+            description: None,
+        }
+    }
+
+    fn config_with_attrs(
+        ports: Vec<(&str, OnAutoForward)>,
+        other: Option<OnAutoForward>,
+    ) -> DevContainerConfig {
+        let mut cfg = DevContainerConfig::default();
+        for (key, oaf) in ports {
+            cfg.ports_attributes
+                .insert(key.to_string(), attrs(Some(&format!("label-{key}")), oaf));
+        }
+        cfg.other_ports_attributes = other.map(|oaf| attrs(None, oaf));
+        cfg
+    }
+
+    #[test]
+    fn declared_port_uses_ports_attributes() {
+        let cfg = config_with_attrs(vec![("3000", OnAutoForward::Silent)], None);
+        let attrs = resolve_attributes(Some(&cfg), 3000);
+        assert_eq!(attrs.on_auto_forward, OnAutoForward::Silent);
+        assert_eq!(attrs.label.as_deref(), Some("label-3000"));
+    }
+
+    #[test]
+    fn ports_attributes_key_with_protocol_suffix_matches() {
+        let cfg = config_with_attrs(vec![("8080/tcp", OnAutoForward::Ignore)], None);
+        let attrs = resolve_attributes(Some(&cfg), 8080);
+        assert_eq!(attrs.on_auto_forward, OnAutoForward::Ignore);
+    }
+
+    #[test]
+    fn undeclared_falls_back_to_other_ports_attributes_then_notify() {
+        let cfg = config_with_attrs(vec![], Some(OnAutoForward::Silent));
+        assert_eq!(
+            resolve_attributes(Some(&cfg), 9999).on_auto_forward,
+            OnAutoForward::Silent
+        );
+        // No other_ports_attributes ⇒ implicit Notify.
+        let cfg2 = config_with_attrs(vec![], None);
+        assert_eq!(
+            resolve_attributes(Some(&cfg2), 9999).on_auto_forward,
+            OnAutoForward::Notify
+        );
+        // No config at all ⇒ Notify.
+        assert_eq!(
+            resolve_attributes(None, 9999).on_auto_forward,
+            OnAutoForward::Notify
+        );
+    }
+
+    #[test]
+    fn open_browser_preview_collapse_to_notify() {
+        let cfg = config_with_attrs(vec![("3000", OnAutoForward::OpenBrowser)], None);
+        assert_eq!(
+            resolve_attributes(Some(&cfg), 3000).on_auto_forward,
+            OnAutoForward::Notify
+        );
+    }
+
+    #[test]
+    fn parse_declared_specs_plain_host_and_service() {
+        // Plain port.
+        let s = parse_declared_spec("3000", None).unwrap();
+        assert_eq!(s.container_port, 3000);
+        assert_eq!(s.service, None);
+        assert_eq!(s.origin, ForwardOrigin::Declared);
+        assert!(s.eager);
+
+        // HOST:CONTAINER → forward the container port, no service.
+        let s = parse_declared_spec("8080:80", None).unwrap();
+        assert_eq!(s.container_port, 80);
+        assert_eq!(s.service, None);
+
+        // service:port → compose service-qualified.
+        let s = parse_declared_spec("db:5432", None).unwrap();
+        assert_eq!(s.container_port, 5432);
+        assert_eq!(s.service.as_deref(), Some("db"));
+
+        // Garbage → None.
+        assert!(parse_declared_spec("not-a-port", None).is_none());
+    }
+
+    #[test]
+    fn ignore_attribute_is_preserved_for_skipping() {
+        let cfg = config_with_attrs(vec![("3000", OnAutoForward::Ignore)], None);
+        let spec = parse_declared_spec("3000", Some(&cfg)).unwrap();
+        assert_eq!(spec.attributes.on_auto_forward, OnAutoForward::Ignore);
+    }
+}

--- a/crates/core/src/port_forward/detect.rs
+++ b/crates/core/src/port_forward/detect.rs
@@ -1,0 +1,187 @@
+//! Pure parsing of `/proc/net/tcp{,6}` LISTEN rows into [`DetectedPort`]s.
+//!
+//! The forwarder polls the container's listening sockets by `cat`-ing
+//! `/proc/net/tcp` and `/proc/net/tcp6` over `docker exec` and feeding the
+//! concatenated text to [`parse_proc_net_tcp`]. This module is pure (no IO)
+//! and fully unit-testable with fixtures.
+//!
+//! Format reference: Linux kernel `Documentation/networking/proc_net_tcp.txt`.
+//! Each data row's whitespace-separated fields are `sl local_address
+//! rem_address st …`. `local_address` is `HEXIP:HEXPORT`; `st == 0A` is
+//! `TCP_LISTEN`. The IP is little-endian hex; the port is plain hex.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use super::{BindScope, DetectedPort, IpFamily};
+
+/// `TCP_LISTEN` state value in `/proc/net/tcp{,6}`.
+const ST_LISTEN: &str = "0A";
+
+/// Parse concatenated `/proc/net/tcp` + `/proc/net/tcp6` text into the set of
+/// distinct listening ports.
+///
+/// Only `st == 0A` (LISTEN) rows bound to loopback or any-interface are kept.
+/// A port listening on both IPv4 and IPv6 collapses to a single logical entry
+/// (FR-003); the first occurrence wins, but an any-interface bind upgrades a
+/// previously-seen loopback bind so the broader scope is reported.
+pub fn parse_proc_net_tcp(text: &str) -> Vec<DetectedPort> {
+    let mut out: Vec<DetectedPort> = Vec::new();
+
+    for line in text.lines() {
+        let Some(detected) = parse_row(line) else {
+            continue;
+        };
+        if let Some(existing) = out.iter_mut().find(|d| d.port == detected.port) {
+            // Dedup by logical port; widen scope to AnyInterface if either bind
+            // is any-interface (informational).
+            if detected.bind_addr == BindScope::AnyInterface {
+                existing.bind_addr = BindScope::AnyInterface;
+            }
+        } else {
+            out.push(detected);
+        }
+    }
+
+    out
+}
+
+/// Parse a single data row. Returns `None` for headers, malformed rows,
+/// non-LISTEN sockets, or binds outside loopback/any-interface.
+fn parse_row(line: &str) -> Option<DetectedPort> {
+    let mut fields = line.split_whitespace();
+    // fields[0] = "sl:" (slot, with trailing colon) — header row has "sl".
+    let _slot = fields.next()?;
+    let local_address = fields.next()?;
+    let _rem_address = fields.next()?;
+    let st = fields.next()?;
+
+    if st != ST_LISTEN {
+        return None;
+    }
+
+    let (ip_hex, port_hex) = local_address.split_once(':')?;
+    let port = u16::from_str_radix(port_hex, 16).ok()?;
+    if port == 0 {
+        return None;
+    }
+
+    let (ip, family) = match ip_hex.len() {
+        8 => (IpAddr::V4(parse_v4(ip_hex)?), IpFamily::V4),
+        32 => (IpAddr::V6(parse_v6(ip_hex)?), IpFamily::V6),
+        _ => return None,
+    };
+
+    let bind_addr = if ip.is_loopback() {
+        BindScope::Loopback
+    } else if ip.is_unspecified() {
+        BindScope::AnyInterface
+    } else {
+        // Bound to a specific external interface — not forwarded in v1.
+        return None;
+    };
+
+    Some(DetectedPort {
+        port,
+        bind_addr,
+        family,
+    })
+}
+
+/// Decode an 8-hex-char little-endian IPv4 address (`0100007F` → `127.0.0.1`).
+fn parse_v4(hex: &str) -> Option<Ipv4Addr> {
+    let v = u32::from_str_radix(hex, 16).ok()?;
+    Some(Ipv4Addr::from(v.to_le_bytes()))
+}
+
+/// Decode a 32-hex-char IPv6 address stored as four per-word little-endian
+/// 32-bit groups (`…01000000` → `::1`).
+fn parse_v6(hex: &str) -> Option<Ipv6Addr> {
+    if hex.len() != 32 {
+        return None;
+    }
+    let mut bytes = [0u8; 16];
+    for i in 0..4 {
+        let word = u32::from_str_radix(&hex[i * 8..i * 8 + 8], 16).ok()?;
+        bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
+    }
+    Some(Ipv6Addr::from(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Header + one loopback LISTEN (127.0.0.1:8080) + one any LISTEN
+    // (0.0.0.0:5001) + one ESTABLISHED row (st=01) that must be ignored.
+    const TCP_V4: &str = "\
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 111 1 0 100 0 0 10 0
+   1: 00000000:1389 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 222 1 0 100 0 0 10 0
+   2: 0100007F:C5BA 0100007F:1F90 01 00000000:00000000 00:00000000 00000000  1000        0 333 1 0 100 0 0 10 0
+";
+
+    // ::1:8080 (dedups with the v4 8080) + :::5900 (any, 0x170C = 5900).
+    const TCP_V6: &str = "\
+  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000001000000:1F90 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  1000 0 444 1 0 100 0 0 10 0
+   1: 00000000000000000000000000000000:170C 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0 0 555 1 0 100 0 0 10 0
+";
+
+    #[test]
+    fn parses_v4_loopback_little_endian() {
+        let ports = parse_proc_net_tcp(TCP_V4);
+        let p = ports.iter().find(|d| d.port == 8080).unwrap();
+        assert_eq!(p.bind_addr, BindScope::Loopback);
+        assert_eq!(p.family, IpFamily::V4);
+    }
+
+    #[test]
+    fn parses_v4_any_interface() {
+        let ports = parse_proc_net_tcp(TCP_V4);
+        let p = ports.iter().find(|d| d.port == 5001).unwrap();
+        assert_eq!(p.bind_addr, BindScope::AnyInterface);
+    }
+
+    #[test]
+    fn ignores_non_listen_rows() {
+        let ports = parse_proc_net_tcp(TCP_V4);
+        // The ESTABLISHED row's local port 0xC5BA = 50618 must not appear.
+        assert!(ports.iter().all(|d| d.port != 0xC5BA));
+        assert_eq!(ports.len(), 2);
+    }
+
+    #[test]
+    fn parses_v6_loopback_and_any() {
+        let ports = parse_proc_net_tcp(TCP_V6);
+        // ::1:8080
+        assert!(
+            ports
+                .iter()
+                .any(|d| d.port == 8080 && d.bind_addr == BindScope::Loopback)
+        );
+        // :::5900
+        assert!(
+            ports
+                .iter()
+                .any(|d| d.port == 5900 && d.bind_addr == BindScope::AnyInterface)
+        );
+    }
+
+    #[test]
+    fn dedups_v4_and_v6_same_port() {
+        let combined = format!("{TCP_V4}{TCP_V6}");
+        let ports = parse_proc_net_tcp(&combined);
+        // Port 8080 listed on both v4 and v6 collapses to one entry.
+        assert_eq!(ports.iter().filter(|d| d.port == 8080).count(), 1);
+        // Distinct ports: 8080, 5001, 5900.
+        let mut nums: Vec<u16> = ports.iter().map(|d| d.port).collect();
+        nums.sort_unstable();
+        assert_eq!(nums, vec![5001, 5900, 8080]);
+    }
+
+    #[test]
+    fn empty_input_yields_nothing() {
+        assert!(parse_proc_net_tcp("").is_empty());
+        assert!(parse_proc_net_tcp("garbage line without enough fields").is_empty());
+    }
+}

--- a/crates/core/src/port_forward/mod.rs
+++ b/crates/core/src/port_forward/mod.rs
@@ -1,0 +1,317 @@
+//! Dynamic, user-space port forwarding for `deacon up --auto-forward`.
+//!
+//! A detached forwarder process polls a running container's TCP LISTEN sockets
+//! (`/proc/net/tcp{,6}` via `docker exec`) and, for each detected or declared
+//! port, opens a `127.0.0.1:<host-port>` listener on the host that relays bytes
+//! into the container's network namespace over `docker exec -i`. This reaches
+//! `127.0.0.1`-bound container servers that static `-p` publishing cannot.
+//!
+//! This is a **deacon consumer extension** — it is not mandated by the upstream
+//! containers.dev spec, but reuses its vocabulary (`portsAttributes`,
+//! `forwardPorts`, `appPort`, compose `"service:port"`). TCP-only, loopback-only,
+//! Unix-only in v1.
+//!
+//! Module layout (Principle V — modular boundaries):
+//! - [`detect`]: pure `/proc/net/tcp{,6}` parser.
+//! - [`registry`]: host-global host-port allocation registry (flock + atomic write).
+//! - [`relay`]: per-connection byte relay over `docker exec -i`.
+//! - [`daemon`]: the detached supervisor loop.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::OnAutoForward;
+
+pub mod daemon;
+pub mod detect;
+pub mod registry;
+pub mod relay;
+
+/// Errors raised by the port-forwarding subsystem.
+#[derive(thiserror::Error, Debug)]
+pub enum PortForwardError {
+    /// An IO error with human context (file path / operation).
+    #[error("port-forward IO error ({context}): {source}")]
+    Io {
+        context: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// JSON (de)serialization error for the registry / marker files.
+    #[error("port-forward JSON error ({context}): {source}")]
+    Serde {
+        context: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The user's home directory could not be resolved and no
+    /// `--user-data-folder` was supplied.
+    #[error("could not determine user home directory for the port-forward registry")]
+    HomeDirUnavailable,
+
+    /// No usable relay program is available inside the container.
+    #[error(
+        "no port-forward relay strategy available in container {container_id}: \
+         need one of an embedded relay, socat, nc, or bash /dev/tcp"
+    )]
+    NoRelayStrategy { container_id: String },
+
+    /// A `docker` invocation (probe / relay / inspect) failed.
+    #[error("docker error ({context}): {message}")]
+    Docker { context: String, message: String },
+}
+
+impl PortForwardError {
+    /// Helper: build an [`PortForwardError::Io`] with context.
+    pub fn io(context: impl Into<String>, source: std::io::Error) -> Self {
+        PortForwardError::Io {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Helper: build a [`PortForwardError::Serde`] with context.
+    pub fn serde(context: impl Into<String>, source: serde_json::Error) -> Self {
+        PortForwardError::Serde {
+            context: context.into(),
+            source,
+        }
+    }
+}
+
+/// Result alias for the port-forwarding subsystem.
+pub type Result<T> = std::result::Result<T, PortForwardError>;
+
+/// The interface a LISTEN socket is bound to inside the container.
+///
+/// Informational only — both loopback and any-interface binds are forwarded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindScope {
+    /// `127.0.0.1` / `::1`.
+    Loopback,
+    /// `0.0.0.0` / `::`.
+    AnyInterface,
+}
+
+/// Address family of a detected socket. Used only for v4/v6 dedup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpFamily {
+    /// IPv4.
+    V4,
+    /// IPv6.
+    V6,
+}
+
+/// One LISTEN socket observed inside the container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DetectedPort {
+    /// Container-side listening port.
+    pub port: u16,
+    /// Interface scope of the bind (informational).
+    pub bind_addr: BindScope,
+    /// Address family (for dedup).
+    pub family: IpFamily,
+}
+
+/// Where a forward intent originated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForwardOrigin {
+    /// From `forwardPorts` / `appPort` / `--forward-port` — bound eagerly.
+    Declared,
+    /// Observed listening at runtime — bound lazily on first observation.
+    AutoDetected,
+}
+
+/// Effective per-port forwarding preferences (subset of `PortAttributes`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedPortAttributes {
+    /// Human label for reporting.
+    pub label: Option<String>,
+    /// `ignore` / `silent` / `notify` (v1); `openBrowser`/`openPreview`
+    /// are accepted but treated as `notify`.
+    pub on_auto_forward: OnAutoForward,
+}
+
+impl Default for ResolvedPortAttributes {
+    fn default() -> Self {
+        ResolvedPortAttributes {
+            label: None,
+            on_auto_forward: OnAutoForward::Notify,
+        }
+    }
+}
+
+/// The reconciled decision that a container port should be forwarded.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForwardSpec {
+    /// Source port inside the container.
+    pub container_port: u16,
+    /// Declared vs auto-detected.
+    pub origin: ForwardOrigin,
+    /// For compose `"service:port"` declared ports; `None` = primary service.
+    pub service: Option<String>,
+    /// Effective `portsAttributes[port]` / `otherPortsAttributes` default.
+    pub attributes: ResolvedPortAttributes,
+    /// `true` for declared (bind host listener at startup), `false` for
+    /// auto-detected (bind on first observation).
+    pub eager: bool,
+}
+
+/// One row in the host-global allocation registry.
+///
+/// **This JSON shape is a binding contract** (`contracts/registry.schema.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    /// Allocated loopback host port (always >= 1024). Unique across the file.
+    pub host_port: u16,
+    /// Full id of the owning container.
+    pub container_id: String,
+    /// Source TCP port inside the container.
+    pub container_port: u16,
+    /// Canonical workspace path of the owning devcontainer.
+    pub workspace: String,
+    /// Process id of the owning forwarder (for stale-pruning).
+    pub pid: u32,
+    /// Effective port label from `portsAttributes`, if any.
+    pub label: Option<String>,
+}
+
+/// Single-owner record proving a live forwarder exists for a container.
+///
+/// **Binding contract** (`contracts/marker.schema.json`). Despite the `.pid`
+/// filename suffix it holds this JSON object, not a bare pid integer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonMarker {
+    /// Forwarder process id.
+    pub pid: u32,
+    /// The container this forwarder owns.
+    pub container_id: String,
+    /// Canonical workspace path.
+    pub workspace: String,
+    /// RFC3339 timestamp the forwarder started (diagnostics only).
+    pub started_at: String,
+    /// Absolute path to this forwarder's per-container log file.
+    pub log_path: String,
+}
+
+/// Resolve the user-data folder base directory.
+///
+/// Mirrors `trust.rs::trust_store_path`: `--user-data-folder` if supplied,
+/// else `~/.deacon`.
+fn user_data_base(user_data_folder: Option<&Path>) -> Result<PathBuf> {
+    match user_data_folder {
+        Some(p) => Ok(p.to_path_buf()),
+        None => {
+            let dirs =
+                directories_next::BaseDirs::new().ok_or(PortForwardError::HomeDirUnavailable)?;
+            Ok(dirs.home_dir().join(".deacon"))
+        }
+    }
+}
+
+/// Path to the host-global registry file `{user_data_folder}/forwarded_ports.json`.
+pub fn registry_path(user_data_folder: Option<&Path>) -> Result<PathBuf> {
+    Ok(user_data_base(user_data_folder)?.join("forwarded_ports.json"))
+}
+
+/// Path to a container's marker file
+/// `{user_data_folder}/forward_daemon_<container_id>.pid`.
+pub fn marker_path(user_data_folder: Option<&Path>, container_id: &str) -> Result<PathBuf> {
+    Ok(user_data_base(user_data_folder)?.join(format!("forward_daemon_{container_id}.pid")))
+}
+
+/// Path to a container's forwarder log file
+/// `{user_data_folder}/forward_daemon_<container_id>.log`.
+pub fn log_path(user_data_folder: Option<&Path>, container_id: &str) -> Result<PathBuf> {
+    Ok(user_data_base(user_data_folder)?.join(format!("forward_daemon_{container_id}.log")))
+}
+
+/// Reap a container's forwarder: `SIGTERM` the marked pid (so it runs its own
+/// cleanup), then force-remove the marker and release its registry entries.
+///
+/// Idempotent and best-effort — used by `down` (FR-013) and by
+/// `up --remove-existing-container` (FR-014). A missing marker is a no-op.
+pub fn reap(user_data_folder: Option<&Path>, container_id: &str) -> Result<()> {
+    let marker = marker_path(user_data_folder, container_id)?;
+    let had_marker = marker.exists();
+    if had_marker {
+        if let Ok(text) = std::fs::read_to_string(&marker) {
+            if let Ok(m) = serde_json::from_str::<DaemonMarker>(&text) {
+                // SIGTERM lets the daemon release ports + remove its own marker.
+                let _ = daemon::terminate_pid(m.pid);
+            }
+        }
+        // Force-remove the marker regardless (belt-and-suspenders).
+        let _ = std::fs::remove_file(&marker);
+    }
+
+    // Only touch the registry when there's something to clean — a marker
+    // existed, or a registry file is present. This keeps a normal `down`
+    // (auto-forward never used) from creating the registry/lock files.
+    if had_marker || registry_path(user_data_folder)?.exists() {
+        registry::release_container(user_data_folder, container_id)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_use_override_folder() {
+        let base = Path::new("/tmp/custom-deacon");
+        assert_eq!(
+            registry_path(Some(base)).unwrap(),
+            base.join("forwarded_ports.json")
+        );
+        assert_eq!(
+            marker_path(Some(base), "abc123").unwrap(),
+            base.join("forward_daemon_abc123.pid")
+        );
+        assert_eq!(
+            log_path(Some(base), "abc123").unwrap(),
+            base.join("forward_daemon_abc123.log")
+        );
+    }
+
+    #[test]
+    fn registry_entry_round_trips() {
+        let entry = RegistryEntry {
+            host_port: 3001,
+            container_id: "abc123".to_string(),
+            container_port: 3000,
+            workspace: "/home/dev/app".to_string(),
+            pid: 4242,
+            label: Some("web".to_string()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let back: RegistryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(entry, back);
+        // null label round-trips as None.
+        assert!(json.contains("\"label\":\"web\""));
+        let no_label = RegistryEntry {
+            label: None,
+            ..entry
+        };
+        let json = serde_json::to_string(&no_label).unwrap();
+        assert!(json.contains("\"label\":null"));
+    }
+
+    #[test]
+    fn marker_round_trips() {
+        let marker = DaemonMarker {
+            pid: 4242,
+            container_id: "abc123".to_string(),
+            workspace: "/home/dev/app".to_string(),
+            started_at: "2026-06-08T14:03:22Z".to_string(),
+            log_path: "/home/dev/.deacon/forward_daemon_abc123.log".to_string(),
+        };
+        let json = serde_json::to_string(&marker).unwrap();
+        let back: DaemonMarker = serde_json::from_str(&json).unwrap();
+        assert_eq!(marker, back);
+    }
+}

--- a/crates/core/src/port_forward/registry.rs
+++ b/crates/core/src/port_forward/registry.rs
@@ -1,0 +1,342 @@
+//! Host-global host-port allocation registry (`forwarded_ports.json`).
+//!
+//! Allocations live in `{user_data_folder}/forwarded_ports.json`, shared by
+//! every forwarder on the host. The allocate-and-bind critical section is
+//! serialized with an advisory `fs2` `flock` on a sibling lock file, and
+//! writes use the atomic temp-file + `fs::rename` pattern (mirrors
+//! `cache/disk.rs::save_index`). Every `host_port` is unique file-wide
+//! (FR-008 / SC-004).
+
+use std::fs::File;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use super::daemon::pid_alive;
+use super::{PortForwardError, RegistryEntry, Result, registry_path};
+
+/// Lowest unprivileged host port we will allocate (never require host root).
+const MIN_HOST_PORT: u16 = 1024;
+
+/// On-disk shape of `forwarded_ports.json` (binding contract —
+/// `contracts/registry.schema.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegistryFile {
+    version: u32,
+    entries: Vec<RegistryEntry>,
+}
+
+impl Default for RegistryFile {
+    fn default() -> Self {
+        RegistryFile {
+            version: 1,
+            entries: Vec::new(),
+        }
+    }
+}
+
+/// The result of allocating (and binding) a host port for a forward.
+#[derive(Debug)]
+pub struct Allocation {
+    /// The allocated loopback host port (always >= 1024).
+    pub host_port: u16,
+    /// `true` if `host_port != container_port` (drives the remap report).
+    pub remapped: bool,
+    /// The reserved listener, already bound to `127.0.0.1:host_port`.
+    pub listener: TcpListener,
+}
+
+/// Acquire the advisory lock guarding the allocate-and-bind critical section.
+///
+/// The lock auto-releases when `lock` is dropped (or the process dies), which
+/// is the crash-safety the multi-container requirement needs.
+fn lock(user_data_folder: Option<&Path>) -> Result<File> {
+    let reg = registry_path(user_data_folder)?;
+    if let Some(parent) = reg.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            PortForwardError::io(format!("create registry dir {}", parent.display()), e)
+        })?;
+    }
+    let lock_path = reg.with_extension("lock");
+    let file = File::create(&lock_path)
+        .map_err(|e| PortForwardError::io(format!("create lock {}", lock_path.display()), e))?;
+    FileExt::lock_exclusive(&file).map_err(|e| PortForwardError::io("acquire registry lock", e))?;
+    Ok(file)
+}
+
+/// Load the registry file (empty default when absent).
+fn load(user_data_folder: Option<&Path>) -> Result<RegistryFile> {
+    let path = registry_path(user_data_folder)?;
+    match std::fs::read_to_string(&path) {
+        Ok(text) => serde_json::from_str(&text)
+            .map_err(|e| PortForwardError::serde(format!("parse {}", path.display()), e)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(RegistryFile::default()),
+        Err(e) => Err(PortForwardError::io(format!("read {}", path.display()), e)),
+    }
+}
+
+/// Atomically persist the registry (temp file + `fs::rename`).
+fn save(user_data_folder: Option<&Path>, registry: &RegistryFile) -> Result<()> {
+    let path = registry_path(user_data_folder)?;
+    let dir = path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+    let content = serde_json::to_string_pretty(registry)
+        .map_err(|e| PortForwardError::serde("serialize registry", e))?;
+
+    // Unique temp name (pid + counter) so concurrent writers don't clobber each
+    // other's staging file before the rename.
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = dir.join(format!(
+        "forwarded_ports.json.tmp.{}.{}",
+        std::process::id(),
+        seq
+    ));
+    std::fs::write(&tmp, content)
+        .map_err(|e| PortForwardError::io(format!("write temp {}", tmp.display()), e))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| PortForwardError::io(format!("publish {}", path.display()), e))?;
+    Ok(())
+}
+
+/// Remove entries whose owning forwarder process is dead (FR-016).
+///
+/// Returns `true` if any entry was removed. Container-existence pruning is the
+/// daemon's responsibility (it has the Docker handle); here we prune by pid so
+/// a crashed forwarder's ports become reusable host-wide.
+fn prune_dead(registry: &mut RegistryFile) -> bool {
+    let before = registry.entries.len();
+    registry.entries.retain(|e| pid_alive(e.pid));
+    registry.entries.len() != before
+}
+
+/// Try to reserve `port` on loopback: fail if already in the registry or not
+/// bindable. On success returns the held listener.
+fn try_reserve(registry: &RegistryFile, port: u16) -> Option<TcpListener> {
+    if registry.entries.iter().any(|e| e.host_port == port) {
+        return None;
+    }
+    TcpListener::bind(("127.0.0.1", port)).ok()
+}
+
+/// Allocate (and bind) a collision-free loopback host port for a forward.
+///
+/// Prefers the same number as `container_port` when free in both the registry
+/// and an actual bind probe; otherwise the next free port. Privileged
+/// container ports (<1024) always remap to >= 1024 (FR-009a). The whole
+/// allocate-and-bind sequence runs under the advisory lock so concurrent
+/// forwarders never collide (FR-008, FR-011).
+pub fn allocate(
+    user_data_folder: Option<&Path>,
+    container_id: &str,
+    container_port: u16,
+    workspace: &str,
+    label: Option<&str>,
+) -> Result<Allocation> {
+    let _guard = lock(user_data_folder)?;
+    let mut registry = load(user_data_folder)?;
+    let dirty = prune_dead(&mut registry);
+
+    // Prefer the same number when unprivileged and free.
+    let mut chosen: Option<(u16, TcpListener)> = None;
+    if container_port >= MIN_HOST_PORT {
+        if let Some(listener) = try_reserve(&registry, container_port) {
+            chosen = Some((container_port, listener));
+        }
+    }
+    // Otherwise scan upward for the next free, bindable, unregistered port.
+    if chosen.is_none() {
+        let start = container_port.max(MIN_HOST_PORT);
+        for candidate in start..=u16::MAX {
+            if candidate < MIN_HOST_PORT {
+                continue;
+            }
+            if let Some(listener) = try_reserve(&registry, candidate) {
+                chosen = Some((candidate, listener));
+                break;
+            }
+        }
+    }
+
+    let (host_port, listener) = chosen.ok_or_else(|| PortForwardError::Docker {
+        context: "allocate".to_string(),
+        message: format!("no free host port available for container port {container_port}"),
+    })?;
+
+    registry.entries.push(RegistryEntry {
+        host_port,
+        container_id: container_id.to_string(),
+        container_port,
+        workspace: workspace.to_string(),
+        pid: std::process::id(),
+        label: label.map(str::to_string),
+    });
+    let _ = dirty; // entries always change here, so we always save.
+    save(user_data_folder, &registry)?;
+
+    Ok(Allocation {
+        host_port,
+        remapped: host_port != container_port,
+        listener,
+    })
+}
+
+/// Release a single host-port entry (used when a forward is withdrawn).
+pub fn release_port(user_data_folder: Option<&Path>, host_port: u16) -> Result<()> {
+    let _guard = lock(user_data_folder)?;
+    let mut registry = load(user_data_folder)?;
+    let before = registry.entries.len();
+    registry.entries.retain(|e| e.host_port != host_port);
+    if registry.entries.len() != before {
+        save(user_data_folder, &registry)?;
+    }
+    Ok(())
+}
+
+/// Release all of a container's entries (reap / self-exit, FR-013 / FR-015).
+pub fn release_container(user_data_folder: Option<&Path>, container_id: &str) -> Result<()> {
+    let _guard = lock(user_data_folder)?;
+    let mut registry = load(user_data_folder)?;
+    let before = registry.entries.len();
+    registry.entries.retain(|e| e.container_id != container_id);
+    if registry.entries.len() != before {
+        save(user_data_folder, &registry)?;
+    }
+    Ok(())
+}
+
+/// Prune entries whose pid is dead **or** whose container is reported gone by
+/// `container_alive` (FR-016). Runs under the lock.
+pub fn prune(
+    user_data_folder: Option<&Path>,
+    container_alive: impl Fn(&str) -> bool,
+) -> Result<()> {
+    let _guard = lock(user_data_folder)?;
+    let mut registry = load(user_data_folder)?;
+    let before = registry.entries.len();
+    registry
+        .entries
+        .retain(|e| pid_alive(e.pid) && container_alive(&e.container_id));
+    if registry.entries.len() != before {
+        save(user_data_folder, &registry)?;
+    }
+    Ok(())
+}
+
+/// Read the current entries (test/diagnostic helper; takes the lock briefly).
+pub fn entries(user_data_folder: Option<&Path>) -> Result<Vec<RegistryEntry>> {
+    let _guard = lock(user_data_folder)?;
+    Ok(load(user_data_folder)?.entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn udf(dir: &TempDir) -> Option<&Path> {
+        Some(dir.path())
+    }
+
+    /// An ephemeral port that is currently free (the listener is dropped
+    /// immediately, so `allocate` can re-bind the same number).
+    fn free_port() -> u16 {
+        TcpListener::bind(("127.0.0.1", 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    #[test]
+    fn prefers_same_number_when_free() {
+        let dir = TempDir::new().unwrap();
+        let port = free_port();
+        let alloc = allocate(udf(&dir), "c1", port, "/ws/a", Some("web")).unwrap();
+        assert_eq!(alloc.host_port, port);
+        assert!(!alloc.remapped);
+        let entries = entries(udf(&dir)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].host_port, port);
+        assert_eq!(entries[0].label.as_deref(), Some("web"));
+    }
+
+    #[test]
+    fn collision_triggers_next_free_remap() {
+        let dir = TempDir::new().unwrap();
+        let port = free_port();
+        // First container takes the natural port.
+        let a = allocate(udf(&dir), "c1", port, "/ws/a", None).unwrap();
+        assert_eq!(a.host_port, port);
+        // Second container also wants it → remapped to next free.
+        let b = allocate(udf(&dir), "c2", port, "/ws/b", None).unwrap();
+        assert_ne!(b.host_port, port);
+        assert!(b.remapped);
+        assert!(b.host_port >= MIN_HOST_PORT);
+        // Both registered, host ports unique.
+        let entries = entries(udf(&dir)).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_ne!(entries[0].host_port, entries[1].host_port);
+        // Keep listeners alive until here so the ports stay reserved.
+        drop(a);
+        drop(b);
+    }
+
+    #[test]
+    fn privileged_port_is_remapped() {
+        let dir = TempDir::new().unwrap();
+        let a = allocate(udf(&dir), "c1", 80, "/ws/a", None).unwrap();
+        assert!(a.host_port >= MIN_HOST_PORT);
+        assert!(a.remapped);
+    }
+
+    #[test]
+    fn release_removes_entries() {
+        let dir = TempDir::new().unwrap();
+        let a = allocate(udf(&dir), "c1", free_port(), "/ws/a", None).unwrap();
+        drop(a); // free the listener so the port is reusable
+        release_container(udf(&dir), "c1").unwrap();
+        assert!(entries(udf(&dir)).unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_dead_pid_entries_are_pruned_on_allocate() {
+        let dir = TempDir::new().unwrap();
+        let port = free_port();
+        // Seed a registry with an entry owned by a definitely-dead pid, holding
+        // the natural port.
+        let stale = RegistryFile {
+            version: 1,
+            entries: vec![RegistryEntry {
+                host_port: port,
+                container_id: "ghost".to_string(),
+                container_port: port,
+                workspace: "/ws/ghost".to_string(),
+                pid: 2_000_000_000, // not a live pid
+                label: None,
+            }],
+        };
+        save(udf(&dir), &stale).unwrap();
+        // Allocating the same container port should prune the stale entry and
+        // reuse the natural port.
+        let a = allocate(udf(&dir), "c1", port, "/ws/a", None).unwrap();
+        assert_eq!(a.host_port, port);
+        let entries = entries(udf(&dir)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].container_id, "c1");
+    }
+
+    #[test]
+    fn prune_drops_missing_containers() {
+        let dir = TempDir::new().unwrap();
+        let a = allocate(udf(&dir), "alive", free_port(), "/ws/a", None).unwrap();
+        // Prune treating the container as gone → entry removed.
+        prune(udf(&dir), |_| false).unwrap();
+        assert!(entries(udf(&dir)).unwrap().is_empty());
+        drop(a);
+    }
+}

--- a/crates/core/src/port_forward/relay.rs
+++ b/crates/core/src/port_forward/relay.rs
@@ -1,0 +1,206 @@
+//! Per-connection byte relay over `docker exec -i`.
+//!
+//! For each accepted host connection on `127.0.0.1:host_port`, the relay spawns
+//! `docker exec -i <id> <relay-program>` that dials a configurable dial host
+//! (default `127.0.0.1`, or a compose service host) on the container port, then
+//! pumps bytes bidirectionally. Because `docker exec` shares the container's
+//! network namespace, this reaches `127.0.0.1`-bound servers that `-p` cannot.
+//!
+//! Relay-program selection probes the container for `socat`, then `nc`, then
+//! bash `/dev/tcp`, failing fast with [`PortForwardError::NoRelayStrategy`] when
+//! none is available (Principle IV — no silent fallback). A persistent embedded
+//! multiplexing relay is a tracked throughput optimization (deferral T055).
+
+use std::process::Stdio;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+use super::PortForwardError;
+
+/// A relay program available inside the container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayProgram {
+    /// `socat` (preferred — robust bidirectional copy).
+    Socat,
+    /// `nc` / netcat.
+    Nc,
+    /// bash `/dev/tcp` pseudo-device (last resort; requires bash).
+    DevTcp,
+}
+
+/// Shell snippet that prints the basename of each available relay program,
+/// one per line, in preference order.
+pub fn probe_script() -> &'static str {
+    "for p in socat nc bash; do if command -v \"$p\" >/dev/null 2>&1; then echo \"$p\"; fi; done"
+}
+
+/// Pick the best relay program from [`probe_script`] output.
+pub fn select_relay_from_probe(probe_stdout: &str) -> Option<RelayProgram> {
+    let available: Vec<&str> = probe_stdout.split_whitespace().collect();
+    if available.contains(&"socat") {
+        Some(RelayProgram::Socat)
+    } else if available.contains(&"nc") {
+        Some(RelayProgram::Nc)
+    } else if available.contains(&"bash") {
+        Some(RelayProgram::DevTcp)
+    } else {
+        None
+    }
+}
+
+/// Build the in-container command (after `docker exec -i <id>`) that dials
+/// `dial_host:container_port` and relays stdin/stdout to it.
+pub fn relay_args(program: RelayProgram, dial_host: &str, container_port: u16) -> Vec<String> {
+    match program {
+        RelayProgram::Socat => vec![
+            "socat".to_string(),
+            "-".to_string(),
+            format!("TCP:{dial_host}:{container_port}"),
+        ],
+        RelayProgram::Nc => vec![
+            "nc".to_string(),
+            dial_host.to_string(),
+            container_port.to_string(),
+        ],
+        RelayProgram::DevTcp => vec![
+            "bash".to_string(),
+            "-c".to_string(),
+            format!("exec 3<>/dev/tcp/{dial_host}/{container_port}; cat <&3 & cat >&3; wait"),
+        ],
+    }
+}
+
+/// Map a failed relay-program probe to a clear fail-fast error.
+pub fn no_relay_strategy(container_id: &str) -> PortForwardError {
+    PortForwardError::NoRelayStrategy {
+        container_id: container_id.to_string(),
+    }
+}
+
+/// Accept connections on `listener` forever, relaying each into the container.
+///
+/// Runs until the task is aborted (forward withdrawn) or the listener errors.
+/// Each connection is handled in its own task with `kill_on_drop` so an aborted
+/// relay tears down its `docker exec` child.
+pub async fn serve(
+    listener: TcpListener,
+    docker_path: String,
+    container_id: String,
+    relay_argv: Vec<String>,
+) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer)) => {
+                debug!(%peer, container_id = %container_id, "relay: accepted connection");
+                let docker_path = docker_path.clone();
+                let container_id = container_id.clone();
+                let relay_argv = relay_argv.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        handle_connection(stream, &docker_path, &container_id, &relay_argv).await
+                    {
+                        warn!(container_id = %container_id, error = %e, "relay connection ended with error");
+                    }
+                });
+            }
+            Err(e) => {
+                warn!(container_id = %container_id, error = %e, "relay: accept failed; stopping listener");
+                return;
+            }
+        }
+    }
+}
+
+/// Relay one host connection through a fresh `docker exec -i` child.
+async fn handle_connection(
+    stream: TcpStream,
+    docker_path: &str,
+    container_id: &str,
+    relay_argv: &[String],
+) -> std::io::Result<()> {
+    let mut cmd = Command::new(docker_path);
+    cmd.arg("exec")
+        .arg("-i")
+        .arg(container_id)
+        .args(relay_argv)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    let mut child = cmd.spawn()?;
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| std::io::Error::other("relay child missing stdin"))?;
+    let mut child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("relay child missing stdout"))?;
+
+    let (mut host_read, mut host_write) = stream.into_split();
+
+    // host -> container
+    let upstream = async {
+        let _ = tokio::io::copy(&mut host_read, &mut child_stdin).await;
+        let _ = child_stdin.shutdown().await;
+    };
+    // container -> host
+    let downstream = async {
+        let _ = tokio::io::copy(&mut child_stdout, &mut host_write).await;
+        let _ = host_write.shutdown().await;
+    };
+
+    tokio::join!(upstream, downstream);
+    let _ = child.wait().await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_socat_first() {
+        assert_eq!(
+            select_relay_from_probe("socat\nnc\nbash\n"),
+            Some(RelayProgram::Socat)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_nc_then_devtcp() {
+        assert_eq!(
+            select_relay_from_probe("nc\nbash\n"),
+            Some(RelayProgram::Nc)
+        );
+        assert_eq!(
+            select_relay_from_probe("bash\n"),
+            Some(RelayProgram::DevTcp)
+        );
+    }
+
+    #[test]
+    fn no_relay_when_none_present() {
+        assert_eq!(select_relay_from_probe(""), None);
+        assert_eq!(select_relay_from_probe("\n  \n"), None);
+    }
+
+    #[test]
+    fn relay_args_shapes() {
+        assert_eq!(
+            relay_args(RelayProgram::Socat, "127.0.0.1", 3000),
+            vec!["socat", "-", "TCP:127.0.0.1:3000"]
+        );
+        assert_eq!(
+            relay_args(RelayProgram::Nc, "db", 5432),
+            vec!["nc", "db", "5432"]
+        );
+        let dev = relay_args(RelayProgram::DevTcp, "127.0.0.1", 8080);
+        assert_eq!(dev[0], "bash");
+        assert!(dev[2].contains("/dev/tcp/127.0.0.1/8080"));
+    }
+}

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -353,6 +353,13 @@ pub enum Commands {
         /// Format: PORT or HOST_PORT:CONTAINER_PORT
         #[arg(long = "forward-port")]
         forward_ports: Vec<String>,
+        /// Start a detached, user-space port forwarder for the container.
+        ///
+        /// Dynamically forwards container TCP ports to loopback host ports
+        /// (reaching even 127.0.0.1-bound servers that `-p` cannot), returns
+        /// control to the shell, and tears down on `down`. Unix-only in v1.
+        #[arg(long)]
+        auto_forward: bool,
 
         // Lifecycle
         /// Automatically shut down when process exits
@@ -721,6 +728,32 @@ pub enum Commands {
         /// Fail CI with exit code 2 when any outdated feature is detected
         #[arg(long)]
         fail_on_outdated: bool,
+    },
+
+    /// Internal: the detached port-forwarder process for `up --auto-forward`.
+    ///
+    /// NOT part of the user-facing surface. `up --auto-forward` re-exec's the
+    /// deacon binary with this hidden subcommand to spawn a detached forwarder.
+    /// End users MUST NOT invoke it directly; its arguments may change between
+    /// releases without notice.
+    ///
+    /// Note: `--user-data-folder`, `--config`, and `--docker-path` are read
+    /// from the global flags (the re-exec passes them on the command line).
+    #[command(name = "__forward-daemon", hide = true)]
+    ForwardDaemon {
+        /// Full id of the container to forward.
+        #[arg(long)]
+        container_id: String,
+        /// Canonical workspace path of the owning devcontainer.
+        #[arg(long)]
+        workspace: PathBuf,
+        /// Declared port spec to forward eagerly (repeatable). Format: PORT,
+        /// HOST:CONTAINER, or "service:port" for a compose service.
+        #[arg(long = "declared-port")]
+        declared_port: Vec<String>,
+        /// Emit machine-readable PORT_EVENT lines as ports come and go.
+        #[arg(long)]
+        ports_events: bool,
     },
 }
 
@@ -1155,6 +1188,7 @@ impl Cli {
                 update_remote_user_uid_default,
                 ports_events,
                 forward_ports,
+                auto_forward,
                 shutdown,
                 container_name,
                 ignore_host_requirements,
@@ -1198,6 +1232,7 @@ impl Cli {
                     ports_events,
                     shutdown,
                     forward_ports,
+                    auto_forward,
                     container_name,
                     workspace_folder: self.workspace_folder,
                     config_path: self.config,
@@ -1599,6 +1634,7 @@ impl Cli {
                     timeout,
                     workspace_folder: self.workspace_folder,
                     config_path: self.config,
+                    user_data_folder: self.user_data_folder.clone(),
                     docker_path: self.docker_path.clone(),
                     docker_compose_path: self.docker_compose_path.clone(),
                 };
@@ -1665,6 +1701,25 @@ impl Cli {
                     Ok(()) => Ok(()),
                     Err(e) => Err(e.into()),
                 }
+            }
+            Some(Commands::ForwardDaemon {
+                container_id,
+                workspace,
+                declared_port,
+                ports_events,
+            }) => {
+                crate::commands::forward_daemon::run_forward_daemon(
+                    crate::commands::forward_daemon::ForwardDaemonArgs {
+                        container_id,
+                        workspace,
+                        user_data_folder: self.user_data_folder.clone(),
+                        declared_ports: declared_port,
+                        config_path: self.config.clone(),
+                        ports_events,
+                        docker_path: self.docker_path.clone(),
+                    },
+                )
+                .await
             }
             None => {
                 // No subcommand provided - show help-like message

--- a/crates/deacon/src/commands/down.rs
+++ b/crates/deacon/src/commands/down.rs
@@ -30,6 +30,8 @@ pub struct DownArgs {
     pub workspace_folder: Option<PathBuf>,
     /// Configuration file path
     pub config_path: Option<PathBuf>,
+    /// Host-side user data folder (locates port-forward markers/registry).
+    pub user_data_folder: Option<PathBuf>,
     /// Path to docker executable
     #[allow(dead_code)] // Future: Will be used for custom docker executable path
     pub docker_path: String,
@@ -202,6 +204,17 @@ async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Resu
     for container in containers {
         debug!("Processing container: {}", container.id);
 
+        // Reap the port forwarder for this container before teardown (FR-013).
+        if let Err(e) =
+            deacon_core::port_forward::reap(args.user_data_folder.as_deref(), &container.id)
+        {
+            warn!(
+                container_id = %container.id,
+                error = %e,
+                "failed to reap port forwarder during down --all"
+            );
+        }
+
         // Only stop if container is running
         if container.state == "running" {
             debug!(
@@ -274,6 +287,19 @@ async fn execute_container_down(
     workspace_hash: &str,
 ) -> Result<()> {
     debug!("Shutting down container: {}", container_state.container_id);
+
+    // Reap the port forwarder (if any) before tearing the container down: stop
+    // its relays, release its host ports, and remove its marker (FR-013).
+    if let Err(e) = deacon_core::port_forward::reap(
+        args.user_data_folder.as_deref(),
+        &container_state.container_id,
+    ) {
+        warn!(
+            container_id = %container_state.container_id,
+            error = %e,
+            "failed to reap port forwarder during down"
+        );
+    }
 
     let docker = CliDocker::new();
 
@@ -546,6 +572,7 @@ mod tests {
             timeout: None,
             workspace_folder: Some(PathBuf::from("/test")),
             config_path: None,
+            user_data_folder: None,
             docker_path: "docker".to_string(),
             docker_compose_path: "docker-compose".to_string(),
         };

--- a/crates/deacon/src/commands/forward_daemon.rs
+++ b/crates/deacon/src/commands/forward_daemon.rs
@@ -1,0 +1,66 @@
+//! Entrypoint for the hidden `__forward-daemon` subcommand.
+//!
+//! `up --auto-forward` re-exec's the deacon binary with this subcommand to
+//! spawn a detached forwarder. The process detaches from its controlling
+//! terminal (`setsid`), reopens its stdio onto a per-container log file, and
+//! then runs the core supervisor loop. It is **not** part of the user-facing
+//! surface; end users must not invoke it directly.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use tracing::info;
+
+use deacon_core::port_forward::daemon::{self, DaemonConfig};
+use deacon_core::port_forward::log_path;
+
+/// Parsed arguments for the hidden daemon subcommand.
+#[derive(Debug, Clone)]
+pub struct ForwardDaemonArgs {
+    /// Full id of the container to forward.
+    pub container_id: String,
+    /// Canonical workspace path.
+    pub workspace: PathBuf,
+    /// User-data folder for registry/marker/log (default `~/.deacon`).
+    pub user_data_folder: Option<PathBuf>,
+    /// Raw declared-port specs to forward eagerly.
+    pub declared_ports: Vec<String>,
+    /// Path to the resolved devcontainer.json.
+    pub config_path: Option<PathBuf>,
+    /// Emit machine-readable `PORT_EVENT:` lines.
+    pub ports_events: bool,
+    /// Docker CLI path.
+    pub docker_path: String,
+}
+
+/// Detach, redirect stdio to the per-container log, and run the supervisor loop.
+pub async fn run_forward_daemon(args: ForwardDaemonArgs) -> anyhow::Result<()> {
+    // Resolve the log file and detach. On a non-Unix build `daemonize` returns
+    // a clear unsupported-platform error (Principle IV — no silent fallback).
+    let log = log_path(args.user_data_folder.as_deref(), &args.container_id)
+        .context("resolve forwarder log path")?;
+    daemon::daemonize(&log).context("detach forwarder process")?;
+
+    // After daemonize, stdout/stderr point at the log file, so existing
+    // tracing (to stderr) and any PORT_EVENT lines (to stdout) land there.
+    info!(
+        container_id = %args.container_id,
+        workspace = %args.workspace.display(),
+        "forward daemon starting"
+    );
+
+    let config = DaemonConfig {
+        container_id: args.container_id,
+        workspace: args.workspace,
+        user_data_folder: args.user_data_folder,
+        declared_ports: args.declared_ports,
+        config_path: args.config_path,
+        ports_events: args.ports_events,
+        docker_path: args.docker_path,
+    };
+
+    daemon::run(config)
+        .await
+        .context("forwarder supervisor loop")?;
+    Ok(())
+}

--- a/crates/deacon/src/commands/mod.rs
+++ b/crates/deacon/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod build;
 pub mod config;
 pub mod down;
 pub mod exec;
+pub mod forward_daemon;
 pub mod outdated;
 pub mod read_configuration;
 pub mod run_user_commands;

--- a/crates/deacon/src/commands/up/args.rs
+++ b/crates/deacon/src/commands/up/args.rs
@@ -420,6 +420,8 @@ pub struct UpArgs {
     // Port handling
     pub ports_events: bool,
     pub forward_ports: Vec<String>,
+    /// Start a detached user-space port forwarder (`--auto-forward`).
+    pub auto_forward: bool,
 
     // Lifecycle
     pub shutdown: bool,
@@ -497,6 +499,7 @@ impl Default for UpArgs {
             update_remote_user_uid_default: None,
             ports_events: false,
             forward_ports: Vec::new(),
+            auto_forward: false,
             shutdown: false,
             container_name: None,
             workspace_folder: None,

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -410,6 +410,22 @@ pub(crate) async fn execute_compose_up(
         }
     };
 
+    // Start the detached port forwarder for the primary service container if
+    // requested. Declared `"service:port"` specs relay over the compose network
+    // to the named service; auto-detection stays scoped to the primary service
+    // (FR-023). Best-effort (FR-002, FR-025).
+    if args.auto_forward {
+        let declared = super::forward::declared_port_specs(config, &args.forward_ports);
+        super::forward::spawn_or_adopt(
+            args,
+            &container_id,
+            workspace_folder,
+            config_path,
+            &declared,
+        )
+        .await;
+    }
+
     let remote_user = config
         .remote_user
         .clone()

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -500,6 +500,40 @@ pub(crate) async fn execute_container_up(
         debug!("GPU mode: {:?}", args.gpu_mode);
     }
 
+    // When `--auto-forward` is set, declared ports are routed to the detached
+    // forwarder and must NOT also be statically `-p` published, so Docker and
+    // the daemon never contend for the same host port (FR-006). Capture the
+    // declared specs first (for the forwarder), then publish via a config clone
+    // with the ports stripped — the unmodified `config` is still used for the
+    // result/report so the stdout contract is unchanged (FR-010).
+    let auto_forward_declared: Vec<String> = if args.auto_forward {
+        crate::commands::up::forward::declared_port_specs(&config, &[])
+    } else {
+        Vec::new()
+    };
+    // When replacing an existing container, reap its forwarder first so its
+    // host ports are released before the replacement's forwarder allocates
+    // (FR-014). No-op when no forwarder marker exists.
+    if args.remove_existing_container {
+        crate::commands::up::forward::reap_existing_forwarders(
+            docker,
+            &identity,
+            args.user_data_folder.as_deref(),
+        )
+        .await;
+    }
+
+    let stripped_config;
+    let config_for_create: &DevContainerConfig = if args.auto_forward {
+        let mut c = config.clone();
+        c.forward_ports.clear();
+        c.app_port = None;
+        stripped_config = c;
+        &stripped_config
+    } else {
+        &config
+    };
+
     // Create container using DockerLifecycle trait.
     //
     // We pass `workspace_mount_source` (#67), not the raw workspace folder,
@@ -511,7 +545,7 @@ pub(crate) async fn execute_container_up(
     let container_result = docker
         .up(
             &identity,
-            &config,
+            config_for_create,
             &workspace_mount_source,
             args.remove_existing_container,
             args.gpu_mode,
@@ -680,6 +714,19 @@ pub(crate) async fn execute_container_up(
             &args.secret_registry,
         )
         .await?;
+    }
+
+    // Start the detached port forwarder if requested. Best-effort: a failure
+    // warns but never fails `up` (FR-002, FR-025).
+    if args.auto_forward {
+        crate::commands::up::forward::spawn_or_adopt(
+            args,
+            &container_result.container_id,
+            workspace_folder,
+            config_path,
+            &auto_forward_declared,
+        )
+        .await;
     }
 
     // Handle shutdown if requested

--- a/crates/deacon/src/commands/up/forward.rs
+++ b/crates/deacon/src/commands/up/forward.rs
@@ -1,0 +1,226 @@
+//! Spawn / adopt the detached port forwarder for `up --auto-forward`.
+//!
+//! The forwarder is a separate process (the deacon binary re-exec'd with the
+//! hidden `__forward-daemon` subcommand) so it can outlive `up` returning to
+//! the shell (FR-002). It is single-owner per container: a live marker is
+//! adopted rather than duplicated (FR-012). Forwarding is best-effort — any
+//! failure here warns loudly but never fails `up` (FR-025, FR-019).
+
+use std::path::Path;
+use std::process::Stdio;
+
+use tracing::{info, warn};
+
+use deacon_core::config::{DevContainerConfig, PortSpec};
+use deacon_core::container::ContainerIdentity;
+use deacon_core::docker::Docker;
+use deacon_core::port_forward::daemon::pid_alive;
+use deacon_core::port_forward::{DaemonMarker, marker_path};
+
+use crate::commands::up::args::UpArgs;
+
+/// Reap any forwarders owning this workspace's existing container(s) before
+/// `up --remove-existing-container` replaces them (FR-014). Best-effort.
+pub async fn reap_existing_forwarders<D: Docker>(
+    docker: &D,
+    identity: &ContainerIdentity,
+    user_data_folder: Option<&Path>,
+) {
+    let selector = identity
+        .workspace_label_selector()
+        .unwrap_or_else(|| identity.label_selector());
+    match docker.list_containers(Some(&selector)).await {
+        Ok(containers) => {
+            for c in containers {
+                if let Err(e) = deacon_core::port_forward::reap(user_data_folder, &c.id) {
+                    warn!(container_id = %c.id, error = %e, "failed to reap forwarder before replace");
+                }
+            }
+        }
+        Err(e) => warn!(error = %e, "failed to list containers to reap forwarders before replace"),
+    }
+}
+
+/// Collect declared port specs (`forwardPorts` + `appPort` + `--forward-port`)
+/// to route to the forwarder, de-duplicated, in declaration order.
+pub fn declared_port_specs(
+    config: &DevContainerConfig,
+    cli_forward_ports: &[String],
+) -> Vec<String> {
+    let mut specs: Vec<String> = Vec::new();
+    let mut push = |s: String| {
+        if !specs.contains(&s) {
+            specs.push(s);
+        }
+    };
+    for ps in &config.forward_ports {
+        push(port_spec_to_string(ps));
+    }
+    if let Some(app) = &config.app_port {
+        for ps in app.specs() {
+            push(port_spec_to_string(ps));
+        }
+    }
+    for s in cli_forward_ports {
+        push(s.clone());
+    }
+    specs
+}
+
+fn port_spec_to_string(spec: &PortSpec) -> String {
+    match spec {
+        PortSpec::Number(n) => n.to_string(),
+        PortSpec::String(s) => s.clone(),
+    }
+}
+
+/// Spawn the forwarder for `container_id`, or adopt an existing live one.
+///
+/// `declared` is the already-collected declared-port spec set (captured before
+/// the static `-p` ports were stripped for the create path). Best-effort:
+/// returns even on failure (after warning) so `up` still succeeds with the
+/// container running. On non-Unix builds it warns that forwarding is
+/// unsupported and returns (the rest of `up` is unaffected).
+pub async fn spawn_or_adopt(
+    args: &UpArgs,
+    container_id: &str,
+    workspace_folder: &Path,
+    config_path: &Path,
+    declared: &[String],
+) {
+    if !cfg!(unix) {
+        warn!("--auto-forward is not supported on this platform (Unix-only in v1); skipping");
+        return;
+    }
+
+    // Adopt-or-reuse: a live marker means a forwarder already owns this
+    // container — do not spawn a duplicate (FR-012).
+    if let Some(pid) = live_forwarder_pid(args.user_data_folder.as_deref(), container_id) {
+        info!(pid, container_id, "reusing existing forwarder");
+        return;
+    }
+
+    let workspace = workspace_folder
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_folder.to_path_buf());
+
+    if let Err(e) = spawn_daemon(args, container_id, &workspace, config_path, declared) {
+        warn!(
+            container_id,
+            error = %e,
+            "failed to start port forwarder; container is up but ports are not forwarded"
+        );
+    }
+}
+
+/// Read a live forwarder pid from the marker, if present and alive.
+pub fn live_forwarder_pid(user_data_folder: Option<&Path>, container_id: &str) -> Option<u32> {
+    let path = marker_path(user_data_folder, container_id).ok()?;
+    let text = std::fs::read_to_string(&path).ok()?;
+    let marker: DaemonMarker = serde_json::from_str(&text).ok()?;
+    if pid_alive(marker.pid) {
+        Some(marker.pid)
+    } else {
+        None
+    }
+}
+
+/// Re-exec the deacon binary with the hidden `__forward-daemon` subcommand,
+/// detached (no stdio inherited; the child reopens its fds onto the log).
+fn spawn_daemon(
+    args: &UpArgs,
+    container_id: &str,
+    workspace: &Path,
+    config_path: &Path,
+    declared: &[String],
+) -> std::io::Result<()> {
+    let exe = std::env::current_exe()?;
+    let mut cmd = std::process::Command::new(exe);
+
+    // Global flags first so they bind to the top-level parser.
+    cmd.arg("--docker-path").arg(&args.docker_path);
+    if let Some(udf) = &args.user_data_folder {
+        cmd.arg("--user-data-folder").arg(udf);
+    }
+    cmd.arg("--config").arg(config_path);
+
+    cmd.arg("__forward-daemon")
+        .arg("--container-id")
+        .arg(container_id)
+        .arg("--workspace")
+        .arg(workspace);
+    for spec in declared {
+        cmd.arg("--declared-port").arg(spec);
+    }
+    if args.ports_events {
+        cmd.arg("--ports-events");
+    }
+
+    // Detach: the child re-opens its own stdio onto the per-container log, so
+    // it must not hold the parent's stdout (which carries the `up` JSON result).
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let child = cmd.spawn()?;
+    info!(
+        container_id,
+        pid = child.id(),
+        declared = declared.len(),
+        "spawned port forwarder"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_core::config::AppPort;
+    use deacon_core::port_forward::DaemonMarker;
+    use tempfile::TempDir;
+
+    fn write_marker(udf: &Path, container_id: &str, pid: u32) {
+        let marker = DaemonMarker {
+            pid,
+            container_id: container_id.to_string(),
+            workspace: "/ws".to_string(),
+            started_at: "2026-06-08T00:00:00Z".to_string(),
+            log_path: "/tmp/x.log".to_string(),
+        };
+        let path = marker_path(Some(udf), container_id).unwrap();
+        std::fs::write(path, serde_json::to_string(&marker).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn adopt_reuses_live_pid_and_ignores_dead_or_missing() {
+        let dir = TempDir::new().unwrap();
+        let udf = dir.path();
+
+        // Missing marker ⇒ no pid (spawn fresh).
+        assert_eq!(live_forwarder_pid(Some(udf), "none"), None);
+
+        // Live pid (our own process) ⇒ reuse.
+        let me = std::process::id();
+        write_marker(udf, "live", me);
+        assert_eq!(live_forwarder_pid(Some(udf), "live"), Some(me));
+
+        // Dead pid ⇒ spawn fresh (None).
+        write_marker(udf, "dead", 2_000_000_000);
+        assert_eq!(live_forwarder_pid(Some(udf), "dead"), None);
+    }
+
+    #[test]
+    fn collects_and_dedups_declared_specs() {
+        let config = DevContainerConfig {
+            forward_ports: vec![
+                PortSpec::Number(3000),
+                PortSpec::String("db:5432".to_string()),
+            ],
+            app_port: Some(AppPort::Single(PortSpec::Number(8080))),
+            ..DevContainerConfig::default()
+        };
+        let cli = vec!["3000".to_string(), "9000".to_string()];
+        let specs = declared_port_specs(&config, &cli);
+        assert_eq!(specs, vec!["3000", "db:5432", "8080", "9000"]);
+    }
+}

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -24,6 +24,7 @@ mod container;
 // `deacon_core::container_lifecycle::execute_dotfiles_in_container`, which
 // runs in the spec-correct `postCreate -> dotfiles -> postStart` slot.
 pub(crate) mod features_build;
+mod forward;
 mod helpers;
 mod image_build;
 mod lifecycle;

--- a/crates/deacon/tests/integration_auto_forward.rs
+++ b/crates/deacon/tests/integration_auto_forward.rs
@@ -1,0 +1,762 @@
+//! Docker integration tests for `up --auto-forward` (dynamic port forwarding).
+//!
+//! These exercise the detached forwarder end-to-end against a real container.
+//! They are docker-gated (skip cleanly when Docker is unavailable) and use a
+//! `TempDir` workspace + a `--user-data-folder` so the host-global registry and
+//! markers are isolated per test (and because in-repo `up` chowns the
+//! workspace — see CLAUDE.md).
+
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Command as StdCommand, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+/// A loopback HTTP-ish server inside an alpine container: an `nc` listen loop
+/// that emits a banner on each connection. `nc` is busybox's, so it is also the
+/// relay program the forwarder discovers. Backgrounded so it survives the
+/// (non-TTY) postStart exec session.
+const SERVER_BANNER: &str = "deacon-forward-ok";
+
+fn is_docker_available() -> bool {
+    StdCommand::new("docker")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Process-unique-ish suffix without external crates.
+fn unique() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static C: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "{}-{}",
+        std::process::id(),
+        C.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn write_config(ws: &Path, body: &str) {
+    let dir = ws.join(".devcontainer");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("devcontainer.json"), body).unwrap();
+}
+
+/// devcontainer.json: alpine, kept alive, with a loopback `nc` banner server on
+/// `port` started in postStart, and `forwardPorts` declaring it.
+fn server_config(port: u16, declare: bool) -> String {
+    let forward = if declare {
+        format!(r#""forwardPorts": [{port}],"#)
+    } else {
+        String::new()
+    };
+    format!(
+        r#"{{
+  "name": "auto-forward-test",
+  "image": "alpine:3.18",
+  "overrideCommand": true,
+  {forward}
+  "postStartCommand": "sh -c '(while true; do echo {SERVER_BANNER} | nc -l -p {port}; done) >/dev/null 2>&1 & sleep 1'"
+}}"#
+    )
+}
+
+/// devcontainer.json: alpine kept alive, with NO server and NO declared ports.
+/// A server is started later via `exec` to exercise auto-detection.
+fn bare_config() -> String {
+    r#"{
+  "name": "auto-forward-bare",
+  "image": "alpine:3.18",
+  "overrideCommand": true
+}"#
+    .to_string()
+}
+
+struct UpOutcome {
+    success: bool,
+    container_id: Option<String>,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_up(ws: &Path, udf: &Path, extra: &[&str]) -> UpOutcome {
+    let bin = env!("CARGO_BIN_EXE_deacon");
+    let mut cmd = StdCommand::new(bin);
+    cmd.arg("--user-data-folder")
+        .arg(udf)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(ws)
+        .args(extra);
+    let out = cmd.output().expect("run deacon up");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let container_id = serde_json::from_str::<Value>(&stdout).ok().and_then(|v| {
+        v.get("containerId")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    });
+    UpOutcome {
+        success: out.status.success(),
+        container_id,
+        stdout,
+        stderr,
+    }
+}
+
+/// Run a plain `deacon exec` against the container by id, with NO
+/// auto-forward-related flags (proves forwarding needs no exec changes,
+/// FR-018). Targeting by `--container-id` is a normal exec feature.
+fn run_exec(container_id: &str, command: &[&str]) -> bool {
+    let bin = env!("CARGO_BIN_EXE_deacon");
+    let mut cmd = StdCommand::new(bin);
+    cmd.arg("exec")
+        .arg("--container-id")
+        .arg(container_id)
+        .args(command);
+    cmd.output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Read the registry and return the host port allocated for `container_port`.
+fn registry_host_port(udf: &Path, container_port: u16) -> Option<u16> {
+    let text = std::fs::read_to_string(udf.join("forwarded_ports.json")).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    v.get("entries")?.as_array()?.iter().find_map(|e| {
+        let cp = e.get("container_port")?.as_u64()? as u16;
+        if cp == container_port {
+            Some(e.get("host_port")?.as_u64()? as u16)
+        } else {
+            None
+        }
+    })
+}
+
+/// Host port for a specific owning container id, if present in the registry.
+fn registry_host_port_by_container(udf: &Path, container_id: &str) -> Option<u16> {
+    let text = std::fs::read_to_string(udf.join("forwarded_ports.json")).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    v.get("entries")?.as_array()?.iter().find_map(|e| {
+        if e.get("container_id")?.as_str()? == container_id {
+            Some(e.get("host_port")?.as_u64()? as u16)
+        } else {
+            None
+        }
+    })
+}
+
+/// Poll until the registry has a host port for `container_port` (or timeout).
+fn wait_for_host_port(udf: &Path, container_port: u16, timeout: Duration) -> Option<u16> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Some(p) = registry_host_port(udf, container_port) {
+            return Some(p);
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    None
+}
+
+/// Poll until the registry no longer has an entry for `container_port`.
+fn wait_for_withdrawal(udf: &Path, container_port: u16, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if registry_host_port(udf, container_port).is_none() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+/// Connect to a host loopback port, send a minimal request, and read whatever
+/// the relayed server sends back. The busybox `nc` server does not half-close,
+/// so we read with a per-read timeout and accept partial data (any bytes
+/// received prove the relay works) rather than requiring EOF. Retries briefly
+/// so the relay's first `docker exec` has time to dial.
+fn fetch(host_port: u16, timeout: Duration) -> Option<String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(mut s) = TcpStream::connect(("127.0.0.1", host_port)) {
+            let _ = s.set_read_timeout(Some(Duration::from_secs(3)));
+            let _ = s.write_all(b"GET / HTTP/1.0\r\n\r\n");
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                match s.read(&mut chunk) {
+                    Ok(0) => break, // EOF
+                    Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                    Err(_) => break, // timeout / would-block: stop reading
+                }
+                if buf.len() > 64 {
+                    break; // got plenty; the banner is small
+                }
+            }
+            if !buf.is_empty() {
+                return Some(String::from_utf8_lossy(&buf).to_string());
+            }
+        }
+        std::thread::sleep(Duration::from_millis(300));
+    }
+    None
+}
+
+/// Host-side liveness check (Linux): does /proc/<pid> exist?
+fn host_pid_alive(pid: u32) -> bool {
+    Path::new(&format!("/proc/{pid}")).exists()
+}
+
+fn marker_exists(udf: &Path, container_id: &str) -> bool {
+    udf.join(format!("forward_daemon_{container_id}.pid"))
+        .exists()
+}
+
+fn run_down(ws: &Path, udf: &Path) -> bool {
+    let bin = env!("CARGO_BIN_EXE_deacon");
+    StdCommand::new(bin)
+        .arg("--user-data-folder")
+        .arg(udf)
+        .arg("down")
+        .arg("--workspace-folder")
+        .arg(ws)
+        .arg("--remove")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn read_marker_pid(udf: &Path, container_id: &str) -> Option<u32> {
+    let text =
+        std::fs::read_to_string(udf.join(format!("forward_daemon_{container_id}.pid"))).ok()?;
+    let v: Value = serde_json::from_str(&text).ok()?;
+    v.get("pid").and_then(Value::as_u64).map(|p| p as u32)
+}
+
+fn kill_pid(pid: u32) {
+    let _ = StdCommand::new("kill")
+        .arg(pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn teardown(ws: &Path, udf: &Path, container_id: Option<&str>) {
+    // Reap the forwarder if its marker is still around.
+    if let Some(id) = container_id {
+        if let Some(pid) = read_marker_pid(udf, id) {
+            kill_pid(pid);
+        }
+        let _ = StdCommand::new("docker")
+            .args(["rm", "-f", id])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    let bin = env!("CARGO_BIN_EXE_deacon");
+    let _ = StdCommand::new(bin)
+        .arg("--user-data-folder")
+        .arg(udf)
+        .arg("down")
+        .arg("--workspace-folder")
+        .arg(ws)
+        .arg("--remove")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// US1 (T010): a loopback-bound container server is reachable on the host via
+/// the forwarder, and `up` returns (does not occupy the terminal).
+#[test]
+fn auto_forward_reaches_loopback_server() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config(3000, true));
+
+    let up = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(
+        up.success,
+        "up --auto-forward failed.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        up.stdout, up.stderr
+    );
+
+    let host_port = wait_for_host_port(&udf, 3000, Duration::from_secs(15));
+    let result = (|| {
+        let host_port = host_port?;
+        fetch(host_port, Duration::from_secs(15))
+    })();
+
+    teardown(&ws, &udf, up.container_id.as_deref());
+
+    let body = result.expect("declared loopback port should be reachable on the host");
+    assert!(
+        body.contains(SERVER_BANNER),
+        "expected banner in relayed response, got: {body:?}"
+    );
+}
+
+/// US1 (T011): without `--auto-forward`, declared ports use static `-p` and no
+/// forwarder process / marker / registry entry is created (backward compat).
+#[test]
+fn without_auto_forward_no_forwarder_artifacts() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config(3000, true));
+
+    let up = run_up(&ws, &udf, &[]);
+    assert!(
+        up.success,
+        "plain up failed.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        up.stdout, up.stderr
+    );
+
+    // Give a forwarder (if one were wrongly spawned) time to write artifacts.
+    std::thread::sleep(Duration::from_secs(2));
+    let registry_exists = udf.join("forwarded_ports.json").exists();
+    let marker_exists = up
+        .container_id
+        .as_deref()
+        .map(|id| udf.join(format!("forward_daemon_{id}.pid")).exists())
+        .unwrap_or(false);
+
+    teardown(&ws, &udf, up.container_id.as_deref());
+
+    assert!(
+        !registry_exists,
+        "no registry file should exist without --auto-forward"
+    );
+    assert!(
+        !marker_exists,
+        "no forwarder marker should exist without --auto-forward"
+    );
+}
+
+/// US2 (T023 + T027): a port that starts listening AFTER `up` (here via
+/// `deacon exec`, with NO exec flags — documents FR-018 transparency) is
+/// auto-detected and forwarded within the detection window; when it stops
+/// listening the forward is withdrawn and the host port released.
+#[test]
+fn auto_detect_and_withdraw_port_from_exec() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &bare_config());
+
+    let up = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(
+        up.success,
+        "up --auto-forward failed.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        up.stdout, up.stderr
+    );
+
+    // Start a one-shot loopback server on :4000 AFTER up, via a plain `exec`
+    // (no auto-forward flag on exec — proves transparency, FR-018). `nc -l`
+    // serves a single connection then exits, so consuming it later also
+    // exercises withdrawal.
+    let cid = up
+        .container_id
+        .as_deref()
+        .expect("up should report a container id");
+    let started = run_exec(
+        cid,
+        &[
+            "sh",
+            "-c",
+            "(echo deacon-forward-ok | nc -l -p 4000) >/dev/null 2>&1 & sleep 1",
+        ],
+    );
+    assert!(started, "exec to start in-container server failed");
+
+    let reachable = (|| {
+        let host_port = wait_for_host_port(&udf, 4000, Duration::from_secs(15))?;
+        fetch(host_port, Duration::from_secs(15))
+    })();
+
+    // After the single connection, `nc -l` exited → port 4000 stops listening →
+    // the daemon should withdraw the forward and release the host port.
+    let withdrawn = wait_for_withdrawal(&udf, 4000, Duration::from_secs(15));
+
+    teardown(&ws, &udf, up.container_id.as_deref());
+
+    let body = reachable.expect("exec-started port should be auto-forwarded");
+    assert!(
+        body.contains(SERVER_BANNER),
+        "expected banner in relayed response, got: {body:?}"
+    );
+    assert!(
+        withdrawn,
+        "forward for container port 4000 should be withdrawn after the server stops"
+    );
+}
+
+/// US3 (T029): two devcontainers both serving container port 3000 get distinct,
+/// collision-free host ports from the shared host-global registry; both are
+/// reachable and registered. Removing one releases its host port (the daemon
+/// self-exits when its container vanishes) while the other keeps working.
+#[test]
+fn multi_container_collision_free_and_release() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    // One shared host-global registry for both forwarders.
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+
+    let ws_a = tmp.path().join(format!("ws-a-{}", unique()));
+    let ws_b = tmp.path().join(format!("ws-b-{}", unique()));
+    std::fs::create_dir_all(&ws_a).unwrap();
+    std::fs::create_dir_all(&ws_b).unwrap();
+    write_config(&ws_a, &server_config(3000, true));
+    write_config(&ws_b, &server_config(3000, true));
+
+    let up_a = run_up(&ws_a, &udf, &["--auto-forward"]);
+    let up_b = run_up(&ws_b, &udf, &["--auto-forward"]);
+    assert!(up_a.success && up_b.success, "both ups should succeed");
+    let cid_a = up_a.container_id.clone();
+    let cid_b = up_b.container_id.clone();
+
+    let outcome = (|| {
+        let id_a = cid_a.as_deref()?;
+        let id_b = cid_b.as_deref()?;
+        // Wait for both forwarders to register.
+        let mut hp_a = None;
+        let mut hp_b = None;
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_secs(15) {
+            hp_a = registry_host_port_by_container(&udf, id_a);
+            hp_b = registry_host_port_by_container(&udf, id_b);
+            if hp_a.is_some() && hp_b.is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        let hp_a = hp_a?;
+        let hp_b = hp_b?;
+        let body_a = fetch(hp_a, Duration::from_secs(15))?;
+        let body_b = fetch(hp_b, Duration::from_secs(15))?;
+        Some((hp_a, hp_b, body_a, body_b))
+    })();
+
+    // Tear down A by removing its container; its forwarder self-exits and
+    // releases the host port. B keeps working.
+    let release_ok = (|| {
+        let id_a = cid_a.as_deref()?;
+        let id_b = cid_b.as_deref()?;
+        let _ = StdCommand::new("docker")
+            .args(["rm", "-f", id_a])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        // Poll until A's entry is gone.
+        let start = Instant::now();
+        let mut a_released = false;
+        while start.elapsed() < Duration::from_secs(20) {
+            if registry_host_port_by_container(&udf, id_a).is_none() {
+                a_released = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(300));
+        }
+        let b_still = registry_host_port_by_container(&udf, id_b);
+        Some((a_released, b_still))
+    })();
+
+    teardown(&ws_a, &udf, cid_a.as_deref());
+    teardown(&ws_b, &udf, cid_b.as_deref());
+
+    let (hp_a, hp_b, body_a, body_b) =
+        outcome.expect("both containers should be forwarded and reachable");
+    assert_ne!(hp_a, hp_b, "two containers must get distinct host ports");
+    assert!(
+        body_a.contains(SERVER_BANNER),
+        "container A should be reachable"
+    );
+    assert!(
+        body_b.contains(SERVER_BANNER),
+        "container B should be reachable"
+    );
+
+    let (a_released, b_still) = release_ok.expect("release outcome");
+    assert!(
+        a_released,
+        "removing container A should release its host port"
+    );
+    assert!(
+        b_still.is_some(),
+        "container B's forward should remain after A is torn down"
+    );
+}
+
+/// US4 (T035a): `down` reaps the forwarder — its pid dies, the marker is
+/// removed, and its registry entries are released.
+#[test]
+fn down_reaps_forwarder_and_releases_ports() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config(3000, true));
+
+    let up = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(up.success, "up failed: {}", up.stderr);
+    let cid = up.container_id.clone().expect("container id");
+
+    // Forwarder should be live with a marker + registry entry.
+    assert!(
+        wait_for_host_port(&udf, 3000, Duration::from_secs(15)).is_some(),
+        "forward should be registered"
+    );
+    let pid = read_marker_pid(&udf, &cid).expect("marker pid");
+    assert!(
+        host_pid_alive(pid),
+        "forwarder pid should be alive after up"
+    );
+
+    // `down --remove` reaps it.
+    let down_ok = run_down(&ws, &udf);
+    assert!(down_ok, "down should succeed");
+
+    // Within a short window: pid dead, marker gone, registry entry released.
+    let start = Instant::now();
+    let mut reaped = false;
+    while start.elapsed() < Duration::from_secs(10) {
+        if !host_pid_alive(pid)
+            && !marker_exists(&udf, &cid)
+            && registry_host_port_by_container(&udf, &cid).is_none()
+        {
+            reaped = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    teardown(&ws, &udf, Some(&cid));
+    assert!(
+        reaped,
+        "down should reap the forwarder (pid dead, marker removed, ports released)"
+    );
+}
+
+/// US4 (T035b): `up --remove-existing-container` reaps the old forwarder before
+/// creating the replacement; the old pid dies and a fresh forwarder owns the
+/// new container.
+#[test]
+fn replace_reaps_old_forwarder() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config(3000, true));
+
+    let up1 = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(up1.success, "first up failed: {}", up1.stderr);
+    let cid1 = up1.container_id.clone().expect("container id 1");
+    assert!(wait_for_host_port(&udf, 3000, Duration::from_secs(15)).is_some());
+    let pid1 = read_marker_pid(&udf, &cid1).expect("marker pid 1");
+
+    // Replace the container; the old forwarder must be reaped first.
+    let up2 = run_up(
+        &ws,
+        &udf,
+        &["--auto-forward", "--remove-existing-container"],
+    );
+    assert!(up2.success, "replace up failed: {}", up2.stderr);
+    let cid2 = up2.container_id.clone().expect("container id 2");
+    assert_ne!(cid1, cid2, "replacement should be a new container");
+
+    // New forwarder is live for the new container.
+    let new_ok = wait_for_host_port(&udf, 3000, Duration::from_secs(15)).is_some();
+
+    // Old forwarder pid should be dead and its marker gone.
+    let start = Instant::now();
+    let mut old_reaped = false;
+    while start.elapsed() < Duration::from_secs(10) {
+        if !host_pid_alive(pid1) && !marker_exists(&udf, &cid1) {
+            old_reaped = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+
+    teardown(&ws, &udf, Some(&cid2));
+    let _ = StdCommand::new("docker")
+        .args(["rm", "-f", &cid1])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    assert!(new_ok, "replacement forwarder should be registered");
+    assert!(
+        old_reaped,
+        "old forwarder should be reaped on --remove-existing-container"
+    );
+}
+
+/// US5 (T041): `onAutoForward` is honored — `ignore` ports are never forwarded,
+/// `silent` ports are forwarded with no human mapping line, `notify` ports are
+/// forwarded with a mapping line (in the per-container forwarder log).
+#[test]
+fn ports_attributes_on_auto_forward_honored() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    let cfg = r#"{
+  "name": "auto-forward-attrs",
+  "image": "alpine:3.18",
+  "overrideCommand": true,
+  "forwardPorts": [3000, 3001, 3002],
+  "portsAttributes": {
+    "3000": { "onAutoForward": "notify" },
+    "3001": { "onAutoForward": "silent" },
+    "3002": { "onAutoForward": "ignore" }
+  },
+  "postStartCommand": "sh -c '(while true; do echo deacon-forward-ok | nc -l -p 3000; done) >/dev/null 2>&1 & (while true; do echo deacon-forward-ok | nc -l -p 3001; done) >/dev/null 2>&1 & sleep 1'"
+}"#;
+    write_config(&ws, cfg);
+
+    let up = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(up.success, "up failed: {}", up.stderr);
+    let cid = up.container_id.clone().expect("container id");
+
+    let outcome = (|| {
+        let hp_notify = wait_for_host_port(&udf, 3000, Duration::from_secs(15))?;
+        let hp_silent = wait_for_host_port(&udf, 3001, Duration::from_secs(15))?;
+        let body_notify = fetch(hp_notify, Duration::from_secs(15))?;
+        let body_silent = fetch(hp_silent, Duration::from_secs(15))?;
+        // Give the eager declared loop a moment; the ignored port must never
+        // appear in the registry.
+        std::thread::sleep(Duration::from_secs(2));
+        let ignored_present = registry_host_port(&udf, 3002).is_some();
+        let log = std::fs::read_to_string(udf.join(format!("forward_daemon_{cid}.log")))
+            .unwrap_or_default();
+        Some((body_notify, body_silent, ignored_present, log))
+    })();
+
+    teardown(&ws, &udf, Some(&cid));
+
+    let (body_notify, body_silent, ignored_present, log) =
+        outcome.expect("notify+silent ports should be reachable");
+    assert!(body_notify.contains(SERVER_BANNER), "notify port reachable");
+    assert!(body_silent.contains(SERVER_BANNER), "silent port reachable");
+    assert!(!ignored_present, "ignored port must not be forwarded");
+    assert!(
+        log.contains("Forwarding container 3000"),
+        "notify port should emit a mapping line; log:\n{log}"
+    );
+    assert!(
+        !log.contains("Forwarding container 3001"),
+        "silent port must NOT emit a mapping line; log:\n{log}"
+    );
+}
+
+/// US5 (T042): a compose `"service:port"` declared port on a non-primary
+/// service is reachable on the host — the relay dials the named service over
+/// the compose network from the primary container (FR-023).
+#[test]
+fn compose_service_port_is_forwarded() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+
+    // docker-compose.yml resolves against the workspace folder (per CLAUDE.md).
+    std::fs::write(
+        ws.join("docker-compose.yml"),
+        r#"services:
+  app:
+    image: alpine:3.18
+    command: ["sleep", "infinity"]
+  db:
+    image: alpine:3.18
+    command: ["sh", "-c", "while true; do echo deacon-forward-ok | nc -l -p 5432; done"]
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        r#"{
+  "name": "af-compose",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": ["db:5432"]
+}"#,
+    )
+    .unwrap();
+
+    let up = run_up(&ws, &udf, &["--auto-forward"]);
+    assert!(
+        up.success,
+        "compose up --auto-forward failed.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        up.stdout, up.stderr
+    );
+    let cid = up.container_id.clone();
+
+    let result = (|| {
+        let host_port = wait_for_host_port(&udf, 5432, Duration::from_secs(20))?;
+        fetch(host_port, Duration::from_secs(20))
+    })();
+
+    // Reap the forwarder, then tear the compose project down.
+    if let Some(id) = cid.as_deref() {
+        if let Some(pid) = read_marker_pid(&udf, id) {
+            kill_pid(pid);
+        }
+    }
+    let _ = run_down(&ws, &udf);
+
+    let body = result.expect("compose service:port should be reachable on the host");
+    assert!(
+        body.contains(SERVER_BANNER),
+        "expected banner relayed from the db service, got: {body:?}"
+    );
+}

--- a/docs/subcommand-specs/up/SPEC.md
+++ b/docs/subcommand-specs/up/SPEC.md
@@ -68,6 +68,10 @@
     - --include-configuration [boolean]
     - --include-merged-configuration [boolean]
     - --user-data-folder <path> (persisted host state)
+  - Port forwarding:
+    - --ports-events [boolean, default false] (emit `PORT_EVENT:` lines)
+    - --forward-port <PORT|HOST:CONTAINER> (repeatable)
+    - --auto-forward [boolean, default false] — **deacon extension**; see §2.1.
   - Deprecated: none (TS reference has no deprecations for up).
 - Validation Rules:
   - At least one of: --workspace-folder or --id-label is required.
@@ -79,6 +83,53 @@
     - --expect-existing-container prevents building/creating a new one; errors if missing.
     - --remove-existing-container forces removal before (re)create.
     - --skip-post-create and --prebuild are mutually shaping lifecycle execution order; see lifecycle section.
+
+### 2.1 `--auto-forward` (deacon extension: dynamic user-space port forwarding)
+
+`--auto-forward` is a **deacon-specific consumer extension**, not mandated by the
+upstream containers.dev spec. It is modeled on the VS Code Dev Containers
+forwarding experience and reuses spec vocabulary (`forwardPorts`, `appPort`,
+`portsAttributes.onAutoForward`, compose `"service:port"`).
+
+- **Model**: when set, `up` starts a **detached, host-side forwarder process**
+  (the deacon binary re-exec'd with a hidden `__forward-daemon` subcommand) for
+  the (primary) container, then returns control to the shell. The forwarder
+  polls the container's TCP LISTEN sockets (`/proc/net/tcp{,6}` via `docker
+  exec`, ~1 s) and, for each detected or declared port, binds a
+  `127.0.0.1:<host-port>` listener that relays bytes into the container's
+  network namespace over `docker exec -i`. Because `docker exec` shares the
+  container netns, this reaches **`127.0.0.1`-bound** servers that static `-p`
+  publishing cannot.
+- **Declared vs auto-detected**: declared ports (`forwardPorts`/`appPort`/
+  `--forward-port`) are forwarded **eagerly** (host port reserved at `up` time)
+  and are **suppressed from static `-p`** so Docker and the daemon never contend
+  for the same host port. Undeclared listening ports are forwarded **lazily**
+  when observed and withdrawn when they stop.
+- **Loopback / TCP only**: host binds are always `127.0.0.1` (never
+  `0.0.0.0`/LAN); TCP only. Privileged container ports (<1024) always remap to a
+  free host port ≥1024 (no host root required); the actual host port is always
+  reported.
+- **Attributes**: `portsAttributes[port].onAutoForward` is honored —
+  `ignore` (not forwarded), `silent` (forwarded, no human mapping line),
+  `notify` (forwarded + line). `otherPortsAttributes` is the default for
+  undeclared ports (else `notify`). `openBrowser`/`openPreview` are treated as
+  `notify` in v1.
+- **Compose**: a `"service:port"` declared port forwards to the named compose
+  service over the project network; auto-detection stays scoped to the primary
+  service.
+- **Best-effort**: if the forwarder cannot start (or no in-container relay —
+  embedded/`socat`/`nc`/bash `/dev/tcp` — is available), `up` prints a clear
+  warning and still exits `0` with the container running. Nothing is silently
+  faked.
+- **Output contract**: per-port mappings go to **stderr** (the forwarder log);
+  the `up` result JSON on **stdout** is unchanged. With `--ports-events`, the
+  forwarder emits `PORT_EVENT:` forward/unforward lines.
+- **Lifecycle**: single forwarder per container (adopt-or-reuse via a pid
+  marker). Reaped on `down` and on `up --remove-existing-container`; self-exits
+  if its container vanishes. State lives under the user-data folder
+  (`forwarded_ports.json` registry + `forward_daemon_<id>.{pid,log}`).
+- **Platform**: Unix hosts only in v1; on a non-Unix build `--auto-forward`
+  warns that it is unsupported and the rest of `up` is unaffected.
 
 ## 3. Input Processing Pipeline
 ```pseudocode

--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -96,6 +96,7 @@ listed.
 | set-up/basic | ✅ pass | 2026-05-29 | |
 | template-management/optional-paths | ✅ pass | 2026-05-29 | |
 | up/additional-mounts | ✅ pass | 2026-05-29 | |
+| up/auto-forward | ✅ pass | 2026-06-09 | `--auto-forward` loopback reach + multi-container collision-free (015) |
 | up/basic-image | ✅ pass | 2026-05-29 | |
 | up/compose-basic | ✅ pass | 2026-05-29 | |
 | up/compose-profiles | ✅ pass | 2026-05-29 | |

--- a/examples/up/auto-forward/.devcontainer/devcontainer.json
+++ b/examples/up/auto-forward/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "auto-forward",
+	"image": "alpine:3.18",
+	"overrideCommand": true,
+	"forwardPorts": [3000],
+	"postStartCommand": "sh -c '(while true; do echo deacon-forward-ok | nc -l -p 3000; done) >/dev/null 2>&1 & sleep 1'"
+}

--- a/examples/up/auto-forward/README.md
+++ b/examples/up/auto-forward/README.md
@@ -1,0 +1,37 @@
+# up --auto-forward (dynamic user-space port forwarding)
+
+`deacon up --auto-forward` is a **deacon extension** (modeled on VS Code Dev
+Containers): it starts a detached, host-side forwarder that makes container TCP
+ports reachable on **loopback** host ports — including `127.0.0.1`-bound servers
+that static `-p` publishing cannot reach — and returns control to your shell.
+
+This example's container (`alpine:3.18`) runs a tiny `nc` banner server bound
+inside the container and declares `forwardPorts: [3000]`.
+
+## Scenarios (`exec.sh`)
+
+1. **Loopback reach** — `up --auto-forward`, then connect to the reported
+   `127.0.0.1:<host-port>` and read the banner the in-container server emits.
+   This is the headline capability static `-p` can't provide.
+2. **Collision-free multi-container** — bring up a second copy of the same
+   config; both serve container port `3000`, and the host-global registry hands
+   each a **distinct** host port (the second is remapped).
+
+The script isolates state under a temporary `--user-data-folder` and removes all
+containers, detached forwarders, and temp dirs on exit.
+
+```bash
+./exec.sh
+```
+
+## Notes & limits (v1)
+
+- **Loopback only** (`127.0.0.1`, never `0.0.0.0`/LAN) and **TCP only**.
+- **Unix hosts only**; **best-effort** (a forwarding failure warns but `up` still
+  succeeds). Privileged container ports (<1024) remap to an unprivileged host
+  port — no host root needed.
+- Forwarder logs: `<user-data-folder>/forward_daemon_<container_id>.log`.
+- Running inside the deacon monorepo, the example passes
+  `--mount-workspace-git-root false` so each workspace mounts directly (the
+  git-root mount default would otherwise relocate files; not a deacon bug — see
+  `CLAUDE.md`).

--- a/examples/up/auto-forward/exec.sh
+++ b/examples/up/auto-forward/exec.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Canary for `deacon up --auto-forward` (deacon extension: dynamic, user-space
+# port forwarding). Demonstrates:
+#   1. Loopback reach — a 127.0.0.1-bound container server reachable on the host
+#      (something static `-p` cannot do).
+#   2. Multi-container collision-free allocation — two devcontainers both serving
+#      container port 3000 get two distinct host ports from the host-global
+#      registry.
+# All resources (containers, detached forwarders, temp dirs) are cleaned up.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+
+# Isolated host-global registry + markers so the canary never touches ~/.deacon.
+UDF="$(mktemp -d)"
+# Second workspace for the multi-container scenario (a copy of this config).
+WS2="$(mktemp -d)"
+cp -r "$SCRIPT_DIR/.devcontainer" "$WS2/.devcontainer"
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+# Inside the monorepo, `up` mounts the git root unless told otherwise (the
+# intended --mount-workspace-git-root default); pass false so each example
+# workspace mounts directly. Not a deacon bug — see CLAUDE.md.
+UP_FLAGS=(--auto-forward --mount-workspace-git-root false --remove-existing-container)
+
+cleanup() {
+	# Kill any forwarders recorded in the isolated registry's markers, remove
+	# the example's containers (matched by the shared config name label), and
+	# drop the temp dirs.
+	for pidfile in "$UDF"/forward_daemon_*.pid; do
+		[ -f "$pidfile" ] || continue
+		pid="$(sed -n 's/.*"pid"[: ]*\([0-9]*\).*/\1/p' "$pidfile" | head -n1 || true)"
+		[ -n "${pid:-}" ] && kill "$pid" 2>/dev/null || true
+	done
+	docker ps -aq --filter "label=devcontainer.name=auto-forward" | xargs -r docker rm -f >/dev/null 2>&1 || true
+	rm -rf "$UDF" "$WS2" "$SCRIPT_DIR/.devcontainer-state"
+}
+trap cleanup EXIT
+
+# Fetch from a loopback host port via bash /dev/tcp (no curl/nc needed on host).
+fetch() {
+	local port="$1" out=""
+	for _ in $(seq 1 20); do
+		# The busybox `nc` server may not half-close, so `cat` is killed by
+		# `timeout` (non-zero exit) *after* receiving the banner — gate on the
+		# captured output, not the exit code. `|| true` keeps set -e happy.
+		out="$(timeout 4 bash -c "exec 3<>/dev/tcp/127.0.0.1/$port; printf 'GET / HTTP/1.0\r\n\r\n' >&3; cat <&3" 2>/dev/null || true)"
+		if [ -n "$out" ]; then
+			printf '%s' "$out"
+			return 0
+		fi
+		sleep 0.5
+	done
+	return 1
+}
+
+wait_for_registry_entries() {
+	local want="$1" n
+	for _ in $(seq 1 30); do
+		# `|| n=0` keeps set -e happy when the file/keys are not present yet.
+		n="$(grep -c '"host_port"' "$UDF/forwarded_ports.json" 2>/dev/null)" || n=0
+		[ "${n:-0}" -ge "$want" ] && return 0
+		sleep 0.5
+	done
+	return 1
+}
+
+echo "== Scenario 1: reach a loopback-only server through the forwarder ==" >&2
+run "$DEACON_BIN" --user-data-folder "$UDF" up --workspace-folder "$SCRIPT_DIR" "${UP_FLAGS[@]}" >/dev/null
+wait_for_registry_entries 1
+HP1="$(sed -n 's/.*"host_port"[: ]*\([0-9]*\).*/\1/p' "$UDF/forwarded_ports.json" | head -n1)"
+echo "  forwarded container 3000 -> host 127.0.0.1:${HP1}" >&2
+body="$(fetch "$HP1")" || { echo "  FAIL: loopback port not reachable" >&2; exit 1; }
+echo "$body" | grep -q "deacon-forward-ok" || { echo "  FAIL: unexpected response: $body" >&2; exit 1; }
+echo "  ok: loopback-only container server reachable on the host" >&2
+
+echo "== Scenario 2: a second devcontainer gets a distinct host port ==" >&2
+run "$DEACON_BIN" --user-data-folder "$UDF" up --workspace-folder "$WS2" "${UP_FLAGS[@]}" >/dev/null
+wait_for_registry_entries 2
+mapfile -t PORTS < <(sed -n 's/.*"host_port"[: ]*\([0-9]*\).*/\1/p' "$UDF/forwarded_ports.json" | sort -u)
+echo "  registry host ports: ${PORTS[*]}" >&2
+if [ "${#PORTS[@]}" -ge 2 ]; then
+	echo "  ok: two devcontainers serving container 3000 got distinct host ports (collision-free)" >&2
+else
+	echo "  FAIL: expected two distinct host ports, got: ${PORTS[*]}" >&2
+	exit 1
+fi
+
+echo "All scenarios run." >&2

--- a/examples/up/exec.sh
+++ b/examples/up/exec.sh
@@ -20,6 +20,7 @@ DEFAULT_EXAMPLES=(
 	"id-labels-reconnect"
 	"remove-existing"
 	"gpu-modes"
+	"auto-forward"
 )
 
 if [ -n "${EXAMPLES_OVERRIDE:-}" ]; then

--- a/specs/015-auto-forward-ports/checklists/requirements.md
+++ b/specs/015-auto-forward-ports/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Dynamic User-Space Port Forwarding (`up --auto-forward`)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. `/speckit.clarify` (Session 2026-06-08) resolved 5 additional decision points: eager declared-port forwarding (FR-024), forwarder-failure `up` exit behavior (FR-025, reconciled FR-019), privileged-port remap (FR-009a), fixed non-configurable poll interval (FR-004), and TCP-only transport scope (FR-003). Earlier session resolved declared-vs-`-p`, loopback-only, no new subcommand, and compose scope (FR-023).
+- Spec is ready for `/speckit.plan`.

--- a/specs/015-auto-forward-ports/contracts/cli.md
+++ b/specs/015-auto-forward-ports/contracts/cli.md
@@ -1,0 +1,57 @@
+# CLI Contract: `--auto-forward`
+
+## User-facing flag
+
+Added to `Commands::Up` (`crates/deacon/src/cli.rs`) and threaded into `UpArgs` (`crates/deacon/src/commands/up/args.rs`) as `auto_forward: bool`.
+
+```
+deacon up --auto-forward
+```
+
+| Property | Value |
+|----------|-------|
+| Name | `--auto-forward` (NOT `--forward`; deliberately distinct from `--forward-port`) |
+| Type | boolean flag (`#[arg(long)]`, no value) |
+| Default | `false` (absent ⇒ today's static `-p` behavior, FR-007) |
+| Scope | `up` subcommand only (no `exec`/standalone form in v1) |
+
+### Behavior contract
+
+- **Absent** (`false`): declared ports (`forwardPorts`/`appPort`/`--forward-port`) → `docker run -p` static publish; no forwarder. Byte-for-byte unchanged (FR-007, SC-006).
+- **Present** (`true`):
+  - Container is created/started normally, but declared ports are **suppressed from `-p`** and routed to the forwarder (FR-006).
+  - After the container is healthy (post-lifecycle, `up/container.rs` ~line 673), `up` spawns-or-adopts the forwarder, then returns to the shell (FR-002).
+  - Per-port loopback mappings are printed to **stderr**; the `up` result document on **stdout** is unchanged (FR-010).
+  - If the forwarder cannot start, a clear warning is printed and `up` still exits `0` (FR-025).
+  - On a **non-Unix** build (Windows), `--auto-forward` returns a clear "not supported on this platform" error (Unix-only in v1; no silent fallback). The rest of `up` is unaffected.
+
+### Interaction with existing flags
+
+| Flag | Interaction |
+|------|-------------|
+| `--forward-port <spec>` | Treated as a declared port; joins the daemon set (eager) when `--auto-forward` is set. |
+| `--ports-events` | Forwarder emits `PORT_EVENT:` forward/unforward lines as ports come/go (FR-020; see `port-events.md`). |
+| `--remove-existing-container` | Reaps the existing container's forwarder before replacing (FR-014). |
+| `--user-data-folder` | Locates the host-global registry and markers (default `~/.deacon`). |
+
+## Hidden daemon subcommand (internal)
+
+The forwarder process is the deacon binary re-exec'd with a hidden subcommand. It is **not** part of the user-facing surface (hidden from `--help`); it exists only so `up` can spawn a detached forwarder from the shipped single binary.
+
+```
+deacon __forward-daemon \
+  --container-id <id> \
+  --workspace <canonical-path> \
+  --user-data-folder <dir> \
+  --declared-port <spec> [--declared-port <spec> ...] \
+  --config <path>
+```
+
+| Property | Value |
+|----------|-------|
+| Visibility | `#[command(hide = true)]` — never shown in help/completions |
+| Stability | Internal; arguments may change between releases without notice |
+| Entry behavior | `setsid()`, reopen stdio → per-container log, then run the supervisor loop |
+| Exit | Self-exits (0) when the container is gone or on SIGTERM after releasing ports/marker (FR-015) |
+
+**Contract note**: end users MUST NOT invoke `__forward-daemon` directly; it is an implementation detail of `up --auto-forward`. Documented here only for completeness.

--- a/specs/015-auto-forward-ports/contracts/marker.schema.json
+++ b/specs/015-auto-forward-ports/contracts/marker.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deacon/specs/015-auto-forward-ports/marker.schema.json",
+  "title": "forward_daemon_<container_id>.pid — single-owner forwarder marker",
+  "description": "Per-container record proving a live forwarder process owns this container. Lives at {user_data_folder}/forward_daemon_<container_id>.pid. NOTE: despite the `.pid` suffix (inherited from issue #186), the file holds this JSON object, not a bare pid integer. Read by `up --auto-forward` (adopt-or-reuse, FR-012) and by `down`/replace (reap, FR-013/FR-014). Removed on reap and on daemon self-exit.",
+  "type": "object",
+  "required": ["pid", "container_id", "workspace", "started_at", "log_path"],
+  "additionalProperties": false,
+  "properties": {
+    "pid": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Forwarder process id. Liveness is checked before adopting (FR-012) and to decide stale-pruning."
+    },
+    "container_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Full id of the owned container."
+    },
+    "workspace": {
+      "type": "string",
+      "description": "Canonical workspace path."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp the forwarder started (diagnostics only)."
+    },
+    "log_path": {
+      "type": "string",
+      "description": "Absolute path to this forwarder's per-container log file ({user_data_folder}/forward_daemon_<container_id>.log)."
+    }
+  },
+  "examples": [
+    {
+      "pid": 12345,
+      "container_id": "abc123def456",
+      "workspace": "/home/dev/app-a",
+      "started_at": "2026-06-08T14:03:22Z",
+      "log_path": "/home/dev/.deacon/forward_daemon_abc123def456.log"
+    }
+  ]
+}

--- a/specs/015-auto-forward-ports/contracts/port-events.md
+++ b/specs/015-auto-forward-ports/contracts/port-events.md
@@ -1,0 +1,46 @@
+# Contract: Port events & human-readable mappings
+
+Two output surfaces, both honoring the Output Streams Contract (Principle VI): the **`up` result JSON stays on stdout, unchanged**; everything below goes to **stderr** (human mappings) or the existing event channel.
+
+## 1. Human-readable mappings (stderr)
+
+Emitted by the forwarder as forwards become active. One line per forward. Format is human-facing (not parsed); examples:
+
+```
+Forwarding container 3000 -> http://127.0.0.1:3000 (web)
+Forwarding container 3000 -> http://127.0.0.1:3001 (remapped; host 3000 in use)
+Forwarding container 80   -> http://127.0.0.1:8080 (remapped; privileged port)
+Unforwarded container 3000 (server stopped)
+```
+
+Rules:
+- MUST always state the **actual** host port, especially on remap (FR-009, FR-010, SC-007) — no silent remaps.
+- `silent` (`onAutoForward: silent`) ports are forwarded but produce **no** mapping line (FR-017).
+- `ignore` ports produce no line and are not forwarded.
+
+## 2. `PORT_EVENT:` machine channel (when `--ports-events` is set)
+
+Reuses the existing `PortEvent` struct and `PORT_EVENT: <json>` emission (`crates/core/src/ports.rs`). The forwarder emits an event when a port is **forwarded** and when it is **unforwarded** (FR-020), extending today's create-time-only emission to the dynamic lifetime.
+
+Existing `PortEvent` shape (camelCase JSON), unchanged:
+
+```json
+PORT_EVENT: {"port":3000,"protocol":"http","label":"web","onAutoForward":"notify","autoForwarded":true,"localPort":3001,"hostIp":"127.0.0.1"}
+```
+
+| Field | Forward event | Unforward event |
+|-------|---------------|-----------------|
+| `port` | container port | container port |
+| `autoForwarded` | `true` | `false` |
+| `localPort` | allocated host port | the freed host port (or null) |
+| `hostIp` | `"127.0.0.1"` | `"127.0.0.1"` |
+| `onAutoForward` | effective attribute | effective attribute |
+
+Rules:
+- `hostIp` is always `127.0.0.1` in v1 (loopback-only, FR-005).
+- Event stream ordering reflects real-time forward/unforward transitions; a `silent` port still emits a `PORT_EVENT` (the event channel is machine-facing; `silent` suppresses only the human stderr line).
+- Channel selection (stdout vs stderr) follows the existing `--ports-events` implementation and the JSON-mode output contract; no change to where `PORT_EVENT:` is written relative to today.
+
+## 3. `up` result document (stdout) — UNCHANGED
+
+The `up` JSON result on stdout MUST NOT gain forward-mapping fields in v1 (FR-010). Tools that need the live mappings use `--ports-events` (channel 2) or read the registry file. This keeps the stdout result contract stable and backward compatible.

--- a/specs/015-auto-forward-ports/contracts/registry.schema.json
+++ b/specs/015-auto-forward-ports/contracts/registry.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://deacon/specs/015-auto-forward-ports/registry.schema.json",
+  "title": "forwarded_ports.json — host-global port allocation registry",
+  "description": "Host-wide record of every active forwarded host port across all `deacon up --auto-forward` forwarders. Lives at {user_data_folder}/forwarded_ports.json. Written atomically (temp file + rename) under an advisory file lock. Every host_port is unique across the whole array.",
+  "type": "object",
+  "required": ["version", "entries"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for forward-compatible evolution."
+    },
+    "entries": {
+      "type": "array",
+      "description": "One entry per active host-port allocation. host_port values MUST be unique across this array.",
+      "items": { "$ref": "#/definitions/entry" }
+    }
+  },
+  "definitions": {
+    "entry": {
+      "type": "object",
+      "required": ["host_port", "container_id", "container_port", "workspace", "pid"],
+      "additionalProperties": false,
+      "properties": {
+        "host_port": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535,
+          "description": "Allocated loopback host port (always >= 1024; privileged ports are remapped per FR-009a). Unique across the registry."
+        },
+        "container_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Full id of the owning container."
+        },
+        "container_port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Source TCP port inside the container."
+        },
+        "workspace": {
+          "type": "string",
+          "description": "Canonical workspace path of the owning devcontainer (for reporting/disambiguation)."
+        },
+        "pid": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Process id of the owning forwarder; used to prune stale entries when the process is dead (FR-016)."
+        },
+        "label": {
+          "type": ["string", "null"],
+          "description": "Effective port label from portsAttributes, if any."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": 1,
+      "entries": [
+        { "host_port": 3000, "container_id": "abc123", "container_port": 3000, "workspace": "/home/dev/app-a", "pid": 12345, "label": "web" },
+        { "host_port": 3001, "container_id": "def456", "container_port": 3000, "workspace": "/home/dev/app-b", "pid": 12346, "label": null }
+      ]
+    }
+  ]
+}

--- a/specs/015-auto-forward-ports/data-model.md
+++ b/specs/015-auto-forward-ports/data-model.md
@@ -1,0 +1,144 @@
+# Phase 1 Data Model: Dynamic User-Space Port Forwarding
+
+Entities below are the runtime/persisted structures for the forwarder. Types are indicative Rust shapes for `crates/core/src/port_forward/`; field names in persisted JSON are the binding contract (see `contracts/`).
+
+---
+
+## 1. `DetectedPort` (in-memory, from `detect.rs`)
+
+One LISTEN socket observed inside the container.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `port` | `u16` | Container-side listening port. |
+| `bind_addr` | `BindScope` enum | `Loopback` (`127.0.0.1`/`::1`) or `AnyInterface` (`0.0.0.0`/`::`). Informational; both are forwarded. |
+| `family` | `IpFamily` enum | `V4` / `V6`. Used only for dedup; the forward is per logical `port`. |
+
+**Validation / rules**:
+- Only rows with state `st == 0A` (TCP_LISTEN) are emitted.
+- The same `port` appearing on V4 and V6 collapses to a single logical port (FR-003).
+- TCP only — UDP tables are not read (FR-003).
+
+**Derivation**: pure function `parse_proc_net_tcp(&str) -> Vec<DetectedPort>` over the concatenated `/proc/net/tcp` + `/proc/net/tcp6` text. No IO; fully unit-testable with fixtures.
+
+---
+
+## 2. `ForwardSpec` (in-memory, the daemon's intent for one port)
+
+The reconciled decision of "this container port should be forwarded."
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `container_port` | `u16` | Source port inside the container. |
+| `origin` | `ForwardOrigin` enum | `Declared` (from `forwardPorts`/`appPort`/`--forward-port`) or `AutoDetected`. |
+| `service` | `Option<String>` | For compose `"service:port"` declared ports; `None` = primary service. |
+| `attributes` | `ResolvedPortAttributes` | Effective `portsAttributes[port]` or `otherPortsAttributes` default. |
+| `eager` | `bool` | `true` for `Declared` (bind host listener at startup), `false` for `AutoDetected` (bind on first observation). FR-024. |
+
+**Rules**:
+- `Declared` ⇒ `eager = true`, host port reserved at `up` time (FR-024); suppressed from static `-p` (FR-006).
+- `AutoDetected` ⇒ `eager = false`; created when observed LISTEN, removed when it stops (FR-004).
+- If `attributes.on_auto_forward == Ignore`, no `ForwardSpec`/listener is created (FR-017).
+
+---
+
+## 3. `ResolvedPortAttributes`
+
+Effective per-port forwarding preferences (subset of the existing `PortAttributes`, `config.rs:192`).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `label` | `Option<String>` | Human label for reporting. |
+| `on_auto_forward` | `OnAutoForward` | `Ignore` / `Silent` / `Notify` (v1 honored); `OpenBrowser`/`OpenPreview` accepted but treated as `Notify` for v1. |
+
+**Derivation**: declared port → `config.ports_attributes[port]`; auto-detected port with no explicit entry → `config.other_ports_attributes` default, else implicit `Notify`.
+
+---
+
+## 4. `ActiveForward` (in-memory live state, owned by the daemon)
+
+A `ForwardSpec` that currently has a host listener bound.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `spec` | `ForwardSpec` | The intent. |
+| `host_port` | `u16` | Allocated loopback host port (≥1024). |
+| `remapped` | `bool` | `true` if `host_port != container_port` (drives the "remapped" report, FR-009). |
+| `listener` | `TcpListener` handle | Bound to `127.0.0.1:host_port`. |
+| `connections` | task set | Per-connection relay tasks. |
+
+**State transitions**:
+```
+            declared (eager)                       observed LISTEN (lazy)
+   (none) ───────────────► Reserved ──relay dials──► Active
+        ▲                     │ container port observed │
+        │                     ▼                          ▼
+        └────── released ◄── Withdrawn ◄── port stops / container gone / down
+```
+- `Reserved`: host listener open, container side not yet listening → host connections refused until ready (FR-024).
+- `Active`: relaying.
+- `Withdrawn`: listener closed, registry entry released (FR-004, FR-013, FR-015).
+
+---
+
+## 5. `RegistryEntry` (persisted — `forwarded_ports.json`)
+
+One row in the host-global allocation registry. **This JSON shape is a binding contract** (`contracts/registry.schema.json`).
+
+| Field | JSON key | Type | Notes |
+|-------|----------|------|-------|
+| host port | `host_port` | number (u16) | Allocated loopback host port. Unique across the file. |
+| container id | `container_id` | string | Owning container (full id). |
+| container port | `container_port` | number (u16) | Source port inside the container. |
+| workspace | `workspace` | string | Canonical workspace path (for reporting / human disambiguation). |
+| pid | `pid` | number | Owning forwarder process id (for stale-reaping). |
+| label | `label` | string \| null | Effective port label, if any. |
+
+**Rules / invariants**:
+- `host_port` is unique across the entire file (the collision-avoidance invariant, FR-008/SC-004).
+- Writes go through an `fs2` advisory lock + temp-file `rename` (Decision 5); no partial/truncated writes.
+- Entries are pruned when `pid` is not alive or `container_id` no longer exists (FR-016).
+- All of a container's entries are removed on reap/self-exit (FR-013, FR-015).
+
+---
+
+## 6. `DaemonMarker` (persisted — `forward_daemon_<container_id>.pid`)
+
+Single-owner record proving a live forwarder exists for a container. **Binding contract** (`contracts/marker.schema.json`).
+
+| Field | JSON key | Type | Notes |
+|-------|----------|------|-------|
+| pid | `pid` | number | Forwarder process id. |
+| container id | `container_id` | string | The container this forwarder owns. |
+| workspace | `workspace` | string | Canonical workspace path. |
+| started at | `started_at` | string (RFC3339) | For diagnostics. |
+| log path | `log_path` | string | Absolute path to the per-container log. |
+
+**Rules**:
+- Located at `{user_data_folder}/forward_daemon_<container_id>.pid` (mirrors env-probe key pattern).
+- `up --auto-forward` reads it: live pid ⇒ adopt/reuse (no duplicate, FR-012); dead/missing ⇒ spawn fresh.
+- Removed on `down` / replace reap and on daemon self-exit.
+- Cleared on `up --remove-existing-container` for the replaced container (FR-014).
+
+---
+
+## Entity relationships
+
+```
+ContainerIdentity (existing) ──derives──► container_id, labels, workspace_hash
+        │                                         │
+        │ one per `up --auto-forward`             │ keys
+        ▼                                         ▼
+   DaemonMarker (1 per container) ───owns───► forwarder process (pid)
+        │                                         │ maintains
+        │                                         ▼
+        │                                  ActiveForward[] (N per container)
+        │                                         │ each allocates
+        ▼                                         ▼
+   forwarded_ports.json ◄──────────────── RegistryEntry[] (host-global, all containers)
+   (1 per host, flock-guarded)             host_port unique across the whole file
+```
+
+- A single `forwarded_ports.json` is shared by **all** forwarders on the host (host-global). Every `RegistryEntry.host_port` is unique file-wide.
+- Each container has exactly one `DaemonMarker` and one forwarder process, which owns N `ActiveForward`s and contributes N `RegistryEntry`s.
+- `ForwardSpec.attributes` is resolved from the existing `DevContainerConfig.ports_attributes` / `other_ports_attributes` — reused, not redefined.

--- a/specs/015-auto-forward-ports/plan.md
+++ b/specs/015-auto-forward-ports/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Dynamic User-Space Port Forwarding (`up --auto-forward`)
+
+**Branch**: `015-auto-forward-ports` | **Date**: 2026-06-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/015-auto-forward-ports/spec.md`
+
+## Summary
+
+Add a boolean `deacon up --auto-forward` flag that starts a **detached, host-side forwarder process** for a running devcontainer. The forwarder polls the container's TCP LISTEN sockets (`/proc/net/tcp{,6}` via `docker exec`), and for each detected (or declared) port opens a `127.0.0.1:<host-port>` listener on the host that relays bytes into the container's network namespace over `docker exec -i`. Declared ports (`forwardPorts`/`appPort`/`--forward-port`) are forwarded **eagerly** (host port reserved at `up` time) and are NOT statically `-p` published when `--auto-forward` is set; auto-detected ports are forwarded **lazily**. A **host-global registry file** under the user-data folder allocates collision-free host ports across concurrent devcontainers, guarded by an advisory file lock. The forwarder is single-owner per container (adopt-or-reuse via a pid marker), is reaped on `down` / `up --remove-existing-container`, and self-exits when its container vanishes. Forwarding is **best-effort**: failures warn loudly but never fail `up`. TCP only; loopback only; v1 targets Unix.
+
+## Technical Context
+
+**Language/Version**: Rust, Edition 2024, MSRV 1.95 (`workspace.package` in root `Cargo.toml`); `unsafe_code = "deny"` workspace-wide.  
+**Primary Dependencies**: `tokio` (rt/process/fs/io-util/net), `clap` (CLI), `serde`/`serde_json` (registry + marker JSON), `tracing` (daemon logging), `thiserror` (core domain errors), `anyhow` (binary boundary), `directories-next` (user-data folder), `libc` (already in core). **New (Unix-only):** `nix` (features `process`, `signal` — safe `setsid()`, `kill()`, `Pid`, process-liveness checks without raw `unsafe`); `fs2` (advisory `flock` on the registry, auto-released on process death).  
+**Storage**: Two host-side JSON files under the user-data folder (default `~/.deacon/`): a host-global `forwarded_ports.json` registry and per-container `forward_daemon_<container_id>.pid` markers; per-container `forward_daemon_<container_id>.log` log files. All writes use the temp-file + `fs::rename` atomic pattern (`crates/core/src/cache/disk.rs::save_index`).  
+**Testing**: `cargo nextest` (unit + docker integration); new docker integration test binary registered in all three `.config/nextest.toml` profile spots per CLAUDE.md.  
+**Target Platform**: Linux/macOS hosts with Docker; container side requires only a way to read `/proc/net/*` and a relay path. **Windows detach/signaling is deferred** (tracked, not a v1 gate — per spec Assumptions).  
+**Project Type**: Single Rust workspace (CLI binary `crates/deacon` + library `crates/core`).  
+**Performance Goals**: Detect a newly-listening port and make it reachable within ≤~2 s (SC-002); poll interval fixed ~1 s (FR-004). 0% host-port collisions across concurrent forwarders (SC-004).  
+**Constraints**: Loopback-only host binds (FR-005); never require host root — privileged container ports (<1024) always remap to ≥1024 host ports (FR-009a); production code stays `unsafe`-free; no blocking IO in async paths (Principle V).  
+**Scale/Scope**: Tens of forwarded ports across a handful of concurrent devcontainers on a developer machine / CI agent; one forwarder process per container.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Parity as Source of Truth | ✅ PASS (with note) | Dynamic forwarding is **not** mandated by upstream devcontainers/spec — it is a deacon consumer extension modeled on VS Code, and the issue explicitly notes this. It reuses spec vocabulary (`portsAttributes.onAutoForward`, `forwardPorts`, `appPort`, `"service:port"`). Behavior will be documented in `docs/subcommand-specs/up/SPEC.md` as a deacon-specific addition. No conflict with existing spec-defined behavior; static `-p` path is unchanged when the flag is absent (FR-007). |
+| II. Consumer-Only Scope | ✅ PASS | Forwarding serves devcontainer *consumers*; `docker exec` into the container is standard consumer behavior (the `exec` subcommand already does it). No authoring surface. |
+| III. Keep the Build Green | ✅ PASS | fmt/clippy/fast-tests after each change; full `make test-nextest` before PR; new tests added to nextest profiles. |
+| IV. No Silent Fallbacks — Fail Fast | ✅ PASS (with rationale) | Relay-unavailable and daemon-start failures emit a **clear, non-silent** error to stderr + the forwarder log (FR-019). Per the clarified FR-025, forwarding is an *additive, best-effort* capability layered on a container that genuinely came up, so the error does not abort `up`. This is not a silent noop or a mock substitution — nothing is faked, and the error is loud. Documented as Decision 4 in research.md. |
+| V. Idiomatic, Safe Rust | ✅ PASS | Daemon is a separate re-exec'd process (an in-process task cannot outlive `up`). Detachment/signaling use `nix` safe wrappers — production stays `unsafe`-free under the `deny` policy. New module decomposed into `detect`/`registry`/`relay`/`daemon` (Principle V modular boundaries). `thiserror` in core, async via `tokio`, no blocking IO in async. |
+| VI. Observability & Output Contracts | ✅ PASS | Human-readable mappings → **stderr**; `up` result JSON on **stdout** unchanged (FR-010). Integrates the existing `PORT_EVENT:` channel for forward/unforward (FR-020). Daemon logs via `tracing` to a per-container file (FR-021). |
+| VII. Testing Completeness | ✅ PASS | Unit: `/proc/net/tcp{,6}` parser (v4/v6/loopback fixtures), registry allocation/collision/release/stale-reap, marker adopt-or-reuse. Integration (docker): loopback reach, post-`up` detection, multi-container collision-free, `down`/replace reaping, self-exit. Nextest groups planned (see Structure). |
+| VIII. Subcommand Consistency & Shared Abstractions | ✅ PASS | Reuses `ContainerIdentity`/labels for container resolution, the `Docker::exec` trait for socket scan + relay, the atomic temp+rename write pattern, the user-data-folder resolution that the trust store uses, and `down`'s identity/label selectors for reaping. New cross-cutting logic lives once in `crates/core/src/port_forward/`. |
+| IX. Executable & Self-Verifying Examples | ✅ PASS | Adds an `examples/auto-forward/` canary with `exec.sh` demonstrating loopback reach + multi-container, registered in the `examples/up` aggregator; cleans up all resources. |
+
+**Initial gate: PASS.** Two new dependencies (`nix`, `fs2`) are justified in Complexity Tracking and research.md; both are Unix-only, minimal, and chosen specifically to keep production code `unsafe`-free.
+
+**Post-Design re-check (after Phase 1): PASS.** The data model (registry/marker/mapping) and contracts introduce no new constitution tension; all writes are atomic, all container resolution reuses `ContainerIdentity`, and the daemon entrypoint is a hidden internal subcommand that does not expand the user-facing surface beyond the single `--auto-forward` flag.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-auto-forward-ports/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   ├── cli.md           #   --auto-forward flag + hidden daemon subcommand contract
+│   ├── registry.schema.json   # forwarded_ports.json entry schema
+│   ├── marker.schema.json     # forward_daemon_<id>.pid marker schema
+│   └── port-events.md   #   PORT_EVENT forward/unforward contract + stderr mapping format
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already complete)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+crates/core/src/
+├── port_forward/                 # NEW module — pure logic + IO, unit-testable
+│   ├── mod.rs                    #   public API surface (re-exports), shared types
+│   ├── detect.rs                 #   parse /proc/net/tcp{,6} LISTEN rows → Vec<DetectedPort> (pure)
+│   ├── registry.rs               #   host-global allocation registry: alloc/release/prune, flock, atomic write
+│   ├── relay.rs                  #   per-connection byte relay over `docker exec -i`; relay-program selection
+│   └── daemon.rs                 #   supervisor loop: detect → reconcile → relay; self-exit; per-container log
+├── ports.rs                      # EXTEND: reuse PortEvent/OnAutoForward; add forward/unforward event emit
+├── container.rs                  # REUSE: ContainerIdentity, labels(), label_selector()
+├── cache/disk.rs                 # REUSE pattern: atomic temp+rename write
+└── trust.rs                      # REUSE pattern: user_data_folder resolution (~/.deacon default)
+
+crates/deacon/src/
+├── cli.rs                        # EXTEND: add `--auto-forward` bool to Commands::Up; add hidden daemon subcommand
+└── commands/
+    ├── up/
+    │   ├── args.rs               # EXTEND: add `auto_forward: bool` to UpArgs
+    │   ├── container.rs          # HOOK: after lifecycle completes (~line 673), spawn/adopt forwarder; suppress -p for declared ports when set
+    │   ├── ports.rs              # EXTEND: route declared ports to daemon vs static publish
+    │   └── forward.rs            # NEW: spawn+detach forwarder (re-exec), marker adopt-or-reuse, declared-port wiring
+    ├── forward_daemon.rs         # NEW: hidden `__forward-daemon` subcommand entrypoint (setsid, reopen stdio→log, run daemon loop)
+    └── down.rs                   # EXTEND: reap forwarder(s) by pid marker, release registry ports
+
+crates/deacon/tests/
+└── integration_auto_forward.rs  # NEW docker integration test binary (registered in all 3 nextest profile spots)
+
+examples/auto-forward/            # NEW canary: README + exec.sh (loopback reach + multi-container)
+
+Cargo.toml (workspace)            # add nix (unix), fs2 to workspace.dependencies
+crates/core/Cargo.toml            # add nix (cfg(unix)), fs2
+.config/nextest.toml              # register integration_auto_forward in default + dev-fast(default-filter + override)
+```
+
+**Structure Decision**: Single Rust workspace. The reusable, runtime-agnostic logic (socket detection, host-port registry, relay, supervisor loop) lives in `crates/core/src/port_forward/` as a focused module decomposed per Principle V. The CLI binary owns only orchestration: the `--auto-forward` flag, the spawn/detach of the forwarder process, the hidden daemon entrypoint subcommand, and the `down` reap hook. This mirrors the existing split (e.g. `up` `{args,compose,lifecycle}`, `oci` `{auth,client,fetcher}`).
+
+## Complexity Tracking
+
+| Violation / Addition | Why Needed | Simpler Alternative Rejected Because |
+|----------------------|------------|--------------------------------------|
+| New dependency `nix` (Unix, `process`+`signal`) | Detached daemon needs `setsid()` (leave the controlling terminal/process group) and `kill()` / liveness checks for reaping and self-exit. | Raw `libc` calls require `unsafe`, and the workspace sets `unsafe_code = "deny"`. `nix` wraps these syscalls in safe APIs, keeping production code `unsafe`-free (the policy's preferred state). A scoped `#[allow(unsafe_code)]` was rejected to avoid normalizing `unsafe` in a long-lived daemon. |
+| New dependency `fs2` | The host-global registry's allocate-and-bind critical section must be serialized across concurrent `up --auto-forward` processes; an advisory `flock` is auto-released when the holder dies. | An `O_EXCL` lockfile mutex (pure std) leaks on crash and needs hand-rolled stale-pid detection and backoff. `flock` releases on process death automatically — exactly the crash-safety the multi-container requirement needs. |
+| Separate re-exec'd daemon process (not an in-process task) | FR-002/FR-021: forwarding must outlive `up` returning to the shell, with no attached terminal. | An in-process `tokio::spawn` task dies when the `up` command process exits — it cannot satisfy "returns control to the shell while forwarding stays active." A separate process is mandatory. |
+| Hidden `__forward-daemon` subcommand | The re-exec'd process needs an entrypoint that runs the supervisor loop. | A separate helper binary would complicate packaging/distribution (single static binary is the deacon distribution model); re-exec'ing `current_exe()` with a hidden subcommand reuses the shipped binary. |

--- a/specs/015-auto-forward-ports/quickstart.md
+++ b/specs/015-auto-forward-ports/quickstart.md
@@ -1,0 +1,88 @@
+# Quickstart: `deacon up --auto-forward`
+
+Dynamic, user-space port forwarding for a running devcontainer — modeled on VS Code. Reaches `127.0.0.1`-bound servers, auto-detects ports that start later, returns control to your shell, and works across multiple devcontainers at once.
+
+## Reach a loopback-only server (the thing `-p` can't do)
+
+```bash
+# A container whose dev server binds 127.0.0.1:3000 inside the container.
+deacon up --auto-forward
+# -> control returns immediately; stderr prints e.g.:
+#    Forwarding container 3000 -> http://127.0.0.1:3000 (web)
+
+curl http://127.0.0.1:3000      # works — even though the server is loopback-only inside
+```
+
+Without `--auto-forward`, a `127.0.0.1`-bound container server is unreachable from the host (static `-p` can only reach `0.0.0.0`).
+
+## Auto-detect a port that starts later
+
+```bash
+deacon up --auto-forward
+deacon exec bash -lc 'npm run dev'   # starts a server on :5173 AFTER up; no exec flag needed
+# within ~1-2s, stderr:  Forwarding container 5173 -> http://127.0.0.1:5173
+```
+
+The forwarder watches the container's listening sockets, so it catches servers started by `postStart`, the entrypoint, a compose `CMD`, or an interactive `exec` — `exec` is unchanged.
+
+## Run two devcontainers at once (collision-free)
+
+```bash
+# Terminal A
+deacon up --auto-forward --workspace-folder ~/app-a   # server on container :3000
+#    Forwarding container 3000 -> http://127.0.0.1:3000
+
+# Terminal B
+deacon up --auto-forward --workspace-folder ~/app-b   # also server on container :3000
+#    Forwarding container 3000 -> http://127.0.0.1:3001 (remapped; host 3000 in use)
+
+curl http://127.0.0.1:3000   # app-a
+curl http://127.0.0.1:3001   # app-b
+```
+
+Host ports are allocated from a host-global registry (`~/.deacon/forwarded_ports.json`); the actual local port is always reported.
+
+## Declared ports
+
+```jsonc
+// devcontainer.json
+{
+  "forwardPorts": [8080, "db:5432"],            // "service:port" targets a compose service
+  "portsAttributes": {
+    "8080": { "label": "api", "onAutoForward": "notify" },
+    "9229": { "onAutoForward": "ignore" }        // never forwarded
+  }
+}
+```
+
+With `--auto-forward`, declared ports are forwarded by the daemon (loopback relay) and are **not** also `-p` published. Declared ports are reserved eagerly at `up` time; undeclared ports are forwarded as they appear.
+
+## Teardown
+
+```bash
+deacon down                       # stops the forwarder, releases its host ports, no orphans
+deacon up --remove-existing-container --auto-forward   # reaps the old forwarder first
+# If the container is removed out-of-band (docker rm -f), the forwarder self-exits and cleans up.
+```
+
+## Notes & limits (v1)
+
+- **Loopback only**: forwards bind `127.0.0.1` on the host (never `0.0.0.0`/LAN).
+- **TCP only**.
+- **Best-effort**: if forwarding can't start, you get a clear warning but `up` still succeeds and the container runs.
+- **No root needed**: privileged container ports (e.g. 80) are remapped to an unprivileged host port and reported.
+- **Unix** host detach in v1 (Windows tracked separately).
+- Forwarder logs: `~/.deacon/forward_daemon_<container_id>.log`.
+
+## Verify (acceptance smoke)
+
+```bash
+# 1. loopback reach
+deacon up --auto-forward && curl -fsS http://127.0.0.1:3000 >/dev/null && echo OK
+
+# 2. registry has the entry
+cat ~/.deacon/forwarded_ports.json | jq '.entries[].host_port'
+
+# 3. clean teardown releases the port
+deacon down && cat ~/.deacon/forwarded_ports.json | jq '.entries | length'   # -> 0 for that container
+```

--- a/specs/015-auto-forward-ports/research.md
+++ b/specs/015-auto-forward-ports/research.md
@@ -1,0 +1,106 @@
+# Phase 0 Research: Dynamic User-Space Port Forwarding (`up --auto-forward`)
+
+All spec-level ambiguities were resolved in the spec's Clarifications section (two `/speckit.specify` + `/speckit.clarify` sessions on 2026-06-08). This document records the **technical** decisions that turn those clarified requirements into an implementable design, plus the deferrals required by the constitution's phased-implementation pattern.
+
+No `NEEDS CLARIFICATION` markers remain in Technical Context.
+
+---
+
+## Decision 1 — Daemon is a separate, re-exec'd process (not an in-process task)
+
+**Decision**: When `--auto-forward` is set and the container is healthy, `up` spawns a child process by re-exec'ing the current deacon binary (`std::env::current_exe()`) with a hidden `__forward-daemon` subcommand, passing the container id, workspace path, user-data folder, and the resolved declared-port set. The child detaches (`setsid()`, reopen stdio to the per-container log), records its pid in a marker, and runs the supervisor loop. `up` does **not** await the child and returns to the shell.
+
+**Rationale**: FR-002 and FR-021 require forwarding to outlive `up` returning to the shell with no attached terminal. A `tokio::spawn` task lives inside the `up` process and dies when `up` exits, so it structurally cannot satisfy this. A separate OS process is mandatory. Re-exec'ing the shipped single binary (rather than a second helper binary) preserves deacon's static-binary distribution model.
+
+**Detachment without `unsafe`**: The workspace sets `unsafe_code = "deny"`. Raw `libc::fork`/`setsid` need `unsafe`. The child therefore calls `nix::unistd::setsid()` (a safe wrapper) at the *start of its own `main`* (a normal function call, not a `pre_exec` closure), then reopens its standard fds onto the log file. Orphan reparenting to init happens naturally when the parent exits; `setsid` additionally divorces the daemon from the terminal session so a closing terminal (SIGHUP) does not kill it.
+
+**Alternatives considered**:
+- *In-process tokio task* — rejected: cannot outlive `up`.
+- *Raw `libc` double-fork with scoped `#[allow(unsafe_code)]`* — rejected: normalizes `unsafe` in a long-lived component; `nix` gives the same result safely.
+- *Separate helper binary* — rejected: complicates packaging vs. the single-binary model.
+
+---
+
+## Decision 2 — Port detection via `docker exec … cat /proc/net/tcp{,6}`, polled ~1 s
+
+**Decision**: The supervisor polls every ~1 s (fixed constant, FR-004) by running `Docker::exec(container_id, ["cat","/proc/net/tcp","/proc/net/tcp6"], ExecConfig{ silent: true, .. })` and parsing the captured stdout. `detect.rs` parses rows where the state field `st == 0A` (TCP_LISTEN), decodes the `local_address` `HEXIP:HEXPORT`, and collects ports bound to `127.0.0.1`, `0.0.0.0`, `::`, `::1`. IPv4 addresses are little-endian hex (`0100007F` → `127.0.0.1`); the port is plain hex (`1F90` → 8080); tcp6 addresses are 32 hex chars in per-word little-endian order. The same logical port on v4 and v6 is deduplicated to one forward (FR-003).
+
+**Rationale**: `/proc/net/tcp{,6}` is the same mechanism VS Code uses; it is process-agnostic (catches entrypoint/`postStart`/compose/`exec`-started servers, so `exec` needs no changes — FR-018) and requires nothing installed in the container to *detect*. `silent: true` already pipes and captures stdout in the existing exec impl (`docker.rs` ~1554). The format is stable and well-documented.
+
+**Alternatives considered**:
+- *`ss`/`netstat` inside the container* — rejected: not present on `alpine`/`distroless`; `/proc/net/*` is always present on Linux containers.
+- *netlink/inotify event-driven detection* — deferred (Decision 7): poll is simplest for v1 and meets the ≤~2 s target (SC-002).
+
+**Reference**: Linux kernel `Documentation/networking/proc_net_tcp.txt`; the `st=0A` LISTEN state and little-endian address encoding are confirmed in the sources cited at the bottom of this file.
+
+---
+
+## Decision 3 — Relay: embedded static relay binary primary; `socat`/`nc`/`/dev/tcp` fallback; fail-fast if none
+
+**Decision**: For each forwarded `(container_port → host_port)`, the daemon binds a `tokio::net::TcpListener` on `127.0.0.1:host_port`. On each accepted host connection it spawns `docker exec -i <id> <relay>` that dials `127.0.0.1:<container_port>` inside the container, and pumps bytes bidirectionally (`tokio::io::copy` both ways). Relay-program selection order: (1) a tiny embedded static relay binary `docker cp`'d into the container on first use (works on `alpine`/`distroless`, no container deps); (2) fall back to `socat`, then `nc`, then bash `/dev/tcp` **only if detected present**; (3) if no relay strategy is available, surface a clear error per FR-019. Per-connection relay for v1.
+
+**Rationale**: `docker exec` shares the container network namespace, which is *exactly* why this reaches `127.0.0.1`-bound servers that `-p` cannot (the headline capability, SC-001). Not assuming `socat` exists honors Principle IV (no silent fallback). The embedded-binary-first strategy keeps it working on minimal images.
+
+**Alternatives considered**:
+- *Assume `socat` present* — rejected: violates no-silent-fallback; absent on many images.
+- *Persistent in-container multiplexing agent (one exec, many streams)* — deferred (Decision 7): a per-connection exec is simplest and correct for v1; the multiplexer is a throughput optimization.
+
+**Open sub-decision deferred to implementation PR**: the exact embedded relay (a ~few-KB statically-linked helper vs. a shell one-liner when a shell exists). Tracked as a deferral; v1 acceptance only requires *a* working relay with fail-fast when none exists.
+
+---
+
+## Decision 4 — Forwarding is best-effort: failures warn loudly, `up` still succeeds (exit 0)
+
+**Decision**: If the forwarder cannot be spawned/detached, the registry lock cannot be taken, or no relay mechanism exists, `up` emits a clear warning to stderr (and, where a daemon exists, its log) and returns success with the container running (FR-025). The error is never swallowed (FR-019).
+
+**Rationale**: The container genuinely came up and is usable; forwarding is additive. Failing `up` would regress the non-`--auto-forward` path and block workflows where forwarding is a convenience. This is consistent with Principle IV because nothing is faked or silently downgraded — the failure is surfaced loudly; only the *exit code* treats forwarding as non-fatal. (Clarified with the user during `/speckit.clarify`.)
+
+---
+
+## Decision 5 — Host-global registry under the user-data folder, flock-guarded, atomic writes
+
+**Decision**: Active allocations live in `{user_data_folder}/forwarded_ports.json` (user-data folder resolved exactly as the trust store: `--user-data-folder` else `~/.deacon`, per `trust.rs::trust_store_path`). The allocate-and-bind critical section is wrapped in an advisory `fs2` `flock` on a sibling lock file; entries are written with the temp-file + `fs::rename` atomic pattern (`cache/disk.rs::save_index`). Allocation policy: prefer the same number (container 3000 → host 3000) when free in both the registry and an actual bind probe; otherwise next free port. Privileged container ports (<1024) skip the same-number attempt and allocate ≥1024 (FR-009a). On daemon start and on each allocation, prune entries whose `pid` is dead or whose container no longer exists (FR-016). On shutdown/reap, remove that container's entries (FR-013).
+
+**Rationale**: Host ports are a host-wide shared resource, so the registry must be host-global (not the per-workspace `--container-data-folder`). `flock` auto-releases on holder death — the crash-safety the multi-container requirement (User Story 3) needs. Atomic writes prevent the "trailing characters" JSON corruption noted in CLAUDE.md.
+
+**Alternatives considered**:
+- *`--container-data-folder` for the registry* — rejected: it may be per-workspace, defeating host-global collision avoidance.
+- *`O_EXCL` lockfile mutex* — rejected: leaks on crash; needs hand-rolled stale detection.
+
+---
+
+## Decision 6 — Single-owner-per-container marker; declared ports eager, auto-detected lazy
+
+**Decision**: A `{user_data_folder}/forward_daemon_<container_id>.pid` marker records the live forwarder for a container. `up --auto-forward` adopts-or-reuses: if the marker names a live pid, it does not spawn a duplicate (FR-012). Declared ports (`forwardPorts`/`appPort`/`--forward-port`, including `"service:port"`) are passed to the daemon and their host listeners opened **eagerly** at startup with the natural host port reserved; the relay connects lazily once the container port is observed listening (FR-024). Auto-detected, undeclared ports are bound **lazily** only once observed and torn down when they stop. When `--auto-forward` is set, declared ports are routed to the daemon and **suppressed** from the static `-p` publish args (FR-006) so Docker and the daemon never contend for the same host port.
+
+**Rationale**: The container id is the natural single-owner key (each `up` yields a distinct `ContainerIdentity`). Eager declared-port forwarding matches VS Code (declared ports appear immediately and their natural host port is reserved against theft by a second container); lazy auto-detection avoids reserving ports for servers that never start. Mirrors the env-probe marker key pattern (`container_env_probe.rs:155`).
+
+---
+
+## Decision 7 — Phased scope: explicit v1 deferrals
+
+Per Constitution Principle I (phased implementation) and the spec's Out-of-Scope/Assumptions, the following are intentionally deferred. Each has a corresponding entry to be carried into `tasks.md` "## Deferred Work" by `/speckit.tasks`:
+
+1. **Windows detach/signaling** — Unix `setsid`/`kill` path only in v1; Windows job-object/detach path tracked separately (spec Assumptions).
+2. **Persistent in-container multiplexing relay agent** — per-connection `docker exec` relay for v1; single-exec multiplexer is a throughput optimization (Decision 3).
+3. **Event-driven detection (netlink/inotify)** — fixed ~1 s poll for v1 (Decision 2).
+4. **`0.0.0.0`/LAN exposure** — loopback-only in v1 (FR-005).
+5. **UDP forwarding** — TCP only in v1 (FR-003).
+6. **`openBrowser`/`openPreview` auto-open** — honor `ignore`/`silent`/`notify` only; browser/preview opening optional (FR-017, spec Out of Scope).
+7. **Configurable poll interval / standalone `forward` subcommand / `exec --auto-forward`** — not in v1 surface (FR-004, spec Out of Scope).
+
+---
+
+## Decision 8 — Reaping on `down` and replace reuses `ContainerIdentity`
+
+**Decision**: `down` resolves the container(s) exactly as today (`ContainerIdentity` → state manager → `label_selector()`/`workspace_label_selector()` for `--all`), then for each resolved container reads the pid marker, sends `SIGTERM` (via `nix::sys::signal::kill`), waits briefly, removes the marker, and releases that container's registry entries (FR-013). `up --remove-existing-container` performs the same reap for the existing container before creating the replacement (FR-014). The daemon independently self-exits if `docker inspect` / relay execs show the container is gone (FR-015).
+
+**Rationale**: Reuses existing container-resolution machinery (Principle VIII) rather than inventing a parallel lookup. SIGTERM (not SIGKILL) lets the daemon run its own cleanup (release ports, remove marker) for belt-and-suspenders correctness.
+
+---
+
+## Sources
+
+- Linux kernel docs — `/proc/net/tcp` interface (state field, address encoding): <https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt>
+- Reading `/proc/net/tcp` (LISTEN `st=0A`, little-endian address/port decode): <https://blog.arkey.fr/2020/10/23/read-network-addresses-in-procfs/>
+- VS Code Dev Containers port forwarding model & compose `"service:port"`: <https://code.visualstudio.com/docs/devcontainers/containers>

--- a/specs/015-auto-forward-ports/spec.md
+++ b/specs/015-auto-forward-ports/spec.md
@@ -1,0 +1,195 @@
+# Feature Specification: Dynamic User-Space Port Forwarding (`up --auto-forward`)
+
+**Feature Branch**: `015-auto-forward-ports`  
+**Created**: 2026-06-08  
+**Status**: Draft  
+**Input**: GitHub issue #186 — "feat(up): add --auto-forward for dynamic user-space port forwarding (daemon)"
+
+## Overview
+
+Today, `deacon up` forwards ports **statically**: ports declared in `forwardPorts` / `appPort` / `--forward-port` are turned into `docker run -p` publish arguments at container-create time. This means a port must be known *before* the container exists, the host can only reach services bound to `0.0.0.0` inside the container, and a server started later (by a lifecycle hook, the entrypoint, or an interactive shell) is never reachable without recreating the container.
+
+This feature adds a `deacon up --auto-forward` flag that turns on **dynamic, user-space port forwarding** for the lifetime of a running devcontainer, modeled on how VS Code Dev Containers forwards ports. When enabled, deacon watches the container for listening sockets as they appear and disappear, and exposes each one on the developer's machine at `127.0.0.1:<host-port>`, returning control to the shell immediately. It works across **multiple devcontainers at once**, allocating non-colliding host ports and reporting the actual local address for each.
+
+## Clarifications
+
+### Session 2026-06-08
+
+- Q: When `--auto-forward` is set, what happens to declared ports (`forwardPorts` / `--forward-port` / `appPort`)? → A: They move to the dynamic forwarder (loopback relay) and are NOT also `-p` published, so the relay and Docker never contend for the same host port. The forwarded set = declared ports ∪ auto-detected ports.
+- Q: What host interface are forwarded ports exposed on for v1? → A: Loopback only (`127.0.0.1`). Exposing on `0.0.0.0` / the LAN is explicitly out of scope for v1.
+- Q: Should this introduce a `deacon forward` subcommand or an `exec --auto-forward` flag? → A: No. A single switch on `up` covers both headless and interactive workflows; standalone/attach affordances are possible future follow-ups, not this feature.
+- Q: For a Compose project with multiple services, which service's ports does auto-forward watch in v1? → A: Match VS Code. Auto-**detection** is scoped to the primary/workspace service container only (other services have separate network namespaces the in-container scan cannot see). **Declared** ports are still forwarded and may target other services via the service-qualified `"service:port"` form (e.g. `"db:5432"`).
+- Q: When `--auto-forward` is set, when is the host listener for a declared port (e.g. `forwardPorts: [8080]`) opened if nothing is listening inside yet? → A: Eagerly. The host listener for each declared port is opened immediately at `up` time and its natural host port reserved; the relay connects lazily once the container port starts listening. Connections that arrive before the server is ready are refused until it is. (Auto-detected, undeclared ports remain lazy — bound only once observed listening.)
+- Q: If the forwarder fails to start/detach (e.g. detach failure, registry lock busy, no relay mechanism available), what is the `up` exit code? → A: Warn and succeed. The container is up and usable; forwarding is additive/best-effort, so `up` emits a clear, non-silent warning to stderr (and the forwarder log) and returns success (exit 0). It does NOT leave `up` exiting non-zero. The "no relay mechanism" case (FR-019) surfaces as this loud warning rather than failing the command.
+- Q: How are privileged container ports (< 1024, e.g. 80/443) allocated on the host, given binding low host ports usually needs elevated privileges? → A: Always remap. For container ports < 1024, the natural same-number host port is skipped and an unprivileged host port (≥ 1024) is allocated and reported. The forwarder never attempts a privileged host bind, keeping the feature root-free.
+- Q: Is the port-detection poll interval configurable in v1? → A: No. It is a fixed internal constant (~1s, satisfying the SC-002 ≤~2s target). The v1 CLI surface is just the boolean `--auto-forward`; a tuning flag/env var is a possible future addition.
+- Q: Which transport protocols are forwarded in v1? → A: TCP only. Detection reads the container's TCP LISTEN tables and the relay handles TCP streams; UDP is explicitly out of scope for v1 (matches VS Code).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reach a loopback-bound server without republishing (Priority: P1)
+
+A developer runs `deacon up --auto-forward`. A web server inside the container binds to `127.0.0.1:3000` (a very common default for dev servers). Without doing anything else, the developer opens `http://127.0.0.1:3000` (or the reported local port) in a browser on their machine and the page loads. Control returns to their shell immediately — no terminal is occupied and they did not have to background any process themselves.
+
+**Why this priority**: This is the core value proposition and the single biggest gap versus static `-p` publishing, which cannot reach a `127.0.0.1`-bound service at all. If only this works, the feature already delivers meaningful value over the status quo.
+
+**Independent Test**: Start a container whose server binds `127.0.0.1:PORT`, run `up --auto-forward`, and assert the host can reach `127.0.0.1:<reported-port>` — something static `-p` provably cannot do.
+
+**Acceptance Scenarios**:
+
+1. **Given** a devcontainer config and a server that binds `127.0.0.1:3000` at startup, **When** the developer runs `deacon up --auto-forward`, **Then** the command returns control to the shell and `127.0.0.1:<reported-port>` on the host serves the container's port 3000.
+2. **Given** the same scenario, **When** the developer inspects the command's reported output, **Then** the actual local address for port 3000 is printed to stderr (and the `up` result document on stdout is unchanged).
+3. **Given** `--auto-forward` is **not** passed, **When** the developer runs `deacon up`, **Then** behavior is identical to today (static `-p` publishing, no forwarder), preserving backward compatibility.
+
+---
+
+### User Story 2 - Auto-detect a port that starts after the container is up (Priority: P1)
+
+A developer runs `deacon up --auto-forward` and then later starts a dev server — via an interactive `deacon exec` shell (`npm run dev`), a `postStart` hook, the container entrypoint, or a compose `CMD`. Without re-running `up` and without any new flag on `exec`, the newly opened port becomes reachable from the host shortly after it starts listening. When the server stops, the forward goes away.
+
+**Why this priority**: Dynamic detection is the defining behavior that distinguishes this from static publishing and is the second half of the issue's core promise. It must work regardless of *who* opened the port, which is what allows `exec` to remain unchanged.
+
+**Independent Test**: After `up --auto-forward`, open a new listening port from inside the container (e.g. via `exec`) and assert it becomes reachable on the host with no additional command and no `exec` flag; then stop it and assert the forward is withdrawn.
+
+**Acceptance Scenarios**:
+
+1. **Given** `up --auto-forward` is already running for a container, **When** a process inside the container begins listening on a new port, **Then** that port becomes reachable on `127.0.0.1:<host-port>` within a bounded detection interval.
+2. **Given** a port that was being forwarded, **When** the process stops listening, **Then** the corresponding host forward is withdrawn and its host port released.
+3. **Given** an interactive `deacon exec` session that starts a server, **When** the server begins listening, **Then** it is forwarded with **no changes to the `exec` command or flags**.
+
+---
+
+### User Story 3 - Multiple devcontainers forwarded concurrently without collisions (Priority: P1)
+
+A developer (or a team member on a shared host / CI agent) runs `deacon up --auto-forward` for two different workspaces at the same time, and each container runs a server on the same container port (e.g. both on `3000`). Both servers are reachable from the host on **distinct, non-colliding** local ports, and the developer is clearly told which local port maps to which container. Tearing down one container frees its host ports and leaves the other working.
+
+**Why this priority**: The issue calls out multi-container collision-free allocation as a KEY REQUIREMENT, not an optional extra. Two containers cannot both bind host `127.0.0.1:3000`; without host-global allocation the feature breaks the moment a second devcontainer appears, which is a normal real-world situation.
+
+**Independent Test**: Run `up --auto-forward` on two workspaces both serving container port `3000`; assert two different host ports are allocated, both reachable, both reported; tear one down and assert its host port is released while the other still works.
+
+**Acceptance Scenarios**:
+
+1. **Given** two devcontainers each serving container port `3000`, **When** both are started with `--auto-forward`, **Then** each is assigned a different host port, both are reachable, and each container's actual local port is reported.
+2. **Given** the natural host port for a container's service is already taken (by another forward or any process), **When** the forwarder allocates a host port, **Then** it remaps to the next available port and clearly reports that a remap occurred and the new port.
+3. **Given** two forwarded containers, **When** one is torn down, **Then** that container's host ports are released and become available for reuse, and the other container's forwards are unaffected.
+
+---
+
+### User Story 4 - Clean teardown with no orphans (Priority: P2)
+
+When the developer runs `deacon down` (or `deacon up --remove-existing-container`), the forwarding process for that container is stopped, its host ports are released, and no leftover process or stale bookkeeping remains. If the container disappears out-of-band (e.g. `docker rm -f`), the forwarder notices and shuts itself down and cleans up on its own.
+
+**Why this priority**: Correct lifecycle is required for the feature to be safe to use repeatedly, but it builds on the forwarding mechanism from P1, so it is sequenced after the core capability. Leaks would accumulate orphan processes and bound host ports across a work session.
+
+**Independent Test**: After `up --auto-forward`, run `down` and assert the forwarder is gone, its marker removed, and its host ports released; separately, remove the container out-of-band and assert the forwarder self-exits and cleans up.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active forwarder for a container, **When** the developer runs `deacon down`, **Then** the forwarder stops, its host ports are released, and no orphan process or leftover bookkeeping remains.
+2. **Given** an active forwarder, **When** the developer runs `deacon up --remove-existing-container`, **Then** the old forwarder is stopped before the new container and forwarder are created.
+3. **Given** an active forwarder, **When** the container is removed out-of-band, **Then** the forwarder self-exits and releases its host ports without manual intervention.
+4. **Given** a forwarder is already active for a container, **When** `deacon up --auto-forward` is run again for the **same** container, **Then** the existing forwarder is reused rather than a duplicate being started.
+
+---
+
+### User Story 5 - Respect declared port intent and attributes (Priority: P3)
+
+A developer's config declares ports and per-port attributes (`forwardPorts`, `appPort`, `portsAttributes`, `otherPortsAttributes`). The forwarder honors these: declared ports are forwarded, ports marked to be ignored are not forwarded, and per-port notification preferences (e.g. silent vs. notify) are respected. Undeclared, auto-detected ports get the default behavior defined by `otherPortsAttributes`.
+
+**Why this priority**: Honoring declared intent aligns the feature with the containers.dev spec vocabulary and avoids surprising the user, but the feature is already valuable for the common "just forward what's listening" case without it, so it is sequenced last.
+
+**Independent Test**: Configure a port with `onAutoForward: ignore` and another with `onAutoForward: silent`; assert the ignored port is not forwarded and the silent port is forwarded without a notification, while a notify port produces a notification.
+
+**Acceptance Scenarios**:
+
+1. **Given** a port with `onAutoForward: ignore`, **When** that port starts listening, **Then** it is not forwarded.
+2. **Given** a port with `onAutoForward: silent`, **When** it is forwarded, **Then** no user-facing notification is emitted for it (but it is still reachable).
+3. **Given** an auto-detected port with no explicit attribute, **When** it is forwarded, **Then** the behavior defined by `otherPortsAttributes` applies.
+4. **Given** declared ports and `--auto-forward`, **When** the container starts, **Then** those declared ports are forwarded by the dynamic forwarder and are NOT also statically `-p` published.
+
+### Edge Cases
+
+- **Natural host port already in use** → remap to the next free host port and clearly report the remap and the actual port (never silently fail or silently bind a different port).
+- **No relay mechanism available in the container** → surface a clear, actionable error (stderr + forwarder log) rather than silently doing nothing (consistent with the project's no-silent-fallback principle); per FR-025 this is a loud warning and `up` still succeeds (exit 0) — it does not fail the command.
+- **Same port appears on both IPv4 and IPv6 LISTEN tables** → treat as one logical port (deduplicate), not two forwards.
+- **Container port bound to `127.0.0.1` vs `0.0.0.0` vs `::` / `::1`** → all are eligible for forwarding (the loopback reach is the headline capability).
+- **Rapid open/close churn of a port** → forwards are added/removed to track current state without leaking host ports or processes.
+- **Concurrent `up --auto-forward` racing for the same natural host port** → host-port allocation is serialized so two starts cannot bind the same host port.
+- **Stale bookkeeping from a crashed prior run** (dead process, container already gone) → pruned automatically on the next start/allocation so it does not block new forwards.
+- **Out-of-band container removal** (`docker rm -f`) → forwarder self-exits and cleans up.
+- **`--auto-forward` combined with `--ports-events`** → forward/unforward transitions are surfaced through the existing events channel as ports come and go.
+- **Compose projects with multiple services** → auto-**detection** is scoped to the primary/workspace service container only (matching VS Code; other services have separate network namespaces the in-container socket scan cannot observe). Ports on other services are forwarded only when **declared** using the service-qualified `"service:port"` form.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `up` subcommand MUST accept a boolean `--auto-forward` flag that enables dynamic user-space port forwarding for the container being started.
+- **FR-002**: When `--auto-forward` is enabled, the system MUST return control to the invoking shell after starting the container and forwarding, without occupying the terminal or requiring the user to background any process.
+- **FR-003**: The system MUST detect **TCP** ports that are listening inside the container, including ports bound to `127.0.0.1` / `::1` (loopback), `0.0.0.0`, and `::`, and MUST treat the same logical port appearing on both IPv4 and IPv6 as a single forward. UDP is out of scope for v1.
+- **FR-004**: The system MUST detect ports that start listening **after** the container is up (from entrypoint, lifecycle hooks, compose command, or an interactive `exec` session) within a bounded detection interval, and MUST withdraw a forward when its port stops listening. The detection interval is a fixed internal constant (~1s) in v1 and is NOT user-configurable; the only v1 CLI surface for this feature is the boolean `--auto-forward` flag.
+- **FR-005**: For each forwarded port, the system MUST expose it on the host bound to `127.0.0.1` only, and MUST NOT bind forwarded ports on `0.0.0.0` or any non-loopback interface in v1.
+- **FR-006**: When `--auto-forward` is enabled, the system MUST forward declared ports (`forwardPorts`, `appPort`, `--forward-port`) via the dynamic forwarder and MUST NOT additionally publish them via static `-p`; the forwarded set is the union of declared ports and auto-detected ports.
+- **FR-007**: When `--auto-forward` is absent, the system MUST behave exactly as today (declared ports published via static `-p`, no forwarder), preserving backward compatibility.
+- **FR-008**: The system MUST support multiple concurrent `up --auto-forward` invocations on the same host and MUST allocate host ports that do not collide across all active forwarders.
+- **FR-009**: When the natural host port (matching the container port number) is unavailable, the system MUST remap to the next available host port and MUST clearly report that a remap occurred and the actual host port chosen.
+- **FR-009a**: For container ports below 1024 (privileged), the system MUST NOT attempt to bind the same-numbered (privileged) host port; it MUST allocate an unprivileged host port (≥ 1024) and report the mapping. The forwarder MUST NOT require elevated host privileges to bind any forwarded port.
+- **FR-010**: The system MUST report, per forwarded port, the actual local address (`127.0.0.1:<host-port>`) the user can reach. Human-readable mappings MUST go to stderr; the `up` result document on stdout MUST be unaffected.
+- **FR-011**: The system MUST maintain host-global bookkeeping of active forwards (which host port maps to which container/container-port) such that concurrent forwarders cooperate; updates to this bookkeeping MUST be performed atomically and be safe under concurrent access.
+- **FR-012**: The system MUST ensure at most one forwarder per container: if a live forwarder already exists for a container, a subsequent `up --auto-forward` for the same container MUST reuse it rather than starting a duplicate.
+- **FR-013**: On `deacon down`, the system MUST stop the forwarder(s) for the resolved container(s), release their host ports, and remove their bookkeeping, leaving no orphan process or stale entries.
+- **FR-014**: On `up --remove-existing-container`, the system MUST stop the existing forwarder before creating the replacement container and forwarder.
+- **FR-015**: The forwarder MUST detect when its container has disappeared out-of-band and MUST self-exit and release its host ports without manual intervention.
+- **FR-016**: The system MUST prune stale bookkeeping entries (forwarder process no longer alive, or container no longer exists) on forwarder start and on host-port allocation, so leftovers from prior runs do not block new forwards.
+- **FR-017**: The system MUST honor `portsAttributes[*].onAutoForward` for declared ports — at minimum `ignore` (do not forward), `silent` (forward without user-facing notification), and `notify` (forward with notification) — and MUST apply `otherPortsAttributes` as the default for auto-detected, undeclared ports.
+- **FR-018**: The system MUST require no changes to the `exec` subcommand for forwarding ports opened inside an `exec` session; detection MUST be based on listening sockets and indifferent to which process opened the port.
+- **FR-019**: When a relay mechanism required to forward a port is unavailable, the system MUST surface a clear, actionable error (to stderr and the forwarder log) rather than silently not forwarding. Per FR-025, this does not make `up` exit non-zero — forwarding is best-effort — but the error MUST NOT be swallowed.
+- **FR-020**: When `--ports-events` is also enabled, the system MUST emit forward and unforward transitions through the existing port-events channel as ports come and go.
+- **FR-021**: The forwarder MUST run with no terminal attached and MUST write diagnostics to a per-container log location so its activity is observable after `up` returns.
+- **FR-022**: The new host-facing surface (a persistent host process and bound loopback host ports) MUST be documented in the project security documentation, and the loopback-only binding MUST be stated as the primary mitigation.
+- **FR-023**: For Compose projects, port auto-detection MUST be scoped to the primary/workspace service container; ports on other services MUST be forwarded only when explicitly declared using the service-qualified `"service:port"` form, matching VS Code behavior.
+- **FR-024**: For **declared** ports (`forwardPorts` / `appPort` / `--forward-port`), the system MUST open the host listener and reserve the natural host port **eagerly** at `up` time, before any container-side server is listening, and MUST relay connections lazily once the container port begins listening (connections arriving earlier are refused until ready). **Auto-detected, undeclared** ports MUST remain lazy — their host listener is opened only once the port is observed LISTENING and torn down when it stops.
+- **FR-025**: When `--auto-forward` is requested and the forwarder cannot be started or detached (detach failure, registry lock contention, no relay mechanism, etc.), the system MUST emit a clear warning (stderr + forwarder log) and the `up` command MUST still return success (exit 0) with the container running. Forwarding is additive and best-effort; failure to forward MUST NOT fail `up` or leave the container in a partially-created state.
+
+### Key Entities *(include if feature involves data)*
+
+- **Forwarder (daemon)**: A host-side, detached process bound to a single running container for the lifetime of its forwards. Responsible for detecting listening ports, allocating host ports, relaying bytes, reconciling on change, and self-exiting when its container is gone. Identified per-container.
+- **Forward mapping**: The association of a container port to an allocated host port for a specific container/workspace, including a human-facing label and whether it was remapped from its natural port. This is what gets reported to the user and what gets released on teardown.
+- **Host-global port registry**: Shared bookkeeping across all active forwarders on the host that records every active host-port allocation (host port, container, container port, workspace, owning process, label) so concurrent forwarders avoid collisions and so teardown/pruning can release ports.
+- **Per-container marker**: A single-owner record indicating a live forwarder exists for a given container, used to adopt/reuse rather than duplicate, and read by `down` / replace to reap the forwarder.
+- **Port attributes**: Per-port and default forwarding preferences sourced from config (`portsAttributes`, `otherPortsAttributes`) — notably the auto-forward action (ignore / silent / notify) and label — that govern whether and how a detected port is forwarded and announced.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With `up --auto-forward`, a developer can reach a container service bound to `127.0.0.1` from their host browser — a scenario that is impossible with static `-p` publishing today (0% → 100% reachable).
+- **SC-002**: A port that starts listening after `up` returns becomes reachable from the host within the detection interval (target: ≤ ~2 seconds under default settings) with no additional command from the user.
+- **SC-003**: Running `up --auto-forward` returns control to the shell while forwarding remains active — the user never has to keep a terminal open or manually background a process to keep forwards alive.
+- **SC-004**: Two or more devcontainers serving the same container port can be forwarded simultaneously with a 0% host-port collision rate; each container's actual local port is reported to the user.
+- **SC-005**: After `down` (or `up --remove-existing-container`, or out-of-band container removal), there are zero orphan forwarder processes and zero leaked host-port registrations attributable to the forwarder.
+- **SC-006**: When `--auto-forward` is absent, port-forwarding behavior is unchanged from today (no regressions in existing static-publishing scenarios).
+- **SC-007**: When a natural host port is taken, the user is always told the actual local port in use (0% silent remaps).
+
+## Assumptions
+
+- **Loopback-only for v1**: Forwarded ports are bound to `127.0.0.1` on the host. Exposing forwards on `0.0.0.0` / the LAN is deliberately out of scope and tracked as possible future work.
+- **Declared ports move to the forwarder when `--auto-forward` is set**: This resolves the open question in the issue in favor of "the daemon owns declared ports, no parallel `-p`," to avoid the daemon and Docker contending for the same host port. (Per Clarifications.)
+- **`appPort` is treated like a declared port** and joins the forwarded set when `--auto-forward` is set.
+- **Allocation policy is VS Code-like**: prefer the same number (container 3000 → host 3000) when free; otherwise pick the next free host port and report the remap. Privileged container ports (< 1024) are always remapped to an unprivileged host port (≥ 1024) — the same-number attempt is skipped to keep the forwarder root-free (per Clarifications / FR-009a).
+- **Detection is poll-based for v1** with a bounded interval; event-driven detection (netlink/inotify) is a possible future optimization, not a requirement.
+- **Unix is the primary target for the detach/lifecycle path in v1**; the Windows detach/signaling path is acknowledged and tracked as a follow-up, not a v1 acceptance gate.
+- **Per-connection relay is acceptable for v1**; a persistent in-container multiplexing agent is a noted future optimization, not required.
+- **No new host-shell-from-workspace trust surface**: forwarding execs *into the container* (standard consumer behavior, like `exec`), so the workspace-trust gate is not required for the exec itself; the new surface is the host process and bound loopback ports, which are documented rather than gated. Whether any additional opt-in beyond the explicit `--auto-forward` flag is warranted is deferred to security review.
+- **Host-global registry lives under the user-data folder** (the same location the trust store uses), not a per-workspace container-data folder, because host ports are a host-wide shared resource.
+- **Compose scope matches VS Code** (per Clarifications): auto-detection watches only the primary/workspace service container's listening sockets; cross-service forwarding requires explicit service-qualified declared ports. Watching every service's network namespace is a possible future enhancement, not v1.
+
+## Out of Scope (v1)
+
+- Replacing or changing static `-p` publishing when `--auto-forward` is **not** passed.
+- Exposing forwarded ports on `0.0.0.0` / the LAN.
+- A standalone `deacon forward` subcommand or an `exec --auto-forward` flag (a post-hoc attach affordance is a possible future follow-up).
+- UDP (and any non-TCP transport) forwarding — TCP listeners only in v1.
+- Remote-tunnel / cloud-relay forwarding (local loopback relay only).
+- Browser/preview auto-open behavior beyond honoring notification preferences (`openBrowser` / `openPreview` are optional, not required for v1).
+- Any feature-authoring or non-consumer surface.

--- a/specs/015-auto-forward-ports/tasks.md
+++ b/specs/015-auto-forward-ports/tasks.md
@@ -186,15 +186,15 @@ description: "Task list for Dynamic User-Space Port Forwarding (up --auto-forwar
 
 ## Deferred Work
 
-Per research.md Decision 7 and the spec's Out-of-Scope/Assumptions. A spec is NOT complete while these remain; track until resolved (Constitution Principle I).
+Per research.md Decision 7 and the spec's Out-of-Scope/Assumptions. A spec is NOT complete while these remain; track until resolved (Constitution Principle I). Each is tracked by a GitHub issue capturing its hidden gotchas + recommended path forward.
 
-- [ ] T054 [Deferral] Windows detach/signaling path (job objects / equivalent of `setsid`+`kill`). **Decision**: research.md Decision 1/7; gated by T008. **Acceptance**: `up --auto-forward` detaches and is reaped correctly on Windows hosts.
-- [ ] T055 [Deferral] Persistent in-container multiplexing relay agent (one `docker exec`, many streams). **Decision**: research.md Decision 3/7. **Acceptance**: relay throughput no longer pays a `docker exec` per connection; same external behavior.
-- [ ] T056 [Deferral] Event-driven detection (netlink/inotify) replacing the ~1 s poll. **Decision**: research.md Decision 2/7. **Acceptance**: forwards appear with lower latency and lower idle CPU; SC-002 still met.
-- [ ] T057 [Deferral] `0.0.0.0`/LAN exposure option. **Decision**: spec Out of Scope. **Acceptance**: an explicit opt-in binds non-loopback with documented security review.
-- [ ] T058 [Deferral] UDP forwarding. **Decision**: FR-003 (TCP-only v1). **Acceptance**: UDP listeners detected and relayed.
-- [ ] T059 [Deferral] `openBrowser`/`openPreview` auto-open actions. **Decision**: FR-017, spec Out of Scope. **Acceptance**: those `onAutoForward` values trigger host browser/preview.
-- [ ] T060 [Deferral] Configurable poll interval / standalone `forward` subcommand / `exec --auto-forward` attach. **Decision**: FR-004, spec Out of Scope. **Acceptance**: evaluated against demand; added without breaking the v1 boolean surface.
+- [ ] T054 [Deferral] Windows detach/signaling path (job objects / equivalent of `setsid`+`kill`). **Decision**: research.md Decision 1/7; gated by T008. **Acceptance**: `up --auto-forward` detaches and is reaped correctly on Windows hosts. **Issue**: get2knowio/deacon#189.
+- [ ] T055 [Deferral] Persistent in-container multiplexing relay agent (one `docker exec`, many streams). **Decision**: research.md Decision 3/7. **Acceptance**: relay throughput no longer pays a `docker exec` per connection; same external behavior. **Issue**: get2knowio/deacon#190.
+- [ ] T056 [Deferral] Event-driven detection (netlink/inotify) replacing the ~1 s poll. **Decision**: research.md Decision 2/7. **Acceptance**: forwards appear with lower latency and lower idle CPU; SC-002 still met. **Issue**: folded into get2knowio/deacon#194 (adaptive polling recommended over netlink/eBPF, which has no real push primitive and reintroduces the in-container-agent problem of #190).
+- [ ] T057 [Deferral] `0.0.0.0`/LAN exposure option. **Decision**: spec Out of Scope. **Acceptance**: an explicit opt-in binds non-loopback with documented security review. **Issue**: get2knowio/deacon#191.
+- [ ] T058 [Deferral] UDP forwarding. **Decision**: FR-003 (TCP-only v1). **Acceptance**: UDP listeners detected and relayed. **Issue**: get2knowio/deacon#192.
+- [ ] T059 [Deferral] `openBrowser`/`openPreview` auto-open actions. **Decision**: FR-017, spec Out of Scope. **Acceptance**: those `onAutoForward` values trigger host browser/preview. **Issue**: get2knowio/deacon#193.
+- [ ] T060 [Deferral] Configurable poll interval / standalone `forward` subcommand / `exec --auto-forward` attach. **Decision**: FR-004, spec Out of Scope. **Acceptance**: evaluated against demand; added without breaking the v1 boolean surface. **Issue**: get2knowio/deacon#194.
 
 ---
 

--- a/specs/015-auto-forward-ports/tasks.md
+++ b/specs/015-auto-forward-ports/tasks.md
@@ -1,0 +1,266 @@
+---
+description: "Task list for Dynamic User-Space Port Forwarding (up --auto-forward)"
+---
+
+# Tasks: Dynamic User-Space Port Forwarding (`up --auto-forward`)
+
+**Input**: Design documents from `/specs/015-auto-forward-ports/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — required by Constitution Principle VII (Testing Completeness) and the spec's per-story Independent Tests + testing plan. Unit tests are hermetic; integration tests are Docker-gated.
+
+**Organization**: Tasks are grouped by user story (US1–US5) to enable independent implementation and testing. P1 stories (US1–US3) are all required for a usable feature; US1 is the demonstrable MVP.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1–US5 (user-story phases only)
+- All paths are repo-relative from `/workspaces/deacon/`
+
+## Path Conventions
+
+- Core logic: `crates/core/src/port_forward/`
+- CLI wiring: `crates/deacon/src/commands/up/`, `crates/deacon/src/commands/`
+- Integration tests: `crates/deacon/tests/`
+- Examples: `examples/auto-forward/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Dependencies and module scaffolding.
+
+- [X] T001 Add `nix` (Unix-only, `features = ["process","signal"]`) and `fs2` to `Cargo.toml` `[workspace.dependencies]`, then reference both in `crates/core/Cargo.toml` (`nix` under `[target.'cfg(unix)'.dependencies]`, `fs2` under `[dependencies]`); per research.md Decision 1 & 5.
+- [X] T002 Create the module scaffold `crates/core/src/port_forward/{mod,detect,registry,relay,daemon}.rs` (empty stubs with module docs) and add `pub mod port_forward;` to `crates/core/src/lib.rs`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared types, paths, CLI surface, the detached-daemon entrypoint, and cross-platform gating that ALL user stories build on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Define core data types + `PortForwardError` (`thiserror`) in `crates/core/src/port_forward/mod.rs` per data-model.md: `DetectedPort`/`BindScope`/`IpFamily`, `ForwardSpec`/`ForwardOrigin` (incl. `service: Option<String>`), `ResolvedPortAttributes`, `RegistryEntry` (serde, matches `contracts/registry.schema.json`), `DaemonMarker` (serde, matches `contracts/marker.schema.json`).
+- [X] T004 Add host-path helpers in `crates/core/src/port_forward/mod.rs` — `registry_path()`, `marker_path(container_id)`, `log_path(container_id)` — reusing the user-data-folder resolution from `crates/core/src/trust.rs` (`--user-data-folder` else `~/.deacon`).
+- [X] T005 Add `--auto-forward` boolean to `Commands::Up` in `crates/deacon/src/cli.rs` and `auto_forward: bool` to `UpArgs` in `crates/deacon/src/commands/up/args.rs`; thread the mapping (default `false`). Per `contracts/cli.md`.
+- [X] T006 Add the hidden `__forward-daemon` subcommand (`#[command(hide = true)]`) to `crates/deacon/src/cli.rs` with args `--container-id`, `--workspace`, `--user-data-folder`, `--declared-port` (repeatable), `--config`, per `contracts/cli.md`.
+- [X] T007 Create the daemon entrypoint `crates/deacon/src/commands/forward_daemon.rs`: parse the hidden-subcommand args, call `nix::unistd::setsid()`, reopen stdio onto the per-container log file, init a `tracing` file subscriber, then call the core daemon `run()` stub; register the module in `crates/deacon/src/commands/mod.rs` and dispatch it from the main command match.
+- [X] T008 Gate the Unix-only forwarder behind `cfg(unix)` (the `port_forward` module, `forward_daemon.rs`, and the spawn path), and make `--auto-forward` on a non-Unix build return a clear "not supported on this platform" error per Principle IV (no silent fallback). Ensure the workspace still **compiles** on Windows. Windows support itself is deferred (see Deferred Work).
+
+**Checkpoint**: Flag parses, daemon process can be spawned and detaches on Unix, builds cleanly on Windows with a clear unsupported-platform error, but does no forwarding yet.
+
+---
+
+## Phase 3: User Story 1 - Reach a loopback-bound server without republishing (Priority: P1) 🎯 MVP
+
+**Goal**: `up --auto-forward` starts a detached forwarder that makes a `127.0.0.1`-bound container server reachable on the host, and returns control to the shell.
+
+**Independent Test**: Start a container whose server binds `127.0.0.1:PORT`, run `up --auto-forward`, assert `127.0.0.1:<reported-port>` on the host serves it — something static `-p` cannot do.
+
+### Tests for User Story 1
+
+- [X] T009 [P] [US1] Unit tests for the `/proc/net/tcp{,6}` parser in `crates/core/src/port_forward/detect.rs` — fixtures for IPv4 little-endian decode, IPv6, `127.0.0.1` vs `0.0.0.0` binds, v4/v6 dedup, and non-LISTEN (`st != 0A`) rows ignored.
+- [X] T010 [P] [US1] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` — `up --auto-forward` against a container serving `127.0.0.1:PORT`; assert host `127.0.0.1:<host_port>` is reachable and `up` returned (no occupied terminal). Use a `TempDir` workspace (per memory: in-repo `up` chowns the workspace).
+- [X] T011 [P] [US1] Docker integration regression test in `crates/deacon/tests/integration_auto_forward.rs` — `up` **without** `--auto-forward` still publishes declared ports via static `-p` and creates **no** forwarder process, marker, or registry entry (guards FR-007 / SC-006, backward compatibility).
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Implement `parse_proc_net_tcp(&str) -> Vec<DetectedPort>` in `crates/core/src/port_forward/detect.rs`: parse `st == 0A` rows, decode little-endian `HEXIP:HEXPORT`, collect loopback/any binds, dedup v4/v6, TCP only (FR-003).
+- [X] T013 [US1] Implement the detection probe in `crates/core/src/port_forward/daemon.rs`: run `Docker::exec(id, ["cat","/proc/net/tcp","/proc/net/tcp6"], ExecConfig{silent:true,..})` and feed stdout to `parse_proc_net_tcp` (FR-018; reuses the existing exec trait).
+- [X] T014 [US1] Implement `crates/core/src/port_forward/relay.rs`: bind `127.0.0.1:host_port` `TcpListener`; per accepted connection spawn `docker exec -i <id> <relay>` dialing a **configurable** dial host (default `127.0.0.1`):`container_port` and pump bytes bidirectionally; relay-program selection (embedded static binary primary → `socat`/`nc`/`/dev/tcp` fallback → fail-fast clear error if none, FR-019). Per research.md Decision 3. (The configurable dial host is generalized for `service:port` in US5/T046.)
+- [X] T015 [US1] Implement minimal single-port allocation in `crates/core/src/port_forward/registry.rs`: prefer same number with a bind probe; remap privileged (<1024) container ports to a free host port ≥1024 (FR-009a). (Host-global/concurrency hardening deferred to US3.)
+- [X] T016 [US1] Implement the supervisor `run()` in `crates/core/src/port_forward/daemon.rs`: eager-bind declared ports (Reserved→Active on observation), poll-detect (~1 s) and forward listening ports, write the `DaemonMarker` on start, append `RegistryEntry` per forward (FR-002, FR-024, FR-021).
+- [X] T017 [US1] Implement `crates/deacon/src/commands/up/forward.rs`: spawn + detach the forwarder by re-exec'ing `std::env::current_exe()` with `__forward-daemon`, passing container id / workspace / user-data-folder / declared ports; do not await; return to the shell (FR-002). Per research.md Decision 1.
+- [X] T018 [US1] Hook forwarder spawn into the up flow in `crates/deacon/src/commands/up/container.rs` after lifecycle completes (~line 673), gated on `args.auto_forward`.
+- [X] T019 [US1] Implement best-effort failure handling around the spawn path in `crates/deacon/src/commands/up/forward.rs` / `container.rs`: if the forwarder cannot be spawned/detached (or no relay strategy exists), emit a clear warning to stderr and let `up` return success (exit 0) with the container running — never swallow the error, never leave a partial container (FR-025, FR-019).
+- [X] T020 [US1] Route declared ports (`forwardPorts`/`appPort`/`--forward-port`) to the forwarder and **suppress** their static `-p` publish args when `auto_forward` is set, in `crates/deacon/src/commands/up/ports.rs` (FR-006).
+- [X] T021 [US1] Print loopback mappings to **stderr** with explicit remap reporting (`Forwarding container P -> http://127.0.0.1:H (...)`) in `forward.rs`/`daemon.rs`; keep the `up` stdout result document unchanged (FR-010, SC-007). Per `contracts/port-events.md`.
+- [X] T022 [US1] Register the `integration_auto_forward` test binary in `.config/nextest.toml` as `docker-shared` (single-container) — add to the `[profile.default]` override filter, the `[profile.dev-fast]` `default-filter` exclusion, and the `[profile.dev-fast]` override filter (3 spots per CLAUDE.md).
+
+**Checkpoint**: US1 fully functional — loopback reach works, shell is free, mapping reported, backward-compat guarded. **This is the demoable MVP.**
+
+---
+
+## Phase 4: User Story 2 - Auto-detect a port that starts after the container is up (Priority: P1)
+
+**Goal**: Ports that start listening after `up` (entrypoint/`postStart`/compose/`exec`) are forwarded within ~1–2 s with no `exec` changes; forwards are withdrawn when the port stops.
+
+**Independent Test**: After `up --auto-forward`, open a new listening port from inside the container (via `exec`); assert it becomes reachable with no extra command/flag; stop it and assert the forward is withdrawn.
+
+### Tests for User Story 2
+
+- [X] T023 [P] [US2] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` — start a server AFTER `up --auto-forward` via `deacon exec` (no exec flag); assert it becomes reachable within the detection window; stop it and assert the host listener is withdrawn and the port released.
+
+### Implementation for User Story 2
+
+- [X] T024 [US2] Implement the reconcile loop in `crates/core/src/port_forward/daemon.rs`: diff detected vs. active each tick; **lazily** bind newly-observed undeclared ports; withdraw + release forwards whose container port stopped listening; handle rapid open/close churn without leaking host ports or relay tasks (FR-004).
+- [X] T025 [US2] Ensure auto-detected (undeclared) ports use lazy binding semantics (bound only on observation, not reserved at start) in `crates/core/src/port_forward/daemon.rs` (FR-024).
+- [X] T026 [US2] Emit `PORT_EVENT:` forward/unforward transitions when `--ports-events` is set, reusing `PortEvent` in `crates/core/src/ports.rs` (extend the create-time-only emission to dynamic lifetime) per `contracts/port-events.md` (FR-020).
+- [X] T027 [US2] Add an integration assertion (in `integration_auto_forward.rs`) proving a port opened inside an `exec` session is forwarded with **zero** changes to `exec` (documents FR-018 transparency).
+
+**Checkpoint**: Dynamic detection + withdrawal works on top of US1.
+
+---
+
+## Phase 5: User Story 3 - Multiple devcontainers forwarded concurrently without collisions (Priority: P1)
+
+**Goal**: Concurrent `up --auto-forward` invocations allocate collision-free host ports via a host-global registry; remaps are reported; tearing one down releases its ports.
+
+**Independent Test**: Two workspaces both serving container `3000`; assert two distinct host ports, both reachable, both in the registry; `down` one and assert its port is released while the other still works.
+
+### Tests for User Story 3
+
+- [X] T028 [P] [US3] Unit tests for `crates/core/src/port_forward/registry.rs` — allocation prefers same number; collision triggers next-free remap; release removes entries; stale entries (dead pid / missing container) are pruned; allocate-and-bind is serialized (simulate concurrent allocation).
+- [X] T029 [P] [US3] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` — two `up --auto-forward` on two `TempDir` workspaces both serving container `3000`; assert distinct host ports, both reachable, both registry entries present; `down` one, assert its host port released and the other still works.
+
+### Implementation for User Story 3
+
+- [X] T030 [US3] Implement the host-global registry in `crates/core/src/port_forward/registry.rs`: load/save `{user_data_folder}/forwarded_ports.json` with atomic temp-file + `fs::rename` (reuse `cache/disk.rs::save_index` pattern), wrapping the allocate-and-bind critical section in an `fs2` advisory `flock` (FR-008, FR-011). Per research.md Decision 5.
+- [X] T031 [US3] Implement collision-free allocation across ALL registry entries (host_port unique file-wide) in `crates/core/src/port_forward/registry.rs`, with remap + report when the natural port is taken (FR-008, FR-009, SC-004).
+- [X] T032 [US3] Implement stale-entry pruning (dead `pid` or missing container) on daemon start and on each allocation, and release-on-shutdown that removes this container's entries (FR-016, FR-013).
+- [X] T033 [US3] If multi-container tests race, reclassify the `integration_auto_forward` binary to `docker-exclusive` in `.config/nextest.toml` (update all 3 profile spots), or split multi-container cases into a `docker-exclusive` filterset while keeping single-container cases `docker-shared`.
+
+**Checkpoint**: All three P1 stories work — the feature is fully usable for real multi-container workflows.
+
+---
+
+## Phase 6: User Story 4 - Clean teardown with no orphans (Priority: P2)
+
+**Goal**: `down` / `up --remove-existing-container` reap the forwarder and release its ports; the daemon self-exits if its container vanishes; a second `up` for the same container reuses the existing forwarder.
+
+**Independent Test**: After `up --auto-forward`, `down` and assert forwarder gone + marker removed + ports released; separately `docker rm -f` the container and assert the forwarder self-exits and cleans up.
+
+### Tests for User Story 4
+
+- [X] T034 [P] [US4] Unit test for marker adopt-or-reuse logic (live pid ⇒ reuse, dead/missing ⇒ spawn) in `crates/core/src/port_forward/registry.rs` or `crates/deacon/src/commands/up/forward.rs`.
+- [X] T035 [P] [US4] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` — (a) `down` reaps the daemon (pid gone, marker removed, registry entries released); (b) `up --remove-existing-container` kills the old daemon before replacing; (c) `docker rm -f` ⇒ daemon self-exits and cleans up.
+
+### Implementation for User Story 4
+
+- [X] T036 [US4] Implement marker adopt-or-reuse in `crates/deacon/src/commands/up/forward.rs`: read `forward_daemon_<id>.pid`; if it names a live pid, reuse it (no duplicate spawn); else spawn fresh (FR-012).
+- [X] T037 [US4] Implement the `down` reap hook in `crates/deacon/src/commands/down.rs`: resolve container(s) via `ContainerIdentity`/label selectors (reuse existing resolution), read each marker, `SIGTERM` via `nix::sys::signal::kill`, wait briefly, remove marker, release that container's registry entries (FR-013). Per research.md Decision 8.
+- [X] T038 [US4] Reap the existing forwarder on `up --remove-existing-container` before creating the replacement, in `crates/deacon/src/commands/up/container.rs`/`forward.rs` (FR-014).
+- [X] T039 [US4] Implement daemon self-exit in `crates/core/src/port_forward/daemon.rs`: detect container gone (relay execs failing / `Docker::inspect_container` returns `None`), then exit after removing the marker and releasing registry entries (FR-015).
+
+**Checkpoint**: Lifecycle is leak-free across down/replace/out-of-band removal.
+
+---
+
+## Phase 7: User Story 5 - Respect declared port intent and attributes (Priority: P3)
+
+**Goal**: `portsAttributes.onAutoForward` (`ignore`/`silent`/`notify`) is honored for declared ports; `otherPortsAttributes` is the default for auto-detected ports; compose service-qualified `"service:port"` declared ports are forwarded.
+
+**Independent Test**: Configure one port `onAutoForward: ignore` and one `silent`; assert the ignored port is not forwarded and the silent port is forwarded without a stderr notification, while a notify port produces one.
+
+### Tests for User Story 5
+
+- [X] T040 [P] [US5] Unit tests for attribute resolution in `crates/core/src/port_forward/` — declared port → `portsAttributes[port]`; undeclared → `otherPortsAttributes` default else `Notify`; `ignore` excluded; `"service:port"` declared spec parses to `(service, port)`.
+- [X] T041 [P] [US5] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` — `ignore` port never forwarded; `silent` port reachable with no stderr mapping line; `notify` port reachable with a mapping line.
+- [X] T042 [P] [US5] Docker integration test in `crates/deacon/tests/integration_auto_forward.rs` (compose) — a `"service:port"` declared port (e.g. `"db:5432"`) on a non-primary compose service is reachable on the host while auto-detection stays scoped to the primary service (FR-023).
+
+### Implementation for User Story 5
+
+- [X] T043 [US5] Resolve `ResolvedPortAttributes` from `DevContainerConfig.ports_attributes` / `other_ports_attributes` in `crates/deacon/src/commands/up/forward.rs` (pass into the daemon) / `crates/core/src/port_forward/daemon.rs`.
+- [X] T044 [US5] Honor `onAutoForward` in `crates/core/src/port_forward/daemon.rs`: `ignore` ⇒ no listener; `silent` ⇒ forward but suppress the human stderr line; `notify` ⇒ forward + line (FR-017).
+- [X] T045 [US5] Apply `otherPortsAttributes` as the default for auto-detected, undeclared ports in `crates/core/src/port_forward/daemon.rs` (FR-017).
+- [X] T046 [US5] Parse service-qualified `"service:port"` declared specs into `ForwardSpec { service: Some(..), container_port }` in `crates/deacon/src/commands/up/forward.rs` (and the declared-port parsing in `crates/deacon/src/commands/up/ports.rs`); auto-detection remains scoped to the primary service (FR-023, FR-024).
+- [X] T047 [US5] Make the relay dial the service host over the compose network when `ForwardSpec.service` is `Some` (i.e. `docker exec <primary> <relay> <service> <port>`) instead of `127.0.0.1`, in `crates/core/src/port_forward/relay.rs`/`daemon.rs` (FR-023). Builds on the configurable dial host from T014.
+
+**Checkpoint**: All five user stories independently functional.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, security, examples, and final gates.
+
+- [X] T048 [P] Document `--auto-forward` as a deacon consumer extension (dynamic forwarding model, declared-vs-`-p`, loopback/TCP-only, best-effort, compose `"service:port"`) in `docs/subcommand-specs/up/SPEC.md`.
+- [X] T049 [P] Add the new host surface (persistent host process + bound loopback host ports) and mitigations (loopback-only bind, `docker exec` is standard consumer behavior) to `SECURITY.md` (FR-022); flag for security review whether opt-in beyond the flag is warranted.
+- [X] T050 [P] Add a `--auto-forward` section to `README.md` (usage + limits), aligned with `quickstart.md`.
+- [X] T051 Create the `examples/auto-forward/` canary (`README.md`, `exec.sh`, `.devcontainer/devcontainer.json`) demonstrating loopback reach + multi-container; register it in the `examples/up` aggregator; clean up all resources; pin images (Principle IX). Note the in-repo git-root mount gotcha (`--mount-workspace-git-root false`).
+- [X] T052 Run `quickstart.md` validation end-to-end (loopback reach, registry entry, clean teardown release) and fix any drift.
+- [X] T053 Full gate: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `make test-nextest`; confirm production code is `unsafe`-free and the workspace builds on non-Unix targets.
+
+---
+
+## Deferred Work
+
+Per research.md Decision 7 and the spec's Out-of-Scope/Assumptions. A spec is NOT complete while these remain; track until resolved (Constitution Principle I).
+
+- [ ] T054 [Deferral] Windows detach/signaling path (job objects / equivalent of `setsid`+`kill`). **Decision**: research.md Decision 1/7; gated by T008. **Acceptance**: `up --auto-forward` detaches and is reaped correctly on Windows hosts.
+- [ ] T055 [Deferral] Persistent in-container multiplexing relay agent (one `docker exec`, many streams). **Decision**: research.md Decision 3/7. **Acceptance**: relay throughput no longer pays a `docker exec` per connection; same external behavior.
+- [ ] T056 [Deferral] Event-driven detection (netlink/inotify) replacing the ~1 s poll. **Decision**: research.md Decision 2/7. **Acceptance**: forwards appear with lower latency and lower idle CPU; SC-002 still met.
+- [ ] T057 [Deferral] `0.0.0.0`/LAN exposure option. **Decision**: spec Out of Scope. **Acceptance**: an explicit opt-in binds non-loopback with documented security review.
+- [ ] T058 [Deferral] UDP forwarding. **Decision**: FR-003 (TCP-only v1). **Acceptance**: UDP listeners detected and relayed.
+- [ ] T059 [Deferral] `openBrowser`/`openPreview` auto-open actions. **Decision**: FR-017, spec Out of Scope. **Acceptance**: those `onAutoForward` values trigger host browser/preview.
+- [ ] T060 [Deferral] Configurable poll interval / standalone `forward` subcommand / `exec --auto-forward` attach. **Decision**: FR-004, spec Out of Scope. **Acceptance**: evaluated against demand; added without breaking the v1 boolean surface.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: depends on Setup — **BLOCKS all user stories**.
+- **US1 (Phase 3)**: depends on Foundational. The MVP.
+- **US2 (Phase 4)**: depends on US1 (extends the detect/supervisor loop).
+- **US3 (Phase 5)**: depends on US1's minimal registry (replaces it with the host-global version); independent of US2.
+- **US4 (Phase 6)**: depends on US1 (markers/registry written by the daemon); independent of US2/US3 but most meaningful after US3.
+- **US5 (Phase 7)**: depends on US1; the `"service:port"` relay (T047) builds on T014's configurable dial host; independent of US2/US3/US4.
+- **Polish (Phase 8)**: after the desired stories.
+
+### Story independence notes
+
+- US1 is independently demoable. US2/US3/US4/US5 each layer onto US1 and are independently testable, but US2/US3/US4 are NOT mutually dependent — they can be staffed in parallel once US1 lands.
+- US3 supersedes the US1 "minimal allocation" (T015) with the host-global registry (T030–T032); keep T015's API stable so US3 is a drop-in.
+
+### Parallel Opportunities
+
+- Setup: T001 then T002 (keep order).
+- Foundational: T003 → T004 (same file `mod.rs`, sequential); T005/T006 (`cli.rs`/`args.rs`), T007 (`forward_daemon.rs`), and T008 (cfg gating) can overlap once T003 lands.
+- US1 tests T009 + T010 + T011 in parallel (T009 different file; T010/T011 share the test file — coordinate or sequence the two integration cases).
+- After US1: US2, US3, US4, US5 implementation can proceed in parallel by different developers (mostly different files; coordinate on `daemon.rs`).
+- Polish T048/T049/T050 in parallel (different docs).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (different files):
+Task: "T009 Unit tests for /proc/net/tcp parser in crates/core/src/port_forward/detect.rs"
+Task: "T010 Docker integration: loopback reach in crates/deacon/tests/integration_auto_forward.rs"
+
+# Then implementation, respecting daemon.rs/registry.rs/relay.rs boundaries:
+Task: "T012 parse_proc_net_tcp in detect.rs"
+Task: "T014 relay.rs byte relay over docker exec -i"
+Task: "T015 minimal single-port allocation in registry.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → Phase 2 Foundational → Phase 3 US1.
+2. **STOP and VALIDATE**: `up --auto-forward` reaches a `127.0.0.1`-bound server; shell is free; mapping on stderr; `up` JSON unchanged on stdout; absent-flag path unchanged.
+3. Demo the one thing static `-p` can't do (SC-001).
+
+### Incremental Delivery
+
+1. Foundation + US1 → MVP (loopback reach).
+2. + US2 → dynamic detection / withdrawal.
+3. + US3 → multi-container collision-free (the real-world unlock).
+4. + US4 → leak-free lifecycle.
+5. + US5 → attribute fidelity + compose `"service:port"`.
+6. Polish → docs, SECURITY.md, examples canary, full gate.
+
+### Notes
+
+- [P] = different files, no incomplete-task dependency.
+- Reuse existing helpers (`ContainerIdentity`, `Docker::exec`, `cache/disk.rs` atomic write, `trust.rs` user-data folder) — do not reimplement (Constitution Principle VIII).
+- Keep production code `unsafe`-free (`nix` wrappers); run fmt+clippy after every change; `make test-nextest` before PR.
+- Add the new integration binary to all 3 `.config/nextest.toml` spots (T022); resolve UNION on conflicts.


### PR DESCRIPTION
## What

Adds `deacon up --auto-forward` — a deacon consumer extension (modeled on VS Code Dev Containers) that starts a **detached, host-side forwarder** for the container, polls its TCP LISTEN sockets (`/proc/net/tcp{,6}` via `docker exec`, ~1s), and relays each detected or declared port to a `127.0.0.1:<host-port>` listener over `docker exec -i`. Because `docker exec` shares the container netns, this reaches **`127.0.0.1`-bound** servers that static `-p` publishing cannot. `up` returns to the shell immediately.

Implements feature spec `specs/015-auto-forward-ports/` (US1–US5); all active tasks T001–T053 done, T054–T060 tracked as intentional deferrals.

## Highlights

- **New core module `crates/core/src/port_forward/`** (`detect`, `registry`, `relay`, `daemon`):
  - Pure `/proc/net/tcp{,6}` LISTEN parser (little-endian v4/v6 decode + dedup).
  - Host-global `forwarded_ports.json` registry: `fs2` advisory lock + atomic temp-file/rename writes; collision-free allocation (same-number preference, privileged→≥1024 remap), stale-pid pruning, release.
  - Per-connection byte relay with `socat`/`nc`/bash-`/dev/tcp` fallback and fail-fast when none.
  - Supervisor loop: eager declared + lazy auto-detected forwarding, withdrawal, `portsAttributes.onAutoForward` honoring (`ignore`/`silent`/`notify`), compose `"service:port"` dialing, `PORT_EVENT:` emission, pid marker, `SIGTERM`/self-exit cleanup. Detach/signaling via safe `nix` wrappers (`setsid`/`dup2`/`kill`) — production stays `unsafe`-free.
- **CLI wiring**: `--auto-forward` flag, hidden `__forward-daemon` re-exec entrypoint, spawn/adopt-or-reuse + static `-p` suppression in the `up` container & compose paths, reap hooks in `down` and `up --remove-existing-container`.
- **Docs/examples**: `up/SPEC.md` §2.1, `SECURITY.md` surface, `README.md` section, and the self-verifying `examples/up/auto-forward/` canary (registered in the aggregator).

## Behavior contract

- **Loopback-only** (`127.0.0.1`, never `0.0.0.0`/LAN), **TCP-only**, **Unix-only** in v1 (non-Unix warns, `up` unaffected).
- Declared ports (`forwardPorts`/`appPort`/`--forward-port`) forward **eagerly** and are **suppressed from static `-p`**; undeclared ports forward **lazily** and are withdrawn when they stop.
- **Best-effort**: a forwarding failure warns loudly but never fails `up` (exit 0).
- Per-port mappings → stderr (forwarder log); the `up` result JSON on stdout is unchanged.

## Tests

- Hermetic unit tests: parser, registry (allocation/collision/release/prune), attribute resolution, marker adopt-or-reuse.
- Docker integration suite (`integration_auto_forward`, **docker-exclusive** — it binds real host ports): loopback reach, dynamic detect/withdraw via `exec`, multi-container collision-free + release, `down`/replace reaping, `ignore`/`silent`/`notify`, compose `"service:port"`.
- Full gate green: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `make test-nextest` (**2784 passed, 0 failed**).

## Notes

- `integration_auto_forward` is classified `docker-exclusive` in `.config/nextest.toml` (per spec task T033) because it binds real host ports and must not race other port-publishing docker tests.
- Surfaced a **pre-existing**, unrelated bug while writing tests: `exec --workspace-folder` can't resolve `up`'s container due to a `configHash` mismatch between the two paths — filed as #187 (the US2 test works around it via `exec --container-id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
