### PR TITLE
chore(tests): spec-anchor lifecycle waitFor and userEnvProbe value sets

### DIFF
--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -958,6 +958,32 @@ mod tests {
         assert_eq!(result.get("KEEP"), Some(&"keep_me".to_string()));
     }
 
+    /// Spec parity: the `userEnvProbe` config field (deserialized via serde from
+    /// devcontainer.json) accepts every containers.dev value. Anchored to the
+    /// spec's authoritative set so a future missing variant fails here rather
+    /// than rejecting a valid config (cf. the onAutoForward gap). The `FromStr`
+    /// CLI path is covered separately by `test_parse_container_probe_mode_*`.
+    #[test]
+    fn test_user_env_probe_serde_accepts_all_spec_values() {
+        let cases = [
+            ("none", ContainerProbeMode::None),
+            ("loginShell", ContainerProbeMode::LoginShell),
+            (
+                "loginInteractiveShell",
+                ContainerProbeMode::LoginInteractiveShell,
+            ),
+            ("interactiveShell", ContainerProbeMode::InteractiveShell),
+        ];
+        for (value, expected) in cases {
+            let json = format!("\"{value}\"");
+            let parsed: ContainerProbeMode = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("userEnvProbe {value:?} must deserialize: {e}"));
+            assert_eq!(parsed, expected, "value {value:?}");
+            // Round-trips back to the same camelCase token.
+            assert_eq!(serde_json::to_value(parsed).unwrap(), value);
+        }
+    }
+
     #[test]
     fn test_parse_container_probe_mode_valid_inputs() {
         // Valid variants map to expected enum

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -1440,6 +1440,37 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Spec parity: `waitFor` accepts every containers.dev lifecycle-command
+    /// value and maps it to the right phase. Anchored to the spec's authoritative
+    /// set (not deacon's enum) so a future missing value fails the test rather
+    /// than silently rejecting a valid config (cf. the onAutoForward gap).
+    #[test]
+    fn test_wait_for_phase_accepts_all_spec_values() {
+        let cases = [
+            ("initializeCommand", LifecyclePhase::Initialize),
+            ("onCreateCommand", LifecyclePhase::OnCreate),
+            ("updateContentCommand", LifecyclePhase::UpdateContent),
+            ("postCreateCommand", LifecyclePhase::PostCreate),
+            ("postStartCommand", LifecyclePhase::PostStart),
+            ("postAttachCommand", LifecyclePhase::PostAttach),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(
+                wait_for_phase(Some(value)).unwrap(),
+                expected,
+                "waitFor {value:?} must map to {expected:?}"
+            );
+        }
+        // Missing waitFor defaults to updateContentCommand (spec default).
+        assert_eq!(wait_for_phase(None).unwrap(), LifecyclePhase::UpdateContent);
+        // An unknown value fails fast naming the allowed set.
+        let err = wait_for_phase(Some("bogusCommand"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Invalid waitFor value"));
+        assert!(err.contains("postAttachCommand"));
+    }
+
     #[test]
     fn test_lifecycle_phase_as_str() {
         assert_eq!(LifecyclePhase::Initialize.as_str(), "initialize");


### PR DESCRIPTION
## Context

Follow-up to the `onAutoForward` `openBrowserOnce` parse gap (#202). That bug survived because the existing test **enumerated the variants we implemented, not the variants the spec requires** — a tautology that can never catch a *missing* spec value.

## Audit

I swept the config surface for spec-defined value sets modeled as closed enums:

| Field | Type | Finding |
|---|---|---|
| `onAutoForward` | `OnAutoForward` | **was missing `openBrowserOnce`** → fixed in #202 (+ spec-anchored test) |
| `waitFor` | `wait_for_phase()` | value-complete (6/6) but **no test at all** |
| `userEnvProbe` | `ContainerProbeMode` | value-complete (4/4); FromStr tested but **serde/config path untested** |
| mount `type` | `MountType` | value-complete; **already spec-anchored** (bind/volume/tmpfs) |
| `shutdownAction` | `Option<String>` | permissive string — no parse-failure risk |

**Conclusion: `onAutoForward` was the only enum actually missing a spec value.** The rest were test gaps, not bugs.

## This PR

Closes the two test gaps with spec-anchored tests that list the authoritative containers.dev value sets (so a future omission fails):

- `test_wait_for_phase_accepts_all_spec_values` — all six lifecycle-command values + the `updateContentCommand` default + fail-fast on unknown.
- `test_user_env_probe_serde_accepts_all_spec_values` — all four values deserialize + round-trip through the serde/config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)