### PR TITLE
fix(read-config): mergedConfiguration parity (hostRequirements bytes, feature env, customizations order)

### DIFF
--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -624,6 +624,55 @@ fn or_merge_bool(current: Option<bool>, new: Option<bool>) -> Option<bool> {
     }
 }
 
+/// Apply final `mergedConfiguration`-only normalizations that match the reference CLI's
+/// `mergeConfiguration` output shape (these do NOT apply to the top-level `configuration`,
+/// which preserves the raw authored values):
+///
+/// - `hostRequirements.memory` / `.storage` are emitted as a byte-count STRING (binary
+///   units), not the raw authored form. So `"8gb"` becomes `"8589934592"`. `cpus` stays
+///   numeric. Matches upstream `imageMetadata.ts` which normalizes these to bytes when
+///   assembling the merged image metadata.
+/// - `init` and `privileged` always materialize as booleans, defaulting to `false` when
+///   no config / image-metadata / feature entry sets them. Matches upstream's
+///   `init: imageMetadata.some(e => e.init)` / `privileged: imageMetadata.some(e => e.privileged)`,
+///   which always yields a boolean.
+fn normalize_merged_configuration_shape(value: &mut serde_json::Value) {
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+
+    // init / privileged: null or absent -> false (always a boolean in the merged shape).
+    for key in ["init", "privileged"] {
+        let needs_default = obj.get(key).map(|v| v.is_null()).unwrap_or(true);
+        if needs_default {
+            obj.insert(key.to_string(), serde_json::Value::Bool(false));
+        }
+    }
+
+    // hostRequirements memory / storage -> byte-count string.
+    if let Some(serde_json::Value::Object(hr)) = obj.get_mut("hostRequirements") {
+        for key in ["memory", "storage"] {
+            if let Some(bytes) = hr.get(key).and_then(resource_value_to_bytes) {
+                hr.insert(
+                    key.to_string(),
+                    serde_json::Value::String(bytes.to_string()),
+                );
+            }
+        }
+    }
+}
+
+/// Parse a hostRequirements resource JSON value (authored string like `"8gb"` or a raw
+/// number) into a byte count, reusing the core [`ResourceSpec`] binary-unit semantics.
+/// Returns `None` (leaving the value untouched) when the value is null or unparseable.
+fn resource_value_to_bytes(v: &serde_json::Value) -> Option<u64> {
+    if v.is_null() {
+        return None;
+    }
+    let spec: deacon_core::config::ResourceSpec = serde_json::from_value(v.clone()).ok()?;
+    spec.parse_bytes().ok()
+}
+
 /// Apply the upstream `mergeConfiguration` customizations shape to the merged base JSON.
 ///
 /// Upstream collects `customizations` per tool key into an array of values across every metadata
@@ -1584,18 +1633,18 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
                 Vec::new()
             };
 
-        Some(
-            compute_merged_configuration(
-                &config,
-                container_info.as_ref(),
-                container_context.as_ref(),
-                features_for_merge,
-                secrets.as_ref(),
-                &fetcher,
-                &image_metadata_entries,
-            )
-            .await?,
+        let mut merged = compute_merged_configuration(
+            &config,
+            container_info.as_ref(),
+            container_context.as_ref(),
+            features_for_merge,
+            secrets.as_ref(),
+            &fetcher,
+            &image_metadata_entries,
         )
+        .await?;
+        normalize_merged_configuration_shape(&mut merged);
+        Some(merged)
     } else {
         None
     };
@@ -1634,8 +1683,62 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
 mod tests {
     use super::*;
     use deacon_core::redaction::{RedactionConfig, SecretRegistry};
+    use serde_json::json;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_normalize_merged_shape_host_requirements_to_bytes() {
+        // mergedConfiguration normalizes memory/storage to a byte-count STRING (binary
+        // units), matching the reference CLI; cpus stays numeric. "8gb" -> 8 * 2^30.
+        let mut v = json!({
+            "hostRequirements": { "cpus": 4, "memory": "8gb", "storage": "32gb" }
+        });
+        normalize_merged_configuration_shape(&mut v);
+        let hr = &v["hostRequirements"];
+        assert_eq!(hr["memory"], json!("8589934592"));
+        assert_eq!(hr["storage"], json!("34359738368"));
+        assert_eq!(hr["cpus"], json!(4));
+    }
+
+    #[test]
+    fn test_normalize_merged_shape_host_requirements_already_bytes() {
+        // A raw byte count (already-merged form) round-trips unchanged.
+        let mut v = json!({ "hostRequirements": { "memory": "536870912" } });
+        normalize_merged_configuration_shape(&mut v);
+        assert_eq!(v["hostRequirements"]["memory"], json!("536870912"));
+    }
+
+    #[test]
+    fn test_normalize_merged_shape_init_privileged_default_false() {
+        // Absent and null both materialize to `false` in the merged shape.
+        let mut absent = json!({ "image": "x" });
+        normalize_merged_configuration_shape(&mut absent);
+        assert_eq!(absent["init"], json!(false));
+        assert_eq!(absent["privileged"], json!(false));
+
+        let mut nulled = json!({ "init": null, "privileged": null });
+        normalize_merged_configuration_shape(&mut nulled);
+        assert_eq!(nulled["init"], json!(false));
+        assert_eq!(nulled["privileged"], json!(false));
+    }
+
+    #[test]
+    fn test_normalize_merged_shape_init_privileged_true_preserved() {
+        // A real `true` (e.g. accumulated from a feature) is never downgraded.
+        let mut v = json!({ "init": true, "privileged": true });
+        normalize_merged_configuration_shape(&mut v);
+        assert_eq!(v["init"], json!(true));
+        assert_eq!(v["privileged"], json!(true));
+    }
+
+    #[test]
+    fn test_normalize_merged_shape_no_host_requirements_is_noop() {
+        // Missing hostRequirements is fine; only init/privileged get defaulted.
+        let mut v = json!({ "image": "x" });
+        normalize_merged_configuration_shape(&mut v);
+        assert!(v.get("hostRequirements").is_none());
+    }
 
     fn create_test_args(
         temp_dir: &TempDir,

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -673,6 +673,28 @@ fn resource_value_to_bytes(v: &serde_json::Value) -> Option<u64> {
     spec.parse_bytes().ok()
 }
 
+/// Order per-contributor `customizations` objects per upstream
+/// `getDevcontainerMetadata` precedence: image-metadata entries (in
+/// label/declaration order) first, then feature entries, then the base config —
+/// `[...image, ...features, base]`. Each argument holds the already-extracted
+/// non-empty `customizations` object for that contributor.
+///
+/// Critically, image entries are concatenated in FORWARD order: a previous
+/// implementation prepended them one-by-one with `insert(0, …)`, which reversed
+/// them and scrambled the merged `customizations` array relative to the
+/// reference CLI.
+fn ordered_customizations_entries(
+    image: &[serde_json::Value],
+    features: &[serde_json::Value],
+    base: &[serde_json::Value],
+) -> Vec<serde_json::Value> {
+    let mut out = Vec::with_capacity(image.len() + features.len() + base.len());
+    out.extend(image.iter().cloned());
+    out.extend(features.iter().cloned());
+    out.extend(base.iter().cloned());
+    out
+}
+
 /// Apply the upstream `mergeConfiguration` customizations shape to the merged base JSON.
 ///
 /// Upstream collects `customizations` per tool key into an array of values across every metadata
@@ -947,7 +969,10 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
         // array shape (see `apply_customizations_shape`).
         let mut derived_config = deacon_core::config::DevContainerConfig::default();
         let mut metadata_entries: Vec<serde_json::Map<String, serde_json::Value>> = Vec::new();
-        let mut customizations_entries: Vec<serde_json::Value> = Vec::new();
+        // Per-contributor customizations, kept in separate buckets so the final
+        // assembly can enforce the `[...image, ...features, base]` order (see
+        // `ordered_customizations_entries`).
+        let mut feature_customizations: Vec<serde_json::Value> = Vec::new();
 
         for feature_set in &features_config.feature_sets {
             for feature in &feature_set.features {
@@ -1034,7 +1059,7 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
                 if let Some(customizations) = &metadata.customizations {
                     if let serde_json::Value::Object(map) = customizations {
                         if !map.is_empty() {
-                            customizations_entries.push(customizations.clone());
+                            feature_customizations.push(customizations.clone());
                         }
                     }
                 }
@@ -1076,9 +1101,10 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
         }
         // Per upstream `getDevcontainerMetadata`, the base config's `customizations` is the
         // final entry in the metadata chain (pickConfigProperties includes `customizations`).
+        let mut base_customizations: Vec<serde_json::Value> = Vec::new();
         if let serde_json::Value::Object(map) = &base_config.customizations {
             if !map.is_empty() {
-                customizations_entries.push(base_config.customizations.clone());
+                base_customizations.push(base_config.customizations.clone());
             }
         }
 
@@ -1099,6 +1125,9 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
         // and base per upstream getDevcontainerMetadata precedence.
         let mut combined_metadata_entries: Vec<serde_json::Map<String, serde_json::Value>> =
             Vec::new();
+        // Image-metadata customizations come first, in label (declaration) order — per
+        // upstream `getDevcontainerMetadata` precedence `[...image, ...features, config]`.
+        let mut image_customizations: Vec<serde_json::Value> = Vec::new();
         for entry in image_metadata_entries {
             let entry_json = serde_json::to_value(entry)?;
             let collected = collect_entry_from_config_json(&entry_json);
@@ -1108,11 +1137,16 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
             if let Some(c) = entry_json.get("customizations") {
                 if let serde_json::Value::Object(map) = c {
                     if !map.is_empty() {
-                        customizations_entries.insert(0, c.clone());
+                        image_customizations.push(c.clone());
                     }
                 }
             }
         }
+        let customizations_entries = ordered_customizations_entries(
+            &image_customizations,
+            &feature_customizations,
+            &base_customizations,
+        );
         combined_metadata_entries.extend(metadata_entries);
 
         debug!(
@@ -1152,21 +1186,25 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
             entries.push(base_entry);
         }
 
-        let mut customizations_entries: Vec<serde_json::Value> = Vec::new();
+        let mut image_customizations: Vec<serde_json::Value> = Vec::new();
         for entry in image_metadata_entries {
             if let Some(c) = serde_json::to_value(entry)?.get("customizations") {
                 if let serde_json::Value::Object(map) = c {
                     if !map.is_empty() {
-                        customizations_entries.push(c.clone());
+                        image_customizations.push(c.clone());
                     }
                 }
             }
         }
+        let mut base_customizations: Vec<serde_json::Value> = Vec::new();
         if let serde_json::Value::Object(map) = &base_config.customizations {
             if !map.is_empty() {
-                customizations_entries.push(base_config.customizations.clone());
+                base_customizations.push(base_config.customizations.clone());
             }
         }
+        // No features in this branch: `[...image, base]`.
+        let customizations_entries =
+            ordered_customizations_entries(&image_customizations, &[], &base_customizations);
 
         let shaped = apply_upstream_merge_shape(merged_json, &entries);
         Ok(apply_customizations_shape(shaped, &customizations_entries))
@@ -1741,6 +1779,32 @@ mod tests {
         let mut v = json!({ "image": "x" });
         normalize_merged_configuration_shape(&mut v);
         assert!(v.get("hostRequirements").is_none());
+    }
+
+    #[test]
+    fn test_ordered_customizations_image_then_features_then_base() {
+        // Precedence is [...image, ...features, base], and image entries keep their
+        // FORWARD declaration order (the prior insert(0,..) bug reversed them).
+        let img = vec![
+            json!({"vscode": {"id": "img0"}}),
+            json!({"vscode": {"id": "img1"}}),
+        ];
+        let feat = vec![json!({"vscode": {"id": "feat0"}})];
+        let base = vec![json!({"vscode": {"id": "base0"}})];
+        let out = ordered_customizations_entries(&img, &feat, &base);
+        let ids: Vec<&str> = out
+            .iter()
+            .map(|e| e["vscode"]["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["img0", "img1", "feat0", "base0"]);
+    }
+
+    #[test]
+    fn test_ordered_customizations_empty_buckets() {
+        // Empty buckets contribute nothing; no panic, correct concatenation.
+        let out = ordered_customizations_entries(&[], &[json!({"a": 1})], &[]);
+        assert_eq!(out, vec![json!({"a": 1})]);
+        assert!(ordered_customizations_entries(&[], &[], &[]).is_empty());
     }
 
     fn create_test_args(

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -1014,11 +1014,14 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
                 // are intentionally NOT folded in here — they're collected separately
                 // for the plural output. Mirrors upstream `mergeConfiguration` which
                 // strips replaceProperties from the base before re-emitting plurals.
-                for (key, value) in &metadata.container_env {
-                    derived_config
-                        .container_env
-                        .insert(key.clone(), value.clone());
-                }
+                //
+                // Feature `containerEnv` (and `remoteEnv`) are intentionally NOT folded
+                // into the merged config: per upstream `imageMetadata.ts`, a feature's
+                // image-metadata entry omits env — feature env is realized by the
+                // feature's own install step (baked into the image), not surfaced via
+                // the `devcontainer.metadata` merge. The reference CLI's read-config
+                // `mergedConfiguration.containerEnv` therefore carries only the base
+                // config's (and image-label) env, never un-built feature env.
 
                 for mount in &metadata.mounts {
                     derived_config.mounts.push(mount.clone());

--- a/crates/deacon/tests/integration_read_configuration.rs
+++ b/crates/deacon/tests/integration_read_configuration.rs
@@ -347,6 +347,46 @@ fn test_local_feature_anchors_to_discovered_config_dir() -> Result<()> {
     Ok(())
 }
 
+/// Parity: a feature's `containerEnv` must NOT be folded into
+/// `mergedConfiguration.containerEnv` at read-config time. Per upstream
+/// `imageMetadata.ts`, a feature's image-metadata entry omits env — feature env
+/// is realized by the feature's install step, not via the `devcontainer.metadata`
+/// merge. The base config's own `containerEnv` MUST still survive the merge.
+/// Hermetic (local feature, no network).
+#[test]
+fn test_merged_config_excludes_feature_container_env() -> Result<()> {
+    let helper = ReadConfigurationTestHelper::new()?;
+    helper.create_config(
+        r#"{
+        "name": "feat-env",
+        "image": "ubuntu:22.04",
+        "containerEnv": { "BASE_VAR": "base-value" },
+        "features": { "./featenv": {} }
+    }"#,
+    )?;
+    let feat_dir = helper.temp_dir().join(".devcontainer").join("featenv");
+    std::fs::create_dir_all(&feat_dir)?;
+    std::fs::write(
+        feat_dir.join("devcontainer-feature.json"),
+        r#"{ "id": "featenv", "version": "1.0.0", "name": "Feat Env",
+            "containerEnv": { "FEATURE_VAR": "feature-value" } }"#,
+    )?;
+    std::fs::write(feat_dir.join("install.sh"), "#!/bin/sh\ntrue\n")?;
+
+    let result = helper.run_with_workspace(&["--include-merged-configuration"])?;
+    let merged_env = &result["mergedConfiguration"]["containerEnv"];
+    assert_eq!(
+        merged_env["BASE_VAR"].as_str(),
+        Some("base-value"),
+        "base config containerEnv must survive the merge: {result:#}"
+    );
+    assert!(
+        merged_env.get("FEATURE_VAR").is_none(),
+        "feature containerEnv must NOT appear in mergedConfiguration: {result:#}"
+    );
+    Ok(())
+}
+
 /// Regression: `featuresConfiguration.featureSets` is emitted ONE-PER-FEATURE in
 /// INSTALL ORDER (a feature's dependencies first), matching the reference CLI —
 /// not grouped by registry. Two local features where `app` dependsOn `lib` must

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -263,6 +263,52 @@ raw-output shape and the string/array/skip serialization.
 All Tier-1 read-configuration divergences against the reference CLI are now
 resolved.
 
+## Round 2 — `mergedConfiguration` sweep (`--include-merged-configuration`)
+
+A second differ compares the `mergedConfiguration` block (deacon vs reference)
+across the corpus, after the same null/empty normalization. Three real,
+Docker-free divergences fixed:
+
+### 17. `mergedConfiguration` leaked raw `hostRequirements` + `null` init/privileged
+
+The reference's merged shape normalizes `hostRequirements.memory`/`.storage` to
+a **byte-count string** (binary units): `"8gb"` → `"8589934592"` (`cpus` stays
+numeric; the top-level `configuration` block keeps the raw authored string).
+It also always materializes `init`/`privileged` as booleans (default `false`,
+per upstream `imageMetadata.some(e => e.init)`). deacon leaked the raw `"8gb"`
+string and emitted `null` for the booleans. **Fix:** a `mergedConfiguration`
+finalization pass (`normalize_merged_configuration_shape`) reusing the core
+`ResourceSpec::parse_bytes` binary-unit semantics. Verified byte-identical on
+`node-ts` (hostRequirements) and across all configs (init/privileged).
+(`crates/deacon/src/commands/read_configuration.rs`.)
+
+### 18. Feature `containerEnv` over-merged into `mergedConfiguration`
+
+deacon folded a feature's `containerEnv` (e.g. `GOROOT`/`GOPATH`, `NVM_*`,
+`DOTNET_*`) into `mergedConfiguration.containerEnv`. The reference does **not**:
+per upstream `imageMetadata.ts`, a feature's image-metadata entry omits env —
+feature env is realized by the feature's own install step (baked into the
+image), not surfaced via the `devcontainer.metadata` merge. So the merged shape
+carries only the base config's (and image-label) env. **Fix:** stop folding
+feature `containerEnv`; feature `mounts`/`customizations`/`init`/`privileged`/
+`capAdd`/`securityOpt` are still folded (those *are* in the upstream metadata
+entry). Base config env survives unchanged. All feature configs (go/python/
+ruby/dotnet) now show `0` deacon-only merged env. Hermetic local-feature
+regression test. (`crates/deacon/src/commands/read_configuration.rs`.)
+
+### 19. Image-metadata `customizations` emitted in reversed order
+
+The merged `customizations.<tool>` array prepended each image
+`devcontainer.metadata` entry with `insert(0, …)` in a forward loop, which
+**reversed** the image entries — scrambling the array relative to the
+reference's `[...image, ...features, config]` (image entries in label order).
+**Fix:** a pure `ordered_customizations_entries` helper concatenating the
+per-contributor buckets in forward order, used by both image-metadata merge
+branches. With the `typescript-node` image present, `node-ts`
+`mergedConfiguration.customizations.vscode` is byte-identical (all 7 contributor
+entries in matching order). Unit tests cover the ordering invariant.
+(`crates/deacon/src/commands/read_configuration.rs`.)
+
 ## Verified non-bugs
 
 - **Feature `containerEnv` with `${...}` shell refs (incl. a *novel* PATH dir) is
@@ -286,6 +332,17 @@ resolved.
 - `appPort` host-port already in use → `docker -p` bind conflict (environmental;
   `ports-mixed` uses uncommon ports). Note: after fix #6 `forwardPorts` are no
   longer bound, so they cannot cause this.
+- **`mergedConfiguration` image-metadata only merges *locally-present* images.**
+  The remaining `customizations.vscode` / `capAdd` / `containerUser` /
+  `entrypoints` / `mounts` divergences in the round-2 sweep (go/python/dotnet/
+  ruby/compose, `universal-jsonc`) are entirely because those base images are
+  not pulled in the test environment. deacon's image-metadata fetch is
+  best-effort **local-only** (it does not pull during a read-only command); the
+  reference CLI pulls the image to read its `devcontainer.metadata` label. With
+  the image present, deacon matches: `node-ts` (typescript-node pulled) is
+  byte-identical after fix #19. This is a deliberate read-config design choice
+  (no implicit network/pull), not a merge-logic bug. Compose configs
+  additionally have no `config.image` to inspect at read-config time.
 
 ## Corpus (20 configs)
 

--- a/fixtures/parity-corpus/run_tier1_merged.py
+++ b/fixtures/parity-corpus/run_tier1_merged.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tier-1b differential parity driver: the `mergedConfiguration` block.
+
+Like `run_tier1.py`, but adds `--include-merged-configuration` and diffs the
+`mergedConfiguration` object (deacon vs reference CLI) after the same null/empty
+normalization. Surfaces image-metadata-merge divergences (collected lifecycle
+arrays, hostRequirements byte normalization, init/privileged defaults,
+customizations ordering, feature-vs-image env handling).
+
+Note: `mergedConfiguration` folds the image's `devcontainer.metadata` label, so
+results depend on which base images are pulled locally — deacon reads metadata
+best-effort (local-only) while the reference pulls. Configs whose base image is
+absent will show image-metadata divergences that vanish once the image is present
+(see REPORT.md "Verified non-bugs").
+
+Usage: python3 fixtures/parity-corpus/run_tier1_merged.py [deacon_bin] [corpus_dir]
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEACON = sys.argv[1] if len(sys.argv) > 1 else "/workspaces/deacon/target/debug/deacon"
+CORPUS = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(__file__).parent
+
+DROP_KEYS = {"configFilePath"}
+
+
+def run(cmd):
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def prune(v):
+    if isinstance(v, dict):
+        out = {}
+        for k, val in v.items():
+            if k in DROP_KEYS:
+                continue
+            pv = prune(val)
+            if pv is None:
+                continue
+            if isinstance(pv, (dict, list, str)) and len(pv) == 0:
+                continue
+            out[k] = pv
+        return out
+    if isinstance(v, list):
+        return [prune(x) for x in v]
+    return v
+
+
+def merged(raw):
+    obj = json.loads(raw)
+    return prune(obj.get("mergedConfiguration", {}))
+
+
+def diff(d, r, path=""):
+    out = []
+    if isinstance(d, dict) and isinstance(r, dict):
+        for k in sorted(set(d) | set(r)):
+            p = f"{path}.{k}" if path else k
+            if k in d and k not in r:
+                out.append(("deacon-only", p, d[k], None))
+            elif k in r and k not in d:
+                out.append(("ref-only", p, None, r[k]))
+            else:
+                out.extend(diff(d[k], r[k], p))
+    elif isinstance(d, list) and isinstance(r, list):
+        if d != r:
+            out.append(("value", path, d, r))
+    else:
+        if d != r:
+            out.append(("value", path, d, r))
+    return out
+
+
+def main():
+    configs = sorted(p for p in CORPUS.iterdir() if (p / ".devcontainer").is_dir())
+    rank = {"ref-only": 0, "value": 1, "deacon-only": 2}
+    totals = {"ref-only": 0, "value": 0, "deacon-only": 0}
+
+    for ws in configs:
+        dc, dout, derr = run(
+            [DEACON, "read-configuration", "--workspace-folder", str(ws),
+             "--include-merged-configuration"]
+        )
+        rc, rout, rerr = run(
+            ["devcontainer", "read-configuration", "--workspace-folder", str(ws),
+             "--include-merged-configuration"]
+        )
+        print(f"\n=== {ws.name} ===")
+        if dc != 0:
+            print(f"  ⚠️  DEACON crashed (exit {dc}): {derr.strip()[:300]}")
+            continue
+        if rc != 0:
+            print(f"  ⚠️  REFERENCE crashed (exit {rc}): {rerr.strip()[:300]}")
+            continue
+        try:
+            dn, rn = merged(dout), merged(rout)
+        except Exception as e:
+            print(f"  ⚠️  normalize failed: {e}")
+            continue
+        ds = diff(dn, rn)
+        if not ds:
+            print("  ✅ identical (after normalization)")
+            continue
+        ds.sort(key=lambda x: rank[x[0]])
+        for kind, p, dv, rv in ds:
+            totals[kind] += 1
+            if kind == "ref-only":
+                print(f"  ❗ ref-only   {p} = {json.dumps(rv)[:160]}  (deacon DROPS this)")
+            elif kind == "value":
+                print(f"  ⚡ mismatch   {p}\n        deacon={json.dumps(dv)[:160]}\n        ref   ={json.dumps(rv)[:160]}")
+            else:
+                print(f"  · deacon-only {p} = {json.dumps(dv)[:120]}")
+
+    print("\n========== SUMMARY ==========")
+    print(f"configs: {len(configs)}")
+    print(f"ref-only (deacon drops): {totals['ref-only']}")
+    print(f"value mismatches:        {totals['value']}")
+    print(f"deacon-only (noise?):    {totals['deacon-only']}")
+    print("(image-metadata divergences depend on locally-pulled images — see REPORT.md)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Round 2 of the differential parity harness, focused on
`read-configuration --include-merged-configuration` (the `mergedConfiguration`
block). A new Tier-1b differ (`run_tier1_merged.py`) compares the merged shape
deacon-vs-`@devcontainers/cli` v0.87.0 across the 23-config corpus. Three real,
Docker-free divergences fixed; each verified against the reference CLI first.

## Fixes

1. **hostRequirements bytes + init/privileged defaults** — merged shape now
   emits `hostRequirements.memory`/`.storage` as a byte-count string (binary
   units, `"8gb"` → `"8589934592"`) and always materializes `init`/`privileged`
   as booleans (default `false`), matching upstream. The top-level
   `configuration` block still keeps the raw authored value.
2. **Feature `containerEnv` exclusion** — stop folding a feature's `containerEnv`
   into `mergedConfiguration.containerEnv`. Per upstream `imageMetadata.ts` a
   feature's image-metadata entry omits env (it's realized by the install step),
   so the merged shape carries only base/image-label env. Feature `mounts`/
   `customizations`/`init`/`privileged`/`capAdd`/`securityOpt` are still folded.
3. **Image-metadata customizations ordering** — image `devcontainer.metadata`
   customizations were prepended with `insert(0, …)` in a forward loop, reversing
   them. Extracted a pure `ordered_customizations_entries` helper enforcing
   `[...image, ...features, config]` in forward order.

## Verification

- Tier-1 base differ: **23/23 identical** (unchanged).
- Tier-1b merged differ: **deacon-only over-merges 0** (was 10). `node-ts`
  (typescript-node image present) is byte-identical including the 7-entry
  customizations array.
- Remaining merged divergences are **locally-absent base images** — deacon reads
  image metadata best-effort/local-only while the reference pulls; documented as
  a non-bug in REPORT.md (they vanish when the image is present).
- New unit tests (normalization + ordering invariants) and a hermetic
  local-feature regression test for the env exclusion.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -D warnings`,
  `make test-nextest-fast` (2580 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)