### PR TITLE
chore(release): prepare v0.2.0-rc.5 prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.4" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.5" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.4"
+version = "0.2.0-rc.5"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bumps `deacon`, `deacon-core`, and the workspace `deacon-core` path-dep pin to `0.2.0-rc.5` so the Release workflow's tag/crate-version gate accepts the `v0.2.0-rc.5` tag.

Rolls up the real-world devcontainer parity hardening from #206:
- `up` reports `/workspaces/<basename>` (spec default) instead of a bare `/workspaces`
- `${containerWorkspaceFolder}` resolves in `read-configuration` without an explicit `workspaceFolder` (reference parity)
- `read-configuration` emits the raw un-merged config with `extends` preserved (reference parity)

After merge, tagging `v0.2.0-rc.5` triggers the Release workflow to build and publish the prerelease binaries (8 targets) + checksums + SBOMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)