### PR TITLE
fix(compose): match reference compose project-name scheme

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -1526,63 +1526,45 @@ fn parse_env_file_for_project_name(env_file_path: &Path) -> Option<String> {
 }
 
 fn derive_project_name(base_path: &Path) -> String {
-    // Task T020: Check for .env file and extract COMPOSE_PROJECT_NAME
+    // An explicit COMPOSE_PROJECT_NAME in a sibling `.env` is used verbatim
+    // (no suffix), matching docker compose and the reference CLI.
     let env_file_path = base_path.join(".env");
     if let Some(project_name) = parse_env_file_for_project_name(&env_file_path) {
         debug!("Using project name from .env file: {}", project_name);
         return project_name;
     }
 
-    // Docker Compose project name rules:
-    // - must start with a lowercase letter or number
-    // - may contain only lowercase alphanumeric characters, hyphens, and underscores
-    // - we also collapse runs of invalid characters into a single '-'
-    const FALLBACK: &str = "deacon-compose";
+    // Folder-derived default. The reference (devcontainers/cli) takes the
+    // workspace folder basename, STRIPS every character outside [a-z0-9_-]
+    // (case-insensitively), lowercases, and appends `_devcontainer`
+    // (e.g. `Foo.Bar-1` -> `foobar-1_devcontainer`, `my proj` ->
+    // `myproj_devcontainer`). Note it strips invalid chars rather than
+    // replacing them with '-'.
+    const FALLBACK_STEM: &str = "deacon";
 
-    let original = base_path
+    let stem = base_path
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or(FALLBACK);
+        .unwrap_or(FALLBACK_STEM);
 
-    // Fallback when directory name is empty or only dots (e.g., "...")
-    if original.is_empty() || original.chars().all(|c| c == '.') {
-        return FALLBACK.to_string();
-    }
+    let stripped: String = stem
+        .chars()
+        .map(|c| c.to_ascii_lowercase())
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
 
-    // Sanitize: lowercase, keep [a-z0-9_-], convert other chars to '-'
-    let mut sanitized = String::with_capacity(original.len());
-    let mut last_was_dash = false;
-    for ch in original.chars() {
-        let lc = ch.to_ascii_lowercase();
-        if lc.is_ascii_alphanumeric() {
-            sanitized.push(lc);
-            last_was_dash = false;
-        } else if lc == '-' || lc == '_' {
-            // Preserve hyphen/underscore but avoid leading repetitions
-            if !(sanitized.is_empty() && (lc == '-' || lc == '_')) {
-                sanitized.push(lc);
-            }
-            last_was_dash = lc == '-';
-        } else {
-            // Replace invalid characters with a single '-'
-            if !last_was_dash {
-                sanitized.push('-');
-                last_was_dash = true;
-            }
-        }
-    }
+    // Docker Compose requires the project name to start with [a-z0-9]. The
+    // reference emits an invalid name (leading '-'/'_', or empty) and docker
+    // compose then rejects it; deacon stays robust by trimming leading
+    // separators and falling back to a stem when nothing valid remains.
+    let trimmed = stripped.trim_start_matches(['-', '_']);
+    let stem = if trimmed.is_empty() {
+        FALLBACK_STEM
+    } else {
+        trimmed
+    };
 
-    // Trim leading/trailing dashes/underscores
-    let sanitized = sanitized
-        .trim_matches(|c: char| c == '-' || c == '_')
-        .to_string();
-
-    // Ensure first character is a lowercase letter or number
-    match sanitized.chars().next() {
-        Some(c) if c.is_ascii_lowercase() || c.is_ascii_digit() => sanitized,
-        Some(_) => format!("d{}", sanitized),
-        None => FALLBACK.to_string(),
-    }
+    format!("{stem}_devcontainer")
 }
 
 #[cfg(test)]
@@ -1867,21 +1849,59 @@ mod tests {
     #[test]
     fn test_derive_project_name_from_hidden_directory() {
         let path = Path::new("/tmp/.tmpAbC123");
-        // Leading dot should be removed and name sanitized to valid compose project name
-        assert_eq!(derive_project_name(path), "tmpabc123");
+        // Leading dot stripped, lowercased, `_devcontainer` suffix appended
+        // (reference parity).
+        assert_eq!(derive_project_name(path), "tmpabc123_devcontainer");
     }
 
     #[test]
-    fn test_derive_project_name_replaces_invalid_characters() {
-        let path = Path::new("/tmp/My Project!");
-        // Sanitize spaces and punctuation, lowercase and replace with hyphen
-        assert_eq!(derive_project_name(path), "my-project");
+    fn test_derive_project_name_strips_invalid_characters() {
+        // The reference STRIPS chars outside [a-z0-9_-] (it does not replace
+        // them with '-'): `My Project!` -> `myproject`, not `my-project`.
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/My Project!")),
+            "myproject_devcontainer"
+        );
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/Foo.Bar-1")),
+            "foobar-1_devcontainer"
+        );
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/UPPER_Case")),
+            "upper_case_devcontainer"
+        );
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/9lives")),
+            "9lives_devcontainer"
+        );
+    }
+
+    #[test]
+    fn test_derive_project_name_appends_devcontainer_suffix() {
+        assert_eq!(
+            derive_project_name(Path::new("/home/user/myapp")),
+            "myapp_devcontainer"
+        );
     }
 
     #[test]
     fn test_derive_project_name_fallback_for_all_invalid() {
-        let path = Path::new("/tmp/...");
-        assert_eq!(derive_project_name(path), "deacon-compose");
+        // Nothing valid remains -> robust fallback stem (the reference would
+        // emit an invalid name and docker compose would reject it).
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/...")),
+            "deacon_devcontainer"
+        );
+    }
+
+    #[test]
+    fn test_derive_project_name_leading_separator_trimmed() {
+        // Leading '-'/'_' would make an invalid compose project name; trim it
+        // so deacon stays robust where the reference fails.
+        assert_eq!(
+            derive_project_name(Path::new("/tmp/-leadingdash")),
+            "leadingdash_devcontainer"
+        );
     }
 
     #[test]

--- a/crates/core/tests/integration_compose.rs
+++ b/crates/core/tests/integration_compose.rs
@@ -9,45 +9,30 @@ use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-/// Helper to compute expected compose project name using same rules as core
+/// Helper to compute expected compose project name using same rules as core:
+/// strip chars outside [a-z0-9_-], lowercase, trim leading separators, then
+/// append the reference's `_devcontainer` suffix.
 fn expected_project_name_for_path(base_path: &std::path::Path) -> String {
-    const FALLBACK: &str = "deacon-compose";
-    let original = base_path
+    const FALLBACK_STEM: &str = "deacon";
+    let stem = base_path
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or(FALLBACK);
+        .unwrap_or(FALLBACK_STEM);
 
-    if original.is_empty() || original.chars().all(|c| c == '.') {
-        return FALLBACK.to_string();
-    }
+    let stripped: String = stem
+        .chars()
+        .map(|c| c.to_ascii_lowercase())
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
 
-    let mut sanitized = String::with_capacity(original.len());
-    let mut last_was_dash = false;
-    for ch in original.chars() {
-        let lc = ch.to_ascii_lowercase();
-        if lc.is_ascii_alphanumeric() {
-            sanitized.push(lc);
-            last_was_dash = false;
-        } else if lc == '-' || lc == '_' {
-            if !(sanitized.is_empty() && (lc == '-' || lc == '_')) {
-                sanitized.push(lc);
-            }
-            last_was_dash = lc == '-';
-        } else if !last_was_dash {
-            sanitized.push('-');
-            last_was_dash = true;
-        }
-    }
+    let trimmed = stripped.trim_start_matches(['-', '_']);
+    let stem = if trimmed.is_empty() {
+        FALLBACK_STEM
+    } else {
+        trimmed
+    };
 
-    let sanitized = sanitized
-        .trim_matches(|c: char| c == '-' || c == '_')
-        .to_string();
-
-    match sanitized.chars().next() {
-        Some(c) if c.is_ascii_lowercase() || c.is_ascii_digit() => sanitized,
-        Some(_) => format!("d{}", sanitized),
-        None => FALLBACK.to_string(),
-    }
+    format!("{stem}_devcontainer")
 }
 
 /// Create a minimal docker-compose.yml file for testing

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -378,14 +378,24 @@ block). Verified end-to-end: `compose-postgres` (compose + `github-cli` feature 
 the reference. Unit test asserts the primary + secondary services each appear
 exactly once. (`crates/core/src/compose.rs`.)
 
-### Known remaining Tier-2 gap (tracked, not yet fixed)
+### 23. Compose project name scheme differed from the reference
 
-- **Compose project name scheme differs.** For the same workspace folder deacon
-  derives the compose `--project-name` as `<folder>` while the reference uses
-  `<folder>_devcontainer` (sanitized). Both isolate correctly and `up`/`exec`/
-  `down` are self-consistent, so it's functional — but a config that hard-codes a
-  project name, or interop with VS Code's reference-built projects, would see a
-  mismatch. Candidate for a future round.
+For the same workspace folder deacon derived the compose `--project-name` as a
+sanitized `<folder>` (invalid chars → `-`, no suffix) while the reference uses
+`<folder>_devcontainer`. The two also sanitized differently: the reference
+**strips** every character outside `[a-z0-9_-]` then lowercases (`Foo.Bar-1` →
+`foobar-1`, `my proj` → `myproj`), whereas deacon replaced them with `-`
+(`my-proj`). Both isolate correctly and deacon's `up`/`exec`/`down` were
+self-consistent, but the project differed from VS Code / reference-built projects
+for the same folder. **Fix:** `derive_project_name` now mirrors the reference —
+strip `[^a-z0-9_-]`, lowercase, append `_devcontainer` — keeping the explicit
+`.env` `COMPOSE_PROJECT_NAME` override verbatim (no suffix). For degenerate
+folders where the reference emits an invalid name and docker compose then fails
+(leading `-`/`_`, or empty after stripping), deacon trims leading separators /
+falls back to a `deacon` stem so it stays robust. Verified end-to-end: for
+workspace `My.App-1` both deacon and the reference now produce
+`myapp-1_devcontainer`. Unit tests cover the strip/lowercase/suffix rules and the
+degenerate fallbacks. (`crates/core/src/compose.rs`.)
 
 ### Tier-2 divergences that are NOT deacon bugs
 


### PR DESCRIPTION
## Summary

Closes the compose project-name divergence tracked in PR #209's REPORT.md. For the same workspace folder, deacon derived the compose `--project-name` as a sanitized `<folder>` (invalid chars → `-`, no suffix), while the reference CLI (`@devcontainers/cli` v0.87.0) and VS Code use `<folder>_devcontainer`. The two also sanitized differently: the reference **strips** every char outside `[a-z0-9_-]` then lowercases; deacon replaced them with `-`.

Confirmed empirically against the reference:

| folder | reference `--project-name` |
|---|---|
| `Foo.Bar-1` | `foobar-1_devcontainer` |
| `my proj` | `myproj_devcontainer` |
| `UPPER_Case` | `upper_case_devcontainer` |
| `9lives` | `9lives_devcontainer` |

## Fix

`derive_project_name` now mirrors the reference: **strip** `[^a-z0-9_-]`, lowercase, append `_devcontainer`. The explicit `.env` `COMPOSE_PROJECT_NAME` override is still used verbatim (no suffix). For degenerate folders where the reference emits an invalid name and docker compose then rejects it (leading `-`/`_`, or empty after stripping — verified the reference exits 1 on `-leadingdash`), deacon trims leading separators / falls back to a `deacon` stem so it stays robust.

**Verified end-to-end:** for workspace `My.App-1` both deacon and the reference now produce `myapp-1_devcontainer` (exact match).

## Tests
- Rewrote/added `derive_project_name` unit tests (strip vs replace, lowercase, suffix, degenerate fallbacks, leading-separator trim).
- Updated the `expected_project_name_for_path` helper in core `integration_compose` to the new scheme.
- `make test-nextest-fast` (2589 passed); docker `smoke_compose_edges` 7/7 (incl. down-keeps-containers — confirms up/exec/down stay self-consistent under the new name).

> Stacked on #209 (base `chore/parity-corpus-round3`); GitHub will retarget to `main` once #209 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)