### PR TITLE
fix: Tier-2 Docker parity (Dockerfile feature layering, compose resolution, runServices override)

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -761,6 +761,7 @@ impl ComposeManager {
         &self,
         config: &DevContainerConfig,
         base_path: &Path,
+        config_dir: &Path,
     ) -> Result<ComposeProject> {
         // Check if docker_compose_file is specified
         if config.docker_compose_file.is_none() {
@@ -785,13 +786,18 @@ impl ComposeManager {
                 message: "No service specified for compose project".to_string(),
             })?;
 
-        // Resolve compose file paths relative to base_path
+        // Resolve compose file paths relative to the directory containing
+        // devcontainer.json (`config_dir`), per the containers.dev spec
+        // ("relative to the devcontainer.json file") and the reference CLI.
+        // For the standard `.devcontainer/docker-compose.yml` layout this is the
+        // `.devcontainer` dir, NOT the workspace folder. The project name and
+        // working dir still derive from `base_path` (the workspace folder).
         let mut resolved_files = Vec::new();
         for file in &compose_files {
             let file_path = if Path::new(file).is_absolute() {
                 PathBuf::from(file)
             } else {
-                base_path.join(file)
+                config_dir.join(file)
             };
 
             if !file_path.exists() {
@@ -1339,6 +1345,14 @@ impl ComposeProject {
                 yaml.push_str(&format!("      {}: {}\n", key, escaped));
             }
             for svc in &self.run_services {
+                // Skip the primary service: it already has a full block above
+                // (with image/command/labels). `runServices` commonly lists the
+                // primary service alongside the others, and emitting it again
+                // here produces a duplicate YAML mapping key ("mapping key
+                // <svc> already defined") that docker compose rejects.
+                if svc == &self.service {
+                    continue;
+                }
                 yaml.push_str(&format!("  {}:\n", svc));
                 yaml.push_str("    labels:\n");
                 for (key, value) in &self.deacon_labels {
@@ -1603,6 +1617,68 @@ mod tests {
         assert!(args.contains(&"test-project".to_string()));
         assert!(args.contains(&"up".to_string()));
         assert!(args.contains(&"-d".to_string()));
+    }
+
+    #[test]
+    fn test_create_project_resolves_compose_files_against_config_dir() {
+        // Compose files must resolve relative to the directory containing
+        // devcontainer.json (the `.devcontainer` dir for the standard layout),
+        // NOT the workspace folder — matching the spec and the reference CLI.
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path().to_path_buf();
+        let config_dir = workspace.join(".devcontainer");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("docker-compose.yml"), "services: {}\n").unwrap();
+        std::fs::write(
+            config_dir.join("docker-compose.override.yml"),
+            "services: {}\n",
+        )
+        .unwrap();
+
+        let config = crate::config::DevContainerConfig {
+            docker_compose_file: Some(serde_json::json!([
+                "docker-compose.yml",
+                "docker-compose.override.yml"
+            ])),
+            service: Some("app".to_string()),
+            ..Default::default()
+        };
+
+        let manager = ComposeManager::new();
+        let project = manager
+            .create_project(&config, &workspace, &config_dir)
+            .unwrap();
+
+        // Files resolved under `.devcontainer`, not the workspace root.
+        assert_eq!(
+            project.compose_files,
+            vec![
+                config_dir.join("docker-compose.yml"),
+                config_dir.join("docker-compose.override.yml"),
+            ]
+        );
+        // Project base_path stays the workspace folder (naming / working dir).
+        assert_eq!(project.base_path, workspace);
+    }
+
+    #[test]
+    fn test_create_project_absolute_compose_path_is_not_rebased() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path().to_path_buf();
+        let config_dir = workspace.join(".devcontainer");
+        let abs = workspace.join("custom-compose.yml");
+        std::fs::write(&abs, "services: {}\n").unwrap();
+
+        let config = crate::config::DevContainerConfig {
+            docker_compose_file: Some(serde_json::json!(abs.to_string_lossy())),
+            service: Some("app".to_string()),
+            ..Default::default()
+        };
+
+        let project = ComposeManager::new()
+            .create_project(&config, &workspace, &config_dir)
+            .unwrap();
+        assert_eq!(project.compose_files, vec![abs]);
     }
 
     #[test]
@@ -2080,6 +2156,46 @@ mod tests {
             zzz_pos,
             aaa_pos,
             mmm_pos
+        );
+    }
+
+    #[test]
+    fn test_generate_injection_override_run_services_includes_primary() {
+        // `runServices` commonly lists the primary service alongside others.
+        // The override must emit the primary service exactly once (it already
+        // has a full block); a second top-level `app:` mapping is invalid YAML
+        // ("mapping key app already defined") and docker compose rejects it.
+        let mut labels: IndexMap<String, String> = IndexMap::new();
+        labels.insert("devcontainer.local_folder".to_string(), "/ws".to_string());
+
+        let project = ComposeProject {
+            name: "test".to_string(),
+            base_path: PathBuf::from("/test"),
+            compose_files: vec![PathBuf::from("docker-compose.yml")],
+            service: "app".to_string(),
+            run_services: vec!["app".to_string(), "db".to_string()],
+            env_files: Vec::new(),
+            additional_mounts: Vec::new(),
+            profiles: Vec::new(),
+            additional_env: IndexMap::new(),
+            external_volumes: Vec::new(),
+            override_command: Some(true),
+            service_image_override: Some("deacon-features:abc123".to_string()),
+            deacon_labels: labels,
+        };
+
+        let yaml = project.generate_injection_override().unwrap();
+
+        // Exactly one `app:` mapping, exactly one `db:` mapping.
+        assert_eq!(
+            yaml.matches("  app:\n").count(),
+            1,
+            "primary service must appear once:\n{yaml}"
+        );
+        assert_eq!(
+            yaml.matches("  db:\n").count(),
+            1,
+            "secondary run service must appear once:\n{yaml}"
         );
     }
 

--- a/crates/core/tests/integration_compose.rs
+++ b/crates/core/tests/integration_compose.rs
@@ -104,7 +104,7 @@ fn test_compose_project_creation() {
 
     let manager = ComposeManager::new();
     let project = manager
-        .create_project(&config, &base_path)
+        .create_project(&config, &base_path, &base_path)
         .expect("Failed to create compose project");
 
     assert_eq!(project.service, "app");
@@ -142,7 +142,7 @@ services:
 
     let manager = ComposeManager::new();
     let project = manager
-        .create_project(&config, &base_path)
+        .create_project(&config, &base_path, &base_path)
         .expect("Failed to create compose project");
 
     assert_eq!(project.compose_files.len(), 2);
@@ -161,7 +161,7 @@ fn test_compose_command_building() {
 
     let manager = ComposeManager::new();
     let project = manager
-        .create_project(&config, &base_path)
+        .create_project(&config, &base_path, &base_path)
         .expect("Failed to create compose project");
 
     let command_builder = manager.get_command(&project);
@@ -199,7 +199,7 @@ fn test_config_validation_without_compose() {
     };
 
     let manager = ComposeManager::new();
-    let result = manager.create_project(&config, &base_path);
+    let result = manager.create_project(&config, &base_path, &base_path);
 
     assert!(result.is_err());
     let error_msg = format!("{:?}", result.unwrap_err());
@@ -219,7 +219,7 @@ fn test_config_validation_missing_service() {
     };
 
     let manager = ComposeManager::new();
-    let result = manager.create_project(&config, &base_path);
+    let result = manager.create_project(&config, &base_path, &base_path);
 
     assert!(result.is_err());
     let error_msg = format!("{:?}", result.unwrap_err());
@@ -295,7 +295,7 @@ fn test_compose_project_name_generation() {
 
     let manager = ComposeManager::new();
     let project = manager
-        .create_project(&config, &base_path)
+        .create_project(&config, &base_path, &base_path)
         .expect("Failed to create compose project");
 
     // Project name should be derived from directory name and sanitized for compose
@@ -373,7 +373,7 @@ services:
     // Create compose project
     let manager = ComposeManager::new();
     let project = manager
-        .create_project(&config, &devcontainer_dir)
+        .create_project(&config, &devcontainer_dir, &devcontainer_dir)
         .expect("Failed to create compose project");
 
     // Project name should be sanitized (leading dot removed)

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -744,7 +744,15 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
             )
             .await
         } else {
-            execute_compose_build(&config, &args, &workspace_folder, &labels, &config_hash).await
+            execute_compose_build(
+                &config,
+                &args,
+                &workspace_folder,
+                &config_path,
+                &labels,
+                &config_hash,
+            )
+            .await
         }
     } else if config.image.is_some() {
         execute_image_reference_build(&config, &args, &workspace_folder, &labels).await
@@ -1266,6 +1274,7 @@ async fn execute_compose_build(
     config: &DevContainerConfig,
     args: &BuildArgs,
     workspace_folder: &Path,
+    config_path: &Path,
     labels: &[(String, String)],
     config_hash: &str,
 ) -> Result<BuildResult> {
@@ -1283,12 +1292,10 @@ async fn execute_compose_build(
 
     // Create compose project. Compose files resolve relative to the directory
     // containing devcontainer.json (spec parity), not the workspace folder.
+    // Use the *resolved* config path (discovery may place it under
+    // `.devcontainer/`); `args.config_path` is only the explicit `--config` flag.
     let compose_manager = ComposeManager::new();
-    let config_dir = args
-        .config_path
-        .as_deref()
-        .and_then(|p| p.parent())
-        .unwrap_or(workspace_folder);
+    let config_dir = config_path.parent().unwrap_or(workspace_folder);
     let project = compose_manager.create_project(config, workspace_folder, config_dir)?;
 
     // Validate service exists

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1281,9 +1281,15 @@ async fn execute_compose_build(
 
     let build_start = Instant::now();
 
-    // Create compose project
+    // Create compose project. Compose files resolve relative to the directory
+    // containing devcontainer.json (spec parity), not the workspace folder.
     let compose_manager = ComposeManager::new();
-    let project = compose_manager.create_project(config, workspace_folder)?;
+    let config_dir = args
+        .config_path
+        .as_deref()
+        .and_then(|p| p.parent())
+        .unwrap_or(workspace_folder);
+    let project = compose_manager.create_project(config, workspace_folder, config_dir)?;
 
     // Validate service exists
     if !compose_manager
@@ -1357,7 +1363,9 @@ async fn execute_compose_build_with_features(
         .ok_or_else(|| anyhow!("Docker Compose configuration must specify a service"))?;
 
     let compose_manager = ComposeManager::new();
-    let project = compose_manager.create_project(config, workspace_folder)?;
+    // Compose files resolve relative to the config dir (spec parity).
+    let config_dir = config_path.parent().unwrap_or(workspace_folder);
+    let project = compose_manager.create_project(config, workspace_folder, config_dir)?;
     if !compose_manager
         .validate_service_exists(&project, service)
         .await?

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -154,6 +154,7 @@ pub async fn resolve_target_container<D>(
     docker_client: &D,
     workspace_folder: &Path,
     config: &DevContainerConfig,
+    config_dir: &Path,
     target_service: Option<&str>,
     docker_path: &str,
     env_files: &[PathBuf],
@@ -169,6 +170,7 @@ where
         return resolve_compose_target_container(
             workspace_folder,
             config,
+            config_dir,
             target_service,
             docker_path,
             env_files,
@@ -312,11 +314,12 @@ where
 fn create_compose_project_for_exec(
     workspace_folder: &Path,
     config: &DevContainerConfig,
+    config_dir: &Path,
     docker_path: &str,
     env_files: &[PathBuf],
 ) -> Result<(ComposeManager, ComposeProject)> {
     let compose_manager = ComposeManager::with_docker_path(docker_path.to_string());
-    let mut project = compose_manager.create_project(config, workspace_folder)?;
+    let mut project = compose_manager.create_project(config, workspace_folder, config_dir)?;
     project.env_files = env_files.to_vec();
     Ok((compose_manager, project))
 }
@@ -326,14 +329,20 @@ fn create_compose_project_for_exec(
 async fn resolve_compose_target_container(
     workspace_folder: &Path,
     config: &DevContainerConfig,
+    config_dir: &Path,
     target_service: Option<&str>,
     docker_path: &str,
     env_files: &[PathBuf],
 ) -> Result<String> {
     debug!("Resolving compose target container");
 
-    let (compose_manager, project) =
-        create_compose_project_for_exec(workspace_folder, config, docker_path, env_files)?;
+    let (compose_manager, project) = create_compose_project_for_exec(
+        workspace_folder,
+        config,
+        config_dir,
+        docker_path,
+        env_files,
+    )?;
 
     debug!("Created compose project: {:?}", project.name);
 
@@ -573,10 +582,15 @@ where
             let config_ctx = resolved_config
                 .as_ref()
                 .expect("workspace resolution requires configuration");
+            let config_dir = config_ctx
+                .config_path
+                .parent()
+                .unwrap_or(config_ctx.workspace_folder.as_path());
             resolve_target_container(
                 docker_client,
                 config_ctx.workspace_folder.as_path(),
                 &config_ctx.config,
+                config_dir,
                 args.service.as_deref(),
                 &args.docker_path,
                 &args.env_file,
@@ -1229,7 +1243,8 @@ services:
 
         let env_files = vec![env_file.clone()];
         let (compose_manager, project) =
-            create_compose_project_for_exec(workspace, &config, "docker", &env_files).unwrap();
+            create_compose_project_for_exec(workspace, &config, workspace, "docker", &env_files)
+                .unwrap();
 
         assert_eq!(project.env_files, env_files);
 

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -92,10 +92,28 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
                 }
             }
         } else {
+            // Compose files resolve relative to the directory containing
+            // devcontainer.json, not the workspace folder (spec parity).
+            let target_config_dir = match args.config_path.as_deref() {
+                Some(cfg) if cfg.is_dir() => cfg.to_path_buf(),
+                Some(cfg) => cfg
+                    .parent()
+                    .unwrap_or(workspace_folder.as_path())
+                    .to_path_buf(),
+                None => {
+                    let dc = workspace_folder.join(".devcontainer");
+                    if dc.is_dir() {
+                        dc
+                    } else {
+                        workspace_folder.to_path_buf()
+                    }
+                }
+            };
             match resolve_target_container(
                 &docker_client,
                 workspace_folder.as_path(),
                 &config,
+                &target_config_dir,
                 None,
                 &args.docker_path,
                 &[],

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -86,7 +86,10 @@ pub(crate) async fn execute_compose_up(
     debug!("Starting Docker Compose project");
 
     let compose_manager = ComposeManager::with_docker_path(args.docker_path.clone());
-    let mut project = compose_manager.create_project(config, workspace_folder)?;
+    // Compose files resolve relative to the directory containing devcontainer.json
+    // (the `.devcontainer` dir for the standard layout), not the workspace folder.
+    let config_dir = config_path.parent().unwrap_or(workspace_folder);
+    let mut project = compose_manager.create_project(config, workspace_folder, config_dir)?;
 
     // Add env files from CLI args
     project.env_files = args.env_file.clone();

--- a/crates/deacon/src/commands/up/image_build.rs
+++ b/crates/deacon/src/commands/up/image_build.rs
@@ -150,5 +150,82 @@ pub(crate) async fn build_image_from_config(
     let image_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
     debug!("Built image with ID: {}", image_id);
 
-    Ok(image_id)
+    // `docker build -q` returns a bare `sha256:<digest>` image ID. Returning
+    // that as the resolved `config.image` works for `docker create`, but when
+    // features are layered on top the generated `FROM ${base}` makes BuildKit
+    // treat a bare digest as a `docker.io/library/sha256:...` repository
+    // (pull access denied / 404). Tag the freshly-built image with a real,
+    // deterministic `repo:tag` so any downstream `FROM` resolves to the local
+    // image — mirroring `deacon build`'s `deacon-build:<hash>` base tag. The
+    // digest is content-addressed, so the derived tag is stable across rebuilds.
+    let tag = derive_local_build_tag(&image_id);
+    tag_built_image(&image_id, &tag).await?;
+    debug!("Tagged built image {} as {}", image_id, tag);
+
+    Ok(tag)
+}
+
+/// Derive a deterministic, BuildKit-`FROM`-safe `repo:tag` from a bare image
+/// digest. `docker build -q` yields `sha256:<64hex>`; a bare digest used as a
+/// `FROM` is resolved as a remote `docker.io/library/...` repo (404), so reuse
+/// the digest's leading hex (content-addressed → stable) as the tag suffix.
+fn derive_local_build_tag(image_id: &str) -> String {
+    let stripped = image_id.strip_prefix("sha256:").unwrap_or(image_id);
+    let short = &stripped[..stripped.len().min(12)];
+    format!("deacon-build:{}", short)
+}
+
+/// Apply `tag` to the locally-built image `image_id` (`docker tag`).
+async fn tag_built_image(image_id: &str, tag: &str) -> Result<()> {
+    let output = tokio::process::Command::new("docker")
+        .args(["tag", image_id, tag])
+        .output()
+        .await
+        .with_context(|| format!("Failed to run 'docker tag {} {}'", image_id, tag))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(DeaconError::Docker(DockerError::CLIError(format!(
+            "Failed to tag built image '{}' as '{}': {}",
+            image_id,
+            tag,
+            stderr.trim()
+        )))
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_local_build_tag_from_digest_is_real_repo_tag() {
+        // A bare `sha256:` digest used as a `FROM` 404s in BuildKit; the derived
+        // tag must be a real `repo:tag` with no `sha256:` prefix.
+        let tag = derive_local_build_tag(
+            "sha256:f621c4937bcb40b86157263eb8c14c45ca0b4c273747da4a57bc301f895d398b",
+        );
+        assert_eq!(tag, "deacon-build:f621c4937bcb");
+        assert!(!tag.contains("sha256:"));
+        // Deterministic: same digest → same tag (content-addressed).
+        assert_eq!(
+            tag,
+            derive_local_build_tag(
+                "sha256:f621c4937bcb40b86157263eb8c14c45ca0b4c273747da4a57bc301f895d398b"
+            )
+        );
+    }
+
+    #[test]
+    fn derive_local_build_tag_without_sha256_prefix() {
+        // Defensive: a non-`sha256:` id still yields a valid-looking tag.
+        assert_eq!(
+            derive_local_build_tag("abcdef123456"),
+            "deacon-build:abcdef123456"
+        );
+        assert_eq!(derive_local_build_tag("short"), "deacon-build:short");
+    }
 }

--- a/crates/deacon/tests/integration_auto_forward.rs
+++ b/crates/deacon/tests/integration_auto_forward.rs
@@ -725,7 +725,7 @@ fn compose_service_port_is_forwarded() {
         ws.join(".devcontainer/devcontainer.json"),
         r#"{
   "name": "af-compose",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "forwardPorts": ["db:5432"]

--- a/crates/deacon/tests/integration_compose_enhancements.rs
+++ b/crates/deacon/tests/integration_compose_enhancements.rs
@@ -28,7 +28,7 @@ fn test_compose_multiservice_project_creation() {
     let compose_manager = ComposeManager::new();
 
     let project = compose_manager
-        .create_project(&config, temp_dir.path())
+        .create_project(&config, temp_dir.path(), temp_dir.path())
         .expect("Should create compose project");
 
     assert_eq!(project.service, "app");

--- a/crates/deacon/tests/integration_compose_features_build.rs
+++ b/crates/deacon/tests/integration_compose_features_build.rs
@@ -79,12 +79,13 @@ fn compose_features_image_shape_installs_feature() {
     // (zsh / oh-my-zsh / package upgrades) to keep the test fast.
     let dc_dir = workspace.join(".devcontainer");
     fs::create_dir_all(&dc_dir).expect("create .devcontainer");
-    // `dockerComposeFile` is resolved relative to the workspace folder per
-    // deacon's compose loader, so we place the compose file at the workspace
-    // root and reference it by name.
+    // `dockerComposeFile` is resolved relative to the directory containing
+    // devcontainer.json (`.devcontainer/`) per the spec and the reference CLI.
+    // The compose file lives at the workspace root (a common layout), so the
+    // config references it with `../`.
     let dc_json = r#"{
   "name": "compose-features-image-shape",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "features": {
@@ -193,13 +194,13 @@ fn compose_features_build_shape_installs_feature() {
 
     let dc_dir = workspace.join(".devcontainer");
     fs::create_dir_all(&dc_dir).expect("create .devcontainer");
-    // dockerComposeFile is resolved relative to the workspace folder, so we
-    // point at `compose-dir/docker-compose.yml`. Compose THEN resolves
-    // build.context/build.dockerfile relative to its OWN directory
+    // dockerComposeFile is resolved relative to the config dir (`.devcontainer/`)
+    // per the spec, so we reference the root-level subdir with `../`. Compose
+    // THEN resolves build.context/build.dockerfile relative to its OWN directory
     // (`<workspace>/compose-dir/`), NOT the workspace.
     let dc_json = r#"{
   "name": "compose-features-build-shape",
-  "dockerComposeFile": "compose-dir/docker-compose.yml",
+  "dockerComposeFile": "../compose-dir/docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "features": {

--- a/crates/deacon/tests/integration_up_dockerfile_features.rs
+++ b/crates/deacon/tests/integration_up_dockerfile_features.rs
@@ -1,0 +1,185 @@
+//! Integration test: `up` with a Dockerfile-built base AND features.
+//!
+//! Regression guard for the bare-digest `FROM` bug: when `up` builds an image
+//! from a `build.dockerfile` (no `image`) and the config also declares features,
+//! deacon used to feed the freshly-built image's bare `sha256:<digest>` ID into
+//! the feature-install Dockerfile as `FROM sha256:...`. BuildKit resolves a bare
+//! digest as a `docker.io/library/sha256:...` repository → pull-access-denied /
+//! 404, so feature layering failed for every Dockerfile+features config.
+//!
+//! The fix tags the Dockerfile build with a real `deacon-build:<hash>` repo:tag
+//! (mirroring `deacon build`) so the downstream `FROM` resolves to the local
+//! image. This test exercises the whole path end-to-end: a multi-stage
+//! Dockerfile (build arg + `target`) plus a local feature, asserting the
+//! resulting container carries BOTH the Dockerfile-stage markers and the
+//! feature marker (i.e. features layered successfully on the built base).
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Removes the container on drop so the test leaves no residue.
+struct ContainerGuard(std::cell::RefCell<Option<String>>);
+
+impl Drop for ContainerGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.0.borrow().as_ref() {
+            let _ = StdCommand::new("docker").args(["rm", "-f", id]).output();
+        }
+    }
+}
+
+/// `docker exec <cid> cat <path>` → trimmed stdout (empty string on failure).
+fn exec_cat(container_id: &str, path: &str) -> String {
+    let output = StdCommand::new("docker")
+        .args(["exec", container_id, "cat", path])
+        .output()
+        .expect("docker exec");
+    if !output.status.success() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn test_up_dockerfile_build_with_features_layers_on_built_base() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_up_dockerfile_build_with_features: Docker not available");
+        return;
+    }
+
+    // TempDir lives under the system temp dir (outside the repo) — required for
+    // `up` tests, which chown the workspace and would otherwise touch the repo.
+    let temp_dir = TempDir::new().unwrap();
+    let dc = temp_dir.path().join(".devcontainer");
+    fs::create_dir_all(&dc).unwrap();
+
+    // Multi-stage Dockerfile with a build arg and a non-default `target`.
+    // Uses debian:bookworm-slim (light, commonly cached) as the base.
+    let dockerfile = r#"FROM debian:bookworm-slim AS base
+ARG MARKER=unset
+RUN echo "${MARKER}" > /etc/dockerfile-marker
+FROM base AS dev
+RUN echo dev > /etc/stage-marker
+"#;
+    fs::write(dc.join("Dockerfile"), dockerfile).unwrap();
+
+    // Local feature that drops a marker file — keeps the test hermetic (no
+    // network) while still exercising the feature-layering build path.
+    let feat = dc.join("markerfeat");
+    fs::create_dir_all(&feat).unwrap();
+    fs::write(
+        feat.join("devcontainer-feature.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "id": "markerfeat",
+            "version": "1.0.0",
+            "name": "Marker Feature"
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        feat.join("install.sh"),
+        "#!/bin/sh\nset -e\nmkdir -p /usr/local/share\necho layered > /usr/local/share/feature-marker\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(feat.join("install.sh")).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(feat.join("install.sh"), perms).unwrap();
+    }
+
+    let config = serde_json::json!({
+        "name": "Dockerfile build + features",
+        "build": {
+            "dockerfile": "Dockerfile",
+            "context": "..",
+            "args": { "MARKER": "built" },
+            "target": "dev"
+        },
+        "features": { "./markerfeat": {} }
+    });
+    fs::write(
+        dc.join("devcontainer.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+
+    let guard = ContainerGuard(std::cell::RefCell::new(None));
+
+    let assert = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .env("DEACON_LOG", "warn")
+        .args([
+            "up",
+            "--workspace-folder",
+            temp_dir.path().to_str().unwrap(),
+            "--mount-workspace-git-root=false",
+            "--remove-existing-container",
+        ])
+        .assert();
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "deacon up should succeed for Dockerfile-build + features\nSTDOUT:\n{}\nSTDERR:\n{}",
+        stdout,
+        stderr
+    );
+
+    let trimmed = stdout.trim();
+    let value: Value = serde_json::from_str::<Value>(trimmed)
+        .ok()
+        .or_else(|| {
+            trimmed
+                .rfind('{')
+                .and_then(|idx| serde_json::from_str::<Value>(&trimmed[idx..]).ok())
+        })
+        .unwrap_or_else(|| panic!("expected JSON result on stdout:\n{}", stdout));
+
+    assert_eq!(value["outcome"], "success", "outcome should be success");
+    let container_id = value["containerId"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    assert!(!container_id.is_empty(), "containerId should be present");
+    *guard.0.borrow_mut() = Some(container_id.clone());
+
+    // Dockerfile build arg honored (proves the user's Dockerfile actually built).
+    assert_eq!(
+        exec_cat(&container_id, "/etc/dockerfile-marker"),
+        "built",
+        "build arg MARKER should reach the built base image"
+    );
+    // Non-default `target: dev` honored.
+    assert_eq!(
+        exec_cat(&container_id, "/etc/stage-marker"),
+        "dev",
+        "build target 'dev' stage should be the final image"
+    );
+    // Feature layered ON TOP of the Dockerfile-built base — this only succeeds
+    // when the feature-install `FROM` resolved to the local build tag rather
+    // than a bare `sha256:` digest (the regression).
+    assert_eq!(
+        exec_cat(&container_id, "/usr/local/share/feature-marker"),
+        "layered",
+        "local feature should be layered on the Dockerfile-built base image"
+    );
+}

--- a/crates/deacon/tests/integration_up_initialize_command.rs
+++ b/crates/deacon/tests/integration_up_initialize_command.rs
@@ -190,7 +190,7 @@ services:
     let devcontainer_config = format!(
         r#"{{
     "name": "Compose Initialize Test",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace",
     "initializeCommand": "echo 'compose-init' > {}",

--- a/crates/deacon/tests/smoke_basic.rs
+++ b/crates/deacon/tests/smoke_basic.rs
@@ -195,7 +195,7 @@ services:
     // Create devcontainer.json with dockerComposeFile + service
     let devcontainer_config = r#"{
     "name": "Compose Test Container",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace"
 }

--- a/crates/deacon/tests/smoke_compose_edges.rs
+++ b/crates/deacon/tests/smoke_compose_edges.rs
@@ -53,7 +53,7 @@ fn test_compose_path_detection_without_docker() {
     // Create devcontainer.json that references the compose file
     let devcontainer_config = r#"{
     "name": "Compose Path Detection Test",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace"
 }"#;
@@ -120,7 +120,7 @@ fn test_compose_subfolder_config() {
     // Create devcontainer.json in subdirectory that references the compose file
     let devcontainer_config = r#"{
     "name": "Compose Subfolder Test",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace"
 }"#;
@@ -233,7 +233,7 @@ services:
     // Create devcontainer.json that references the invalid compose file
     let devcontainer_config = r#"{
     "name": "Compose Invalid Syntax Test",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace"
 }"#;
@@ -317,7 +317,7 @@ fn test_compose_multiple_files() {
     // Create devcontainer.json that references multiple compose files
     let devcontainer_config = r#"{
     "name": "Compose Multiple Files Test",
-    "dockerComposeFile": ["docker-compose.yml", "docker-compose.override.yml"],
+    "dockerComposeFile": ["../docker-compose.yml", "../docker-compose.override.yml"],
     "service": "app",
     "workspaceFolder": "/workspace"
 }"#;
@@ -384,7 +384,7 @@ RUN echo "app service" > /tmp/app.txt
     // Create devcontainer.json that references the compose file and targets app service
     let devcontainer_config = r#"{
     "name": "Compose Build Target Service Test",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "../docker-compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace"
 }"#;

--- a/crates/deacon/tests/smoke_compose_override_command.rs
+++ b/crates/deacon/tests/smoke_compose_override_command.rs
@@ -88,7 +88,7 @@ fn test_compose_override_command_default_keeps_service_alive() {
 "#;
     let devcontainer_json = r#"{
   "name": "Compose Override Default",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace"
 }"#;
@@ -150,7 +150,7 @@ fn test_compose_override_command_explicit_false_runs_natural_command() {
 "#;
     let devcontainer_json = r#"{
   "name": "Compose Override False",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "overrideCommand": false
@@ -217,7 +217,7 @@ fn test_compose_override_command_lifecycle_runs() {
 "#;
     let devcontainer_json = r#"{
   "name": "Compose Lifecycle Marker",
-  "dockerComposeFile": "docker-compose.yml",
+  "dockerComposeFile": "../docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "touch /tmp/deacon-lifecycle-marker"

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -318,7 +318,7 @@ container-running state, then tear both down (deacon's container is removed
 host ports, a false positive). Lifecycle ordering, object-form parallel commands
 (`lint`/`deps`), array/string forms, feature install, mounts, user-mapping,
 init/privileged, and `appPort` bindings (`ports-mixed`: deacon and reference emit
-byte-identical `-p` host bindings) all reach parity. One real bug:
+byte-identical `-p` host bindings) all reach parity. Three real bugs:
 
 ### 20. `up` Dockerfile-build + features: bare `sha256:` digest as `FROM` (BuildKit 404)
 
@@ -344,6 +344,48 @@ installed — both CLIs failed identically on it); it now uses `vscode` +
 `git --version` (the git feature it installs), reaching parity-success.
 (`crates/deacon/src/commands/up/image_build.rs`,
 `crates/deacon/tests/integration_up_dockerfile_features.rs`.)
+
+### 21. Compose: `dockerComposeFile` resolved against the workspace folder, not the config dir
+
+deacon resolved `dockerComposeFile` paths relative to the **workspace folder**,
+so the standard `.devcontainer/docker-compose.yml` layout failed at `up` with
+`open <workspace>/docker-compose.yml: no such file or directory`. The spec
+("relative to the devcontainer.json file") and the reference both resolve them
+relative to the **directory containing devcontainer.json** (`.devcontainer/` for
+the nested layout) — confirmed by the reference's
+`-f <ws>/.devcontainer/docker-compose.yml`. **Fix:** thread the config dir into
+`ComposeManager::create_project` and resolve relative compose files against it,
+while keeping the project name + working dir on the workspace folder. Volume
+`..:/workspace` still resolves to the workspace root (compose's project dir
+defaults to the first `-f` file's dir = `.devcontainer/`), so the bind mount
+matches the reference byte-for-byte (`<ws> -> /workspace`). Threaded through `up`,
+`exec`, `run-user-commands`, and `build` compose paths. Absolute compose paths are
+left un-rebased. Unit tests cover config-dir resolution + absolute passthrough.
+(`crates/core/src/compose.rs` + the four command call sites.)
+
+### 22. Compose: `runServices` listing the primary service produced duplicate YAML keys
+
+The feature/keep-alive injection override emits a full block for the primary
+service, then a labels-only block for **every** `runServices` entry. When
+`runServices` lists the primary service alongside the others (e.g.
+`["app","db"]` — the common form), `app:` was emitted twice, so
+`docker compose` rejected the piped override with `mapping key "app" already
+defined`. Every compose config with features (or a non-default
+`overrideCommand`) plus a primary-inclusive `runServices` failed. **Fix:** skip
+the primary service in the `runServices` label loop (it already has a full
+block). Verified end-to-end: `compose-postgres` (compose + `github-cli` feature +
+`runServices:[app,db]`) now brings up both services with `gh` installed, matching
+the reference. Unit test asserts the primary + secondary services each appear
+exactly once. (`crates/core/src/compose.rs`.)
+
+### Known remaining Tier-2 gap (tracked, not yet fixed)
+
+- **Compose project name scheme differs.** For the same workspace folder deacon
+  derives the compose `--project-name` as `<folder>` while the reference uses
+  `<folder>_devcontainer` (sanitized). Both isolate correctly and `up`/`exec`/
+  `down` are self-consistent, so it's functional — but a config that hard-codes a
+  project name, or interop with VS Code's reference-built projects, would see a
+  mismatch. Candidate for a future round.
 
 ### Tier-2 divergences that are NOT deacon bugs
 

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -309,6 +309,64 @@ branches. With the `typescript-node` image present, `node-ts`
 entries in matching order). Unit tests cover the ordering invariant.
 (`crates/deacon/src/commands/read_configuration.rs`.)
 
+## Round 3 — Tier-2 (Docker) `up` sweep
+
+A Docker-level differential: copy each corpus config to a TempDir **outside** the
+repo, run `deacon up` and `devcontainer up`, compare exit/outcome/remoteUser and
+container-running state, then tear both down (deacon's container is removed
+**before** the reference runs — otherwise the two collide on `appPort`/published
+host ports, a false positive). Lifecycle ordering, object-form parallel commands
+(`lint`/`deps`), array/string forms, feature install, mounts, user-mapping,
+init/privileged, and `appPort` bindings (`ports-mixed`: deacon and reference emit
+byte-identical `-p` host bindings) all reach parity. One real bug:
+
+### 20. `up` Dockerfile-build + features: bare `sha256:` digest as `FROM` (BuildKit 404)
+
+For a config with `build.dockerfile` (no `image`) **and** `features`, `up` first
+builds the user Dockerfile via `docker build -q`, which yields a bare
+`sha256:<digest>` image ID, and stored that verbatim as `config.image`. The
+feature-layering stage then emitted `ARG _DEV_CONTAINERS_BASE_IMAGE=sha256:<digest>`
++ `FROM ${_DEV_CONTAINERS_BASE_IMAGE}` — and BuildKit resolves a **bare digest**
+as a remote `docker.io/library/sha256:...` repository → `pull access denied` /
+404. So **every** Dockerfile+features `up` failed at feature build, while the
+reference (which tags its build) succeeded. **Fix:** `build_image_from_config`
+tags the freshly-built image with a deterministic real `repo:tag`
+(`deacon-build:<digest12>`, mirroring `deacon build`'s base tag) and returns the
+tag, so the downstream `FROM` resolves to the local image. With no features the
+bare digest also worked for `docker create`, so only the features path was
+affected. Verified end-to-end: deacon now builds + layers features and the
+container carries both the Dockerfile-stage markers and the feature marker.
+Unit tests cover the digest→tag derivation; a hermetic docker integration test
+(`integration_up_dockerfile_features`) guards the full path (reverting the fix
+makes it fail with the 404). Also corrected the `dockerfile-build` fixture, which
+was invalid two ways (`remoteUser: node` + `node --version` though node is never
+installed — both CLIs failed identically on it); it now uses `vscode` +
+`git --version` (the git feature it installs), reaching parity-success.
+(`crates/deacon/src/commands/up/image_build.rs`,
+`crates/deacon/tests/integration_up_dockerfile_features.rs`.)
+
+### Tier-2 divergences that are NOT deacon bugs
+
+- **`bare-base-node-feature`: deacon succeeds, reference fails.** Config is
+  `debian:bookworm-slim` + `ghcr.io/devcontainers/features/node` + `remoteUser:
+  node` (no `common-utils`). deacon's node-feature install **creates** the `node`
+  user (`node:x:1000:1000`, node v22 on PATH) and `postCreate` runs as `node`.
+  The reference installs the same feature but its image has **no** `node` user
+  (`getent passwd node` → none; node binary present at
+  `/usr/local/share/nvm/...`), so its `up` dies with `unable to find user node`.
+  deacon is **more permissive** here (materializes the declared `remoteUser` via
+  the feature), not silently falling back — verified the user genuinely exists in
+  deacon's container. Not a deacon defect.
+- **`extends-child`: deacon resolves `extends` at `up`/merged; reference errors.**
+  Raw `read-configuration` is parity (both emit the raw child with `extends`
+  preserved — fix #16). But `deacon up` and `deacon read-configuration
+  --include-merged-configuration` fully resolve the chain (`image` =
+  `base:bookworm`, `containerEnv` = `{CHILD, BASE}`, `forwardPorts` =
+  `[3000,4000]`), whereas the reference CLI v0.87.0 **errors** (`up`: "missing one
+  of image/dockerFile/dockerComposeFile"; merged read-config: exit 1, empty
+  stdout). `extends` is a deliberate deacon capability beyond the reference, not a
+  regression — do not "fix" by dropping support.
+
 ## Verified non-bugs
 
 - **Feature `containerEnv` with `${...}` shell refs (incl. a *novel* PATH dir) is

--- a/fixtures/parity-corpus/dockerfile-build/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/dockerfile-build/.devcontainer/devcontainer.json
@@ -12,6 +12,6 @@
   },
   "runArgs": ["--cap-add=NET_ADMIN"],
   "containerEnv": { "BUILT_BY": "deacon" },
-  "postCreateCommand": "node --version",
-  "remoteUser": "node"
+  "postCreateCommand": "git --version",
+  "remoteUser": "vscode"
 }


### PR DESCRIPTION
## Summary

Round 3 of differential parity hardening vs the reference CLI (`@devcontainers/cli` v0.87.0) — the **Tier-2 (Docker) `up` sweep**. Copied each corpus config to a TempDir outside the repo, ran `deacon up` and `devcontainer up`, and compared exit/outcome/user/running state (deacon torn down before the reference to avoid host-port collisions). Lifecycle ordering, object-form parallel commands, array/string forms, feature install, mounts, user-mapping, init/privileged, and `appPort` bindings all reached parity. **Three real bugs found and fixed**, each confirmed against the reference before fixing.

## Fixes

**1. `up` Dockerfile-build + features → bare `sha256:` digest as `FROM` (BuildKit 404)**
For a config with `build.dockerfile` (no `image`) **and** features, `up` built the Dockerfile via `docker build -q` (bare `sha256:` digest) and fed it as the feature-layering `FROM`, which BuildKit resolves as `docker.io/library/sha256:…` → pull-access-denied. Every Dockerfile+features `up` failed. Now tags the built image `deacon-build:<digest12>` (mirroring `deacon build`) and returns the tag. Unit tests + hermetic docker integration test (reverting the fix makes it fail with the 404).

**2. Compose: `dockerComposeFile` resolved against the workspace folder, not the config dir**
The standard `.devcontainer/docker-compose.yml` layout failed with `open <workspace>/docker-compose.yml: no such file or directory`. The spec ("relative to the devcontainer.json file") and the reference resolve relative to the config dir — verified the reference errors identically when the file is at the workspace root. Now resolves relative to the config dir (threaded through up/exec/run-user-commands/build); project name + working dir stay on the workspace folder, so the `..:/workspace` bind matches the reference byte-for-byte.

**3. Compose: `runServices` listing the primary service produced duplicate YAML keys**
The injection override emitted a labels-only block for every `runServices` entry, including the primary service (which already has a full block), so `runServices:[app,db]` defined `app:` twice → `docker compose` rejected it. Now skips the primary service in the loop. `compose-postgres` (compose + github-cli feature + runServices) now brings up both services with `gh` installed.

## Tests
- New unit tests: digest→tag derivation; compose config-dir resolution + absolute passthrough; runServices single-emission of the primary service.
- New hermetic docker integration test `integration_up_dockerfile_features`.
- Corrected `dockerfile-build` corpus fixture (was invalid: `remoteUser: node` + `node --version`, node never installed) and several compose test fixtures that had encoded the workspace-relative bug (now use the spec-correct `../docker-compose.yml`).
- Validated green: `make test-nextest-fast` (2587 passed); docker suites `smoke_compose_edges`, `smoke_compose_override_command`, `smoke_basic`, `integration_up_initialize_command`, `integration_auto_forward`, `integration_compose_features_build`, `integration_up_traditional`.

## Also documented (verified NOT deacon bugs)
- `bare-base-node-feature`: deacon's node-feature install creates the `node` user (reference's doesn't → reference fails); deacon is more permissive, not silently falling back.
- `extends-child`: deacon resolves `extends` at up/merged; the reference CLI errors (no extends support) — a deliberate deacon capability.
- Known remaining gap (tracked): compose project-name scheme differs (`<folder>` vs `<folder>_devcontainer`).

See `fixtures/parity-corpus/REPORT.md` (Round 3 section) for full detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)