### PR TITLE
fix(up): anchor container identity to as-loaded config so exec can resolve it

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -540,7 +540,7 @@ slow-timeout = { period = "5m", terminate-after = 1 }
 status-level = "pass"
 fail-fast = false
 # MVP integration tests: smoke, parity, and core integration tests for up/exec/down/read-configuration
-default-filter = 'binary(#smoke_*) | binary(#parity_*) | binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(=integration_down) | binary(=integration_runtime_selection) | binary(=integration_read_configuration) | binary(=integration_read_configuration_output) | binary(=integration_config) | binary(=integration_custom_container_name) | binary(=integration_exec) | binary(=integration_exec_env) | binary(=integration_exec_pty) | binary(=integration_e2e) | binary(#integration_env_probe_*)'
+default-filter = 'binary(#smoke_*) | binary(#parity_*) | binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(=integration_up_exec_identity) | binary(=integration_down) | binary(=integration_runtime_selection) | binary(=integration_read_configuration) | binary(=integration_read_configuration_output) | binary(=integration_config) | binary(=integration_custom_container_name) | binary(=integration_exec) | binary(=integration_exec_env) | binary(=integration_exec_pty) | binary(=integration_e2e) | binary(#integration_env_probe_*)'
 
 # Smoke test grouping
 [[profile.mvp-integration.overrides]]
@@ -567,8 +567,9 @@ test-group = 'parity-cli'
 
 # Docker integration grouping
 [[profile.mvp-integration.overrides]]
-filter = 'binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(#integration_env_probe_*)'
+filter = 'binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(=integration_up_exec_identity) | binary(#integration_env_probe_*)'
 test-group = 'docker-shared'
+slow-timeout = { period = "10m", terminate-after = 1 }
 
 [[profile.mvp-integration.overrides]]
 filter = 'binary(=integration_config)'

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -71,6 +71,7 @@ use tracing::{debug, info, instrument, warn};
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_container_up(
     config: &DevContainerConfig,
+    identity: &ContainerIdentity,
     workspace_folder: &Path,
     args: &UpArgs,
     state_manager: &mut StateManager,
@@ -182,15 +183,13 @@ pub(crate) async fn execute_container_up(
     let emit_progress_event =
         crate::commands::shared::progress::make_progress_callback(&args.progress_tracker);
 
-    // Create container identity for deterministic naming and labels.
-    // Carry the resolved devcontainer.json path so the spec-mandated
-    // `devcontainer.config_file` label is applied at create time (#68).
-    let identity = ContainerIdentity::new_with_custom_name(
-        workspace_folder,
-        &config,
-        args.container_name.clone(),
-    )
-    .with_config_file(config_path);
+    // Container identity (deterministic naming + labels, incl. the
+    // spec-mandated `devcontainer.config_file` label, #68) is computed by the
+    // caller from the as-loaded config and passed in, so the stamped
+    // `devcontainer.configHash` is reproducible by `exec`/`run-user-commands`
+    // (#187). It must NOT be recomputed from the post-mutation `config` here
+    // (CLI `--mount`, forward-ports, and the Dockerfile-built image would all
+    // perturb the hash and break `up` ↔ `exec` reconnection).
     debug!("Container identity: {:?}", identity);
 
     // Initialize Docker client
@@ -252,7 +251,7 @@ pub(crate) async fn execute_container_up(
         // `config_path` anchors local feature references (#69).
         let feature_build = build_image_with_features(
             &config,
-            &identity,
+            identity,
             workspace_folder,
             config_path,
             Some(build_options),
@@ -517,7 +516,7 @@ pub(crate) async fn execute_container_up(
     if args.remove_existing_container {
         crate::commands::up::forward::reap_existing_forwarders(
             docker,
-            &identity,
+            identity,
             args.user_data_folder.as_deref(),
         )
         .await;
@@ -544,7 +543,7 @@ pub(crate) async fn execute_container_up(
     // affects the bind mount and not workspace+config hashing.
     let container_result = docker
         .up(
-            &identity,
+            identity,
             config_for_create,
             &workspace_mount_source,
             args.remove_existing_container,

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -200,6 +200,17 @@ pub(crate) async fn execute_up_with_runtime(
 
     debug!("Loaded configuration: {:?}", config.name);
 
+    // Container identity must be reproducible by `exec` / `run-user-commands`
+    // (#187). Those commands resolve `up`'s container by hashing the config
+    // exactly as loaded — so the label hash MUST be derived from the
+    // as-loaded config, BEFORE any of up's runtime mutations: CLI `--mount`,
+    // image-metadata merge, feature merge, variable substitution, and
+    // especially the Dockerfile build (which replaces `build` with a
+    // `deacon-build:<hash>` image). Hashing the post-build/post-substitution
+    // config stamps a `devcontainer.configHash` label that `exec` can never
+    // reproduce, breaking `up` ↔ `exec` reconnection for Dockerfile configs.
+    let identity_config = config.clone();
+
     // T029: Check for disallowed features before any runtime operations
     check_for_disallowed_features(&config.features)?;
     debug!("Validated features - no disallowed features found");
@@ -471,8 +482,17 @@ pub(crate) async fn execute_up_with_runtime(
         }
     }
 
-    // Create container identity for state tracking
-    let identity = ContainerIdentity::new(workspace_folder.as_path(), &config);
+    // Create container identity for state tracking and labels. Built from the
+    // as-loaded `identity_config` (see snapshot above) so the stamped labels
+    // are reproducible by `exec`/`run-user-commands` (#187). The custom name
+    // and config-file path are part of the durable identity, so attach them
+    // here and thread the result into the create path rather than recomputing.
+    let identity = ContainerIdentity::new_with_custom_name(
+        workspace_folder.as_path(),
+        &identity_config,
+        args.container_name.clone(),
+    )
+    .with_config_file(config_path.as_path());
     let workspace_hash = identity.workspace_hash.clone();
 
     // Initialize state manager
@@ -494,6 +514,7 @@ pub(crate) async fn execute_up_with_runtime(
     } else {
         execute_container_up(
             &config,
+            &identity,
             workspace_folder.as_path(),
             &args,
             &mut state_manager,

--- a/crates/deacon/tests/integration_up_exec_identity.rs
+++ b/crates/deacon/tests/integration_up_exec_identity.rs
@@ -1,0 +1,133 @@
+//! Compound-flow regression tests for `up` → `exec --workspace-folder` (#187).
+//!
+//! These guard against `up` and `exec`/`run-user-commands` computing different
+//! `devcontainer.configHash` values for the *same* authored `devcontainer.json`.
+//! When they diverge, `exec --workspace-folder X` cannot resolve the container
+//! that `up --workspace-folder X` just created (its label selector matches
+//! nothing) and fails with "No running container found …".
+//!
+//! The original bug: `up` builds a Dockerfile config into a
+//! `deacon-build:<hash>` image and stamps the identity from the *post-build*
+//! config, while `exec` hashes the original `build.dockerfile` config. The fix
+//! anchors `up`'s label identity to the config **as loaded**, before any
+//! runtime mutation (image-metadata merge, feature merge, substitution, and the
+//! Dockerfile build).
+//!
+//! Docker-gated: skips cleanly when Docker is unavailable. Uses a `TempDir`
+//! workspace (in-repo `up` chowns the workspace — see CLAUDE.md) and targets
+//! containers purely by `--workspace-folder` (never `--container-id`), which is
+//! the whole point of the regression.
+
+use std::path::Path;
+use std::process::{Command as StdCommand, Stdio};
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    StdCommand::new("docker")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn deacon() -> StdCommand {
+    StdCommand::new(env!("CARGO_BIN_EXE_deacon"))
+}
+
+fn write(ws: &Path, rel: &str, body: &str) {
+    let path = ws.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+fn up(ws: &Path) {
+    let status = deacon()
+        .args(["up", "--workspace-folder"])
+        .arg(ws)
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("spawn deacon up");
+    assert!(status.success(), "`deacon up` failed for {}", ws.display());
+}
+
+/// Run `exec --workspace-folder <ws> -- echo <marker>` (NO `--container-id`)
+/// and return its trimmed stdout. The container must be resolved purely from
+/// the workspace folder + config — exactly the path that regressed in #187.
+fn exec_echo(ws: &Path, marker: &str) -> String {
+    let out = deacon()
+        .args(["exec", "--workspace-folder"])
+        .arg(ws)
+        .args(["echo", marker])
+        .stderr(Stdio::inherit())
+        .output()
+        .expect("spawn deacon exec");
+    assert!(
+        out.status.success(),
+        "`deacon exec --workspace-folder {}` failed (#187 regression: exec could not \
+         resolve up's container by workspace folder)",
+        ws.display()
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn down(ws: &Path) {
+    let _ = deacon()
+        .args(["down", "--workspace-folder"])
+        .arg(ws)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// Control case: a plain `image` config already resolved correctly; keep a
+/// guard so it can't silently regress alongside the dockerfile fix.
+#[test]
+fn up_then_exec_resolves_image_config_by_workspace_folder() {
+    if !is_docker_available() {
+        eprintln!("skipping: docker unavailable");
+        return;
+    }
+    let ws = TempDir::new().unwrap();
+    write(
+        ws.path(),
+        ".devcontainer/devcontainer.json",
+        r#"{ "name": "identity-image", "image": "alpine:3.18", "overrideCommand": true }"#,
+    );
+
+    up(ws.path());
+    let got = exec_echo(ws.path(), "IDENTITY_IMAGE_OK");
+    down(ws.path());
+
+    assert_eq!(got, "IDENTITY_IMAGE_OK");
+}
+
+/// The #187 regression: a `build.dockerfile` config. `up` builds it into a
+/// `deacon-build:<hash>` image; `exec` must still resolve the container by
+/// workspace folder despite that runtime image substitution.
+#[test]
+fn up_then_exec_resolves_dockerfile_config_by_workspace_folder() {
+    if !is_docker_available() {
+        eprintln!("skipping: docker unavailable");
+        return;
+    }
+    let ws = TempDir::new().unwrap();
+    write(
+        ws.path(),
+        ".devcontainer/devcontainer.json",
+        r#"{ "name": "identity-dockerfile", "build": { "dockerfile": "Dockerfile" }, "overrideCommand": true }"#,
+    );
+    write(
+        ws.path(),
+        ".devcontainer/Dockerfile",
+        "FROM alpine:3.18\nRUN echo built > /identity-marker\n",
+    );
+
+    up(ws.path());
+    let got = exec_echo(ws.path(), "IDENTITY_DOCKERFILE_OK");
+    down(ws.path());
+
+    assert_eq!(got, "IDENTITY_DOCKERFILE_OK");
+}

--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -116,6 +116,7 @@ listed.
 | up/remove-existing | ✅ pass | 2026-05-29 | full-ID reuse (#143) |
 | up/security-options | ✅ pass | 2026-05-29 | |
 | up/skip-lifecycle | ✅ pass | 2026-05-29 | |
+| up/up-exec-down | ✅ pass | 2026-06-11 | compound-flow up→exec→run-user-commands→down by --workspace-folder (#187 configHash fix) |
 | up/update-remote-user-uid | ✅ pass | 2026-05-29 | |
 | up/user-env-probe-modes | ✅ pass | 2026-05-29 | |
 | up/wait-for | ✅ pass | 2026-05-29 | |

--- a/examples/up/README.md
+++ b/examples/up/README.md
@@ -50,6 +50,7 @@ deacon up --workspace-folder .
 | Example | Description | Key Features |
 |---------|-------------|--------------|
 | [id-labels-reconnect/](id-labels-reconnect/) | Container reconnection | ID labels, container discovery, `--expect-existing-container` |
+| [up-exec-down/](up-exec-down/) | Compound-flow resolution | `up` → `exec`/`run-user-commands` → `down` by `--workspace-folder` (#187) |
 | [remove-existing/](remove-existing/) | Container replacement | `--remove-existing-container`, force recreation |
 
 ### GPU & Hardware

--- a/examples/up/exec.sh
+++ b/examples/up/exec.sh
@@ -18,6 +18,7 @@ DEFAULT_EXAMPLES=(
 	"remote-env-secrets"
 	"configuration-output"
 	"id-labels-reconnect"
+	"up-exec-down"
 	"remove-existing"
 	"gpu-modes"
 	"auto-forward"

--- a/examples/up/up-exec-down/.devcontainer/devcontainer.json
+++ b/examples/up/up-exec-down/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "up-exec-down",
+	"image": "alpine:3.18",
+	"overrideCommand": true,
+	"postCreateCommand": "echo up-exec-down-ok > /tmp/identity-marker"
+}

--- a/examples/up/up-exec-down/README.md
+++ b/examples/up/up-exec-down/README.md
@@ -1,0 +1,47 @@
+# up → exec → down (compound-flow resolution)
+
+Demonstrates that subcommands resolve the **same** container across a session
+using only `--workspace-folder` — no `--container-id` and no `--id-label`.
+
+This is the regression guard for [#187](https://github.com/get2knowio/deacon/issues/187):
+`up` and `exec`/`run-user-commands` must compute the **same**
+`devcontainer.configHash` label for an identical `devcontainer.json`. When they
+diverge, `exec --workspace-folder X` cannot find the container that
+`up --workspace-folder X` just created.
+
+## What it does
+
+```bash
+# 1. up creates the container; postCreate writes /tmp/identity-marker.
+#    --mount-workspace-git-root false keeps the canary self-contained in-repo
+#    (see below); it affects only up's bind mount, not container identity.
+deacon up --workspace-folder . --mount-workspace-git-root false
+
+# 2. exec resolves THAT container purely by workspace folder and reads the marker
+deacon exec --workspace-folder . cat /tmp/identity-marker
+#   -> up-exec-down-ok
+
+# 3. run-user-commands shares the same identity-resolution path
+deacon run-user-commands --workspace-folder .
+
+# 4. down resolves and removes the container by workspace folder
+deacon down --workspace-folder .
+```
+
+The canary fails loudly if `exec` resolves a *different* container (the marker
+won't match) or none at all (the #187 symptom).
+
+## Why `--mount-workspace-git-root false`
+
+So the example is self-contained when run from inside this monorepo: `up`
+otherwise mounts the enclosing git root. Container **identity** is anchored to
+`--workspace-folder` regardless of the mount source, which is precisely the
+property under test.
+
+## Run
+
+```bash
+./exec.sh
+```
+
+Requires Docker. The script removes the container on exit.

--- a/examples/up/up-exec-down/exec.sh
+++ b/examples/up/up-exec-down/exec.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compound-flow canary for issue #187: a later subcommand must resolve the
+# container an earlier one created, using ONLY --workspace-folder (no
+# --container-id, no --id-label). This exercises the pure workspace + config
+# container-identity path that regressed when `up` and `exec`/`run-user-commands`
+# computed different `devcontainer.configHash` values for the same config.
+#
+# README mapping ("Compound flow: up -> exec -> run-user-commands -> down"):
+#   1. up                  creates the container; postCreate writes a marker
+#   2. exec                resolves it by --workspace-folder, reads the marker
+#   3. run-user-commands   resolves the same container (shared identity path)
+#   4. down                resolves and removes it by --workspace-folder
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEACON_BIN="${DEACON_BIN:-deacon}"
+MARKER="up-exec-down-ok"
+
+# Identity resolution is anchored to --workspace-folder for every subcommand,
+# which is exactly what this canary verifies — so this is all exec /
+# run-user-commands / down need to find up's container.
+WS_ARGS=(--workspace-folder "$SCRIPT_DIR")
+
+# `up` additionally bind-mounts the workspace. Mount only THIS example folder
+# (not the enclosing monorepo git root) so the canary is self-contained when
+# run from within this repo. The mount source does not affect identity.
+UP_ARGS=("${WS_ARGS[@]}" --mount-workspace-git-root false)
+
+run() {
+	echo "+ $*" >&2
+	"$@"
+}
+
+cleanup() {
+	"$DEACON_BIN" down "${WS_ARGS[@]}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cd "$SCRIPT_DIR"
+
+echo "== up: create the container ==" >&2
+run "$DEACON_BIN" up "${UP_ARGS[@]}" --remove-existing-container >/dev/null
+
+echo "== exec: resolve up's container by --workspace-folder (no --container-id) ==" >&2
+got="$(run "$DEACON_BIN" exec "${WS_ARGS[@]}" cat /tmp/identity-marker 2>/dev/null | tr -d '[:space:]')"
+if [ "$got" != "$MARKER" ]; then
+	echo "FAIL: exec --workspace-folder did not resolve up's container (got '$got', want '$MARKER')" >&2
+	echo "      This is the #187 configHash-mismatch regression." >&2
+	exit 1
+fi
+echo "exec resolved up's container by --workspace-folder ✓" >&2
+
+echo "== run-user-commands: same identity resolution path ==" >&2
+run "$DEACON_BIN" run-user-commands "${WS_ARGS[@]}" >/dev/null
+echo "run-user-commands resolved the same container ✓" >&2
+
+echo "== down: resolve and remove by --workspace-folder ==" >&2
+run "$DEACON_BIN" down "${WS_ARGS[@]}" >/dev/null
+echo "down removed the container ✓" >&2
+
+trap - EXIT
+echo "up-exec-down canary passed ✓" >&2


### PR DESCRIPTION
Fixes #187.

## Problem

`deacon exec --workspace-folder X` (and `run-user-commands`) could not resolve the container `deacon up --workspace-folder X` had just created, because the two commands computed **different `devcontainer.configHash` labels for the identical `devcontainer.json`**. `exec`'s label selector matched nothing and it failed with:

```
Error: No running container found for workspace '<X>' with config '<name>'. Run 'deacon up' first to create the container.
```

## Root cause

`up` stamped the identity label from its **post-mutation** config. For a `build.dockerfile` config it had already replaced `build` with a `deacon-build:<hash>` image (mod.rs), so it hashed `image: deacon-build:…` while `exec` hashed the original `build.dockerfile`. The same divergence is latent for CLI `--mount`/`--forward-ports`, the image-metadata merge, feature merge, and variable substitution — none of which `exec` replays.

Empirically (current `main`):

| config shape | `up` ↔ `exec` resolution |
|---|---|
| `image` | ✅ already matched |
| `build.dockerfile` (+ legacy top-level `dockerFile`) | ❌ **mismatch → exec fails** |
| `compose` | ✅ resolves via compose **project name**, not the configHash label |

(The compose path looked broken in early testing but that was leftover-container/network pollution from repeated manual runs — it resolves correctly in a clean environment.)

## Fix

Snapshot the config **immediately after load** — before any of `up`'s runtime mutations — and derive the `ContainerIdentity` (labels + name, incl. the `devcontainer.config_file` label) from that snapshot, threading it into the create path instead of recomputing from the mutated config. That snapshot is exactly what `exec`/`run-user-commands` hash, so all shapes now resolve by `--workspace-folder`. This also matches the documented intent in `container.rs` that identity be host-path-independent and stable across `up` ↔ `exec`.

Verified after the fix (clean env), all resolved by `--workspace-folder` with no `--container-id`:

```
image          RESOLVED
dockerfile     RESOLVED
dockerfile-leg RESOLVED
compose        RESOLVED
```

## Regression coverage

- **`integration_up_exec_identity`** (docker, wired into `mvp-integration` so it runs on PRs): `up` → `exec --workspace-folder` for image + dockerfile, asserting resolution with **no** `--container-id`. Both pass (~40s; includes the Dockerfile build).
- **`examples/up/up-exec-down/`** canary (issue suggestion #1): `up` → `exec` → `run-user-commands` → `down`, all by `--workspace-folder`, wired into the `examples/up` aggregator + `CANARY_STATUS.md`. Passes.

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `make test-nextest-fast` — 2494 passed ✓
- Identity-sensitive docker tests (`integration_custom_container_name`, `integration_down`, `integration_exec_selection`, `up_reconnect_full_id`, `smoke_up_idempotent`) ✓
- New `integration_up_exec_identity` ✓ and `up-exec-down` canary ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)