### PR TITLE
fix(ports): accept onAutoForward openBrowserOnce (spec parity)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -175,8 +175,10 @@ pub enum OnAutoForward {
     Silent,
     /// Show a notification when port is auto-forwarded  
     Notify,
-    /// Open the port in a browser when auto-forwarded
+    /// Open the port in a browser every time it is auto-forwarded
     OpenBrowser,
+    /// Open the port in a browser only the first time it is auto-forwarded
+    OpenBrowserOnce,
     /// Open the port in a preview panel when auto-forwarded
     OpenPreview,
     /// Ignore the port (don't auto-forward)
@@ -3824,6 +3826,29 @@ mod tests {
         assert_eq!(other_attrs.on_auto_forward, Some(OnAutoForward::Silent));
 
         Ok(())
+    }
+
+    /// Spec parity: `onAutoForward` accepts all six containers.dev values,
+    /// including `openBrowserOnce` (which previously failed to deserialize).
+    #[test]
+    fn test_on_auto_forward_accepts_all_spec_values() {
+        let cases = [
+            ("silent", OnAutoForward::Silent),
+            ("notify", OnAutoForward::Notify),
+            ("openBrowser", OnAutoForward::OpenBrowser),
+            ("openBrowserOnce", OnAutoForward::OpenBrowserOnce),
+            ("openPreview", OnAutoForward::OpenPreview),
+            ("ignore", OnAutoForward::Ignore),
+        ];
+        for (value, expected) in cases {
+            let json = format!(r#"{{ "onAutoForward": "{value}" }}"#);
+            let attrs: PortAttributes = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("onAutoForward {value:?} must parse: {e}"));
+            assert_eq!(attrs.on_auto_forward, Some(expected), "value {value:?}");
+            // Round-trips back to the same camelCase token.
+            let round = serde_json::to_value(&attrs).unwrap();
+            assert_eq!(round["onAutoForward"], value);
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/ports.rs
+++ b/crates/core/src/ports.rs
@@ -304,7 +304,11 @@ impl PortForwardingManager {
                         event.local_port.unwrap_or(event.port)
                     );
                 }
-                OnAutoForward::OpenBrowser => {
+                OnAutoForward::OpenBrowser | OnAutoForward::OpenBrowserOnce => {
+                    // `openBrowserOnce` differs from `openBrowser` only in an
+                    // editor-UX detail (open the browser the first time vs every
+                    // time). A headless CLI has no browser, so both are surfaced
+                    // the same way; the distinction is moot here.
                     info!(
                         "Port {} is now available - would open browser at {}://localhost:{}",
                         event.port,


### PR DESCRIPTION
## Problem

`portsAttributes.<port>.onAutoForward` in the containers.dev spec accepts **six** values — `notify`, `openBrowser`, `openBrowserOnce`, `openPreview`, `silent`, `ignore` — but deacon's `OnAutoForward` enum had only five (missing `openBrowserOnce`). Because serde rejects unknown enum variants, a valid devcontainer.json using `openBrowserOnce` failed to load:

```
Deserialization error: unknown variant 'openBrowserOnce', expected one of
'silent', 'notify', 'openBrowser', 'openPreview', 'ignore'
```

## Fix

- Add the `OpenBrowserOnce` variant to `OnAutoForward` (`config.rs`).
- Handle it alongside `OpenBrowser` in the port-event path (`ports.rs`). As with the other editor-UX actions, deacon's headless paths surface it as a notify/log; the `--auto-forward` daemon already collapses `openBrowser*`/`openPreview` → `notify`. **Actually opening a host browser/preview remains deferred** (no code path opens anything today).
- Unit test asserts all six values parse and round-trip to their camelCase token.

Closes the only remaining gap in deacon's `onAutoForward` vocabulary; the rest of the port-attribute surface (`label`, `protocol`, `requireLocalPort`, `elevateIfNeeded`, `otherPortsAttributes`) was already covered and unknown keys are tolerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)