### PR TITLE
feat(config): preserve unknown fields + consistent type-strictness

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -39,6 +39,70 @@ fn default_empty_object() -> serde_json::Value {
     serde_json::Value::Object(Default::default())
 }
 
+/// Human-readable name for a JSON value's type, for type-mismatch diagnostics.
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "a boolean",
+        serde_json::Value::Number(_) => "a number",
+        serde_json::Value::String(_) => "a string",
+        serde_json::Value::Array(_) => "an array",
+        serde_json::Value::Object(_) => "an object",
+    }
+}
+
+/// Deserialize a field that the spec defines as a `map<string, …>`, rejecting
+/// any non-object value.
+///
+/// `features` and `customizations` are stored as raw `serde_json::Value` for
+/// flexibility, but the spec shape is an object. Accepting a bare string (or
+/// array/number) here would silently carry an invalid config downstream, where
+/// it surfaces as a confusing late error. We instead fail fast with a precise
+/// message — the same strictness `forwardPorts` (a typed `Vec`) already enforces.
+/// This keeps deacon's type-checking *consistent* across modeled fields.
+fn deserialize_object_value<'de, D>(
+    deserializer: D,
+) -> std::result::Result<serde_json::Value, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_object() {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "expected an object (map), found {}",
+            json_type_name(&value)
+        )))
+    }
+}
+
+/// Deep-merge two flattened "extra" maps of unmodeled fields, with the overlay
+/// winning on conflicting keys. Nested objects merge recursively (mirroring how
+/// `features`/`customizations` deep-merge); all other values are replaced. Used
+/// to preserve forward-compatible unknown fields through the merge chain instead
+/// of dropping them.
+fn merge_extra_maps(
+    base: &serde_json::Map<String, serde_json::Value>,
+    overlay: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut result = base.clone();
+    for (key, overlay_val) in overlay {
+        match (result.get(key), overlay_val) {
+            (Some(serde_json::Value::Object(base_obj)), serde_json::Value::Object(overlay_obj)) => {
+                result.insert(
+                    key.clone(),
+                    serde_json::Value::Object(merge_extra_maps(base_obj, overlay_obj)),
+                );
+            }
+            _ => {
+                result.insert(key.clone(), overlay_val.clone());
+            }
+        }
+    }
+    result
+}
+
 /// Port specification that can be either a number or a string.
 ///
 /// Supports port numbers (e.g., 3000) and port mappings (e.g., "3000:3000").
@@ -505,7 +569,10 @@ pub struct DevContainerConfig {
     /// Kept as raw JSON value for initial implementation. Will be strongly typed in future iterations.
     ///
     /// Reference: [Features](https://containers.dev/implementors/json_reference/#features)
-    #[serde(default = "default_empty_object")]
+    #[serde(
+        default = "default_empty_object",
+        deserialize_with = "deserialize_object_value"
+    )]
     pub features: serde_json::Value,
 
     /// Override the default feature installation order.
@@ -522,7 +589,10 @@ pub struct DevContainerConfig {
     /// Kept as raw JSON value for initial implementation.
     ///
     /// Reference: [Customizations](https://containers.dev/implementors/json_reference/#customizations)
-    #[serde(default = "default_empty_object")]
+    #[serde(
+        default = "default_empty_object",
+        deserialize_with = "deserialize_object_value"
+    )]
     pub customizations: serde_json::Value,
 
     /// Path to workspace folder inside the container.
@@ -690,6 +760,18 @@ pub struct DevContainerConfig {
     /// expect, and `read-configuration` must surface it intact (#72).
     #[serde(default)]
     pub secrets: Option<std::collections::HashMap<String, SecretMetadata>>,
+
+    /// Unknown / unmodeled fields, preserved verbatim for forward-compatibility.
+    ///
+    /// The spec's extensibility model assumes tools tolerate fields they don't
+    /// understand (new spec properties, editor-specific keys). Silently dropping
+    /// them on `read-configuration` is a fidelity loss versus the reference CLI,
+    /// which echoes them. We neither reject (that would break configs valid in
+    /// VS Code / the reference) nor drop (that loses data) — we preserve and pass
+    /// them through unchanged. They are intentionally *not* substituted: deacon
+    /// does not know their semantics, so it leaves them exactly as authored.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Metadata describing a declarative secret entry.
@@ -1281,6 +1363,7 @@ impl Default for DevContainerConfig {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             secrets: None,
+            extra: serde_json::Map::new(),
         }
     }
 }
@@ -1468,6 +1551,10 @@ impl ConfigMerger {
             // containerEnv semantics; #72). Parent keys not redeclared in
             // the overlay are preserved.
             secrets: Self::merge_secrets(base.secrets.as_ref(), overlay.secrets.as_ref()),
+
+            // Unmodeled fields: deep-merge, overlay wins (preserved for
+            // forward-compat rather than dropped). Mirrors customizations/features.
+            extra: merge_extra_maps(&base.extra, &overlay.extra),
         }
     }
 
@@ -2863,6 +2950,177 @@ mod tests {
         assert_eq!(config.run_args.len(), 0);
         assert!(config.features.is_object());
         assert!(config.customizations.is_object());
+        assert!(config.extra.is_empty());
+    }
+
+    /// Unknown / unmodeled top-level fields must survive a parse → serialize
+    /// round-trip instead of being silently dropped. The spec's extensibility
+    /// model assumes tools pass unknown fields through (the reference CLI does);
+    /// dropping them is a fidelity loss on `read-configuration`.
+    #[test]
+    fn test_unknown_top_level_fields_preserved() {
+        let raw = serde_json::json!({
+            "name": "x",
+            "image": "alpine:3.18",
+            "someFutureSpecField": { "enabled": true },
+            "x-tool-specific": "hello"
+        });
+        let config: DevContainerConfig = serde_json::from_value(raw).expect("parse");
+
+        // Captured into `extra`, not dropped.
+        assert_eq!(
+            config.extra.get("someFutureSpecField"),
+            Some(&serde_json::json!({ "enabled": true }))
+        );
+        assert_eq!(
+            config.extra.get("x-tool-specific"),
+            Some(&serde_json::Value::String("hello".to_string()))
+        );
+        // Modeled fields did NOT leak into `extra`.
+        assert!(!config.extra.contains_key("name"));
+        assert!(!config.extra.contains_key("image"));
+
+        // And they round-trip back out on serialize.
+        let out = serde_json::to_value(&config).expect("serialize");
+        assert_eq!(
+            out["someFutureSpecField"],
+            serde_json::json!({ "enabled": true })
+        );
+        assert_eq!(out["x-tool-specific"], serde_json::json!("hello"));
+    }
+
+    /// Unknown fields are preserved verbatim — NOT variable-substituted. deacon
+    /// does not know their semantics, so it leaves `${...}` exactly as authored.
+    #[test]
+    fn test_unknown_fields_not_substituted() {
+        let raw = serde_json::json!({
+            "image": "alpine:3.18",
+            "x-custom": "${localWorkspaceFolder}/keep-literal"
+        });
+        let config: DevContainerConfig = serde_json::from_value(raw).expect("parse");
+        let workspace = TempDir::new().expect("tempdir");
+        let ctx = SubstitutionContext::new(workspace.path()).expect("ctx");
+        let (substituted, _report) = config.apply_variable_substitution(&ctx);
+        assert_eq!(
+            substituted.extra.get("x-custom"),
+            Some(&serde_json::Value::String(
+                "${localWorkspaceFolder}/keep-literal".to_string()
+            )),
+            "unmodeled fields must be preserved verbatim, not substituted"
+        );
+    }
+
+    /// `features` is spec-shaped as `map<string, …>`. A non-object value is a
+    /// clear authoring mistake and must fail fast with a precise message —
+    /// matching the typed strictness `forwardPorts` already enforces, so
+    /// deacon's type-checking is *consistent* across modeled fields.
+    #[test]
+    fn test_features_must_be_an_object() {
+        let err = serde_json::from_value::<DevContainerConfig>(serde_json::json!({
+            "image": "alpine:3.18",
+            "features": "ghcr.io/devcontainers/features/node:1"
+        }))
+        .expect_err("features as a bare string must be rejected");
+        assert!(
+            err.to_string().contains("expected an object"),
+            "message should name the type mismatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_customizations_must_be_an_object() {
+        let err = serde_json::from_value::<DevContainerConfig>(serde_json::json!({
+            "image": "alpine:3.18",
+            "customizations": "vscode"
+        }))
+        .expect_err("customizations as a bare string must be rejected");
+        assert!(err.to_string().contains("expected an object"));
+    }
+
+    #[test]
+    fn test_features_object_still_accepted() {
+        let config: DevContainerConfig = serde_json::from_value(serde_json::json!({
+            "image": "alpine:3.18",
+            "features": { "ghcr.io/devcontainers/features/node:1": { "version": "20" } }
+        }))
+        .expect("a proper features map must still parse");
+        assert!(config.features.is_object());
+    }
+
+    /// Merging deep-merges `extra`: overlay wins on conflicts, base-only keys
+    /// survive, and nested objects merge recursively (mirroring features).
+    #[test]
+    fn test_merge_preserves_and_overrides_extra() {
+        let base = DevContainerConfig {
+            extra: serde_json::json!({
+                "baseOnly": 1,
+                "shared": { "a": 1, "b": 1 }
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+            ..Default::default()
+        };
+        let overlay = DevContainerConfig {
+            extra: serde_json::json!({
+                "overlayOnly": 2,
+                "shared": { "b": 2, "c": 2 }
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+            ..Default::default()
+        };
+        let merged = ConfigMerger::merge_configs(&[base, overlay]);
+        assert_eq!(merged.extra.get("baseOnly"), Some(&serde_json::json!(1)));
+        assert_eq!(merged.extra.get("overlayOnly"), Some(&serde_json::json!(2)));
+        // nested deep-merge: a from base, b overridden by overlay, c from overlay
+        assert_eq!(
+            merged.extra.get("shared"),
+            Some(&serde_json::json!({ "a": 1, "b": 2, "c": 2 }))
+        );
+    }
+
+    /// `MergedDevContainerConfig` flattens both `config` and (transitively)
+    /// `config.extra`, while keeping its own `__meta` field. Guard the
+    /// nested-flatten boundary: on round-trip, `__meta` must route to `meta`
+    /// and an unknown field must route to `config.extra` — no cross-contamination.
+    #[test]
+    fn test_merged_config_flatten_keeps_meta_separate_from_extra() {
+        use merge::{ConfigLayer, ConfigMeta, MergedDevContainerConfig};
+        let merged = MergedDevContainerConfig {
+            config: DevContainerConfig {
+                image: Some("alpine:3.18".to_string()),
+                extra: serde_json::json!({ "someFutureSpecField": true })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                ..Default::default()
+            },
+            meta: Some(ConfigMeta {
+                layers: vec![ConfigLayer {
+                    source: "test".to_string(),
+                    hash: "abc".to_string(),
+                    precedence: 0,
+                }],
+            }),
+        };
+        let json = serde_json::to_value(&merged).expect("serialize");
+        // Both surface at the top level on serialize.
+        assert_eq!(json["someFutureSpecField"], serde_json::json!(true));
+        assert!(json.get("__meta").is_some());
+
+        let round: MergedDevContainerConfig = serde_json::from_value(json).expect("deserialize");
+        assert!(round.meta.is_some(), "__meta must route back to meta");
+        assert_eq!(
+            round.config.extra.get("someFutureSpecField"),
+            Some(&serde_json::json!(true)),
+            "unknown field must route to config.extra"
+        );
+        assert!(
+            !round.config.extra.contains_key("__meta"),
+            "__meta must NOT leak into config.extra"
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/plugins.rs
+++ b/crates/core/src/plugins.rs
@@ -585,6 +585,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             secrets: None,
+            extra: Default::default(),
         };
 
         PluginManager::augment_config(&mut config).unwrap();
@@ -663,6 +664,7 @@ mod tests {
             cap_add: Vec::new(),
             security_opt: Vec::new(),
             secrets: None,
+            extra: Default::default(),
         };
 
         assert!(plugin.augment_config(&mut config).is_ok());

--- a/docs/DIFFERENTIATORS.md
+++ b/docs/DIFFERENTIATORS.md
@@ -18,6 +18,31 @@ kind of thing worth calling out in a blog post or on the project page.
   user can drop in the `.env` file they already have for `docker`/`compose` instead of
   hand-converting it to JSON. (`crates/core/src/secrets.rs`.)
 
+- **Config validation that fails fast on *your* mistakes, but never loses *your* data.**
+  Deacon applies one consistent rule the reference CLI does not: **fail fast and
+  precisely where the developer made a mistake; preserve silently where deacon
+  doesn't model the field.**
+  - *Precise early errors instead of confusing late ones.* The reference's
+    `read-configuration` is a lenient parse-and-echo: it recovers from malformed
+    JSONC by silently dropping the broken property, and accepts type errors like
+    `forwardPorts: "3000"` or `features: "<ref>"` verbatim. Those mistakes don't
+    vanish — they resurface much later as a misleading downstream failure (e.g. a
+    dropped `"image":` becomes *"No image information specified"* at build time,
+    pointing nowhere near the typo). Deacon rejects them up front with the exact
+    cause and location (`JSONC parsing error: … line 6`, `expected an object (map),
+    found a string`), and does so *consistently* across modeled fields — typed
+    fields (`forwardPorts`) and object-shaped fields (`features`, `customizations`)
+    are all held to their spec shape, so there's no "deacon caught this one but not
+    that one" surprise.
+  - *Forward-compatible field preservation.* For fields deacon does **not** model
+    (new spec properties, editor-specific keys), it neither rejects (which would
+    break a config that's valid in VS Code / the reference) nor silently drops them
+    — it passes them through verbatim, matching the reference's fidelity. The spec's
+    extensibility model assumes tools tolerate unknown fields; deacon honors that.
+    (`crates/core/src/config.rs` — strict `deserialize_object_value` for
+    `features`/`customizations`; `#[serde(flatten)] extra` round-trips unknown
+    top-level fields. Differential coverage: `fixtures/parity-corpus/errors/`.)
+
 ## Capability
 
 - **`extends` is resolved for `up` and `read-configuration --include-merged-configuration`.**

--- a/fixtures/parity-corpus/README.md
+++ b/fixtures/parity-corpus/README.md
@@ -28,6 +28,20 @@ deep-diffs, and prints a ranked report:
 
 Requires the reference CLI on `PATH` (`npm i -g @devcontainers/cli`).
 
+## Tier 1c — error-path differential (fast, Docker-free)
+
+```bash
+python3 fixtures/parity-corpus/run_tier1_errors.py [deacon_bin] [corpus_dir]
+```
+
+Where Tier 1 diffs *successful* output, Tier 1c diffs the **accept/reject
+decision** over invalid / edge-case configs under `errors/`: do both CLIs agree
+on whether the input is an error? Exits non-zero on any divergence from each
+fixture's encoded expectation (CI-gateable). It surfaced that deacon validates
+eagerly/strictly at `read-configuration` while the reference parses leniently and
+defers `extends` resolution — see `errors/README.md` for the full matrix and why
+those divergences are characterized rather than treated as bugs.
+
 ## Tier 3 — pinned real-world corpus fetch
 
 ```bash

--- a/fixtures/parity-corpus/errors/README.md
+++ b/fixtures/parity-corpus/errors/README.md
@@ -1,0 +1,92 @@
+# Error corpus — Tier 1c differential
+
+Invalid / edge-case `devcontainer.json` inputs, diffed for **error-decision
+parity**: do deacon and the reference CLI (`@devcontainers/cli` v0.87.0) *agree
+on whether the input is an error?* The valid-config tiers diff successful
+output; this tier diffs the accept/reject decision (and, when both accept, the
+resolved value after pruning).
+
+Run it:
+
+```bash
+python3 fixtures/parity-corpus/run_tier1_errors.py [deacon_bin] [corpus_dir]
+```
+
+Exit 0 when every fixture matches its encoded `expect`, else 1 (CI-gateable).
+Each fixture is `errors/<name>/expect.json` + (usually) a `.devcontainer/`.
+
+## Headline finding
+
+deacon's `read-configuration` validates **eagerly and strictly**; the
+reference's is a **lenient parse-and-echo**. Concretely, at `read-configuration`:
+
+| input                       | deacon            | reference                              |
+|-----------------------------|-------------------|----------------------------------------|
+| malformed JSONC             | **reject** (parse error) | accept — recovering parser drops the broken key |
+| `extends` → missing file    | **reject** (resolves eagerly) | accept — `extends` echoed literally, not resolved |
+| `extends` → cycle           | **reject** (loop detected) | accept — not resolved                  |
+| `forwardPorts: "3000"`      | **reject** (typed deser) | accept — raw JSON kept                  |
+| `features: "<string>"`      | **reject** (type-strict, see note) | accept — raw JSON kept     |
+| duplicate key (last-wins)   | accept            | accept (same value)                    |
+| unknown / future top-level field | accept — **preserved** (see note) | accept — preserved          |
+| no config / bad `--config`  | **reject**        | **reject**                              |
+
+### Two deliberate refinements (not just characterization)
+
+deacon's strictness is meant to be a *consistent* policy, applied per our
+design discussion:
+
+- **Type-strict on modeled object fields.** `features` and `customizations` are
+  spec-shaped as `map<string, …>`. deacon now rejects a non-object value for
+  them, matching the typed strictness `forwardPorts` already had. Previously
+  `features` was accepted untyped — an inconsistency (forwardPorts strict,
+  features lenient). Fixed so deacon fails fast and *predictably* on a clear
+  authoring mistake. (`wrong-type-features` → `deacon-stricter`.)
+- **Preserve, never drop, unmodeled fields.** Unknown / future top-level fields
+  are passed through verbatim (the spec's extensibility model assumes tools
+  tolerate fields they don't understand). Previously deacon silently *dropped*
+  them — a fidelity loss versus the reference. Now both accept and both
+  preserve. (`unknown-field-preserved` → `both-accept`, value compared.)
+
+The guiding principle: **fail fast and precisely where the developer made a
+mistake; preserve silently where deacon simply does not model the field.**
+
+The reference does **not resolve `extends` even at `build` time** — it errors
+with "No image information specified" rather than on the missing/cyclic target,
+i.e. it never followed the `extends` field at all. That is a deeper divergence
+worth its own investigation (is deacon's `extends` an extension beyond what the
+reference implements?) and is tracked separately, not by this tier.
+
+## Why these are encoded as PASS, not bugs
+
+deacon's strictness follows its constitution (*fail fast, no silent fallbacks,
+filter invalid inputs at ingress*). Rejecting malformed JSON and detecting
+`extends` cycles up front is defensible and arguably better than the reference's
+leniency. So the divergences are **characterized** with `expect:
+"deacon-stricter"`: the corpus stays green while that exact pattern holds and
+goes red only if EITHER CLI's behavior *changes* (e.g. a deacon refactor makes
+read-config lenient, or a reference upgrade makes it strict). True agreement
+cases (`both-reject`, `both-accept`) guard the other direction.
+
+## `expect` vocabulary
+
+- `both-reject` — both CLIs must reject (exit != 0). True error-parity agreement.
+- `both-accept` — both accept **and** emit the same resolved config after pruning.
+- `deacon-stricter` — deacon rejects, reference leniently accepts (characterized).
+
+## Adding a fixture
+
+1. `errors/<name>/.devcontainer/devcontainer.json` (or supporting files; omit
+   it entirely for a "no config" case).
+2. `errors/<name>/expect.json` with `description` + `expect` (+ optional
+   `config` for an explicit `--config`, `signal` for stderr substrings).
+3. Run the driver; if it flags a DIVERGENCE, triage whether it's a deacon bug or
+   a defensible characterized divergence, and set `expect` accordingly.
+
+## Natural next step
+
+This tier compares at `read-configuration` (Docker-free). A Tier-2c
+**up/build error tier** would compare where the reference *does* finally
+validate — surfacing whether deacon and the reference agree on runtime-stage
+rejections (missing image, unresolvable feature, conflicting mounts). Not yet
+built.

--- a/fixtures/parity-corpus/errors/bad-config-path/expect.json
+++ b/fixtures/parity-corpus/errors/bad-config-path/expect.json
@@ -1,0 +1,5 @@
+{
+  "description": "Explicit --config points at a file that does not exist. Both CLIs must reject (the file was named explicitly, so silent discovery fallback is wrong).",
+  "expect": "both-reject",
+  "config": "nope.json"
+}

--- a/fixtures/parity-corpus/errors/duplicate-keys/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/duplicate-keys/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "duplicate-keys",
+	"image": "alpine:3.18",
+	"image": "busybox:1.36"
+}

--- a/fixtures/parity-corpus/errors/duplicate-keys/expect.json
+++ b/fixtures/parity-corpus/errors/duplicate-keys/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "Object with a duplicate key (image declared twice). Both CLIs accept and both apply last-wins (image=busybox:1.36). After pruning deacon's default/null fields, the resolved configs agree.",
+  "expect": "both-accept"
+}

--- a/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/base-a.json
+++ b/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/base-a.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./base-b.json"
+}

--- a/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/base-b.json
+++ b/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/base-b.json
@@ -1,0 +1,3 @@
+{
+	"extends": "./base-a.json"
+}

--- a/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/extends-cycle/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "extends-cycle",
+	"extends": "./base-a.json"
+}

--- a/fixtures/parity-corpus/errors/extends-cycle/expect.json
+++ b/fixtures/parity-corpus/errors/extends-cycle/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "extends chain forms a cycle (a -> b -> a). deacon resolves eagerly and detects the loop (no stack overflow — good); the reference does not resolve extends at read-configuration so it accepts. Characterized divergence: eager (deacon) vs lazy (reference) extends resolution.",
+  "expect": "deacon-stricter"
+}

--- a/fixtures/parity-corpus/errors/extends-missing/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/extends-missing/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "extends-missing",
+	"extends": "./does-not-exist.json"
+}

--- a/fixtures/parity-corpus/errors/extends-missing/expect.json
+++ b/fixtures/parity-corpus/errors/extends-missing/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "extends points at a nonexistent file. deacon resolves extends eagerly at read-configuration and errors on the missing target; the reference does NOT resolve extends during read-configuration (echoes the literal field). Characterized divergence: eager (deacon) vs lazy (reference) extends resolution.",
+  "expect": "deacon-stricter"
+}

--- a/fixtures/parity-corpus/errors/malformed-json/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/malformed-json/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "malformed-json",
+	// hard syntax error: a key with no value. jsonc tolerates comments and
+	// trailing commas, but not a missing value — both CLIs must reject.
+	"image":
+}

--- a/fixtures/parity-corpus/errors/malformed-json/expect.json
+++ b/fixtures/parity-corpus/errors/malformed-json/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "JSONC with a hard syntax error (key with no value). deacon rejects at parse; the reference uses a recovering jsonc parser that drops the broken property and accepts. Characterized divergence: deacon fails fast (constitution: no silent fallbacks), reference is lenient at read-configuration.",
+  "expect": "deacon-stricter"
+}

--- a/fixtures/parity-corpus/errors/missing-config/expect.json
+++ b/fixtures/parity-corpus/errors/missing-config/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "Workspace folder with NO devcontainer config at all. Both CLIs must reject — a true 'both-reject' agreement case that guards deacon doesn't silently invent an empty config.",
+  "expect": "both-reject"
+}

--- a/fixtures/parity-corpus/errors/unknown-field-preserved/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/unknown-field-preserved/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "unknown-field-preserved",
+	"image": "alpine:3.18",
+	"someFutureSpecField": { "enabled": true },
+	"x-tool-specific": "hello"
+}

--- a/fixtures/parity-corpus/errors/unknown-field-preserved/expect.json
+++ b/fixtures/parity-corpus/errors/unknown-field-preserved/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "Config carries unknown/forward-compat top-level fields the tool does not model. Both CLIs must accept AND preserve them verbatim in read-configuration output. Guards against deacon silently dropping unmodeled fields (the pre-fix behavior): the spec's extensibility model assumes tools pass unknown fields through. Value comparison (after pruning) confirms deacon now matches the reference.",
+  "expect": "both-accept"
+}

--- a/fixtures/parity-corpus/errors/wrong-type-features/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/wrong-type-features/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "wrong-type-features",
+	"image": "alpine:3.18",
+	"features": "ghcr.io/devcontainers/features/node:1"
+}

--- a/fixtures/parity-corpus/errors/wrong-type-features/expect.json
+++ b/fixtures/parity-corpus/errors/wrong-type-features/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "features is a bare string instead of a map. deacon now rejects this (type-strict, matching forwardPorts) instead of passing it through untyped. This is the deliberate consistency fix: modeled fields enforce their spec shape and fail fast on a clear mistake. The reference keeps the raw JSON and accepts.",
+  "expect": "deacon-stricter"
+}

--- a/fixtures/parity-corpus/errors/wrong-type-forwardports/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/errors/wrong-type-forwardports/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "wrong-type-forwardports",
+	"image": "alpine:3.18",
+	"forwardPorts": "3000"
+}

--- a/fixtures/parity-corpus/errors/wrong-type-forwardports/expect.json
+++ b/fixtures/parity-corpus/errors/wrong-type-forwardports/expect.json
@@ -1,0 +1,4 @@
+{
+  "description": "forwardPorts is a bare string instead of an array. deacon deserializes into a typed struct and rejects the type mismatch; the reference keeps the raw JSON and accepts. Characterized divergence: typed (deacon) vs untyped (reference) read-configuration. Note deacon is NOT uniformly strict here — see wrong-type-features, which deacon accepts.",
+  "expect": "deacon-stricter"
+}

--- a/fixtures/parity-corpus/run_tier1_errors.py
+++ b/fixtures/parity-corpus/run_tier1_errors.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Tier-1c differential parity driver: the ERROR path, deacon vs reference CLI.
+
+Every fixture in `errors/<name>/` is an *invalid* or edge-case devcontainer
+config. Where the valid-config tiers (`run_tier1.py`, `run_tier1_merged.py`) diff
+*successful* output, this tier asks the question those tiers can't:
+
+    Do the two CLIs AGREE on whether this input is an error?
+
+Exact error wording is expected to differ between a Rust CLI and a Node CLI, so
+we deliberately do NOT diff messages. We diff the accept/reject *decision*
+(exit-code class) and, when both accept, the resolved configuration value (after
+the same null/default pruning `run_tier1.py` uses).
+
+What this tier already surfaced (see errors/README.md): deacon validates
+**eagerly and strictly** at `read-configuration` (typed deserialization + full
+`extends` resolution), while the reference is a **lenient parse-and-echo** that
+recovers from malformed JSON and does not resolve `extends` until up/build time.
+Those are characterized, defensible divergences (deacon's constitution mandates
+fail-fast / no silent fallbacks) — encoded as `deacon-stricter` so the corpus
+goes red only if EITHER CLI's behavior *changes*.
+
+Each fixture carries an `errors/<name>/expect.json`:
+
+    {
+      "description": "...",                 # human triage note
+      "expect": "both-reject" | "both-accept" | "deacon-stricter",
+      "config": "<rel/path>",               # optional explicit --config
+      "signal": ["substr", ...]             # optional stderr substrings (info only)
+    }
+
+`expect` semantics (PASS = reality matches the encoded expectation):
+  - both-reject     : both CLIs reject (exit != 0). True error-parity agreement.
+  - both-accept     : both accept AND, after pruning, emit the same resolved
+                      configuration. Catches silent value divergence on inputs
+                      both tolerate (duplicate keys, untyped passthrough).
+  - deacon-stricter : deacon rejects, reference accepts. A characterized
+                      eager/strict-vs-lazy/lenient divergence. PASS while that
+                      exact pattern holds; flagged if it flips either way.
+
+Anything not matching its expectation is a DIVERGENCE (the signal to triage).
+Exit status: 0 if every fixture PASSES, else 1 (CI-gateable).
+
+Usage: python3 fixtures/parity-corpus/run_tier1_errors.py [deacon_bin] [corpus_dir]
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from run_tier1 import normalize  # reuse {configuration}-unwrap + null/default prune
+
+DEACON = sys.argv[1] if len(sys.argv) > 1 else "/workspaces/deacon/target/debug/deacon"
+CORPUS = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(__file__).parent
+ERRORS = CORPUS / "errors"
+
+SNIP = 240  # stderr snippet length for triage output
+
+
+def run(cmd):
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+
+def build_command(cli, workspace, config_rel):
+    cmd = [cli, "read-configuration", "--workspace-folder", str(workspace)]
+    if config_rel:
+        cmd.extend(["--config", str(workspace / config_rel)])
+    return cmd
+
+
+def cases():
+    if not ERRORS.is_dir():
+        return []
+    out = []
+    for d in sorted(ERRORS.iterdir()):
+        spec = d / "expect.json"
+        if d.is_dir() and spec.is_file():
+            out.append((d.name, d, json.loads(spec.read_text())))
+    return out
+
+
+def values_agree(dout, rout):
+    """True if the two CLIs' resolved configs match after pruning noise."""
+    try:
+        return normalize(dout) == normalize(rout)
+    except Exception:
+        return dout.strip() == rout.strip()
+
+
+def check_signals(meta, derr, rerr):
+    notes = []
+    for s in meta.get("signal") or []:
+        d_has, r_has = s.lower() in derr.lower(), s.lower() in rerr.lower()
+        if not (d_has and r_has):
+            notes.append(f"signal {s!r}: deacon={'y' if d_has else 'n'} ref={'y' if r_has else 'n'}")
+    return notes
+
+
+def evaluate(expect, d_accept, r_accept, dout, rout):
+    """Return (is_pass, reason). reason is None on PASS."""
+    if expect == "both-reject":
+        if not d_accept and not r_accept:
+            return True, None
+        return False, f"expected both to reject (deacon {'accept' if d_accept else 'reject'}, ref {'accept' if r_accept else 'reject'})"
+    if expect == "both-accept":
+        if not (d_accept and r_accept):
+            return False, f"expected both to accept (deacon {'accept' if d_accept else 'reject'}, ref {'accept' if r_accept else 'reject'})"
+        if not values_agree(dout, rout):
+            return False, "both accept but resolved configuration differs after pruning"
+        return True, None
+    if expect == "deacon-stricter":
+        if not d_accept and r_accept:
+            return True, None
+        return False, f"expected deacon-reject / ref-accept, got deacon {'accept' if d_accept else 'reject'} / ref {'accept' if r_accept else 'reject'}"
+    return False, f"unknown expect value: {expect!r}"
+
+
+def main():
+    found = cases()
+    if not found:
+        print(f"no error fixtures found under {ERRORS}")
+        return 0
+
+    passes = 0
+    divergences = []
+
+    for name, d, meta in found:
+        config_rel = meta.get("config", "")
+        expect = meta.get("expect", "both-reject")
+
+        dc, dout, derr = run(build_command(DEACON, d, config_rel))
+        rc, rout, rerr = run(build_command("devcontainer", d, config_rel))
+        d_accept, r_accept = (dc == 0), (rc == 0)
+
+        print(f"\n=== {name} ===")
+        print(f"  {meta.get('description','').strip()}")
+        print(f"  expect={expect}  deacon exit={dc} ({'accept' if d_accept else 'reject'})"
+              f"  ref exit={rc} ({'accept' if r_accept else 'reject'})")
+
+        is_pass, reason = evaluate(expect, d_accept, r_accept, dout, rout)
+
+        if not d_accept:
+            print(f"  deacon stderr: {derr.strip()[:SNIP]}")
+        if not r_accept:
+            print(f"  ref    stderr: {rerr.strip()[:SNIP]}")
+        for n in check_signals(meta, derr, rerr):
+            print(f"  ⚠️  {n}")
+
+        if is_pass:
+            passes += 1
+            print("  ✅ parity as expected")
+        else:
+            divergences.append((name, reason))
+            print(f"  ❗ DIVERGENCE: {reason}")
+
+    print("\n========== SUMMARY ==========")
+    print(f"fixtures: {len(found)}  as-expected: {passes}  divergences: {len(divergences)}")
+    for n, r in divergences:
+        print(f"  ❗ {n}: {r}")
+    return 1 if divergences else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Applies one consistent config-validation policy, deliberately distinct from the reference CLI's lenient parse-and-echo:

> **Fail fast and precisely where the developer made a mistake; preserve silently where deacon does not model the field.**

- **Preserve unmodeled fields.** `#[serde(flatten)] extra` on `DevContainerConfig` — unknown / future / editor-specific top-level fields now round-trip through `read-configuration` instead of being silently dropped (a fidelity loss vs the reference). Threaded through `Default` + `merge_two_configs` (deep-merge, overlay wins). Preserved verbatim — **not** variable-substituted, since their semantics are unknown.
- **Consistent type-strictness.** `features` and `customizations` now reject a non-object value (`deserialize_object_value`) with a precise message, matching the typed strictness `forwardPorts` already had. Removes the `forwardPorts`-strict / `features`-lenient inconsistency.

## Error corpus (Tier 1c)

Adds `fixtures/parity-corpus/run_tier1_errors.py` + `errors/` — a Docker-free differential that diffs the **accept/reject decision** between deacon and the reference over invalid / edge-case configs, with characterized expectations (`both-reject` / `both-accept` / `deacon-stricter`). Surfaced that the reference's `read-configuration` is a lenient parse-and-echo that doesn't resolve `extends`.

## Tests
- 6 new config unit tests incl. the merged-config nested-flatten round-trip (`__meta` stays separate from `extra`).
- Full fast suite green; valid corpus still 0 divergences; error corpus 9/9 as-expected.

## Notes
- Stacked on #225 — GitHub will retarget this to `main` when #225 merges.
- Philosophy documented in `docs/DIFFERENTIATORS.md`.
- Scoped out: unknown **sub**-field preservation under nested typed structs (HostRequirements/PortAttributes/SecretMetadata) — ~43 exhaustive-literal edits for a rare case; tracked as optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)