### PR TITLE
fix(secrets): redact --secrets-file values in lifecycle command output

### DIFF
--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1653,12 +1653,35 @@ impl Docker for CliRuntime {
 
             // Forward child stdout to deacon's stderr when stdout_to_stderr
             // is set. Lifecycle output remains live-streamed, but it lands on
-            // stderr so the result JSON on stdout stays single-document. #113.
+            // stderr so the result JSON on stdout stays single-document (#113)
+            // and is redacted line-by-line so injected secrets (e.g. from
+            // `--secrets-file`) don't leak in command output — matching the
+            // reference CLI's `********`. With no secrets registered (or
+            // `--no-redact`) redaction is a no-op, leaving output unchanged.
             if config.stdout_to_stderr {
-                if let Some(mut stdout) = child.stdout.take() {
+                if let Some(stdout) = child.stdout.take() {
                     tokio::spawn(async move {
+                        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+                        let cfg = crate::redaction::RedactionConfig::default();
+                        let mut reader = BufReader::new(stdout);
                         let mut stderr = tokio::io::stderr();
-                        let _ = tokio::io::copy(&mut stdout, &mut stderr).await;
+                        let mut line = Vec::new();
+                        loop {
+                            line.clear();
+                            // read_until keeps the trailing '\n' (and emits a
+                            // final unterminated line as-is on EOF).
+                            match reader.read_until(b'\n', &mut line).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(_) => {
+                                    let text = String::from_utf8_lossy(&line);
+                                    let redacted = crate::redaction::redact_if_enabled(&text, &cfg);
+                                    if stderr.write_all(redacted.as_bytes()).await.is_err() {
+                                        break;
+                                    }
+                                    let _ = stderr.flush().await;
+                                }
+                            }
+                        }
                     });
                 }
             }

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -329,6 +329,14 @@ pub(crate) async fn execute_up_with_runtime(
     };
     if let Some(secrets) = &secrets_collection {
         for (key, value) in secrets.as_env_vars() {
+            // Register the secret value in the (global) redaction registry so it
+            // doesn't leak into lifecycle command output or logs — parity with
+            // the `build` path and the reference CLI (which prints `********`).
+            // Gated on redaction being enabled so `--no-redact` still surfaces
+            // raw values for debugging.
+            if args.redaction_config.enabled {
+                args.secret_registry.add_secret(value);
+            }
             cli_remote_env
                 .entry(key.clone())
                 .or_insert_with(|| value.clone());

--- a/crates/deacon/tests/integration_up_secrets_redaction.rs
+++ b/crates/deacon/tests/integration_up_secrets_redaction.rs
@@ -1,0 +1,124 @@
+//! Integration test: `up --secrets-file` redacts secret values in lifecycle output.
+//!
+//! Regression guard for the plaintext-leak bug: a secret injected via
+//! `--secrets-file` and echoed by a lifecycle command was streamed to deacon's
+//! stderr verbatim (the reference CLI prints `********`). deacon now registers
+//! `--secrets-file` values in the global redaction registry and redacts the
+//! `stdout_to_stderr` lifecycle stream line-by-line. `--no-redact` still surfaces
+//! the raw value (debugging escape hatch).
+
+use assert_cmd::Command;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+const SECRET: &str = "topsecret_marker_9f3a2b";
+
+/// Run `up` with a `.env` secrets file whose `MY_SECRET` is echoed by
+/// `postCreateCommand`. Returns (stderr, container_id). Caller removes the id.
+fn run_up(temp: &TempDir, extra: &[&str]) -> (String, String) {
+    let dc = temp.path().join(".devcontainer");
+    fs::create_dir_all(&dc).unwrap();
+    fs::write(
+        temp.path().join("secrets.env"),
+        format!("MY_SECRET={SECRET}\n"),
+    )
+    .unwrap();
+    fs::write(
+        dc.join("devcontainer.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "name": "secrets-redaction",
+            "image": "debian:bookworm-slim",
+            "postCreateCommand": "echo \"the-secret-is=$MY_SECRET\""
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let secrets_path = temp.path().join("secrets.env");
+    let mut args = vec![
+        "up",
+        "--workspace-folder",
+        temp.path().to_str().unwrap(),
+        "--remove-existing-container",
+        "--mount-workspace-git-root=false",
+        "--secrets-file",
+        secrets_path.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+
+    let out = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(temp.path())
+        .env("DEACON_LOG", "info")
+        .args(&args)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    let cid = serde_json::from_str::<serde_json::Value>(stdout.trim())
+        .ok()
+        .or_else(|| {
+            stdout
+                .rfind('{')
+                .and_then(|i| serde_json::from_str(&stdout[i..]).ok())
+        })
+        .and_then(|v| v.get("containerId")?.as_str().map(str::to_string))
+        .unwrap_or_default();
+    (stderr, cid)
+}
+
+fn rm(cid: &str) {
+    if !cid.is_empty() {
+        let _ = StdCommand::new("docker").args(["rm", "-f", cid]).output();
+    }
+}
+
+#[test]
+fn secret_value_is_redacted_in_lifecycle_output() {
+    if !is_docker_available() {
+        eprintln!("Skipping secret_value_is_redacted_in_lifecycle_output: Docker not available");
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let (stderr, cid) = run_up(&temp, &[]);
+    rm(&cid);
+
+    // The postCreate ran (its line prefix reaches the stream)...
+    assert!(
+        stderr.contains("the-secret-is="),
+        "postCreate output should be streamed to stderr:\n{stderr}"
+    );
+    // ...but the secret VALUE must not appear in plaintext anywhere.
+    assert!(
+        !stderr.contains(SECRET),
+        "secret value leaked in lifecycle output (should be redacted):\n{stderr}"
+    );
+}
+
+#[test]
+fn no_redact_surfaces_secret_value() {
+    if !is_docker_available() {
+        eprintln!("Skipping no_redact_surfaces_secret_value: Docker not available");
+        return;
+    }
+    let temp = TempDir::new().unwrap();
+    let (stderr, cid) = run_up(&temp, &["--no-redact"]);
+    rm(&cid);
+
+    // The debugging escape hatch leaves the value un-redacted.
+    assert!(
+        stderr.contains(SECRET),
+        "--no-redact should surface the raw secret value:\n{stderr}"
+    );
+}

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -483,27 +483,41 @@ the fix all four modes match the reference byte-for-byte. Unit tests cover each
 mode's flags. (`crates/core/src/container_env_probe.rs`,
 `crates/core/src/container_lifecycle.rs`.)
 
+## Round 6 — `--secrets-file`
+
+### 26. `--secrets-file` secrets leaked in plaintext in lifecycle output
+
+With a secret injected and `postCreateCommand: echo "the secret is $MY_SECRET"`,
+the reference prints `the secret is ********` (redacted) while deacon printed
+`the secret is topsecret123` (**plaintext leak**). deacon redacted lifecycle
+*command strings* (for progress events) but streamed the command *output* through
+`CliDocker::exec` via a raw `tokio::io::copy` with no redaction — and the loaded
+secrets were registered only in a local `SecretsCollection::redaction_registry`,
+never the **global** registry the lifecycle redaction consults. **Fix:** `up`
+now registers the loaded secret values in the global registry (gated on
+redaction being enabled, mirroring the `build` path), and the `stdout_to_stderr`
+lifecycle stream is redacted line-by-line through `redact_if_enabled`. With no
+secrets registered (or `--no-redact`) it's a no-op, so normal output is
+unchanged. Verified: the secret value no longer appears in deacon's output (it's
+replaced by the redaction placeholder), while `--no-redact` still surfaces the
+raw value for debugging. Hermetic docker test
+(`integration_up_secrets_redaction`) asserts both, and fails (leak) if the
+stream fix is reverted. (`crates/deacon/src/commands/up/mod.rs`,
+`crates/core/src/docker.rs`.)
+
 ## Open divergences (confirmed, not yet fixed)
 
-### `--secrets-file`: format mismatch + lifecycle-output secret leak
+### `--secrets-file` format: `.env` vs JSON
 
-Two confirmed divergences (security-sensitive — flagged for a dedicated PR):
-
-1. **File format.** The reference CLI (and the spec) expect `--secrets-file` to be
-   **JSON** (`{"MY_SECRET":"…"}`) — it rejects a `KEY=VALUE` `.env` file with
-   `Error: Invalid json data`. deacon parses **`.env`** (`KEY=VALUE`) and does NOT
-   parse JSON (a JSON file leaves the secret unset). So a reference-format secrets
-   file silently yields empty secrets in deacon, and vice-versa.
-   (`crates/core/src/secrets.rs::parse_secrets_file`.)
-2. **Redaction of lifecycle output.** With a secret injected and
-   `postCreateCommand: echo "the secret is $MY_SECRET"`, the reference prints
-   `the secret is ********` (redacted) while deacon prints
-   `the secret is topsecret123` (**plaintext leak**). deacon redacts lifecycle
-   *command strings* (for progress events) but streams the command *output*
-   through `CliDocker::exec` with no redaction, and loaded secrets are registered
-   only in a local `SecretsCollection::redaction_registry`, not the global
-   registry the lifecycle redaction consults. Fixing this needs the secrets wired
-   into the output-stream redaction path (cross-cutting).
+The reference CLI (and the spec) expect `--secrets-file` to be **JSON**
+(`{"MY_SECRET":"…"}`) — it rejects a `KEY=VALUE` `.env` file with `Error: Invalid
+json data`. deacon parses **`.env`** (`KEY=VALUE`) and does NOT parse JSON (a JSON
+file leaves the secret unset). So a reference-format secrets file silently yields
+empty secrets in deacon, and vice-versa. Switching deacon to JSON is a breaking
+change to its current `.env` contract (and its existing tests), so it's deferred
+as a product decision (accept JSON only, or both?).
+(`crates/core/src/secrets.rs::parse_secrets_file`.) Note the redaction fix (#26)
+is independent of the format.
 
 ## Verified non-bugs
 


### PR DESCRIPTION
## Summary

Round 6 of Tier-2 parity hardening — closes the **secret plaintext leak** found in the previous sweep (#214). A secret injected via `--secrets-file` and echoed by a lifecycle command was streamed to deacon's stderr verbatim, where the reference CLI prints `********`.

Root cause: deacon redacted lifecycle command *strings* (for progress events) but streamed the command *output* through `CliDocker::exec` via a raw `tokio::io::copy` with no redaction — and loaded secrets were registered only in a local `SecretsCollection::redaction_registry`, never the **global** registry the lifecycle redaction consults.

## Fix
- `up` now registers the loaded secret values in the **global** redaction registry, gated on `redaction_config.enabled` (mirroring the existing `build` path), so `--no-redact` still surfaces raw values for debugging.
- The `stdout_to_stderr` lifecycle stream is redacted **line-by-line** via `redact_if_enabled`. With no secrets registered (or `--no-redact`) it's a no-op, so normal lifecycle output is byte-unchanged.

## Verification
```
deacon (default):    the secret is ****            leaked_plaintext=0
deacon --no-redact:  the secret is topsecret123    (raw, intended)
```
- Hermetic docker test `integration_up_secrets_redaction` asserts the secret value is **absent** under default redaction and **present** under `--no-redact`; it fails (leak detected) if the stream fix is reverted.
- `make test-nextest-fast` (2592 passed); docker `integration_feature_lifecycle`, `lifecycle_parallel_output`, `up_lifecycle_recovery`, `smoke_compose_override_command` all green (line-buffering change doesn't regress normal output).

## Still open (documented, not in this PR)
The `--secrets-file` **format** divergence — deacon parses `.env` (`KEY=VALUE`), the reference/spec expect JSON. Switching is a breaking change to deacon's current contract, deferred as a product decision. The redaction fix is independent of the format. See `fixtures/parity-corpus/REPORT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)