### PR TITLE
chore(release): prepare v0.2.0-rc.4 prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.3" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.4" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.3"
+version = "0.2.0-rc.4"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bump `deacon`, `deacon-core`, and the workspace `deacon-core` path-dep pin from `0.2.0-rc.3` to `0.2.0-rc.4` so the release workflow's tag/crate-version gate accepts the `v0.2.0-rc.4` tag.

Rolls up since rc.3:
- **#202** `fix(ports): accept onAutoForward openBrowserOnce` (spec parity)
- **#203** `chore(tests): spec-anchor lifecycle waitFor and userEnvProbe value sets`
- **#201** `ci: label PRs by conventional-commit title type for release notes`

After merge, the `v0.2.0-rc.4` tag will be pushed to trigger the release workflow (binaries + SBOMs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)