### PR TITLE
chore(release): bump version to 0.2.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.5" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.6" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.6"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bumps `0.2.0-rc.5` → `0.2.0-rc.6` across the workspace (`Cargo.toml` dep pin, both crate manifests, `Cargo.lock`).

Cuts the next prerelease after this batch landed on `main`:
- #227 config-validation fidelity (preserve unknown fields + consistent type-strictness + Tier 1c error corpus)
- #205 `openBrowser`/`openBrowserOnce` auto-open
- #184 chrono 0.4.45; #169–#172 GitHub Actions bumps

Once merged, pushing tag `v0.2.0-rc.6` triggers the Release workflow (8-target binary build + checksums + SBOM + SLSA provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)