### PR TITLE
fix(parity): real-world corpus fixes for read-config/up/exec (#218–#224)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -2564,6 +2564,7 @@ impl ConfigLoader {
         override_config_path: Option<&Path>,
         secrets: Option<&crate::secrets::SecretsCollection>,
         workspace_path: &Path,
+        resolve_devcontainer_id: bool,
     ) -> Result<(DevContainerConfig, crate::variable::SubstitutionReport)> {
         debug!(
             "Loading configuration with overrides and substitution from {}",
@@ -2596,6 +2597,10 @@ impl ConfigLoader {
 
         // Apply variable substitution with secrets
         let mut substitution_context = crate::variable::SubstitutionContext::new(workspace_path)?;
+        // `read-configuration` defers `${devcontainerId}` to a container-aware
+        // pass (it has no container identity yet), so it asks us to leave the
+        // token literal. Runtime callers (`up`/`exec`/…) keep the default.
+        substitution_context.resolve_devcontainer_id = resolve_devcontainer_id;
 
         // When the config sets an explicit `workspaceFolder`, that IS the
         // container workspace folder, so `${containerWorkspaceFolder}` can be
@@ -3755,6 +3760,7 @@ mod tests {
                 None,
                 None,
                 temp_dir.path(),
+                true,
             ))
             .unwrap();
         assert_eq!(

--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -618,6 +618,7 @@ impl ContainerEnvironmentProber {
                 container_env: Some(probed_env.clone()),
                 feature_vars: HashMap::new(),
                 template_options: None,
+                resolve_devcontainer_id: true,
             };
             let mut report = crate::variable::SubstitutionReport::new();
             for (k, v_opt) in remote {

--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -788,6 +788,88 @@ fn strip_oci_tag(reference: &str) -> &str {
     }
 }
 
+/// Resolves a feature reference written in *features-object* form (the same
+/// syntax used for `dependsOn`/`installsAfter`/`overrideFeatureInstallOrder`)
+/// to the canonical `ResolvedFeature.id`.
+///
+/// A reference may be spelled as the canonical id, the metadata id, or the
+/// fetch-time source (a local path or full OCI ref), and OCI refs are matched
+/// tag-insensitively. Building the lookup maps once lets both dependency-graph
+/// construction and `overrideFeatureInstallOrder` translation share the exact
+/// same matching rules (#218).
+struct FeatureIdResolver {
+    feature_ids: HashSet<String>,
+    alias_to_canonical: HashMap<String, String>,
+    source_to_canonical: HashMap<String, String>,
+    source_notag_to_canonical: HashMap<String, String>,
+}
+
+impl FeatureIdResolver {
+    fn new(features: &[ResolvedFeature]) -> Self {
+        let feature_ids: HashSet<String> = features.iter().map(|f| f.id.clone()).collect();
+
+        // Map a feature's metadata id to its canonical id, but only when it
+        // does not itself collide with a real canonical id (so OCI features
+        // keyed by their short metadata id stay unambiguous).
+        let mut alias_to_canonical: HashMap<String, String> = HashMap::new();
+        for feature in features {
+            let meta_id = &feature.metadata.id;
+            if !meta_id.is_empty() && meta_id != &feature.id && !feature_ids.contains(meta_id) {
+                alias_to_canonical
+                    .entry(meta_id.clone())
+                    .or_insert_with(|| feature.id.clone());
+            }
+        }
+
+        // Map each candidate `source` (and its tag-stripped form, plus the
+        // tag-stripped canonical id) to a canonical id.
+        let mut source_to_canonical: HashMap<String, String> = HashMap::new();
+        let mut source_notag_to_canonical: HashMap<String, String> = HashMap::new();
+        for feature in features {
+            source_to_canonical
+                .entry(feature.source.clone())
+                .or_insert_with(|| feature.id.clone());
+            let src_notag = strip_oci_tag(&feature.source);
+            source_notag_to_canonical
+                .entry(src_notag.to_string())
+                .or_insert_with(|| feature.id.clone());
+            let id_notag = strip_oci_tag(&feature.id);
+            source_notag_to_canonical
+                .entry(id_notag.to_string())
+                .or_insert_with(|| feature.id.clone());
+        }
+
+        Self {
+            feature_ids,
+            alias_to_canonical,
+            source_to_canonical,
+            source_notag_to_canonical,
+        }
+    }
+
+    /// Resolve `dep_id` to a canonical id, or `None` when no feature matches.
+    fn resolve(&self, dep_id: &str) -> Option<String> {
+        // 1. Exact canonical id.
+        if self.feature_ids.contains(dep_id) {
+            return Some(dep_id.to_string());
+        }
+        // 2. Metadata-id alias.
+        if let Some(canonical) = self.alias_to_canonical.get(dep_id) {
+            return Some(canonical.clone());
+        }
+        // 3. Exact features-object reference (source) form.
+        if let Some(canonical) = self.source_to_canonical.get(dep_id) {
+            return Some(canonical.clone());
+        }
+        // 4. Tag-insensitive OCI ref match (key and/or candidate without tag).
+        let dep_notag = strip_oci_tag(dep_id);
+        if let Some(canonical) = self.source_notag_to_canonical.get(dep_notag) {
+            return Some(canonical.clone());
+        }
+        None
+    }
+}
+
 /// Feature dependency resolver that builds DAG and performs topological sort
 #[derive(Debug)]
 pub struct FeatureDependencyResolver {
@@ -809,8 +891,25 @@ impl FeatureDependencyResolver {
     ) -> std::result::Result<InstallationPlan, FeatureError> {
         debug!("Resolving dependencies for {} features", features.len());
 
+        // Translate `overrideFeatureInstallOrder` entries (written in
+        // features-object form, e.g. `ghcr.io/devcontainers/features/common-utils`
+        // or `./local-feature`) to canonical `ResolvedFeature.id`s before
+        // validating/sorting. Different resolution paths canonicalize OCI
+        // features differently (the short metadata id in read-configuration vs.
+        // the registry path in up/build), so an exact string match against the
+        // override list is unreliable and previously crashed when local + OCI
+        // features coexisted (#218). Unmatched entries are preserved so the
+        // validation step still reports them with the user's spelling.
+        let override_order = self.override_order.as_ref().map(|order| {
+            let id_resolver = FeatureIdResolver::new(features);
+            order
+                .iter()
+                .map(|entry| id_resolver.resolve(entry).unwrap_or_else(|| entry.clone()))
+                .collect::<Vec<_>>()
+        });
+
         // Validate all features exist in override order
-        if let Some(ref override_order) = self.override_order {
+        if let Some(ref override_order) = override_order {
             self.validate_override_order(features, override_order)?;
         }
 
@@ -821,8 +920,7 @@ impl FeatureDependencyResolver {
         let levels = self.compute_parallel_levels(&graph)?;
 
         // Apply override order constraints if present
-        let (sorted_features, final_levels) = if let Some(ref override_order) = self.override_order
-        {
+        let (sorted_features, final_levels) = if let Some(ref override_order) = override_order {
             // Priority topological sort: features listed in
             // `overrideFeatureInstallOrder` are preferred (in the listed order)
             // among the ready set each round; the rest tie-break lexicographically
@@ -884,77 +982,17 @@ impl FeatureDependencyResolver {
         features: &[ResolvedFeature],
     ) -> std::result::Result<HashMap<String, HashSet<String>>, FeatureError> {
         let mut graph: HashMap<String, HashSet<String>> = HashMap::new();
-        let feature_ids: HashSet<String> = features.iter().map(|f| f.id.clone()).collect();
 
-        // Per spec (https://containers.dev/implementors/features/#dependson),
-        // `dependsOn`/`installsAfter` reference features by their canonical
-        // `id`. For local features our canonical lookup key is the absolute
-        // path (e.g. `local:/abs/path/feature-a`), but authors write the
-        // sibling's metadata id (`feature-a`). Build an alias map so both
-        // spellings resolve. The metadata id is overridden by a real
-        // `ResolvedFeature.id` collision so OCI features remain unambiguous.
-        let mut alias_to_canonical: HashMap<String, String> = HashMap::new();
-        for feature in features {
-            let meta_id = &feature.metadata.id;
-            if !meta_id.is_empty() && meta_id != &feature.id && !feature_ids.contains(meta_id) {
-                alias_to_canonical
-                    .entry(meta_id.clone())
-                    .or_insert_with(|| feature.id.clone());
-            }
-        }
-
-        // Per spec (https://containers.dev/implementors/features/#installation-order),
-        // `dependsOn`/`installsAfter` keys use "the same syntax as the `features`
-        // object". That means besides the canonical `id` and the metadata-`id`
-        // alias, a key may be the *features-object reference form* that was used to
-        // fetch the feature — i.e. `ResolvedFeature.source`. This covers:
-        //   * local relative/absolute paths (`./feature-lib`, `../x`, `/abs`), and
-        //   * full/partial OCI refs (`ghcr.io/owner/repo/feat:1`).
-        //
-        // For OCI refs we also match tag-insensitively: a key without a version/tag
-        // should match a candidate whose only difference is the trailing `:tag`
-        // (and vice versa). Local paths are compared as exact strings since they use
-        // identical syntax on both sides.
-
-        // Map each candidate `source` (and its tag-stripped form) to a canonical id.
-        let mut source_to_canonical: HashMap<String, String> = HashMap::new();
-        let mut source_notag_to_canonical: HashMap<String, String> = HashMap::new();
-        for feature in features {
-            source_to_canonical
-                .entry(feature.source.clone())
-                .or_insert_with(|| feature.id.clone());
-            let src_notag = strip_oci_tag(&feature.source);
-            source_notag_to_canonical
-                .entry(src_notag.to_string())
-                .or_insert_with(|| feature.id.clone());
-            // Also index the canonical id without its tag so a tagless dep key can
-            // match an `id` that carries a tag.
-            let id_notag = strip_oci_tag(&feature.id);
-            source_notag_to_canonical
-                .entry(id_notag.to_string())
-                .or_insert_with(|| feature.id.clone());
-        }
-
-        let resolve_dep = |dep_id: &str| -> Option<String> {
-            // 1. Exact canonical id.
-            if feature_ids.contains(dep_id) {
-                return Some(dep_id.to_string());
-            }
-            // 2. Metadata-id alias.
-            if let Some(canonical) = alias_to_canonical.get(dep_id) {
-                return Some(canonical.clone());
-            }
-            // 3. Exact features-object reference (source) form.
-            if let Some(canonical) = source_to_canonical.get(dep_id) {
-                return Some(canonical.clone());
-            }
-            // 4. Tag-insensitive OCI ref match (key and/or candidate without tag).
-            let dep_notag = strip_oci_tag(dep_id);
-            if let Some(canonical) = source_notag_to_canonical.get(dep_notag) {
-                return Some(canonical.clone());
-            }
-            None
-        };
+        // Per spec (https://containers.dev/implementors/features/#dependson and
+        // #installation-order), `dependsOn`/`installsAfter` keys use "the same
+        // syntax as the `features` object": the canonical `id`, the metadata
+        // `id` alias (e.g. a local feature referenced by its sibling's short
+        // id), or the fetch-time `source` (local path or full/partial OCI ref,
+        // matched tag-insensitively). `FeatureIdResolver` encapsulates exactly
+        // those rules and is shared with `overrideFeatureInstallOrder`
+        // translation in `resolve()`.
+        let id_resolver = FeatureIdResolver::new(features);
+        let resolve_dep = |dep_id: &str| -> Option<String> { id_resolver.resolve(dep_id) };
 
         // Initialize graph with all feature IDs
         for feature in features {
@@ -2540,6 +2578,57 @@ mod tests {
         } else {
             panic!("Expected dependency resolution error");
         }
+    }
+
+    #[test]
+    fn test_override_order_accepts_full_oci_ref_against_short_canonical_id() {
+        // Regression for #218: `read-configuration` canonicalizes OCI features
+        // to their short metadata id (`common-utils`), but the user writes the
+        // full registry ref in `overrideFeatureInstallOrder`
+        // (`ghcr.io/devcontainers/features/common-utils`). The resolver must
+        // translate the override entry to the canonical id instead of crashing
+        // with "does not exist in feature set" — including when a local feature
+        // (canonical `local:/abs/path`) coexists.
+        let common_utils = ResolvedFeature {
+            id: "common-utils".to_string(),
+            source: "ghcr.io/devcontainers/features/common-utils:2".to_string(),
+            options: HashMap::new(),
+            metadata: FeatureMetadata {
+                id: "common-utils".to_string(),
+                ..create_test_feature("common-utils", vec![], HashMap::new()).metadata
+            },
+        };
+        let node = ResolvedFeature {
+            id: "node".to_string(),
+            source: "ghcr.io/devcontainers/features/node:1".to_string(),
+            options: HashMap::new(),
+            metadata: FeatureMetadata {
+                id: "node".to_string(),
+                ..create_test_feature("node", vec![], HashMap::new()).metadata
+            },
+        };
+        let apache = ResolvedFeature {
+            id: "local:/abs/path/apache-config".to_string(),
+            source: "./local-features/apache-config".to_string(),
+            options: HashMap::new(),
+            metadata: FeatureMetadata {
+                id: "apache-config".to_string(),
+                ..create_test_feature("apache-config", vec![], HashMap::new()).metadata
+            },
+        };
+        let features = vec![common_utils, node, apache];
+
+        let resolver = FeatureDependencyResolver::new(Some(vec![
+            "ghcr.io/devcontainers/features/common-utils".to_string(),
+        ]));
+        let plan = resolver
+            .resolve(&features)
+            .expect("full OCI ref in override order must resolve to the short canonical id");
+        let ids = plan.feature_ids();
+
+        // The override-listed feature installs first; the rest follow.
+        assert_eq!(ids.first().map(String::as_str), Some("common-utils"));
+        assert_eq!(ids.len(), 3);
     }
 
     #[test]

--- a/crates/core/src/mount.rs
+++ b/crates/core/src/mount.rs
@@ -451,6 +451,25 @@ pub fn merge_mounts(
 
     // Process config mounts (these override features)
     for mount_value in config_mounts {
+        // Config mounts are normally substituted upstream during config load.
+        // But mounts contributed by the image's `devcontainer.metadata` LABEL
+        // are merged in *after* that pass (see
+        // `merge_image_metadata_after_image_ready`), so they can still carry
+        // literal tokens like `${devcontainerId}`. Run them through the same
+        // substitution context as feature mounts before parsing — substitution
+        // is idempotent, so already-resolved config mounts are unaffected (#224).
+        let substituted_mount_value: serde_json::Value;
+        let mount_value = if let Some(ctx) = substitution_context {
+            let mut report = crate::variable::SubstitutionReport::new();
+            substituted_mount_value = crate::variable::VariableSubstitution::substitute_json_value(
+                mount_value,
+                ctx,
+                &mut report,
+            );
+            &substituted_mount_value
+        } else {
+            mount_value
+        };
         let mount_str = match mount_value {
             serde_json::Value::String(s) => s.clone(),
             serde_json::Value::Object(obj) => {
@@ -1741,6 +1760,37 @@ mod merge_mounts_tests {
         assert!(
             mount.contains("dind-var-lib-docker-abc123def456"),
             "expected substituted volume name; got: {mount}"
+        );
+        assert!(
+            !mount.contains("${devcontainerId}"),
+            "literal token must not survive into docker mount string"
+        );
+    }
+
+    #[test]
+    fn test_merge_mounts_config_mount_with_devcontainer_id_substitution() {
+        // Per #224: a config mount source containing ${devcontainerId} (e.g.
+        // contributed by an image's devcontainer.metadata label, which is
+        // merged into config.mounts AFTER the up substitution pass) must also
+        // be substituted before reaching Docker. Substitution is idempotent, so
+        // already-resolved config mounts are unaffected.
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut ctx = crate::variable::SubstitutionContext::new(temp.path()).unwrap();
+        ctx.devcontainer_id = "abc123def456".to_string();
+
+        let config_mounts = vec![serde_json::json!({
+            "source": "dind-var-lib-docker-${devcontainerId}",
+            "target": "/var/lib/docker",
+            "type": "volume"
+        })];
+        let features = vec![];
+
+        let result = merge_mounts(&config_mounts, &features, Some(&ctx)).unwrap();
+        assert_eq!(result.mounts.len(), 1);
+        let mount = &result.mounts[0];
+        assert!(
+            mount.contains("dind-var-lib-docker-abc123def456"),
+            "expected substituted config volume name; got: {mount}"
         );
         assert!(
             !mount.contains("${devcontainerId}"),

--- a/crates/core/src/variable.rs
+++ b/crates/core/src/variable.rs
@@ -81,6 +81,15 @@ pub struct SubstitutionContext {
     pub feature_vars: HashMap<String, String>,
     /// Template option values (for template variable substitution)
     pub template_options: Option<HashMap<String, String>>,
+    /// Whether `${devcontainerId}` should be resolved in this pass.
+    ///
+    /// The reference CLI only resolves `${devcontainerId}` once a container
+    /// identity exists (during `up`/runtime). At config-load /
+    /// `read-configuration` time — before any container has been created — the
+    /// token is left literal. Defaults to `true` so runtime substitution passes
+    /// (which set `devcontainer_id` to a meaningful value) keep resolving it;
+    /// `read-configuration`'s pre-container output passes set this to `false`.
+    pub resolve_devcontainer_id: bool,
 }
 
 impl SubstitutionContext {
@@ -152,6 +161,7 @@ impl SubstitutionContext {
             container_env: None,
             feature_vars: HashMap::new(),
             template_options: None,
+            resolve_devcontainer_id: true,
         })
     }
 
@@ -461,7 +471,15 @@ impl VariableSubstitution {
                     .map(|s| s.to_string_lossy().into_owned())
                     .unwrap_or_default(),
             ),
-            "devcontainerId" => Some(context.devcontainer_id.clone()),
+            // Per the reference CLI, `${devcontainerId}` is only resolved once a
+            // container identity exists. When `resolve_devcontainer_id` is false
+            // (config-load / `read-configuration` output before any container),
+            // return None so the literal token is preserved for a later
+            // container-aware pass — mirroring the `containerEnv` deferral above.
+            "devcontainerId" if context.resolve_devcontainer_id => {
+                Some(context.devcontainer_id.clone())
+            }
+            "devcontainerId" => None,
             "containerWorkspaceFolder" => context.container_workspace_folder.clone(),
             "containerWorkspaceFolderBasename" => {
                 context.container_workspace_folder.as_ref().map(|p| {
@@ -682,6 +700,37 @@ mod tests {
         assert!(result.starts_with("container-"));
         assert_eq!(result.len(), "container-".len() + 12); // 12-char ID
         assert!(report.replacements.contains_key("devcontainerId"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_devcontainer_id_left_literal_when_disabled() -> anyhow::Result<()> {
+        // Parity (#219): before a container identity exists,
+        // `${devcontainerId}` must survive substitution as a literal while
+        // other variables still resolve.
+        let temp_dir = TempDir::new()?;
+        let mut context = SubstitutionContext::new(temp_dir.path())?;
+        context.resolve_devcontainer_id = false;
+        let mut report = SubstitutionReport::new();
+
+        let input = "vol-${devcontainerId}-${localWorkspaceFolderBasename}";
+        let result = VariableSubstitution::substitute_string(input, &context, &mut report);
+
+        assert!(
+            result.starts_with("vol-${devcontainerId}-"),
+            "devcontainerId should remain literal, got: {result}"
+        );
+        assert!(
+            !report.replacements.contains_key("devcontainerId"),
+            "devcontainerId must not be recorded as replaced"
+        );
+        assert!(
+            report
+                .replacements
+                .contains_key("localWorkspaceFolderBasename"),
+            "other variables must still resolve"
+        );
 
         Ok(())
     }

--- a/crates/core/tests/integration_override_secrets.rs
+++ b/crates/core/tests/integration_override_secrets.rs
@@ -64,6 +64,7 @@ UNUSED_SECRET=ignored-value
         Some(&override_config_path),
         Some(&secrets),
         temp_dir.path(),
+        true,
     )
     .await?;
 

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -556,6 +556,7 @@ pub async fn execute_build(mut args: BuildArgs) -> Result<()> {
         config_path: args.config_path.as_deref(),
         override_config_path: args.override_config_path.as_deref(),
         secrets_files: &args.secrets_files,
+        resolve_devcontainer_id: true,
     })
     .await?;
 

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -523,6 +523,7 @@ where
                     config_path: args.config_path.as_deref(),
                     override_config_path: args.override_config_path.as_deref(),
                     secrets_files: &args.secrets_files,
+                    resolve_devcontainer_id: true,
                 })
                 .await
                 .map_err(map_config_error)?,
@@ -611,15 +612,30 @@ where
         if let Some(config_ctx) = resolved_config.as_ref() {
             let resolved = match docker_client.inspect_container(&container_id).await {
                 Ok(Some(container_info)) => {
+                    // #223: `up` resolves `remoteUser` (and other fields) from the
+                    // image's `devcontainer.metadata` LABEL as a lower-precedence
+                    // layer. `exec` only loads the raw devcontainer.json, so a
+                    // remoteUser that lives solely in image metadata (e.g.
+                    // vscode-remote-try-node's `node`) would be lost and exec would
+                    // fall back to `root`. Re-apply that same image-metadata merge
+                    // against the running container's image before resolving the
+                    // effective config, so exec runs as the same user `up` reported.
+                    let base =
+                        crate::commands::up::merged_config::merge_image_metadata_after_image_ready(
+                            docker_client,
+                            &container_info.image,
+                            config_ctx.config.clone(),
+                        )
+                        .await;
                     match deacon_core::config::ConfigMerger::resolve_effective_config(
-                        &config_ctx.config,
+                        &base,
                         Some(&container_info.labels),
                         config_ctx.workspace_folder.as_path(),
                     ) {
                         Ok((resolved_config, _report)) => resolved_config,
                         Err(e) => {
                             tracing::warn!("Failed to resolve effective config with labels: {}", e);
-                            config_ctx.config.clone()
+                            base
                         }
                     }
                 }

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -1082,6 +1082,9 @@ async fn compute_merged_configuration<C: deacon_core::oci::HttpClient>(
 
         // Apply variable substitution to the derived config
         let mut substitution_context = SubstitutionContext::new(Path::new("."))?;
+        // This branch only runs without a container identity, so leave
+        // ${devcontainerId} literal in feature-provided mounts too (#219).
+        substitution_context.resolve_devcontainer_id = container_context.is_some();
         if let Some(secrets) = secrets {
             for (key, value) in secrets.as_env_vars() {
                 substitution_context
@@ -1313,6 +1316,9 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
             config_path: args.config_path.as_deref(),
             override_config_path: args.override_config_path.as_deref(),
             secrets_files: &args.secrets_files,
+            // read-configuration has no container identity yet: leave
+            // ${devcontainerId} literal in the output, matching the reference.
+            resolve_devcontainer_id: false,
         })
         .await?;
         resolved_config_path = Some(config_result.config_path);
@@ -1499,6 +1505,8 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         if !container_only_mode && container_info.is_none() && config.workspace_folder.is_none() {
             let mut ctx = SubstitutionContext::new(workspace_folder)?;
             ctx.container_workspace_folder = Some(ctx.local_workspace_folder.clone());
+            // No container identity yet: keep ${devcontainerId} literal (#219).
+            ctx.resolve_devcontainer_id = false;
             if let Some(secrets) = &secrets {
                 for (key, value) in secrets.as_env_vars() {
                     ctx.local_env.insert(key.clone(), value.clone());
@@ -1529,6 +1537,8 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
                     raw.apply_variable_substitution(ctx).0
                 } else {
                     let mut ctx = SubstitutionContext::new(workspace_folder)?;
+                    // No container identity yet: keep ${devcontainerId} literal (#219).
+                    ctx.resolve_devcontainer_id = false;
                     // Mirror the shared loader (fix #4) + Divergence A seam.
                     match raw.workspace_folder.as_deref() {
                         Some(wf) if !wf.trim().is_empty() && !wf.contains("${") => {

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -57,6 +57,7 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
         config_path: args.config_path.as_deref(),
         override_config_path: args.override_config_path.as_deref(),
         secrets_files: &args.secrets_files,
+        resolve_devcontainer_id: true,
     })
     .await?;
 

--- a/crates/deacon/src/commands/shared/config_loader.rs
+++ b/crates/deacon/src/commands/shared/config_loader.rs
@@ -19,6 +19,11 @@ pub struct ConfigLoadArgs<'a> {
     pub override_config_path: Option<&'a Path>,
     /// Secrets file paths (--secrets-file)
     pub secrets_files: &'a [PathBuf],
+    /// Whether `${devcontainerId}` should be resolved during load-time
+    /// substitution. Runtime commands (`up`/`exec`/`build`/…) pass `true`;
+    /// `read-configuration` passes `false` so the token stays literal in its
+    /// pre-container output, matching the reference CLI.
+    pub resolve_devcontainer_id: bool,
 }
 
 /// Loaded configuration and supporting context.
@@ -93,6 +98,7 @@ pub async fn load_config(args: ConfigLoadArgs<'_>) -> Result<ConfigLoadResult> {
         override_config_path.as_deref(),
         secrets.as_ref(),
         &workspace_folder,
+        args.resolve_devcontainer_id,
     )
     .await?;
 
@@ -125,6 +131,7 @@ mod tests {
             config_path: None,
             override_config_path: Some(override_path.as_path()),
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await
         .unwrap();
@@ -142,6 +149,7 @@ mod tests {
             config_path: None,
             override_config_path: None,
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await
         .unwrap_err();
@@ -177,6 +185,7 @@ mod tests {
             config_path: Some(config_path.as_path()),
             override_config_path: None,
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await
         .unwrap();
@@ -214,6 +223,7 @@ mod tests {
             config_path: Some(explicit_config.as_path()),
             override_config_path: None,
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await
         .unwrap();
@@ -235,6 +245,7 @@ mod tests {
             config_path: Some(nonexistent_path.as_path()),
             override_config_path: None,
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await
         .unwrap_err();

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -28,7 +28,7 @@ mod forward;
 mod helpers;
 mod image_build;
 mod lifecycle;
-mod merged_config;
+pub(crate) mod merged_config;
 mod ports;
 mod result;
 #[cfg(test)]
@@ -198,6 +198,7 @@ pub(crate) async fn execute_up_with_runtime(
         config_path: args.config_path.as_deref(),
         override_config_path: args.override_config_path.as_deref(),
         secrets_files: &args.secrets_files,
+        resolve_devcontainer_id: true,
     })
     .await?;
 

--- a/crates/deacon/src/commands/upgrade.rs
+++ b/crates/deacon/src/commands/upgrade.rs
@@ -82,6 +82,7 @@ pub async fn execute_upgrade(args: UpgradeArgs) -> Result<()> {
         config_path: args.config_path.as_deref(),
         override_config_path: None,
         secrets_files: &[],
+        resolve_devcontainer_id: true,
     })
     .await?;
     let config_path = initial.config_path.clone();
@@ -107,6 +108,7 @@ pub async fn execute_upgrade(args: UpgradeArgs) -> Result<()> {
             config_path: args.config_path.as_deref(),
             override_config_path: None,
             secrets_files: &[],
+            resolve_devcontainer_id: true,
         })
         .await?
         .config

--- a/crates/deacon/tests/integration_read_configuration.rs
+++ b/crates/deacon/tests/integration_read_configuration.rs
@@ -230,6 +230,48 @@ fn test_acceptance_devcontainer_id_order_independence() -> Result<()> {
     Ok(())
 }
 
+/// Parity (#219): without a container identity (plain --workspace-folder,
+/// no --id-label/--container-id), `${devcontainerId}` must stay LITERAL in the
+/// raw `configuration` output — including inside mount sources and containerEnv
+/// — while other variables (e.g. `${localWorkspaceFolderBasename}`) still
+/// resolve. The reference CLI defers `${devcontainerId}` to a container-aware
+/// pass it never reaches in read-configuration.
+#[test]
+fn test_devcontainer_id_left_literal_without_container() -> Result<()> {
+    let helper = ReadConfigurationTestHelper::new()?;
+    helper.create_config(
+        r#"{
+        "name": "test-literal-id",
+        "image": "ubuntu:22.04",
+        "mounts": [
+            { "source": "vol-${devcontainerId}", "target": "/data", "type": "volume" }
+        ],
+        "containerEnv": {
+            "DC_ID": "${devcontainerId}",
+            "BASENAME": "${localWorkspaceFolderBasename}"
+        }
+    }"#,
+    )?;
+
+    let result = helper.run_with_workspace(&[])?;
+
+    assert_eq!(
+        result["configuration"]["mounts"][0]["source"], "vol-${devcontainerId}",
+        "mount source must keep ${{devcontainerId}} literal without a container"
+    );
+    assert_eq!(
+        result["configuration"]["containerEnv"]["DC_ID"], "${devcontainerId}",
+        "containerEnv must keep ${{devcontainerId}} literal without a container"
+    );
+    // Sanity: other variables still resolve in the same output.
+    assert_ne!(
+        result["configuration"]["containerEnv"]["BASENAME"], "${localWorkspaceFolderBasename}",
+        "other variables must still resolve"
+    );
+
+    Ok(())
+}
+
 /// Test acceptance: with --container-id and --include-merged-configuration, error if inspect fails (no fallback)
 #[test]
 fn test_acceptance_container_id_with_merged_config_errors_on_inspect_failure() -> Result<()> {

--- a/crates/deacon/tests/integration_up_exec_identity.rs
+++ b/crates/deacon/tests/integration_up_exec_identity.rs
@@ -73,6 +73,24 @@ fn exec_echo(ws: &Path, marker: &str) -> String {
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
+/// Run `exec --workspace-folder <ws> -- <args...>` and return trimmed stdout.
+fn exec_cmd(ws: &Path, cmd: &[&str]) -> String {
+    let out = deacon()
+        .args(["exec", "--workspace-folder"])
+        .arg(ws)
+        .arg("--")
+        .args(cmd)
+        .stderr(Stdio::inherit())
+        .output()
+        .expect("spawn deacon exec");
+    assert!(
+        out.status.success(),
+        "`deacon exec --workspace-folder {}` failed",
+        ws.display()
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 fn down(ws: &Path) {
     let _ = deacon()
         .args(["down", "--workspace-folder"])
@@ -130,4 +148,73 @@ fn up_then_exec_resolves_dockerfile_config_by_workspace_folder() {
     down(ws.path());
 
     assert_eq!(got, "IDENTITY_DOCKERFILE_OK");
+}
+
+/// #223: when `remoteUser` comes only from the image's `devcontainer.metadata`
+/// LABEL (not the user's devcontainer.json), `exec` must run as that user —
+/// matching what `up` reports — instead of falling back to root. `up` merges
+/// image metadata as a lower-precedence layer; `exec` previously loaded only the
+/// raw config and so lost the metadata-derived user.
+#[test]
+fn exec_honors_remote_user_from_image_metadata() {
+    if !is_docker_available() {
+        eprintln!("skipping: docker unavailable");
+        return;
+    }
+
+    // Build a tiny image with a non-root `appuser` and a devcontainer.metadata
+    // label that sets remoteUser. The devcontainer.json below does NOT set a
+    // user, so the only source of `appuser` is the image label.
+    let tag = "deacon-test-img-metadata-user:latest";
+    let build_dir = TempDir::new().unwrap();
+    std::fs::write(
+        build_dir.path().join("Dockerfile"),
+        "FROM alpine:3.18\n\
+         RUN adduser -D appuser\n\
+         LABEL devcontainer.metadata='[{\"remoteUser\":\"appuser\"}]'\n",
+    )
+    .unwrap();
+    let built = StdCommand::new("docker")
+        .args(["build", "-t", tag, "."])
+        .current_dir(build_dir.path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("spawn docker build");
+    assert!(built.success(), "failed to build metadata-label test image");
+
+    let ws = TempDir::new().unwrap();
+    write(
+        ws.path(),
+        ".devcontainer/devcontainer.json",
+        &format!(r#"{{ "name": "md-user", "image": "{tag}", "overrideCommand": true }}"#),
+    );
+
+    // Mirror the issue repro: no UID remapping so the container user stays appuser.
+    let up_status = deacon()
+        .args(["up", "--workspace-folder"])
+        .arg(ws.path())
+        .args([
+            "--remove-existing-container",
+            "--update-remote-user-uid-default",
+            "off",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .status()
+        .expect("spawn deacon up");
+    assert!(up_status.success(), "`deacon up` failed");
+
+    let got = exec_cmd(ws.path(), &["sh", "-lc", "id -un"]);
+    down(ws.path());
+    let _ = StdCommand::new("docker")
+        .args(["rmi", "-f", tag])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    assert_eq!(
+        got, "appuser",
+        "exec must run as the image-metadata remoteUser (#223), got {got:?}"
+    );
 }

--- a/fixtures/parity-corpus/README.md
+++ b/fixtures/parity-corpus/README.md
@@ -28,6 +28,26 @@ deep-diffs, and prints a ranked report:
 
 Requires the reference CLI on `PATH` (`npm i -g @devcontainers/cli`).
 
+## Tier 3 — pinned real-world corpus fetch
+
+```bash
+python3 fixtures/parity-corpus/fetch_realworld_corpus.py --clean --dest /tmp/realworld-corpus
+python3 fixtures/parity-corpus/run_tier1.py target/debug/deacon /tmp/realworld-corpus
+python3 fixtures/parity-corpus/run_tier1_merged.py target/debug/deacon /tmp/realworld-corpus
+```
+
+`fetch_realworld_corpus.py` downloads a pinned set of public workspace snapshots
+into `/tmp/realworld-corpus` without vendoring third-party content into this
+repository. The current manifest mixes:
+
+- `devcontainers/images` workspace subtrees
+- two compose-based `devcontainers/templates` workspace subtrees
+- `microsoft/vscode-remote-try-*` sample repos
+- a couple of small real OSS repos with checked-in devcontainers
+
+The fetched corpus includes a `_manifest.json` file recording the exact repos and
+commit SHAs used for the run.
+
 ## Tier 2 — up/build (Docker)
 
 Copy a config to a TempDir **outside** the repo (in-repo `up` chowns the

--- a/fixtures/parity-corpus/REPORT.md
+++ b/fixtures/parity-corpus/REPORT.md
@@ -521,7 +521,114 @@ injects + redacts under deacon exactly as under the reference, and the existing
 `.env` path is unchanged. Unit tests cover JSON parsing, whitespace-led detection,
 non-string coercion, and the invalid-JSON error. (`crates/core/src/secrets.rs`.)
 
+## Round 7 — real-world corpus sweep (pinned upstream repos)
+
+First sweep using the pinned real-world fetcher
+(`fixtures/parity-corpus/fetch_realworld_corpus.py`), comparing deacon against
+`@devcontainers/cli` v0.87.0 on actual `devcontainers/images`,
+`devcontainers/templates`, and `microsoft/*` devcontainers. Four real bugs
+fixed; three diff clusters classified as non-bugs (cold-image caveat /
+reference-side failures) so future sweeps don't re-file them.
+
+### 28. read-configuration eagerly resolved `${devcontainerId}` (#219)
+
+Raw `read-configuration` substituted `${devcontainerId}` (a deterministic
+workspace hash) inside mount sources and `containerEnv`, e.g.
+`devcontainer-cargo-cache-${devcontainerId}` → `devcontainer-cargo-cache-4ba8fc…`
+on `astral-sh/ruff`. The reference leaves the token **literal** in both
+`configuration` and `mergedConfiguration` — `${devcontainerId}` is only knowable
+once a container identity exists, which read-configuration never reaches. **Fix:**
+`${devcontainerId}` is now deferred (left literal) whenever no container identity
+is present. A new `SubstitutionContext.resolve_devcontainer_id` flag (default
+`true`, so `up`/`exec`/runtime are unchanged) is set `false` for
+read-configuration's pre-container load + output passes. All other variables
+(`${localWorkspaceFolder}`, `…Basename`) still resolve. Verified byte-identical
+to the reference for raw + merged mounts and `containerEnv`.
+(`crates/core/src/variable.rs`, `config.rs::load_with_overrides_and_substitution`,
+`commands/shared/config_loader.rs`, `commands/read_configuration.rs`.)
+
+### 29. merged read-configuration crashed on `overrideFeatureInstallOrder` (#218)
+
+`read-configuration --include-merged-configuration` on `devcontainers/images`
+PHP (`common-utils`/`node`/`git` OCI features + a local `./apache-config`)
+**crashed**: `Feature 'ghcr.io/devcontainers/features/common-utils' in
+overrideFeatureInstallOrder does not exist in feature set`. read-configuration
+canonicalizes OCI features to their short metadata id (`common-utils`), but the
+override list is written as the full registry ref — and
+`validate_override_order`/`topological_sort` matched by exact string. **Fix:** the
+resolver now translates each `overrideFeatureInstallOrder` entry to the canonical
+`ResolvedFeature.id` before validating/sorting, reusing a new shared
+`FeatureIdResolver` (canonical id / metadata-id alias / source form /
+tag-insensitive OCI match — the same rules `build_dependency_graph` already used,
+now factored out and shared with the `up`/`build` path). Verified: images-php
+merged config now resolves all four features instead of crashing.
+(`crates/core/src/features.rs`.)
+
+### 30. `up` left `${devcontainerId}` literal in image-metadata mounts (#224)
+
+`deacon up` on `microsoft/AgenticCookBook` (`mcr…/universal:2`, nonstandard
+`.devcontainer/.devcontainer.json`) failed at `docker create`:
+`create dind-var-lib-docker-${devcontainerId}: … includes invalid characters`.
+The dind volume mount comes from the image's `devcontainer.metadata` LABEL, which
+is merged into `config.mounts` **after** `up`'s substitution pass
+(`merge_image_metadata_after_image_ready`). `merge_mounts` substituted *feature*
+mounts but not *config* mounts (assuming they were already done upstream), so the
+late-arriving image-metadata mount kept its literal token. **Fix:** `merge_mounts`
+now runs config mounts through the same substitution context as feature mounts
+(idempotent for already-resolved mounts), so the label-based `${devcontainerId}`
+resolves before `docker create`. Verified end-to-end: the dind volume is created
+with a substituted name and the AgenticCookBook container starts.
+(`crates/core/src/mount.rs`.)
+
+### 31. `exec` ignored image-metadata `remoteUser` (#223)
+
+After `deacon up` on `microsoft/vscode-remote-try-node` (`remoteUser: node`
+sourced from the image's `devcontainer.metadata` label, not `Config.User`),
+`deacon exec … id -un` returned **`root`** while the reference returned `node`.
+`up` merges image metadata as a lower-precedence layer before resolving the user;
+`exec` loaded only the raw devcontainer.json and recovered just `deacon.remoteEnv.*`
+container labels, so the metadata-derived `remoteUser` was lost. **Fix:** `exec`
+now re-applies the same image-metadata merge against the running container's image
+(`merge_image_metadata_after_image_ready`) before resolving the effective config.
+Verified: `exec … id -un` returns `node`, matching the reference; an explicit
+config `remoteUser` and CLI `--user` still win (lower-precedence merge).
+(`commands/exec.rs`, `commands/up/merged_config.rs` made `pub(crate)`.)
+
 ## Verified non-bugs
+
+- **Real-world `mergedConfiguration` cold-image cluster is the documented
+  image-metadata caveat (#221).** The repeated ref-only `remoteUser` / `capAdd` /
+  `securityOpt` / `containerEnv` / value-mismatch `init` / `customizations.vscode`
+  diffs across `oss-ruff`, `try-{node,go,java,php,python,rust,…}`, `oss-gh-cli`,
+  `try-cpp`, `try-dotnetcore` are entirely because the base images were **not
+  pulled** in the sweep environment. deacon's image-metadata fetch is best-effort
+  **local-only** (a read-only command never pulls); the reference pulls the image
+  to read its `devcontainer.metadata` label. Confirmed empirically: with
+  `mcr…/javascript-node:1-18-bullseye` present locally, `try-node`'s merged config
+  matches the reference (`remoteUser: node`, `init: false`,
+  `customizations.vscode` length 4 — all previously ref-only). The only residual
+  is `capAdd`/`securityOpt` serialized as `[]` (deacon) vs `null` (reference), a
+  cosmetic empty-vs-null shape difference. Not a merge-logic bug.
+- **`images-java` `customizations.vscode` length 4 vs 5 is the same caveat,
+  build-config variant (#220).** The reference's extra 5th block is an **exact
+  duplicate** of the `git` feature's customizations. images-java is a
+  `build.dockerfile` config whose four resolved features (common-utils, java,
+  node, git) each contribute their vscode block once — deacon emits git once. The
+  reference builds the image and reads the **built image's baked
+  `devcontainer.metadata` label** (which already contains the layered features'
+  customizations) *in addition to* fresh feature resolution, so git's block
+  appears twice. deacon's read-configuration has no built image to inspect (no
+  `config.image`, no container), so it lacks the duplicate. Same root as #221, not
+  a feature-aggregation bug.
+- **Two compose `devcontainers/templates` entries fail in the *reference*, not
+  deacon (#222).** `templates-go-postgres` and `templates-javascript-node-postgres`
+  ship uninstantiated `${templateOption:imageVariant}` in their Dockerfile `FROM`
+  (`mcr…/go:2-${templateOption:imageVariant}`). The reference CLI's merged-config
+  path fails resolving the image (`Tag 'imagevariant}' … failed validation`);
+  deacon's raw read-config is clean (exit 0). These are uninstantiated template
+  inputs — a template must be applied (options filled) before
+  `--include-merged-configuration` is a meaningful comparison. Excluded from the
+  merged real-world sweep as reference-side failures, not deacon regressions.
 
 - **`updateRemoteUserUID` is at parity.** With a Dockerfile user at uid/gid
   `2000:2000`, `updateRemoteUserUID: true` remaps the remote user to the host's

--- a/fixtures/parity-corpus/fetch_realworld_corpus.py
+++ b/fixtures/parity-corpus/fetch_realworld_corpus.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Fetch a pinned real-world devcontainer corpus into /tmp/realworld-corpus.
+
+This materializes reproducible workspace snapshots from public GitHub repos
+without vendoring any third-party content into the repository. Each entry is a
+workspace root that can be passed to the existing Tier-1 parity drivers:
+
+    python3 fixtures/parity-corpus/run_tier1.py target/debug/deacon /tmp/realworld-corpus
+    python3 fixtures/parity-corpus/run_tier1_merged.py target/debug/deacon /tmp/realworld-corpus
+
+The script uses pinned commit SHAs and GitHub's contents API via `gh api`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable
+
+
+DEFAULT_DEST = Path("/tmp/realworld-corpus")
+
+
+@dataclass(frozen=True)
+class CorpusEntry:
+    name: str
+    repo: str
+    ref: str
+    workspace_root: str = ""
+    include_paths: tuple[str, ...] = ()
+    config_path: str = ""
+    notes: str = ""
+
+
+ENTRIES: tuple[CorpusEntry, ...] = (
+    CorpusEntry(
+        name="images-javascript-node",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/javascript-node",
+        notes="Dockerfile + feature-heavy image recipe with scripts.",
+    ),
+    CorpusEntry(
+        name="images-python",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/python",
+        notes="Dockerfile build with multiple official features.",
+    ),
+    CorpusEntry(
+        name="images-go",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/go",
+        notes="Dockerfile build plus Go/Node/common-utils features.",
+    ),
+    CorpusEntry(
+        name="images-rust",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/rust",
+        notes="Dockerfile build with Rust feature and lifecycle customizations.",
+    ),
+    CorpusEntry(
+        name="images-java",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/java",
+        notes="Dockerfile build with Java/Node features.",
+    ),
+    CorpusEntry(
+        name="images-php",
+        repo="devcontainers/images",
+        ref="31b61b521d55926d62c748b659f24ae71774c0e3",
+        workspace_root="src/php",
+        notes="Dockerfile build with a checked-in local feature.",
+    ),
+    CorpusEntry(
+        name="templates-javascript-node-postgres",
+        repo="devcontainers/templates",
+        ref="95f7406a57fc5f0798964a5853c5ac04added322",
+        workspace_root="src/javascript-node-postgres",
+        notes="Compose-based template workspace with app + Postgres services.",
+    ),
+    CorpusEntry(
+        name="templates-go-postgres",
+        repo="devcontainers/templates",
+        ref="95f7406a57fc5f0798964a5853c5ac04added322",
+        workspace_root="src/go-postgres",
+        notes="Compose-based template workspace for Go + Postgres.",
+    ),
+    CorpusEntry(
+        name="try-node",
+        repo="microsoft/vscode-remote-try-node",
+        ref="45f5e33e47f4b113804ea808b7ce4c90a6823867",
+        include_paths=(".devcontainer", "package.json", "package-lock.json", "server.js"),
+        notes="Small image-based Node workspace used by the reference ecosystem.",
+    ),
+    CorpusEntry(
+        name="try-python",
+        repo="microsoft/vscode-remote-try-python",
+        ref="e351212b72f76fb557c6f31956eb44756300b8b4",
+        include_paths=(".devcontainer", "app.py", "requirements.txt", "static"),
+        notes="Small image-based Python workspace with app files.",
+    ),
+    CorpusEntry(
+        name="try-go",
+        repo="microsoft/vscode-remote-try-go",
+        ref="f4575309350c5ca2f1495c28a13b4b07088e8cea",
+        include_paths=(".devcontainer", "go.mod", "hello", "server.go"),
+        notes="Small image-based Go workspace with module files.",
+    ),
+    CorpusEntry(
+        name="try-rust",
+        repo="microsoft/vscode-remote-try-rust",
+        ref="d3cb2a9843af67d20491c9fde829b2c77230847b",
+        include_paths=(".devcontainer", "Cargo.toml", "Cargo.lock", "src"),
+        notes="Small image-based Rust workspace with crate sources.",
+    ),
+    CorpusEntry(
+        name="try-java",
+        repo="microsoft/vscode-remote-try-java",
+        ref="4638a925031f05cca946b8ce6ab640c433c93585",
+        include_paths=(".devcontainer", "pom.xml", "src"),
+        notes="Small image-based Java workspace with Maven sources.",
+    ),
+    CorpusEntry(
+        name="try-dotnetcore",
+        repo="microsoft/vscode-remote-try-dotnetcore",
+        ref="ca7ad4d9216a1bcc1469e4ca3545a66ff3e771a0",
+        include_paths=(
+            ".devcontainer",
+            "Program.cs",
+            "vscode-remote-try-dotnet.csproj",
+            "appsettings.json",
+            "appsettings.Development.json",
+            "appsettings.HttpsDevelopment.json",
+        ),
+        notes="Small image-based .NET workspace.",
+    ),
+    CorpusEntry(
+        name="try-cpp",
+        repo="microsoft/vscode-remote-try-cpp",
+        ref="22af031095a03864b8c2032b6498ff6d21e46c36",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based C++ sample; .devcontainer contains required support files.",
+    ),
+    CorpusEntry(
+        name="try-php",
+        repo="microsoft/vscode-remote-try-php",
+        ref="9c4c759e95499bb57be2a35e2e0c55f292036908",
+        include_paths=(".devcontainer", "index.php"),
+        notes="Small image-based PHP workspace.",
+    ),
+    CorpusEntry(
+        name="oss-ruff",
+        repo="astral-sh/ruff",
+        ref="82b550741e8766224f23ce6d71fea262b866966b",
+        include_paths=(".devcontainer",),
+        notes="Real OSS Rust/Python workspace with volume mounts and a post-create script.",
+    ),
+    CorpusEntry(
+        name="oss-gh-cli",
+        repo="cli/cli",
+        ref="57b9b207d900114092f30d78020c193b40621dfa",
+        include_paths=(".devcontainer",),
+        notes="Real OSS Go workspace with sshd feature and explicit remoteUser.",
+    ),
+    CorpusEntry(
+        name="oss-vscode",
+        repo="microsoft/vscode",
+        ref="af752dba42ade664df7d6e01f4f459e0c1718512",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace with desktop-lite and rust features.",
+    ),
+    CorpusEntry(
+        name="oss-typescript",
+        repo="microsoft/TypeScript",
+        ref="7964e22f2b85f16e520f0e902c7fd7b6f0c15416",
+        include_paths=(".devcontainer",),
+        notes="Image-based workspace with feature metadata and rich VS Code customizations.",
+    ),
+    CorpusEntry(
+        name="oss-fluentui",
+        repo="microsoft/fluentui",
+        ref="de337cf86b501d2aa7d9b12c472489c7c88d6b24",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace with build args and feature metadata.",
+    ),
+    CorpusEntry(
+        name="oss-promptflow",
+        repo="microsoft/promptflow",
+        ref="3928a727b406e66d64ff42621534bb58e0ca18ce",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace with remoteEnv, runArgs, and Azure CLI feature.",
+    ),
+    CorpusEntry(
+        name="oss-autogen",
+        repo="microsoft/autogen",
+        ref="027ecf0a379bcc1d09956d46d12d44a3ad9cee14",
+        include_paths=(".devcontainer",),
+        notes="Compose-based real repo with many features and explicit workspaceFolder.",
+    ),
+    CorpusEntry(
+        name="oss-fhir-server",
+        repo="microsoft/fhir-server",
+        ref="7769ecc5eb170920f384f309afa6e852e7fdee78",
+        include_paths=(".devcontainer",),
+        notes="Compose-based real repo with custom workspaceFolder and helper scripts.",
+    ),
+    CorpusEntry(
+        name="oss-monaco-editor",
+        repo="microsoft/monaco-editor",
+        ref="7374dcb41a787a63d5885a5be5e6bbc2e6bc338c",
+        include_paths=(".devcontainer",),
+        notes="Simple image-based workspace with lightweight customizations.",
+    ),
+    CorpusEntry(
+        name="oss-web-dev-for-beginners",
+        repo="microsoft/Web-Dev-For-Beginners",
+        ref="5f220217d35499881cfff61a5b4c2dab033ab228",
+        include_paths=(".devcontainer",),
+        notes="Universal-image workspace with a feature and editor customizations.",
+    ),
+    CorpusEntry(
+        name="oss-generative-ai-for-beginners",
+        repo="microsoft/generative-ai-for-beginners",
+        ref="61a1240c5de4109ceac54142934411365c67c759",
+        include_paths=(".devcontainer",),
+        notes="Universal-image workspace with hostRequirements and post-create script.",
+    ),
+    CorpusEntry(
+        name="oss-ml-for-beginners",
+        repo="microsoft/ML-For-Beginners",
+        ref="24028ae995117b45fabb883cf42114e721ed65b5",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace with context '..' and init runArgs.",
+    ),
+    CorpusEntry(
+        name="oss-code-with-engineering-playbook",
+        repo="microsoft/code-with-engineering-playbook",
+        ref="016770e43d8a75be87b98c000c049f07c4a6e6f8",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace with parent build context.",
+    ),
+    CorpusEntry(
+        name="oss-procdump-linux",
+        repo="microsoft/ProcDump-for-Linux",
+        ref="f2717626a2960f8e0d0aebd9efe2e95bfe6c43b1",
+        include_paths=(".devcontainer",),
+        notes="Dockerfile-based workspace selecting a non-default Dockerfile variant.",
+    ),
+    CorpusEntry(
+        name="oss-sample-app-aoai-chatgpt",
+        repo="microsoft/sample-app-aoai-chatGPT",
+        ref="54f0af2c09bfe71f93da4acfb06422e11f984d71",
+        include_paths=(".devcontainer",),
+        notes="Image-based workspace with multiple OCI features including latest azd.",
+    ),
+    CorpusEntry(
+        name="oss-agentic-cookbook",
+        repo="microsoft/AgenticCookBook",
+        ref="32c6b754cff666962b6cd4679a2bdd9183fbe28e",
+        include_paths=(".devcontainer",),
+        config_path=".devcontainer/.devcontainer.json",
+        notes="Nonstandard config path (.devcontainer/.devcontainer.json) with hostRequirements.",
+    ),
+    CorpusEntry(
+        name="oss-presidio-anonymizer",
+        repo="microsoft/presidio",
+        ref="83ab7eb85609c49d9b0b17c44b5c025575966876",
+        include_paths=(".devcontainer/presidio-anonymizer", "presidio-anonymizer/Dockerfile.dev"),
+        config_path=".devcontainer/presidio-anonymizer/devcontainer.json",
+        notes="Nested config path with workspaceMount and cross-directory Dockerfile/context references.",
+    ),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dest", type=Path, default=DEFAULT_DEST, help="Corpus output directory.")
+    parser.add_argument(
+        "--name",
+        dest="names",
+        action="append",
+        default=[],
+        help="Fetch only the named entry (repeatable).",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove the destination directory before fetching.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the pinned corpus entries and exit.",
+    )
+    return parser.parse_args()
+
+
+def run_gh_json(endpoint: str) -> object:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+@lru_cache(maxsize=None)
+def get_commit_tree_sha(repo: str, ref: str) -> str:
+    commit = run_gh_json(f"repos/{repo}/commits/{ref}")
+    return commit["commit"]["tree"]["sha"]
+
+
+@lru_cache(maxsize=None)
+def get_tree_modes(repo: str, ref: str) -> dict[str, str]:
+    tree_sha = get_commit_tree_sha(repo, ref)
+    tree = run_gh_json(f"repos/{repo}/git/trees/{tree_sha}?recursive=1")
+    return {item["path"]: item.get("mode", "") for item in tree.get("tree", [])}
+
+
+@lru_cache(maxsize=None)
+def get_content_metadata(repo: str, ref: str, remote_path: str) -> object:
+    endpoint = f"repos/{repo}/contents"
+    if remote_path:
+        endpoint = f"{endpoint}/{remote_path}"
+    return run_gh_json(f"{endpoint}?ref={ref}")
+
+
+def get_file_bytes(repo: str, ref: str, remote_path: str) -> bytes:
+    metadata = get_content_metadata(repo, ref, remote_path)
+    if not isinstance(metadata, dict) or metadata.get("type") != "file":
+        raise RuntimeError(f"Expected file at {repo}:{remote_path}@{ref}")
+
+    content = metadata.get("content")
+    if not isinstance(content, str):
+        raise RuntimeError(f"Missing inline file content for {repo}:{remote_path}@{ref}")
+    return base64.b64decode(content)
+
+
+def write_file(repo: str, ref: str, remote_path: str, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(get_file_bytes(repo, ref, remote_path))
+
+    mode = get_tree_modes(repo, ref).get(remote_path, "")
+    if mode == "100755":
+        destination.chmod(0o755)
+
+
+def fetch_tree(repo: str, ref: str, remote_dir: str, destination: Path) -> None:
+    metadata = get_content_metadata(repo, ref, remote_dir)
+    if not isinstance(metadata, list):
+        raise RuntimeError(f"Expected directory at {repo}:{remote_dir}@{ref}")
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for child in metadata:
+        child_type = child["type"]
+        child_name = child["name"]
+        child_remote_path = child["path"]
+        child_destination = destination / child_name
+        if child_type == "dir":
+            fetch_tree(repo, ref, child_remote_path, child_destination)
+        elif child_type == "file":
+            write_file(repo, ref, child_remote_path, child_destination)
+        else:
+            raise RuntimeError(
+                f"Unsupported GitHub contents type {child_type!r} at {repo}:{child_remote_path}@{ref}"
+            )
+
+
+def fetch_path(repo: str, ref: str, remote_path: str, destination: Path) -> None:
+    metadata = get_content_metadata(repo, ref, remote_path)
+    if isinstance(metadata, list):
+        fetch_tree(repo, ref, remote_path, destination)
+        return
+    if metadata.get("type") != "file":
+        raise RuntimeError(f"Unsupported path type at {repo}:{remote_path}@{ref}: {metadata}")
+    write_file(repo, ref, remote_path, destination)
+
+
+def selected_entries(names: Iterable[str]) -> list[CorpusEntry]:
+    if not names:
+        return list(ENTRIES)
+
+    by_name = {entry.name: entry for entry in ENTRIES}
+    missing = sorted(set(names) - set(by_name))
+    if missing:
+        raise SystemExit(f"Unknown corpus entries: {', '.join(missing)}")
+    return [by_name[name] for name in names]
+
+
+def write_manifest(entries: list[CorpusEntry], dest: Path) -> None:
+    manifest_path = dest / "_manifest.json"
+    payload = {
+        "entries": [asdict(entry) for entry in entries],
+        "generated_by": "fixtures/parity-corpus/fetch_realworld_corpus.py",
+    }
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def list_entries(entries: list[CorpusEntry]) -> None:
+    for entry in entries:
+        payload = {
+            "name": entry.name,
+            "repo": entry.repo,
+            "ref": entry.ref,
+            "workspace_root": entry.workspace_root,
+            "include_paths": list(entry.include_paths),
+            "config_path": entry.config_path,
+            "notes": entry.notes,
+        }
+        print(json.dumps(payload, sort_keys=True))
+
+
+def fetch_entry(entry: CorpusEntry, dest: Path) -> None:
+    target = dest / entry.name
+    if target.exists():
+        shutil.rmtree(target)
+    target.mkdir(parents=True, exist_ok=True)
+
+    if entry.workspace_root:
+        fetch_tree(entry.repo, entry.ref, entry.workspace_root, target)
+
+    for include_path in entry.include_paths:
+        fetch_path(entry.repo, entry.ref, include_path, target / include_path)
+
+
+def main() -> None:
+    args = parse_args()
+    entries = selected_entries(args.names)
+
+    if args.list:
+        list_entries(entries)
+        return
+
+    if args.clean and args.dest.exists():
+        shutil.rmtree(args.dest)
+    args.dest.mkdir(parents=True, exist_ok=True)
+
+    for entry in entries:
+        print(f"==> fetching {entry.name} from {entry.repo}@{entry.ref}")
+        fetch_entry(entry, args.dest)
+
+    write_manifest(entries, args.dest)
+    print(f"\nFetched {len(entries)} workspace snapshots into {args.dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fixtures/parity-corpus/run_tier1.py
+++ b/fixtures/parity-corpus/run_tier1.py
@@ -33,6 +33,36 @@ def ref_read(ws):
     return run(["devcontainer", "read-configuration", "--workspace-folder", str(ws)])
 
 
+def corpus_entries():
+    manifest = CORPUS / "_manifest.json"
+    if manifest.is_file():
+        data = json.loads(manifest.read_text())
+        return [
+            {
+                "name": entry["name"],
+                "workspace": CORPUS / entry["name"],
+                "config_path": entry.get("config_path", ""),
+            }
+            for entry in data.get("entries", [])
+        ]
+    return [
+        {
+            "name": p.name,
+            "workspace": p,
+            "config_path": "",
+        }
+        for p in sorted(CORPUS.iterdir())
+        if (p / ".devcontainer").is_dir()
+    ]
+
+
+def build_command(cli, workspace, config_path):
+    cmd = [cli, "read-configuration", "--workspace-folder", str(workspace)]
+    if config_path:
+        cmd.extend(["--config", str(workspace / config_path)])
+    return cmd
+
+
 def prune(v):
     """Recursively drop nulls, empty arrays/objects/strings, and DROP_KEYS."""
     if isinstance(v, dict):
@@ -81,15 +111,17 @@ def diff(d, r, path=""):
 
 
 def main():
-    configs = sorted(p for p in CORPUS.iterdir() if (p / ".devcontainer").is_dir())
+    configs = corpus_entries()
     rank = {"ref-only": 0, "value": 1, "deacon-only": 2}
     totals = {"ref-only": 0, "value": 0, "deacon-only": 0}
     crashes = []
 
-    for ws in configs:
-        name = ws.name
-        dc, dout, derr = deacon_read(ws)
-        rc, rout, rerr = ref_read(ws)
+    for entry in configs:
+        name = entry["name"]
+        workspace = entry["workspace"]
+        config_path = entry["config_path"]
+        dc, dout, derr = run(build_command(DEACON, workspace, config_path))
+        rc, rout, rerr = run(build_command("devcontainer", workspace, config_path))
         print(f"\n=== {name} ===")
         if dc != 0:
             print(f"  ⚠️  DEACON crashed (exit {dc}): {derr.strip()[:400]}")

--- a/fixtures/parity-corpus/run_tier1_merged.py
+++ b/fixtures/parity-corpus/run_tier1_merged.py
@@ -31,6 +31,37 @@ def run(cmd):
     return p.returncode, p.stdout, p.stderr
 
 
+def corpus_entries():
+    manifest = CORPUS / "_manifest.json"
+    if manifest.is_file():
+        data = json.loads(manifest.read_text())
+        return [
+            {
+                "name": entry["name"],
+                "workspace": CORPUS / entry["name"],
+                "config_path": entry.get("config_path", ""),
+            }
+            for entry in data.get("entries", [])
+        ]
+    return [
+        {
+            "name": p.name,
+            "workspace": p,
+            "config_path": "",
+        }
+        for p in sorted(CORPUS.iterdir())
+        if (p / ".devcontainer").is_dir()
+    ]
+
+
+def build_command(cli, workspace, config_path):
+    cmd = [cli, "read-configuration", "--workspace-folder", str(workspace)]
+    if config_path:
+        cmd.extend(["--config", str(workspace / config_path)])
+    cmd.append("--include-merged-configuration")
+    return cmd
+
+
 def prune(v):
     if isinstance(v, dict):
         out = {}
@@ -75,20 +106,17 @@ def diff(d, r, path=""):
 
 
 def main():
-    configs = sorted(p for p in CORPUS.iterdir() if (p / ".devcontainer").is_dir())
+    configs = corpus_entries()
     rank = {"ref-only": 0, "value": 1, "deacon-only": 2}
     totals = {"ref-only": 0, "value": 0, "deacon-only": 0}
 
-    for ws in configs:
-        dc, dout, derr = run(
-            [DEACON, "read-configuration", "--workspace-folder", str(ws),
-             "--include-merged-configuration"]
-        )
-        rc, rout, rerr = run(
-            ["devcontainer", "read-configuration", "--workspace-folder", str(ws),
-             "--include-merged-configuration"]
-        )
-        print(f"\n=== {ws.name} ===")
+    for entry in configs:
+        name = entry["name"]
+        workspace = entry["workspace"]
+        config_path = entry["config_path"]
+        dc, dout, derr = run(build_command(DEACON, workspace, config_path))
+        rc, rout, rerr = run(build_command("devcontainer", workspace, config_path))
+        print(f"\n=== {name} ===")
         if dc != 0:
             print(f"  ⚠️  DEACON crashed (exit {dc}): {derr.strip()[:300]}")
             continue


### PR DESCRIPTION
First real-world parity sweep using the pinned fetcher (`fixtures/parity-corpus/fetch_realworld_corpus.py`) against `@devcontainers/cli` v0.87.0 on actual `devcontainers/images`, `devcontainers/templates`, and `microsoft/*` devcontainers. **Four real bugs fixed; three diff clusters classified as non-bugs** (documented in `REPORT.md` Round 7 so future sweeps don't re-file them).

## Fixes (verified against the reference CLI)

### #219 — read-configuration eagerly resolved `${devcontainerId}`
Raw `read-configuration` substituted `${devcontainerId}` (a workspace hash) in mount sources / `containerEnv`; the reference keeps it **literal** in both `configuration` and `mergedConfiguration` (no container identity yet). Added `SubstitutionContext.resolve_devcontainer_id` (default `true`, so `up`/`exec`/runtime are unchanged), set `false` for read-config's pre-container load + output passes. Other variables still resolve. Verified byte-identical to the reference.

### #218 — merged read-configuration **crashed** on `overrideFeatureInstallOrder`
Mixing OCI (`common-utils`/`node`/`git`) + a local (`./apache-config`) feature crashed with `… does not exist in feature set`: read-config canonicalizes OCI features to their short metadata id while the override list uses full registry refs, and matching was exact-string. Extracted a shared `FeatureIdResolver` (canonical id / metadata-id alias / source form / tag-insensitive OCI match — the rules `build_dependency_graph` already used) and canonicalize override entries before validate/sort. images-php now resolves all 4 features.

### #224 — `up` left `${devcontainerId}` literal in image-metadata mounts
The docker-in-docker `dind-var-lib-docker-${devcontainerId}` volume comes from the image's `devcontainer.metadata` label, merged into `config.mounts` **after** `up`'s substitution pass — and `merge_mounts` only substituted *feature* mounts. Now it substitutes config mounts too (idempotent). AgenticCookBook (`universal:2`, nonstandard `.devcontainer/.devcontainer.json`) now creates its container.

### #223 — `exec` ignored image-metadata `remoteUser`
After `up` on `vscode-remote-try-node` (`remoteUser: node` from image metadata), `exec … id -un` returned `root`. `exec` now re-applies the image-metadata merge against the running container's image before resolving the user. Returns `node`, matching the reference; explicit config `remoteUser` and CLI `--user` still win.

## Classified as non-bugs (REPORT.md Round 7)
- **#221** — cold-image-cache merged-config cluster. Confirmed: with the base image pulled locally, `try-node`'s merged config matches the reference (`remoteUser`, `init`, `customizations.vscode`). Residual is cosmetic `[] vs null`.
- **#220** — images-java `customizations.vscode` 4-vs-5 is the same caveat for `build.dockerfile` configs: the reference's extra block is a **duplicate** of the git feature's customizations, sourced from the built image's baked metadata (which deacon's read-config has no image to inspect).
- **#222** — two compose templates carry uninstantiated `${templateOption:imageVariant}`; the **reference itself fails**. Reference-side, not deacon.

## Tests
- Unit: `variable.rs` (literal devcontainerId), `features.rs` (full OCI ref vs short canonical id + local feature), `mount.rs` (config-mount `${devcontainerId}`).
- Docker integration: `integration_up_exec_identity::exec_honors_remote_user_from_image_metadata` (#223).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -D warnings`, and `make test-nextest-fast` (2599 passed) all green.

## Note
This PR also includes the pre-existing **parity-corpus harness** (`fetch_realworld_corpus.py`, `run_tier1*.py`, `README.md`) that produced these issues, since `REPORT.md` Round 7 references it. Unrelated working-tree edits (`constitution.md`, `CLAUDE.md`) were intentionally left out.

Closes #218, #219, #220, #221, #222, #223, #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)