### PR TITLE
feat(ports): open the browser for onAutoForward openBrowser/openBrowserOnce

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,31 @@ deacon down                        # reaps the forwarder and releases its host p
 How it works: the forwarder polls the container's listening sockets and relays
 bytes via `docker exec` into the container's network namespace. Declared ports
 (`forwardPorts`/`appPort`/`--forward-port`) forward eagerly and are not also
-`-p` published; `portsAttributes.onAutoForward` (`ignore`/`silent`/`notify`) is
+`-p` published; `portsAttributes.onAutoForward`
+(`ignore`/`silent`/`notify`/`openBrowser`/`openBrowserOnce`/`openPreview`) is
 honored; compose `"service:port"` declared ports are forwarded too.
 
+**Auto-open a browser.** A port whose `onAutoForward` is `openBrowser` (every
+time it forwards) or `openBrowserOnce` (the first time per forwarder session)
+opens your browser at the forwarded loopback URL. `openPreview` has no CLI
+analog and is treated as `notify`. Which browser is a **machine-owner** choice,
+resolved with precedence:
+
+```bash
+DEACON_BROWSER=firefox deacon up --auto-forward     # env var (highest)
+# or persist it: ~/.deacon/settings.json  ->  { "browser": "firefox" }
+# else the OS default opener (xdg-open / open / start) is used.
+```
+
+The value is a bare program (the URL is appended as the final argument — no
+shell). Auto-open is **skipped in CI / non-TTY sessions** unless a browser is
+explicitly configured. Nothing in `devcontainer.json` can choose the program;
+the workspace can only *request* an open via `onAutoForward` (a loopback URL).
+
 **Limits (v1):** loopback-only (never `0.0.0.0`/LAN), TCP only, Unix hosts only,
-and best-effort — if forwarding can't start you get a clear warning but `up`
-still succeeds. Forwarder logs: `~/.deacon/forward_daemon_<container_id>.log`.
+and best-effort — if forwarding (or the browser launch) can't start you get a
+clear warning but `up` still succeeds. Forwarder logs:
+`~/.deacon/forward_daemon_<container_id>.log`.
 
 ## Corporate CA injection (`--inject-host-ca`)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,6 +117,21 @@ require a separate, documented opt-in. Reviewers evaluating whether
 forwarding warrants opt-in beyond the flag itself should weigh that it
 only ever exposes the user's own container to the user's own loopback.
 
+- **Browser auto-open** — a forwarded port whose `onAutoForward` is
+  `openBrowser`/`openBrowserOnce` launches a host browser at the forwarded
+  **loopback** URL. The `onAutoForward` value is **workspace-requested**
+  (`devcontainer.json` can ask deacon to open a `127.0.0.1` URL, exactly like
+  the VS Code Dev Containers extension), but the **browser program itself is
+  machine-owner-only** — `DEACON_BROWSER` env var or the `browser` key in
+  `{user_data_folder}/settings.json`, never sourced from the workspace. So a
+  hostile workspace can never choose *which* program runs, only request that
+  the OS-default/owner-chosen browser open a loopback port. The URL is passed
+  as a non-shell argument (no shell interpolation of a workspace-influenced
+  URL), and the whole action is best-effort and suppressed in CI/non-TTY
+  sessions unless a browser is explicitly configured. No trust gate is applied
+  (the program is machine-owner-controlled, the same rationale as host-CA
+  injection).
+
 ## Corporate CA injection (`--inject-host-ca`)
 
 Behind a TLS-intercepting corporate proxy, dev containers need the corporate

--- a/crates/core/src/browser.rs
+++ b/crates/core/src/browser.rs
@@ -1,0 +1,166 @@
+//! Host browser launching for port auto-open (`onAutoForward: openBrowser`).
+//!
+//! When the `--auto-forward` daemon forwards a port whose `onAutoForward`
+//! attribute is `openBrowser`/`openBrowserOnce`, deacon opens the machine
+//! owner's browser at the forwarded loopback URL. Which browser is a
+//! **machine-owner** choice — `DEACON_BROWSER` env var, then the `browser` key
+//! in `{user_data_folder}/settings.json`, then the OS default opener. It is
+//! never sourced from the workspace (the workspace's `devcontainer.json` can
+//! only *request* an open via `onAutoForward`; it can never choose the program).
+//!
+//! The browser value is a **bare program** (no shell): the URL is appended as
+//! the final argument, so a hostile URL can't inject shell. Everything here is
+//! best-effort — a missing/broken browser or headless host never fails `up` or
+//! the daemon.
+
+use crate::settings::Settings;
+use std::process::Stdio;
+use tracing::debug;
+
+/// Env var the machine owner sets to choose the browser program.
+/// Precedence: this > `settings.browser` > OS default.
+pub const DEACON_BROWSER: &str = "DEACON_BROWSER";
+
+/// Resolve the browser program from the machine-owner sources, in precedence
+/// order: `DEACON_BROWSER` env > `settings.browser` > `None` (= OS default).
+///
+/// Empty/whitespace values are treated as unset at each tier (mirrors
+/// [`crate::host_ca::resolve_host_ca_activation`]).
+pub fn resolve_browser(env: Option<&str>, settings: &Settings) -> Option<String> {
+    if let Some(v) = env {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Some(t.to_string());
+        }
+    }
+    if let Some(v) = settings.browser.as_deref() {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Some(t.to_string());
+        }
+    }
+    None
+}
+
+/// Build the `(program, args)` to open `url`. **Pure** (no spawn) so it is
+/// unit-testable across platforms via `cfg!`.
+///
+/// - `Some(prog)` ⇒ run `prog <url>` (URL appended verbatim, no shell).
+/// - `None` ⇒ the OS default opener: `open` (macOS), `cmd /C start "" <url>`
+///   (Windows), `xdg-open` (Linux/other Unix).
+pub fn browser_command(browser: Option<&str>, url: &str) -> (String, Vec<String>) {
+    match browser {
+        Some(prog) => (prog.to_string(), vec![url.to_string()]),
+        None => {
+            if cfg!(target_os = "macos") {
+                ("open".to_string(), vec![url.to_string()])
+            } else if cfg!(target_os = "windows") {
+                // `start` is a cmd builtin; the empty "" is the window title arg
+                // so a URL with spaces isn't mistaken for the title.
+                (
+                    "cmd".to_string(),
+                    vec![
+                        "/C".to_string(),
+                        "start".to_string(),
+                        String::new(),
+                        url.to_string(),
+                    ],
+                )
+            } else {
+                ("xdg-open".to_string(), vec![url.to_string()])
+            }
+        }
+    }
+}
+
+/// Fire-and-forget browser launch (async, for the daemon). Spawns and **drops**
+/// the child without awaiting it — the opener (xdg-open/open/start) returns
+/// promptly. Best-effort: returns the spawn error for the caller to log at
+/// debug; never blocks the async runtime and never panics.
+pub async fn open_url(browser: Option<&str>, url: &str) -> std::io::Result<()> {
+    let (program, args) = browser_command(browser, url);
+    let child = tokio::process::Command::new(&program)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    drop(child); // detach; tokio reaps the orphan via its process driver
+    debug!(program = %program, url = %url, "launched browser (best-effort)");
+    Ok(())
+}
+
+/// Synchronous sibling of [`open_url`] for non-async call sites (the static
+/// `--ports-events` path). Same fire-and-forget, best-effort contract.
+pub fn open_url_blocking(browser: Option<&str>, url: &str) -> std::io::Result<()> {
+    let (program, args) = browser_command(browser, url);
+    let child = std::process::Command::new(&program)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    drop(child); // detach; the short-lived `up` process exits soon after
+    debug!(program = %program, url = %url, "launched browser (best-effort)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_with(browser: Option<&str>) -> Settings {
+        Settings {
+            host_ca: None,
+            browser: browser.map(String::from),
+        }
+    }
+
+    #[test]
+    fn resolve_prefers_env_over_settings() {
+        let s = settings_with(Some("from-settings"));
+        assert_eq!(
+            resolve_browser(Some("from-env"), &s).as_deref(),
+            Some("from-env")
+        );
+    }
+
+    #[test]
+    fn resolve_uses_settings_when_env_unset_or_empty() {
+        let s = settings_with(Some("firefox"));
+        assert_eq!(resolve_browser(None, &s).as_deref(), Some("firefox"));
+        assert_eq!(resolve_browser(Some("   "), &s).as_deref(), Some("firefox"));
+    }
+
+    #[test]
+    fn resolve_none_when_both_unset() {
+        assert_eq!(resolve_browser(None, &settings_with(None)), None);
+        assert_eq!(resolve_browser(Some(""), &settings_with(Some("  "))), None);
+    }
+
+    #[test]
+    fn command_uses_configured_program_verbatim() {
+        let (prog, args) = browser_command(Some("firefox"), "http://127.0.0.1:3000");
+        assert_eq!(prog, "firefox");
+        assert_eq!(args, vec!["http://127.0.0.1:3000".to_string()]);
+    }
+
+    #[test]
+    fn command_default_opener_for_this_platform() {
+        let (prog, args) = browser_command(None, "http://127.0.0.1:8080");
+        if cfg!(target_os = "macos") {
+            assert_eq!(prog, "open");
+            assert_eq!(args, vec!["http://127.0.0.1:8080".to_string()]);
+        } else if cfg!(target_os = "windows") {
+            assert_eq!(prog, "cmd");
+            assert_eq!(args.first().map(String::as_str), Some("/C"));
+            assert_eq!(
+                args.last().map(String::as_str),
+                Some("http://127.0.0.1:8080")
+            );
+        } else {
+            assert_eq!(prog, "xdg-open");
+            assert_eq!(args, vec!["http://127.0.0.1:8080".to_string()]);
+        }
+    }
+}

--- a/crates/core/src/host_ca/activation.rs
+++ b/crates/core/src/host_ca/activation.rs
@@ -86,6 +86,7 @@ mod tests {
     fn settings_with(host_ca: Option<&str>) -> Settings {
         Settings {
             host_ca: host_ca.map(String::from),
+            ..Default::default()
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate contains shared logic for configuration resolution, Docker integration,
 //! feature system, template system, lifecycle execution, logging, and error handling.
 
+pub mod browser;
 pub mod build;
 pub mod cache;
 pub mod compose;

--- a/crates/core/src/port_forward/daemon.rs
+++ b/crates/core/src/port_forward/daemon.rs
@@ -14,7 +14,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::{
     DaemonMarker, DetectedPort, ForwardOrigin, ForwardSpec, PortForwardError,
@@ -47,6 +47,14 @@ pub struct DaemonConfig {
     pub ports_events: bool,
     /// Docker CLI path used for `exec`/`inspect`.
     pub docker_path: String,
+    /// Resolved browser program for `onAutoForward: openBrowser` auto-open
+    /// (`DEACON_BROWSER` > settings, resolved by the parent `up`); `None` ⇒ OS
+    /// default opener. See [`crate::browser`].
+    pub browser: Option<String>,
+    /// Master gate for browser auto-open. The parent `up` sets this from the
+    /// headless/CI/TTY check (the daemon's own stdio is `/dev/null`, so it can't
+    /// evaluate `is_terminal()` itself).
+    pub auto_open: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -207,13 +215,17 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
     );
 
     let mut active: HashMap<u16, ActiveForward> = HashMap::new();
+    // Container ports already browser-opened in this daemon's lifetime. Never
+    // cleared on withdraw, so `openBrowserOnce` holds across listener restarts
+    // within the session (resets only when the daemon/container is recreated).
+    let mut opened: HashSet<u16> = HashSet::new();
 
     // Eager-bind declared ports (Reserved → Active once the container listens).
     for spec in &declared {
         if spec.attributes.on_auto_forward == OnAutoForward::Ignore {
             continue;
         }
-        match start_forward(spec.clone(), relay_program, &config).await {
+        match start_forward(spec.clone(), relay_program, &config, &mut opened).await {
             Ok(af) => {
                 active.insert(spec.container_port, af);
             }
@@ -264,6 +276,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
 
         reconcile(
             &mut active,
+            &mut opened,
             &detected,
             &declared_ports,
             cfg.as_ref(),
@@ -291,6 +304,7 @@ pub async fn run(config: DaemonConfig) -> Result<()> {
 /// listening (FR-004, FR-024). Declared ports stay reserved regardless.
 async fn reconcile(
     active: &mut HashMap<u16, ActiveForward>,
+    opened: &mut HashSet<u16>,
     detected: &[DetectedPort],
     declared_ports: &HashSet<u16>,
     cfg: Option<&DevContainerConfig>,
@@ -315,7 +329,7 @@ async fn reconcile(
             attributes,
             eager: false,
         };
-        match start_forward(spec, relay_program, config).await {
+        match start_forward(spec, relay_program, config, opened).await {
             Ok(af) => {
                 active.insert(d.port, af);
             }
@@ -343,11 +357,50 @@ async fn reconcile(
     }
 }
 
+/// Decide whether to open a browser for this action, given whether the
+/// container port has already been opened in this daemon's lifetime.
+/// `openBrowser` always opens; `openBrowserOnce` opens only the first time;
+/// everything else (including `openPreview`, which has no CLI analog) does not.
+fn should_open(action: &OnAutoForward, already_opened: bool) -> bool {
+    match action {
+        OnAutoForward::OpenBrowser => true,
+        OnAutoForward::OpenBrowserOnce => !already_opened,
+        _ => false,
+    }
+}
+
+/// Best-effort browser auto-open for a freshly-live forward. Inserts the port
+/// into `opened` BEFORE spawning so a broken browser binary can't retry on every
+/// poll tick. Never fails the daemon.
+async fn maybe_open_browser(
+    spec: &ForwardSpec,
+    host_port: u16,
+    config: &DaemonConfig,
+    opened: &mut HashSet<u16>,
+) {
+    if !config.auto_open
+        || !should_open(
+            &spec.attributes.on_auto_forward,
+            opened.contains(&spec.container_port),
+        )
+    {
+        return;
+    }
+    let scheme = spec.attributes.protocol.as_deref().unwrap_or("http");
+    let url = format!("{scheme}://{DEFAULT_DIAL_HOST}:{host_port}");
+    opened.insert(spec.container_port);
+    match crate::browser::open_url(config.browser.as_deref(), &url).await {
+        Ok(()) => info!(url = %url, "opened browser for forwarded port"),
+        Err(e) => debug!(error = %e, url = %url, "browser auto-open failed (best-effort)"),
+    }
+}
+
 /// Allocate + bind a host port, start the relay task, and report the mapping.
 async fn start_forward(
     spec: ForwardSpec,
     relay_program: relay::RelayProgram,
     config: &DaemonConfig,
+    opened: &mut HashSet<u16>,
 ) -> Result<ActiveForward> {
     let udf = config.user_data_folder.as_deref();
     let workspace = config.workspace.display().to_string();
@@ -380,6 +433,7 @@ async fn start_forward(
     ));
 
     report_forward(&spec, alloc.host_port, alloc.remapped, config.ports_events);
+    maybe_open_browser(&spec, alloc.host_port, config, opened).await;
 
     Ok(ActiveForward {
         spec,
@@ -486,17 +540,14 @@ fn resolve_attributes(cfg: Option<&DevContainerConfig>, port: u16) -> ResolvedPo
     ResolvedPortAttributes::default()
 }
 
-/// Convert a [`PortAttributes`] into [`ResolvedPortAttributes`], collapsing
-/// `openBrowser`/`openPreview` to `Notify` for v1 (auto-open is deferred).
+/// Convert a [`PortAttributes`] into [`ResolvedPortAttributes`], preserving the
+/// real `onAutoForward` action (so `openBrowser`/`openBrowserOnce` can drive
+/// auto-open) and carrying the `protocol` hint for the URL/PORT_EVENT scheme.
 fn to_resolved(pa: &PortAttributes) -> ResolvedPortAttributes {
-    let on_auto_forward = match pa.on_auto_forward {
-        Some(OnAutoForward::Ignore) => OnAutoForward::Ignore,
-        Some(OnAutoForward::Silent) => OnAutoForward::Silent,
-        _ => OnAutoForward::Notify,
-    };
     ResolvedPortAttributes {
         label: pa.label.clone(),
-        on_auto_forward,
+        on_auto_forward: pa.on_auto_forward.clone().unwrap_or(OnAutoForward::Notify),
+        protocol: pa.protocol.clone(),
     }
 }
 
@@ -547,7 +598,7 @@ fn report_unforward(af: &ActiveForward, ports_events: bool) {
 fn port_event(spec: &ForwardSpec, host_port: Option<u16>, forwarded: bool) -> PortEvent {
     PortEvent {
         port: spec.container_port,
-        protocol: None,
+        protocol: spec.attributes.protocol.clone(),
         label: spec.attributes.label.clone(),
         on_auto_forward: Some(spec.attributes.on_auto_forward.clone()),
         auto_forwarded: forwarded,
@@ -674,12 +725,45 @@ mod tests {
     }
 
     #[test]
-    fn open_browser_preview_collapse_to_notify() {
-        let cfg = config_with_attrs(vec![("3000", OnAutoForward::OpenBrowser)], None);
+    fn resolve_preserves_open_actions_and_protocol() {
+        // The real action is no longer collapsed to Notify (auto-open needs it).
+        for action in [
+            OnAutoForward::OpenBrowser,
+            OnAutoForward::OpenBrowserOnce,
+            OnAutoForward::OpenPreview,
+        ] {
+            let cfg = config_with_attrs(vec![("3000", action.clone())], None);
+            assert_eq!(resolve_attributes(Some(&cfg), 3000).on_auto_forward, action);
+        }
+        // protocol hint is carried through for the URL/PORT_EVENT scheme.
+        let mut cfg = DevContainerConfig::default();
+        let mut pa = attrs(None, OnAutoForward::OpenBrowser);
+        pa.protocol = Some("https".to_string());
+        cfg.ports_attributes.insert("3000".to_string(), pa);
         assert_eq!(
-            resolve_attributes(Some(&cfg), 3000).on_auto_forward,
-            OnAutoForward::Notify
+            resolve_attributes(Some(&cfg), 3000).protocol.as_deref(),
+            Some("https")
         );
+    }
+
+    #[test]
+    fn should_open_semantics() {
+        // openBrowser: always.
+        assert!(should_open(&OnAutoForward::OpenBrowser, false));
+        assert!(should_open(&OnAutoForward::OpenBrowser, true));
+        // openBrowserOnce: only the first time.
+        assert!(should_open(&OnAutoForward::OpenBrowserOnce, false));
+        assert!(!should_open(&OnAutoForward::OpenBrowserOnce, true));
+        // everything else (incl. openPreview): never opens.
+        for a in [
+            OnAutoForward::Notify,
+            OnAutoForward::Silent,
+            OnAutoForward::Ignore,
+            OnAutoForward::OpenPreview,
+        ] {
+            assert!(!should_open(&a, false));
+            assert!(!should_open(&a, true));
+        }
     }
 
     #[test]

--- a/crates/core/src/port_forward/mod.rs
+++ b/crates/core/src/port_forward/mod.rs
@@ -130,9 +130,13 @@ pub enum ForwardOrigin {
 pub struct ResolvedPortAttributes {
     /// Human label for reporting.
     pub label: Option<String>,
-    /// `ignore` / `silent` / `notify` (v1); `openBrowser`/`openPreview`
-    /// are accepted but treated as `notify`.
+    /// The real `onAutoForward` action. `openBrowser`/`openBrowserOnce` drive
+    /// browser auto-open in the daemon; `openPreview` (no CLI analog) and the
+    /// rest are surfaced but do not open a browser.
     pub on_auto_forward: OnAutoForward,
+    /// `protocol` hint (`http`/`https`) used to build the auto-open URL and the
+    /// PORT_EVENT scheme. `None` ⇒ `http`.
+    pub protocol: Option<String>,
 }
 
 impl Default for ResolvedPortAttributes {
@@ -140,6 +144,7 @@ impl Default for ResolvedPortAttributes {
         ResolvedPortAttributes {
             label: None,
             on_auto_forward: OnAutoForward::Notify,
+            protocol: None,
         }
     }
 }

--- a/crates/core/src/ports.rs
+++ b/crates/core/src/ports.rs
@@ -305,24 +305,26 @@ impl PortForwardingManager {
                     );
                 }
                 OnAutoForward::OpenBrowser | OnAutoForward::OpenBrowserOnce => {
-                    // `openBrowserOnce` differs from `openBrowser` only in an
-                    // editor-UX detail (open the browser the first time vs every
-                    // time). A headless CLI has no browser, so both are surfaced
-                    // the same way; the distinction is moot here.
+                    // Report availability + the URL. The actual browser launch
+                    // happens in the `up` caller (which owns the machine-owner
+                    // browser resolution + headless gate); this core path stays
+                    // pure reporting. `openBrowserOnce` vs `openBrowser` is moot
+                    // on this one-shot static path.
                     info!(
-                        "Port {} is now available - would open browser at {}://localhost:{}",
+                        "Port {} is now available at {}://localhost:{}",
                         event.port,
                         url_scheme,
                         event.local_port.unwrap_or(event.port)
                     );
-                    // In a real implementation, this would open the browser
                 }
                 OnAutoForward::OpenPreview => {
+                    // No preview pane in a CLI; surface availability only (the
+                    // user chose notify-only semantics for openPreview).
                     info!(
-                        "Port {} is now available - would open preview panel",
-                        event.port
+                        "Port {} is now available at localhost:{}",
+                        event.port,
+                        event.local_port.unwrap_or(event.port)
                     );
-                    // In a real implementation, this would open a preview panel
                 }
                 OnAutoForward::Silent => {
                     // Do nothing - silent forwarding

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -32,6 +32,12 @@ pub struct Settings {
     /// Absent ⇒ no setting (the lowest-precedence activation source).
     #[serde(rename = "hostCa", default, skip_serializing_if = "Option::is_none")]
     pub host_ca: Option<String>,
+
+    /// Browser program for port auto-open (`onAutoForward: openBrowser`). A bare
+    /// program name/path (the forwarded URL is appended). Absent ⇒ fall back to
+    /// `DEACON_BROWSER` then the OS default opener. See [`crate::browser`].
+    #[serde(rename = "browser", default, skip_serializing_if = "Option::is_none")]
+    pub browser: Option<String>,
 }
 
 impl Settings {
@@ -121,6 +127,20 @@ mod tests {
         std::fs::write(tmp.path().join("settings.json"), "{}").unwrap();
         let settings = Settings::load(Some(tmp.path())).unwrap();
         assert!(settings.host_ca.is_none());
+        assert!(settings.browser.is_none());
+    }
+
+    #[test]
+    fn browser_parses_alongside_host_ca() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("settings.json"),
+            r#"{ "hostCa": "auto", "browser": "firefox" }"#,
+        )
+        .unwrap();
+        let settings = Settings::load(Some(tmp.path())).unwrap();
+        assert_eq!(settings.host_ca.as_deref(), Some("auto"));
+        assert_eq!(settings.browser.as_deref(), Some("firefox"));
     }
 
     #[test]

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -768,6 +768,13 @@ pub enum Commands {
         /// Emit machine-readable PORT_EVENT lines as ports come and go.
         #[arg(long)]
         ports_events: bool,
+        /// Parent-resolved browser program for onAutoForward auto-open
+        /// (absent ⇒ OS default opener).
+        #[arg(long)]
+        browser: Option<String>,
+        /// Suppress browser auto-open (parent decided headless/CI/no-TTY).
+        #[arg(long)]
+        no_auto_open: bool,
     },
 }
 
@@ -1770,6 +1777,8 @@ impl Cli {
                 workspace,
                 declared_port,
                 ports_events,
+                browser,
+                no_auto_open,
             }) => {
                 crate::commands::forward_daemon::run_forward_daemon(
                     crate::commands::forward_daemon::ForwardDaemonArgs {
@@ -1780,6 +1789,8 @@ impl Cli {
                         config_path: self.config.clone(),
                         ports_events,
                         docker_path: self.docker_path.clone(),
+                        browser,
+                        auto_open: !no_auto_open,
                     },
                 )
                 .await

--- a/crates/deacon/src/commands/forward_daemon.rs
+++ b/crates/deacon/src/commands/forward_daemon.rs
@@ -31,6 +31,11 @@ pub struct ForwardDaemonArgs {
     pub ports_events: bool,
     /// Docker CLI path.
     pub docker_path: String,
+    /// Parent-resolved browser program for `onAutoForward` auto-open
+    /// (`DEACON_BROWSER` > settings); `None` ⇒ OS default opener.
+    pub browser: Option<String>,
+    /// Whether browser auto-open is enabled (parent's headless/CI/TTY decision).
+    pub auto_open: bool,
 }
 
 /// Detach, redirect stdio to the per-container log, and run the supervisor loop.
@@ -57,6 +62,8 @@ pub async fn run_forward_daemon(args: ForwardDaemonArgs) -> anyhow::Result<()> {
         config_path: args.config_path,
         ports_events: args.ports_events,
         docker_path: args.docker_path,
+        browser: args.browser,
+        auto_open: args.auto_open,
     };
 
     daemon::run(config)

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -415,6 +415,8 @@ pub(crate) async fn execute_compose_up(
             &args.redaction_config,
             &args.secret_registry,
             &args.docker_path,
+            args.auto_forward,
+            args.user_data_folder.as_deref(),
         )
         .await?;
     }

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -733,6 +733,8 @@ pub(crate) async fn execute_container_up(
             runtime,
             &args.redaction_config,
             &args.secret_registry,
+            args.auto_forward,
+            args.user_data_folder.as_deref(),
         )
         .await?;
     }

--- a/crates/deacon/src/commands/up/forward.rs
+++ b/crates/deacon/src/commands/up/forward.rs
@@ -6,16 +6,19 @@
 //! adopted rather than duplicated (FR-012). Forwarding is best-effort — any
 //! failure here warns loudly but never fails `up` (FR-025, FR-019).
 
+use std::io::IsTerminal;
 use std::path::Path;
 use std::process::Stdio;
 
 use tracing::{info, warn};
 
+use deacon_core::browser::{DEACON_BROWSER, resolve_browser};
 use deacon_core::config::{DevContainerConfig, PortSpec};
 use deacon_core::container::ContainerIdentity;
 use deacon_core::docker::Docker;
 use deacon_core::port_forward::daemon::pid_alive;
 use deacon_core::port_forward::{DaemonMarker, marker_path};
+use deacon_core::settings::Settings;
 
 use crate::commands::up::args::UpArgs;
 
@@ -113,6 +116,29 @@ pub async fn spawn_or_adopt(
     }
 }
 
+/// Resolve the auto-open browser program (machine-owner only). Precedence:
+/// `DEACON_BROWSER` env, then `settings.browser`, else `None` (OS default
+/// opener). Best-effort — a settings read error degrades to "no configured
+/// browser" and never fails `up`.
+pub(crate) fn resolve_browser_cli(user_data_folder: Option<&Path>) -> Option<String> {
+    let env = std::env::var(DEACON_BROWSER).ok();
+    let settings = Settings::load(user_data_folder).unwrap_or_default();
+    resolve_browser(env.as_deref(), &settings)
+}
+
+/// Whether to enable browser auto-open. Skip in CI / when `stderr` isn't a TTY,
+/// UNLESS a browser is explicitly configured — an explicit machine-owner choice
+/// signals intent (and is the lever hermetic tests use to force-enable).
+pub(crate) fn auto_open_enabled(browser_configured: bool) -> bool {
+    if browser_configured {
+        return true;
+    }
+    let ci = std::env::var("CI").is_ok()
+        || std::env::var("GITHUB_ACTIONS").is_ok()
+        || std::env::var("CONTINUOUS_INTEGRATION").is_ok();
+    !ci && std::io::stderr().is_terminal()
+}
+
 /// Read a live forwarder pid from the marker, if present and alive.
 pub fn live_forwarder_pid(user_data_folder: Option<&Path>, container_id: &str) -> Option<u32> {
     let path = marker_path(user_data_folder, container_id).ok()?;
@@ -154,6 +180,18 @@ fn spawn_daemon(
     }
     if args.ports_events {
         cmd.arg("--ports-events");
+    }
+
+    // Browser auto-open (onAutoForward: openBrowser) is machine-owner-resolved
+    // here (env > settings) and the headless/CI gate is decided here too — the
+    // daemon's stdio is /dev/null so it cannot evaluate `is_terminal()` itself.
+    // Adoption returns before this, so an adopted daemon keeps its own setting.
+    let browser = resolve_browser_cli(args.user_data_folder.as_deref());
+    if let Some(b) = &browser {
+        cmd.arg("--browser").arg(b);
+    }
+    if !auto_open_enabled(browser.is_some()) {
+        cmd.arg("--no-auto-open");
     }
 
     // Detach: the child re-opens its own stdio onto the per-container log, so

--- a/crates/deacon/src/commands/up/ports.rs
+++ b/crates/deacon/src/commands/up/ports.rs
@@ -6,11 +6,45 @@
 
 use anyhow::Result;
 use deacon_core::compose::{ComposeManager, ComposeProject};
-use deacon_core::config::DevContainerConfig;
+use deacon_core::config::{DevContainerConfig, OnAutoForward};
 use deacon_core::docker::Docker;
-use deacon_core::ports::PortForwardingManager;
+use deacon_core::ports::{PortEvent, PortForwardingManager};
 use deacon_core::runtime::ContainerRuntimeImpl;
+use std::path::Path;
 use tracing::{debug, instrument, warn};
+
+use super::forward::{auto_open_enabled, resolve_browser_cli};
+
+/// Open the machine owner's browser for static-path port events whose
+/// `onAutoForward` is `openBrowser`/`openBrowserOnce` and which have a reachable
+/// host port (i.e. `-p`-published). Suppressed entirely when `--auto-forward` is
+/// active (the forwarder daemon owns browser-opening). Best-effort — never
+/// fails `up`; only opens a loopback URL with a machine-owner-chosen program.
+fn open_browsers_for_events(events: &[PortEvent], auto_forward: bool, udf: Option<&Path>) {
+    if auto_forward {
+        return; // the --auto-forward daemon is the single opener
+    }
+    let browser = resolve_browser_cli(udf);
+    if !auto_open_enabled(browser.is_some()) {
+        return;
+    }
+    for ev in events {
+        let opens = matches!(
+            ev.on_auto_forward,
+            Some(OnAutoForward::OpenBrowser) | Some(OnAutoForward::OpenBrowserOnce)
+        );
+        // Only open when the port is actually reachable on the host (a `-p`
+        // mapping gave it a host `local_port`).
+        let Some(host_port) = ev.local_port.filter(|_| opens) else {
+            continue;
+        };
+        let scheme = ev.protocol.as_deref().unwrap_or("http");
+        let url = format!("{scheme}://127.0.0.1:{host_port}");
+        if let Err(e) = deacon_core::browser::open_url_blocking(browser.as_deref(), &url) {
+            debug!(error = %e, url = %url, "static-path browser open failed (best-effort)");
+        }
+    }
+}
 
 /// Handle port events for compose projects
 #[instrument(skip(config, project, redaction_config, secret_registry, docker_path))]
@@ -20,6 +54,8 @@ pub(crate) async fn handle_port_events(
     redaction_config: &deacon_core::redaction::RedactionConfig,
     secret_registry: &deacon_core::redaction::SecretRegistry,
     docker_path: &str,
+    auto_forward: bool,
+    user_data_folder: Option<&Path>,
 ) -> Result<()> {
     debug!("Processing port events for compose project");
 
@@ -79,6 +115,7 @@ pub(crate) async fn handle_port_events(
                 events.len(),
                 service.name
             );
+            open_browsers_for_events(&events, auto_forward, user_data_folder);
             total_events += events.len();
         }
     }
@@ -98,6 +135,8 @@ pub(crate) async fn handle_container_port_events(
     runtime: &ContainerRuntimeImpl,
     redaction_config: &deacon_core::redaction::RedactionConfig,
     secret_registry: &deacon_core::redaction::SecretRegistry,
+    auto_forward: bool,
+    user_data_folder: Option<&Path>,
 ) -> Result<()> {
     debug!("Processing port events for container");
 
@@ -128,6 +167,7 @@ pub(crate) async fn handle_container_port_events(
     );
 
     debug!("Emitted {} port events", events.len());
+    open_browsers_for_events(&events, auto_forward, user_data_folder);
 
     Ok(())
 }

--- a/crates/deacon/tests/integration_auto_forward.rs
+++ b/crates/deacon/tests/integration_auto_forward.rs
@@ -760,3 +760,153 @@ fn compose_service_port_is_forwarded() {
         "expected banner relayed from the db service, got: {body:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Browser auto-open (onAutoForward: openBrowser) — hermetic via a fake browser.
+// ---------------------------------------------------------------------------
+
+/// devcontainer.json declaring `port` with a given `onAutoForward` action, plus
+/// the loopback `nc` banner server (so the port actually forwards).
+fn server_config_on_auto_forward(port: u16, action: &str) -> String {
+    format!(
+        r#"{{
+  "name": "auto-forward-browser-test",
+  "image": "alpine:3.18",
+  "overrideCommand": true,
+  "forwardPorts": [{port}],
+  "portsAttributes": {{ "{port}": {{ "onAutoForward": "{action}" }} }},
+  "postStartCommand": "sh -c '(while true; do echo {SERVER_BANNER} | nc -l -p {port}; done) >/dev/null 2>&1 & sleep 1'"
+}}"#
+    )
+}
+
+/// Write a fake "browser": a host shell script that appends its first arg (the
+/// URL deacon passes) to a marker file. Returns `(script_path, marker_path)`.
+fn write_fake_browser(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+    let marker = dir.join("opened-urls.txt");
+    let script = dir.join("fake-browser.sh");
+    std::fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (script, marker)
+}
+
+/// `up --auto-forward` with `DEACON_BROWSER` set to the fake browser script.
+fn run_up_with_browser(ws: &Path, udf: &Path, browser: &Path) -> UpOutcome {
+    let bin = env!("CARGO_BIN_EXE_deacon");
+    let out = StdCommand::new(bin)
+        .env("DEACON_BROWSER", browser)
+        .arg("--user-data-folder")
+        .arg(udf)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(ws)
+        .arg("--auto-forward")
+        .output()
+        .expect("run deacon up");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let container_id = serde_json::from_str::<Value>(&stdout).ok().and_then(|v| {
+        v.get("containerId")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    });
+    UpOutcome {
+        success: out.status.success(),
+        container_id,
+        stdout,
+        stderr,
+    }
+}
+
+fn marker_contains(marker: &Path, needle: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(s) = std::fs::read_to_string(marker) {
+            if s.contains(needle) {
+                return true;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+/// `onAutoForward: openBrowser` launches the configured browser at the forwarded
+/// loopback URL. The "browser" is a recording script (hermetic; no real browser
+/// or display needed). `DEACON_BROWSER` being set also force-enables auto-open
+/// despite the test having no TTY.
+#[test]
+fn auto_forward_opens_browser_for_openbrowser() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config_on_auto_forward(3000, "openBrowser"));
+    let (script, marker) = write_fake_browser(&udf);
+
+    let up = run_up_with_browser(&ws, &udf, &script);
+    let cid = up.container_id.clone();
+    let result = (|| {
+        assert!(
+            up.success,
+            "up --auto-forward failed.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            up.stdout, up.stderr
+        );
+        let host_port = wait_for_host_port(&udf, 3000, Duration::from_secs(15))?;
+        let url = format!("http://127.0.0.1:{host_port}");
+        marker_contains(&marker, &url, Duration::from_secs(15)).then_some(url)
+    })();
+
+    teardown(&ws, &udf, cid.as_deref());
+
+    let url =
+        result.expect("openBrowser should have launched the fake browser at the loopback URL");
+    assert!(url.starts_with("http://127.0.0.1:"));
+}
+
+/// `onAutoForward: notify` must NOT open a browser even though one is configured.
+#[test]
+fn auto_forward_notify_does_not_open_browser() {
+    if !is_docker_available() {
+        eprintln!("docker unavailable; skipping");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    let ws = tmp.path().join(format!("ws-{}", unique()));
+    std::fs::create_dir_all(&ws).unwrap();
+    let udf = tmp.path().join("udf");
+    std::fs::create_dir_all(&udf).unwrap();
+    write_config(&ws, &server_config_on_auto_forward(3000, "notify"));
+    let (script, marker) = write_fake_browser(&udf);
+
+    let up = run_up_with_browser(&ws, &udf, &script);
+    let cid = up.container_id.clone();
+    let opened = (|| {
+        if !up.success {
+            return false;
+        }
+        // Wait for the port to actually forward, then give any (erroneous) open
+        // a chance to land before asserting the marker stayed empty.
+        if wait_for_host_port(&udf, 3000, Duration::from_secs(15)).is_none() {
+            return false;
+        }
+        marker_contains(&marker, "http://127.0.0.1:", Duration::from_secs(3))
+    })();
+
+    teardown(&ws, &udf, cid.as_deref());
+
+    assert!(!opened, "notify must not open a browser");
+}


### PR DESCRIPTION
## Summary

Implements the **auto-open** action behind `onAutoForward` (which we recently fixed *parsing* for in #202, but which deacon collapsed to `notify` everywhere). When the `--auto-forward` daemon forwards a port whose `onAutoForward` is **`openBrowser`** (every forward) or **`openBrowserOnce`** (first time per forwarder session), deacon now launches the machine owner's browser at the forwarded **loopback** URL — matching the VS Code Dev Containers experience the feature is modeled on.

## Browser selection (machine-owner only)

Precedence **`DEACON_BROWSER` env > `settings.json` `browser` > OS default opener** (xdg-open / open / start). The value is a **bare program** — the URL is appended as the final arg, no shell. Nothing in `devcontainer.json` can choose the program; the workspace can only *request* an open via `onAutoForward` (a loopback URL).

```bash
DEACON_BROWSER=firefox deacon up --auto-forward
# or persist:  ~/.deacon/settings.json -> { "browser": "firefox" }
```

## Design

- New `crates/core/src/browser.rs`: `resolve_browser`, a **pure** `browser_command` builder, fire-and-forget `open_url`(`_blocking`).
- `port_forward`: `ResolvedPortAttributes` now carries the **real** `onAutoForward` + a `protocol` hint — the daemon no longer collapses `openBrowser*` to `notify` (and PORT_EVENT now reports the correct `http`/`https` scheme). The daemon opens at `start_forward` with a per-session `opened` set for the **once** semantics. `openPreview` stays `notify` (no CLI preview pane — confirmed design choice).
- The **parent `up`** resolves the browser + the headless/CI gate (skip non-TTY **unless** a browser is explicitly configured) and passes `--browser`/`--no-auto-open` to the **detached** daemon (its stdio is `/dev/null`, so it can't evaluate `is_terminal()` itself).
- The static `--ports-events` path also opens (for reachable `-p` ports), **suppressed** when `--auto-forward` owns opening.
- `SECURITY.md` + `README` updated (threat model: machine-owner-only program, workspace-requested loopback open, non-shell URL arg, best-effort, CI-suppressed).

## Testing

- **Unit:** `resolve_browser` precedence, `browser_command` per-platform, `should_open` once-semantics, `to_resolved` no-longer-collapsing + protocol carry, settings `browser` parse.
- **Docker (hermetic, fake browser)** in `integration_auto_forward.rs`: `DEACON_BROWSER` points at a recording shell script; `openBrowser` → the script captures `http://127.0.0.1:<hostport>`; `notify` → nothing opens. Both green locally.
- `cargo fmt`/`clippy --all-targets --all-features -D warnings` clean; **2550 fast tests pass**.

## Notes

`openBrowserOnce` is per-daemon-session (resets if the container/daemon is recreated), matching VS Code's per-session behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)