### PR TITLE
ci(dependabot): stop auto-bumping the MSRV rust-toolchain pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,11 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # The MSRV-check job pins dtolnay/rust-toolchain@<rust-version> on purpose
+      # (see .github/workflows/ci.yml — it must equal `rust-version` in
+      # [workspace.package]). Dependabot reads that ref as an action version and
+      # tries to bump it (e.g. PR #168 → @1.100, a Rust release that doesn't even
+      # exist → 404). Raising the MSRV is a deliberate decision made in lockstep
+      # with Cargo.toml, never an automatic bump.
+      - dependency-name: dtolnay/rust-toolchain


### PR DESCRIPTION
## What

Adds `dtolnay/rust-toolchain` to the github-actions `ignore` list in `.github/dependabot.yml`.

## Why

The MSRV-check job in `ci.yml` pins `dtolnay/rust-toolchain@<rust-version>` **on purpose** — it must equal `rust-version` in `[workspace.package]` (currently `1.95`). Dependabot reads that ref as an action version and keeps trying to bump it:

- **#168** bumped it to `@1.100` → `rustup toolchain install 1.100.0` → **HTTP 404, Rust 1.100.0 does not exist** → the MSRV job can never pass.

Raising the MSRV is a deliberate decision made in lockstep with `Cargo.toml`, never an automatic dependency bump. This ignore rule mirrors the existing `reqwest` major-version ignore.

Closes the recurring-noise root cause behind #168 (which is being closed as invalid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)