### PR TITLE
fix(lifecycle): honor userEnvProbe mode for lifecycle command shells

### DIFF
--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -647,57 +647,46 @@ impl ContainerEnvironmentProber {
     }
 }
 
-/// Get shell command for lifecycle execution
+/// Get shell command for lifecycle execution.
 ///
-/// Determines the appropriate shell and flags to use for executing lifecycle commands.
-/// Defaults to login shell mode for best environment parity.
+/// The shell's login/interactive flags follow the `userEnvProbe` `mode`, so a
+/// lifecycle command sources exactly the startup files the reference CLI would
+/// for that mode:
+///
+/// | mode                    | shell invocation        | sources                       |
+/// |-------------------------|-------------------------|-------------------------------|
+/// | `none`                  | `sh -c`                 | nothing (minimal env)         |
+/// | `loginShell`            | `<shell> -l -c`         | `/etc/profile`, `~/.profile`  |
+/// | `interactiveShell`      | `<shell> -i -c`         | `~/.bashrc` (interactive rc)  |
+/// | `loginInteractiveShell` | `<shell> -l -i -c`      | both (the default)            |
+///
+/// Login+interactive is what puts feature-installed tools (nvm/node, which hook
+/// the *interactive* startup files) on `PATH`, so it stays the default; the
+/// other modes are honored verbatim for parity (deacon previously always used
+/// `-l -i`, ignoring `none`/`loginShell`/`interactiveShell`).
 pub fn get_shell_command_for_lifecycle(
     shell: &str,
     command: &str,
-    use_login_shell: bool,
+    mode: ContainerProbeMode,
 ) -> Vec<String> {
-    if !use_login_shell {
-        // Legacy mode: plain sh -c
+    // `none` opts out of startup-file sourcing entirely: a plain `sh -c` with no
+    // probed env injected (the caller skips the probe for `none`).
+    if mode == ContainerProbeMode::None {
         return vec!["sh".to_string(), "-c".to_string(), command.to_string()];
     }
 
-    // Determine shell name for flag compatibility
-    let shell_name = shell.split('/').next_back().unwrap_or(shell);
+    let flags: &[&str] = match mode {
+        ContainerProbeMode::None => unreachable!("handled above"),
+        ContainerProbeMode::LoginShell => &["-l", "-c"],
+        ContainerProbeMode::InteractiveShell => &["-i", "-c"],
+        ContainerProbeMode::LoginInteractiveShell => &["-l", "-i", "-c"],
+    };
 
-    match shell_name {
-        "zsh" => {
-            // Use login + interactive shell for zsh to source .zshrc
-            // This is critical for tools installed via package managers like nvm
-            vec![
-                shell.to_string(),
-                "-l".to_string(),
-                "-i".to_string(),
-                "-c".to_string(),
-                command.to_string(),
-            ]
-        }
-        "bash" => {
-            // Login + interactive for bash, for the same reason as zsh: many
-            // feature-installed tools (notably nvm/node) hook into the
-            // *interactive* startup files (`/etc/bash.bashrc`, `~/.bashrc`),
-            // which a non-interactive `bash -lc` skips (those files commonly
-            // early-return when `$PS1` is unset). The reference CLI runs
-            // lifecycle commands in an interactive-login shell too. Without
-            // `-i`, `node --version` in postCreate fails with `command not
-            // found` (exit 127) on bases that don't put the tool on PATH.
-            vec![
-                shell.to_string(),
-                "-l".to_string(),
-                "-i".to_string(),
-                "-c".to_string(),
-                command.to_string(),
-            ]
-        }
-        _ => {
-            // Fallback: try -lc, may not work for all shells
-            vec![shell.to_string(), "-lc".to_string(), command.to_string()]
-        }
-    }
+    let mut args = Vec::with_capacity(flags.len() + 2);
+    args.push(shell.to_string());
+    args.extend(flags.iter().map(|f| f.to_string()));
+    args.push(command.to_string());
+    args
 }
 
 /// Resolve the container user's home directory.
@@ -941,29 +930,55 @@ mod tests {
     }
 
     #[test]
-    fn test_get_shell_command_legacy_mode() {
-        let cmd = get_shell_command_for_lifecycle("/bin/bash", "echo hello", false);
+    fn test_get_shell_command_none_is_plain() {
+        // `none` opts out of startup-file sourcing: plain `sh -c`, no shell rc.
+        let cmd =
+            get_shell_command_for_lifecycle("/bin/bash", "echo hello", ContainerProbeMode::None);
         assert_eq!(cmd, vec!["sh", "-c", "echo hello"]);
     }
 
     #[test]
     fn test_get_shell_command_bash_login_interactive() {
-        // bash uses login + interactive (like zsh) so feature-installed tools
+        // The default mode keeps login + interactive so feature-installed tools
         // hooked into interactive bashrc (nvm/node) are on PATH for lifecycle.
-        let cmd = get_shell_command_for_lifecycle("/bin/bash", "echo hello", true);
+        let cmd = get_shell_command_for_lifecycle(
+            "/bin/bash",
+            "echo hello",
+            ContainerProbeMode::LoginInteractiveShell,
+        );
         assert_eq!(cmd, vec!["/bin/bash", "-l", "-i", "-c", "echo hello"]);
     }
 
     #[test]
-    fn test_get_shell_command_zsh_login() {
-        let cmd = get_shell_command_for_lifecycle("/usr/bin/zsh", "echo hello", true);
-        assert_eq!(cmd, vec!["/usr/bin/zsh", "-l", "-i", "-c", "echo hello"]);
+    fn test_get_shell_command_login_shell_only() {
+        // loginShell sources /etc/profile (+ ~/.profile), not the interactive rc.
+        let cmd = get_shell_command_for_lifecycle(
+            "/bin/bash",
+            "echo hello",
+            ContainerProbeMode::LoginShell,
+        );
+        assert_eq!(cmd, vec!["/bin/bash", "-l", "-c", "echo hello"]);
     }
 
     #[test]
-    fn test_get_shell_command_sh_fallback() {
-        let cmd = get_shell_command_for_lifecycle("/bin/sh", "echo hello", true);
-        assert_eq!(cmd, vec!["/bin/sh", "-lc", "echo hello"]);
+    fn test_get_shell_command_interactive_shell_only() {
+        // interactiveShell sources ~/.bashrc, not the login profile.
+        let cmd = get_shell_command_for_lifecycle(
+            "/bin/bash",
+            "echo hello",
+            ContainerProbeMode::InteractiveShell,
+        );
+        assert_eq!(cmd, vec!["/bin/bash", "-i", "-c", "echo hello"]);
+    }
+
+    #[test]
+    fn test_get_shell_command_zsh_login_interactive() {
+        let cmd = get_shell_command_for_lifecycle(
+            "/usr/bin/zsh",
+            "echo hello",
+            ContainerProbeMode::LoginInteractiveShell,
+        );
+        assert_eq!(cmd, vec!["/usr/bin/zsh", "-l", "-i", "-c", "echo hello"]);
     }
 
     #[test]

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -1441,13 +1441,18 @@ where
 
                 // Detect shell and create appropriate command args
                 let command_args = if config.use_login_shell {
-                    // Use detected shell or fallback to sh
+                    // Use detected shell or fallback to sh. The login/interactive
+                    // flags follow `userEnvProbe` so the command sources exactly
+                    // the startup files the reference CLI would for that mode.
                     let shell = detected_shell.unwrap_or("sh");
-                    debug!("Using login shell for lifecycle command: {}", shell);
+                    debug!(
+                        "Using {:?} shell for lifecycle command: {}",
+                        config.user_env_probe, shell
+                    );
                     crate::container_env_probe::get_shell_command_for_lifecycle(
                         shell,
                         &substituted_command,
-                        true,
+                        config.user_env_probe,
                     )
                 } else {
                     // Legacy mode: plain sh -c
@@ -1769,7 +1774,9 @@ where
                                 if config.use_login_shell {
                                     let shell = detected_shell.unwrap_or("sh");
                                     crate::container_env_probe::get_shell_command_for_lifecycle(
-                                        shell, cmd, true,
+                                        shell,
+                                        cmd,
+                                        config.user_env_probe,
                                     )
                                 } else {
                                     vec!["sh".to_string(), "-c".to_string(), cmd.clone()]

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -452,8 +452,48 @@ partial override (`w` first, then `y, x` per override, then unlisted `z`). Unit
 tests cover the partial-override and dependency-interaction cases.
 (`crates/core/src/features.rs`.)
 
+## Round 5 — `userEnvProbe` modes
+
+Docker differential: a Dockerfile sets `PROFILE_VAR` in `/etc/profile.d` (login
+shells) and `BASHRC_VAR` in `~/.bashrc` (interactive shells); `postCreateCommand`
+records which the lifecycle env captured, per `userEnvProbe` mode.
+
+### 25. Lifecycle commands ignored `userEnvProbe` (always login+interactive)
+
+deacon ran every lifecycle command through a **login + interactive** shell
+(`bash -l -i -c`) regardless of `userEnvProbe`, so `none`/`loginShell`/
+`interactiveShell` all behaved like `loginInteractiveShell` — sourcing both
+`/etc/profile` and `~/.bashrc`. The reference varies the shell by mode. Full
+matrix (before fix deacon was `P=[fromprofile] B=[frombashrc]` for **all** four):
+
+| mode | reference | deacon (before) |
+|------|-----------|-----------------|
+| `none` | `P=[] B=[]` | `P=[…] B=[…]` ✗ |
+| `loginShell` | `P=[fromprofile] B=[]` | `P=[…] B=[…]` ✗ |
+| `interactiveShell` | `P=[] B=[frombashrc]` | `P=[…] B=[…]` ✗ |
+| `loginInteractiveShell` | `P=[fromprofile] B=[frombashrc]` | ✓ |
+
+**Fix:** `get_shell_command_for_lifecycle` now takes the `userEnvProbe` mode and
+maps it to the shell's login/interactive flags — `none` → plain `sh -c`,
+`loginShell` → `-l -c`, `interactiveShell` → `-i -c`, `loginInteractiveShell` →
+`-l -i -c`. The default (`loginInteractiveShell`) is unchanged, so the
+feature-installed-tools-on-PATH behavior (nvm/node via interactive rc) is
+preserved — confirmed by the docker `integration_feature_lifecycle` suite. After
+the fix all four modes match the reference byte-for-byte. Unit tests cover each
+mode's flags. (`crates/core/src/container_env_probe.rs`,
+`crates/core/src/container_lifecycle.rs`.)
+
 ## Verified non-bugs
 
+- **Feature typed-option handling is at parity.** A local feature with `string`,
+  `boolean`, and `enum` options, the user setting only one: deacon and the
+  reference both apply the omitted options' **defaults**, stringify `boolean`
+  to `true`/`false`, and pass an **invalid** enum value through unchanged
+  (neither validates enum membership at install time). All cases byte-identical.
+- **`build --image-name` resolves to the feature-extended image (single + multiple
+  names).** `deacon build --image-name a:1 --image-name b:2` on an image+features
+  config tags BOTH names with the layered image (feature marker present), matching
+  the reference.
 - **Feature `containerEnv` with `${...}` shell refs (incl. a *novel* PATH dir) is
   NOT applied — by deacon AND the reference.** Empirically tested a feature whose
   `containerEnv` adds `/opt/novel/bin:${PATH}`, `DERIVED=got-${NOVEL_VAR}`, and


### PR DESCRIPTION
## Summary

Round 5 of Tier-2 parity hardening — **`userEnvProbe` modes**. deacon ran every lifecycle command through a login + interactive shell (`bash -l -i -c`) regardless of `userEnvProbe`, so `none`/`loginShell`/`interactiveShell` all behaved like `loginInteractiveShell` (sourcing both `/etc/profile` and `~/.bashrc`).

Verified against the reference with a Dockerfile that sets `PROFILE_VAR` in `/etc/profile.d` (login) and `BASHRC_VAR` in `~/.bashrc` (interactive); `postCreateCommand` records which the lifecycle env captured:

| mode | reference | deacon (before) | deacon (after) |
|------|-----------|-----------------|----------------|
| `none` | `P=[] B=[]` | `P=[…] B=[…]` ✗ | ✓ |
| `loginShell` | `P=[fromprofile] B=[]` | `P=[…] B=[…]` ✗ | ✓ |
| `interactiveShell` | `P=[] B=[frombashrc]` | `P=[…] B=[…]` ✗ | ✓ |
| `loginInteractiveShell` | `P=[fromprofile] B=[frombashrc]` | ✓ | ✓ |

## Fix

`get_shell_command_for_lifecycle` now takes the `userEnvProbe` mode and maps it to the shell's login/interactive flags:
- `none` → `sh -c` (no startup files)
- `loginShell` → `<shell> -l -c`
- `interactiveShell` → `<shell> -i -c`
- `loginInteractiveShell` → `<shell> -l -i -c` (the default, unchanged)

Because the default is unchanged, feature-installed tools (nvm/node, which hook the interactive rc) stay on `PATH` for `postCreate` — confirmed by the docker `integration_feature_lifecycle` suite (13/13). After the fix all four modes match the reference byte-for-byte.

## Tests
- New/updated unit tests for each mode's shell flags.
- `make test-nextest-fast` (2592 passed); docker `integration_feature_lifecycle`, `lifecycle_parallel_output`, `run_user_commands_feature_lifecycle` all green.

Also recorded two areas verified at parity this session (no fix needed): feature typed-option defaults/bool/enum handling, and `build --image-name` (single + multiple) resolving to the feature-extended image. See `fixtures/parity-corpus/REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)