### PR TITLE
ci(test): experimental Podman parity lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,3 +227,71 @@ jobs:
         name: nextest-mvp-integration-timing
         path: artifacts/nextest/mvp-integration-timing.json
         if-no-files-found: warn
+
+  # Experimental Podman parity lane. deacon's PodmanRuntime is trait-complete but
+  # had no execution coverage; this runs the integration suite against a real
+  # `podman` (via DEACON_CONTAINER_RUNTIME=podman) to surface parity gaps
+  # (rootless userns, image-ref defaults, networking, compose). Non-blocking
+  # (continue-on-error) while the gaps are burned down; promote to required when
+  # green. Tracks 1.1 Podman support.
+  test-podman:
+    name: Test (Podman, experimental)
+    if: github.event_name != 'schedule'
+    needs: test-fast
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    env:
+      DEACON_CONTAINER_RUNTIME: podman
+      DEACON_NETWORK_TESTS: "1"
+    steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry and target
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-nextest-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-nextest-
+          ${{ runner.os }}-cargo-
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+
+    - name: Set up Podman (rootless)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+        podman version
+        # deacon's PodmanRuntime drives the `podman` CLI directly (no socket).
+        # Sanity-check rootless pull + run before the suite.
+        podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
+
+    - name: Acquire GHCR bearer token (read-only)
+      run: |
+        set -euo pipefail
+        TOKEN_URL="https://ghcr.io/token?service=ghcr.io\
+        &scope=repository:devcontainers/features/node:pull\
+        &scope=repository:devcontainers/features/common-utils:pull\
+        &scope=repository:devcontainers/features/docker-in-docker:pull\
+        &scope=repository:devcontainers/features/python:pull\
+        &scope=repository:devcontainers/features/git:pull"
+        TOKEN=$(curl -fsSL "$TOKEN_URL" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')
+        echo "DEACON_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+    - name: Run integration suite against Podman (non-blocking, full failure set)
+      run: cargo nextest run --profile mvp-integration --no-fail-fast


### PR DESCRIPTION
## Goal (Plan B kickoff)

deacon's `PodmanRuntime` is trait-complete (delegates to the shared `CliRuntime`) and runtime selection is unit-tested, but **nothing exercises a real `podman`**. This adds a non-blocking CI lane that runs the `mvp-integration` suite with `DEACON_CONTAINER_RUNTIME=podman` to surface execution-parity gaps.

## Approach

Draft + `continue-on-error` (experimental, never blocks merges) + `--no-fail-fast` so a single run reports the complete gap set. I'll burn down whatever it surfaces, expected to cluster around:
- rootless UID/GID mapping (`--userns=keep-id`)
- image-ref defaults (`docker.io/` vs `localhost/`)
- networking / port publishing (pasta/slirp4netns)
- compose (`podman compose`)
- `inspect`/`--format json` field differences
- tests that shell out to `docker` directly for verification (will see real docker, not podman — a harness class to gate/adapt)

Promote to a required lane once green. Tracks 1.1 Podman support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)