### PR TITLE
fix(secrets): accept JSON --secrets-file (reference/spec format)

### DIFF
--- a/crates/core/src/secrets.rs
+++ b/crates/core/src/secrets.rs
@@ -1,17 +1,19 @@
 //! Secrets file parsing and management
 //!
-//! This module handles parsing and management of secrets files in KEY=VALUE format,
-//! supports multiple files with conflict resolution (later wins), and provides
-//! integration with the redaction system.
+//! This module parses secrets files (JSON or `.env`), supports multiple files
+//! with conflict resolution (later wins), and integrates with the redaction
+//! system.
 //!
 //! ## File Format
 //!
-//! Secrets files support:
-//! - KEY=VALUE format (one per line)
-//! - Empty lines (ignored)
-//! - Comments starting with # (ignored)
-//! - Values may contain spaces and special characters
-//! - No quotes around values (taken literally)
+//! Two formats are accepted (auto-detected by a leading `{`):
+//!
+//! - **JSON** — a flat object `{"KEY": "value", ...}`, the format used by the
+//!   reference CLI and the containers.dev spec. Non-string values are coerced to
+//!   their string form.
+//! - **`.env`** (`KEY=VALUE`, one per line) — deacon's original format, retained
+//!   for backwards compatibility. Empty lines and `#` comments are ignored;
+//!   values are taken literally (no quoting) and may contain spaces.
 //!
 //! ## Example
 //!
@@ -116,6 +118,15 @@ impl SecretsCollection {
         let content =
             fs::read_to_string(file_path).map_err(|e| DeaconError::Config(ConfigError::Io(e)))?;
 
+        // Accept BOTH formats: the reference CLI / spec use a flat JSON object
+        // (`{"KEY":"value"}`); deacon historically used `.env` (`KEY=VALUE`). A
+        // leading `{` (after whitespace) selects JSON, otherwise fall back to
+        // KEY=VALUE. The two are syntactically disjoint, so detection is
+        // unambiguous and JSON support is purely additive (no `.env` regression).
+        if content.trim_start().starts_with('{') {
+            return Self::parse_secrets_json(file_path, &content);
+        }
+
         let mut secrets = HashMap::new();
 
         for (line_num, line) in content.lines().enumerate() {
@@ -150,6 +161,39 @@ impl SecretsCollection {
                     line
                 );
             }
+        }
+
+        Ok(secrets)
+    }
+
+    /// Parse a flat JSON object secrets file (`{"KEY":"value", ...}`), matching
+    /// the reference CLI / containers.dev spec. Non-string values are coerced to
+    /// their string form (number/bool → literal, object/array → compact JSON,
+    /// null → empty) so a value type doesn't hard-fail injection.
+    fn parse_secrets_json(file_path: &Path, content: &str) -> Result<HashMap<String, String>> {
+        let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(content)
+            .map_err(|e| {
+                DeaconError::Config(ConfigError::Validation {
+                    message: format!("Invalid JSON secrets file {}: {}", file_path.display(), e),
+                })
+            })?;
+
+        let mut secrets = HashMap::new();
+        for (key, value) in map {
+            if key.is_empty() {
+                warn!(
+                    "Empty key found in JSON secrets file {}",
+                    file_path.display()
+                );
+                continue;
+            }
+            let value = match value {
+                serde_json::Value::String(s) => s,
+                serde_json::Value::Null => String::new(),
+                other => other.to_string(),
+            };
+            debug!("Parsed secret key: {}", key);
+            secrets.insert(key, value);
         }
 
         Ok(secrets)
@@ -210,6 +254,53 @@ mod tests {
         let secrets = SecretsCollection::parse_secrets_file(&secrets_file)?;
         assert!(secrets.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn test_parse_json_secrets_file() -> Result<()> {
+        // Reference / spec format: a flat JSON object. Non-string values are
+        // coerced to their string form.
+        let temp_dir = TempDir::new().unwrap();
+        let secrets_file = temp_dir.path().join("secrets.json");
+        fs::write(
+            &secrets_file,
+            r#"{ "MY_SECRET": "topsecret", "NUM": 42, "FLAG": true }"#,
+        )
+        .unwrap();
+
+        let secrets = SecretsCollection::parse_secrets_file(&secrets_file)?;
+        assert_eq!(secrets.len(), 3);
+        assert_eq!(secrets.get("MY_SECRET"), Some(&"topsecret".to_string()));
+        assert_eq!(secrets.get("NUM"), Some(&"42".to_string()));
+        assert_eq!(secrets.get("FLAG"), Some(&"true".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_detected_by_leading_brace_with_whitespace() -> Result<()> {
+        // Leading whitespace before `{` still selects JSON (not KEY=VALUE).
+        let temp_dir = TempDir::new().unwrap();
+        let secrets_file = temp_dir.path().join("secrets.txt");
+        fs::write(&secrets_file, "\n  { \"K\": \"v\" }\n").unwrap();
+        let secrets = SecretsCollection::parse_secrets_file(&secrets_file)?;
+        assert_eq!(secrets.get("K"), Some(&"v".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_json_secrets_file_errors() {
+        // A `{`-leading file that isn't valid JSON fails fast (no silent
+        // fallback to KEY=VALUE parsing).
+        let temp_dir = TempDir::new().unwrap();
+        let secrets_file = temp_dir.path().join("secrets.json");
+        fs::write(&secrets_file, r#"{ "MY_SECRET": "x",, }"#).unwrap();
+        let result = SecretsCollection::parse_secrets_file(&secrets_file);
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("Invalid JSON secrets file"),
+            "expected JSON parse error, got: {msg}"
+        );
     }
 
     #[test]

--- a/docs/DIFFERENTIATORS.md
+++ b/docs/DIFFERENTIATORS.md
@@ -1,0 +1,56 @@
+# What makes Deacon unique (net-positive differentiators)
+
+A living list of places where Deacon **intentionally does more (or better)** than the
+reference Dev Containers CLI (`@devcontainers/cli`) while staying spec-compliant — the
+kind of thing worth calling out in a blog post or on the project page.
+
+> Scope rule: entries here must be *net-positive* differences a user would be glad
+> about (better DX, security, performance, robustness) — **not** spec divergences
+> that are bugs. Bugs/divergences-to-fix live in `fixtures/parity-corpus/REPORT.md`.
+> When you land a change that makes Deacon distinctively better, add it here.
+
+## Developer experience
+
+- **`--secrets-file` accepts both JSON *and* `.env`.** The reference CLI (and the
+  spec) require a flat JSON object and reject a `KEY=VALUE` file with
+  `Error: Invalid json data`. Deacon auto-detects the format (leading `{` → JSON,
+  otherwise `KEY=VALUE`) and accepts either. JSON support is a strict superset, so a
+  user can drop in the `.env` file they already have for `docker`/`compose` instead of
+  hand-converting it to JSON. (`crates/core/src/secrets.rs`.)
+
+## Capability
+
+- **`extends` is resolved for `up` and `read-configuration --include-merged-configuration`.**
+  The reference CLI v0.87.0 errors on a config that uses `extends`
+  (`up`: "missing one of image/dockerFile/dockerComposeFile"; merged read-config:
+  exit 1, empty stdout). Deacon resolves the full extends chain — base `image`,
+  merged `containerEnv`, merged `forwardPorts`, etc. — so multi-file config
+  composition just works.
+
+## Robustness
+
+- **Valid compose project names where the reference fails.** Both derive the compose
+  project name from the workspace folder; the reference emits it verbatim, so a folder
+  like `-myproj` produces an invalid `--project-name` that `docker compose` rejects
+  (exit 1). Deacon trims leading separators / falls back to a safe stem, so the same
+  folder still comes up. (Normal folders produce the identical `<folder>_devcontainer`
+  name as the reference.) (`crates/core/src/compose.rs`.)
+
+## Security
+
+- **Workspace-trust gate for host-side lifecycle hooks.** `initializeCommand` (and
+  future workspace-resident host hooks) run on the developer's host *before* any
+  container sandboxing. Deacon gates these behind an explicit trust opt-in
+  (`--trust-workspace[-persist]`, a persisted allowlist, or `DEACON_NO_PROMPT=1` to
+  fail closed in CI) — a protection the upstream spec does not mandate. See
+  `SECURITY.md` and `crates/core/src/trust.rs`.
+
+## Performance & deployment
+
+- **Single static Rust binary, no Node.js runtime.** Deacon ships as one native
+  executable — nothing to `npm install`, no Node version to manage — which makes it
+  cheap to drop into CI images and constrained environments.
+- **Container environment-probe caching.** The shared `resolve_env_and_user()` path
+  caches the per-container user-env probe (`{cache_folder}/env_probe_*`), giving a
+  10–50× speedup (90–98% latency reduction) on repeat invocations across
+  `up`/`exec`/`run-user-commands`. See `docs/ARCHITECTURE.md`.

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -505,19 +505,21 @@ raw value for debugging. Hermetic docker test
 stream fix is reverted. (`crates/deacon/src/commands/up/mod.rs`,
 `crates/core/src/docker.rs`.)
 
-## Open divergences (confirmed, not yet fixed)
+### 27. `--secrets-file` did not accept the reference's JSON format
 
-### `--secrets-file` format: `.env` vs JSON
-
-The reference CLI (and the spec) expect `--secrets-file` to be **JSON**
-(`{"MY_SECRET":"…"}`) — it rejects a `KEY=VALUE` `.env` file with `Error: Invalid
-json data`. deacon parses **`.env`** (`KEY=VALUE`) and does NOT parse JSON (a JSON
-file leaves the secret unset). So a reference-format secrets file silently yields
-empty secrets in deacon, and vice-versa. Switching deacon to JSON is a breaking
-change to its current `.env` contract (and its existing tests), so it's deferred
-as a product decision (accept JSON only, or both?).
-(`crates/core/src/secrets.rs::parse_secrets_file`.) Note the redaction fix (#26)
-is independent of the format.
+The reference CLI (and the containers.dev spec) expect `--secrets-file` to be a
+flat **JSON** object (`{"MY_SECRET":"…"}`) — it rejects a `KEY=VALUE` `.env` file
+with `Error: Invalid json data`. deacon parsed only `.env` and silently left
+secrets unset when given a reference-format JSON file. **Fix:** `parse_secrets_file`
+now accepts **both** — a leading `{` (after whitespace) selects JSON, otherwise
+`KEY=VALUE`. The two are syntactically disjoint, so JSON support is purely additive
+(no `.env` regression) and a deacon superset of the reference. Non-string JSON
+values are coerced to their string form (number/bool literal, object/array as
+compact JSON, null → empty); a `{`-leading file that isn't valid JSON fails fast
+with a clear error (no silent fallback). Verified end-to-end: a JSON secrets file
+injects + redacts under deacon exactly as under the reference, and the existing
+`.env` path is unchanged. Unit tests cover JSON parsing, whitespace-led detection,
+non-string coercion, and the invalid-JSON error. (`crates/core/src/secrets.rs`.)
 
 ## Verified non-bugs
 


### PR DESCRIPTION
## Summary

Closes the `--secrets-file` **format** divergence documented in #214/#215. The reference CLI and the containers.dev spec expect a flat **JSON** object (`{"MY_SECRET":"…"}`) — it rejects a `.env` file with `Error: Invalid json data`. deacon parsed only `.env` (`KEY=VALUE`) and silently left secrets unset when given a JSON file.

## Fix

`parse_secrets_file` now accepts **both** formats, auto-detected: a leading `{` (after whitespace) selects JSON, otherwise `KEY=VALUE`. The two are syntactically disjoint, so JSON support is **purely additive** — no `.env` regression — and a deacon superset of the reference (a user with either format now works).

- Non-string JSON values are coerced to their string form (number/bool literal, object/array → compact JSON, null → empty), matching the reference's lenient acceptance.
- A `{`-leading file that isn't valid JSON **fails fast** with a clear `Invalid JSON secrets file …` error (no silent fallback to `KEY=VALUE`).

## Verification
- JSON secrets file injects + redacts under deacon exactly as under the reference (`got=****`, no plaintext leak); `.env` path unchanged.
- New unit tests: JSON parsing + non-string coercion, whitespace-led `{` detection, invalid-JSON error. Existing `.env` tests unchanged.
- `make test-nextest-fast` (2595 passed); docker `integration_up_secrets_redaction` green.

This completes the `--secrets-file` parity work (redaction was #215; format is this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)