### PR TITLE
fix(podman): qualify image refs so create/inspect resolve under podman

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
         podman version
+        # ROOT-CAUSE FIX CANDIDATE (#30): under the default systemd cgroup
+        # manager + crun + cgroup v2, the transient systemd scopes created for
+        # each `podman exec` session can cascade-tear-down the CONTAINER's own
+        # scope, so a healthy container vanishes ("No such container") after
+        # deacon's env-probe exec burst — failing every up->exec->lifecycle
+        # test. cgroupfs avoids the per-exec transient-scope teardown.
+        mkdir -p ~/.config/containers
+        printf '[engine]\ncgroup_manager = "cgroupfs"\n' > ~/.config/containers/containers.conf
         # deacon's PodmanRuntime drives the `podman` CLI directly (no socket).
         # Sanity-check rootless pull + run before the suite.
         podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
@@ -310,13 +318,12 @@ jobs:
         DEACON_CONTAINER_RUNTIME=podman RUST_LOG=deacon=debug,deacon_core=debug \
           "$BIN" up --workspace-folder "$WS" --mount-workspace-git-root false
         echo "=== deacon up exit: $? ==="
-        sleep 1
+        sleep 3   # let any teardown event flush before killing the stream
         kill "$EVPID" 2>/dev/null
         echo "=== podman ps -a (did the container survive?) ==="
         podman ps -a --format '{{.ID}} {{.Names}} {{.Status}}'
-        echo "=== container lifecycle events (died vs remove vs cleanup) ==="
-        grep -iE "type=container" /tmp/podman_events.log \
-          | grep -iE "create|init|start|died|remove|cleanup|stop|exec" | tail -50
+        echo "=== ALL container lifecycle events (look for died/remove/cleanup/stop) ==="
+        grep -iE "type=container" /tmp/podman_events.log | tail -80
         podman rm -f -a 2>&1 | tail -2 || true
 
     - name: Acquire GHCR bearer token (read-only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,39 @@ jobs:
         # Sanity-check rootless pull + run before the suite.
         podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
 
+    # TEMPORARY diagnostic (issue #30): the experimental lane shows containers
+    # vanishing ~0.1s after `podman start` (mid-`up`), failing every
+    # up->exec->lifecycle test with "No such container". Reproduce deacon's
+    # exact create+start+keepalive manually and capture WHY the container exits
+    # (host cgroup/event config + container exit code/error + conmon logs).
+    # Non-blocking; remove once the root cause is understood.
+    - name: Diagnose rootless podman container persistence (#30)
+      run: |
+        set -x
+        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-<unset>}"
+        id
+        loginctl show-user "$(id -un)" 2>&1 | grep -i linger || echo "no linger info"
+        systemctl --user is-system-running 2>&1 || echo "no user systemd session"
+        podman info --format 'cgroupManager={{.Host.CgroupManager}} cgroupVersion={{.Host.CgroupsVersion}} eventLogger={{.Host.EventLogger}} ociRuntime={{.Host.OCIRuntime.Name}}'
+        podman pull -q docker.io/library/alpine:3.19
+        # Mirror deacon's create_container: overrideCommand keep-alive.
+        CID=$(podman create docker.io/library/alpine:3.19 /bin/sh -c \
+          'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"; sleep infinity || tail -f /dev/null')
+        echo "created: $CID"
+        podman start "$CID"
+        echo "=== immediately after start ==="
+        podman ps -a --filter "id=$CID" --format '{{.ID}} {{.Status}}'
+        sleep 1
+        echo "=== +1s ==="
+        podman inspect "$CID" --format 'status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} error={{.State.Error}}' 2>&1 || echo "inspect failed (container gone?)"
+        echo "=== exec probe (what deacon does) ==="
+        podman exec "$CID" sh -c 'echo alive' 2>&1 || echo "exec failed"
+        echo "=== container logs ==="
+        podman logs "$CID" 2>&1 || echo "logs unavailable"
+        echo "=== conmon / cleanup events (last 30s) ==="
+        podman events --stream=false --filter "container=$CID" 2>&1 | tail -20 || echo "no events"
+        podman rm -f "$CID" 2>&1 || true
+
     - name: Acquire GHCR bearer token (read-only)
       run: |
         set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,38 +281,43 @@ jobs:
         # Sanity-check rootless pull + run before the suite.
         podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
 
-    # TEMPORARY diagnostic (issue #30): the experimental lane shows containers
-    # vanishing ~0.1s after `podman start` (mid-`up`), failing every
-    # up->exec->lifecycle test with "No such container". Reproduce deacon's
-    # exact create+start+keepalive manually and capture WHY the container exits
-    # (host cgroup/event config + container exit code/error + conmon logs).
-    # Non-blocking; remove once the root cause is understood.
-    - name: Diagnose rootless podman container persistence (#30)
+    # TEMPORARY diagnostic (issue #30): a manual container with deacon's exact
+    # keepalive STAYS RUNNING under this rootless podman, so it is not a generic
+    # reaping/cgroup issue. Isolate ONE real `deacon up --runtime podman` (no
+    # concurrency) with a live `podman events` capture to learn whether the
+    # container is removed by something (remove/cleanup) or exits on its own
+    # (died), and what removes it. Non-blocking; removed once understood.
+    - name: Diagnose deacon up under podman, isolated + events (#30)
       run: |
         set -x
-        echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-<unset>}"
-        id
-        loginctl show-user "$(id -un)" 2>&1 | grep -i linger || echo "no linger info"
-        systemctl --user is-system-running 2>&1 || echo "no user systemd session"
-        podman info --format 'cgroupManager={{.Host.CgroupManager}} cgroupVersion={{.Host.CgroupsVersion}} eventLogger={{.Host.EventLogger}} ociRuntime={{.Host.OCIRuntime.Name}}'
-        podman pull -q docker.io/library/alpine:3.19
-        # Mirror deacon's create_container: overrideCommand keep-alive.
-        CID=$(podman create docker.io/library/alpine:3.19 /bin/sh -c \
-          'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}"; sleep infinity || tail -f /dev/null')
-        echo "created: $CID"
-        podman start "$CID"
-        echo "=== immediately after start ==="
-        podman ps -a --filter "id=$CID" --format '{{.ID}} {{.Status}}'
+        podman info --format 'cgroupManager={{.Host.CgroupManager}} eventLogger={{.Host.EventLogger}} ociRuntime={{.Host.OCIRuntime.Name}}'
+        cargo build -p deacon
+        BIN="$(pwd)/target/debug/deacon"
+        WS="$(mktemp -d)"
+        mkdir -p "$WS/.devcontainer"
+        cat > "$WS/.devcontainer/devcontainer.json" <<'JSON'
+        {
+          "name": "diag-podman",
+          "image": "alpine:3.19",
+          "workspaceFolder": "/workspace",
+          "postCreateCommand": "echo diag-postcreate"
+        }
+        JSON
+        # Live event stream for the whole up.
+        podman events --format '{{.Time}} type={{.Type}} status={{.Status}} name={{.Name}}' > /tmp/podman_events.log 2>&1 &
+        EVPID=$!
+        set +e
+        DEACON_CONTAINER_RUNTIME=podman RUST_LOG=deacon=debug,deacon_core=debug \
+          "$BIN" up --workspace-folder "$WS" --mount-workspace-git-root false
+        echo "=== deacon up exit: $? ==="
         sleep 1
-        echo "=== +1s ==="
-        podman inspect "$CID" --format 'status={{.State.Status}} exitCode={{.State.ExitCode}} oomKilled={{.State.OOMKilled}} error={{.State.Error}}' 2>&1 || echo "inspect failed (container gone?)"
-        echo "=== exec probe (what deacon does) ==="
-        podman exec "$CID" sh -c 'echo alive' 2>&1 || echo "exec failed"
-        echo "=== container logs ==="
-        podman logs "$CID" 2>&1 || echo "logs unavailable"
-        echo "=== conmon / cleanup events (last 30s) ==="
-        podman events --stream=false --filter "container=$CID" 2>&1 | tail -20 || echo "no events"
-        podman rm -f "$CID" 2>&1 || true
+        kill "$EVPID" 2>/dev/null
+        echo "=== podman ps -a (did the container survive?) ==="
+        podman ps -a --format '{{.ID}} {{.Names}} {{.Status}}'
+        echo "=== container lifecycle events (died vs remove vs cleanup) ==="
+        grep -iE "type=container" /tmp/podman_events.log \
+          | grep -iE "create|init|start|died|remove|cleanup|stop|exec" | tail -50
+        podman rm -f -a 2>&1 | tail -2 || true
 
     - name: Acquire GHCR bearer token (read-only)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,54 +277,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
         podman version
-        # ROOT-CAUSE FIX CANDIDATE (#30): under the default systemd cgroup
-        # manager + crun + cgroup v2, the transient systemd scopes created for
-        # each `podman exec` session can cascade-tear-down the CONTAINER's own
-        # scope, so a healthy container vanishes ("No such container") after
-        # deacon's env-probe exec burst — failing every up->exec->lifecycle
-        # test. cgroupfs avoids the per-exec transient-scope teardown.
-        mkdir -p ~/.config/containers
-        printf '[engine]\ncgroup_manager = "cgroupfs"\n' > ~/.config/containers/containers.conf
         # deacon's PodmanRuntime drives the `podman` CLI directly (no socket).
         # Sanity-check rootless pull + run before the suite.
         podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
-
-    # TEMPORARY diagnostic (issue #30): a manual container with deacon's exact
-    # keepalive STAYS RUNNING under this rootless podman, so it is not a generic
-    # reaping/cgroup issue. Isolate ONE real `deacon up --runtime podman` (no
-    # concurrency) with a live `podman events` capture to learn whether the
-    # container is removed by something (remove/cleanup) or exits on its own
-    # (died), and what removes it. Non-blocking; removed once understood.
-    - name: Diagnose deacon up under podman, isolated + events (#30)
-      run: |
-        set -x
-        podman info --format 'cgroupManager={{.Host.CgroupManager}} eventLogger={{.Host.EventLogger}} ociRuntime={{.Host.OCIRuntime.Name}}'
-        cargo build -p deacon
-        BIN="$(pwd)/target/debug/deacon"
-        WS="$(mktemp -d)"
-        mkdir -p "$WS/.devcontainer"
-        cat > "$WS/.devcontainer/devcontainer.json" <<'JSON'
-        {
-          "name": "diag-podman",
-          "image": "alpine:3.19",
-          "workspaceFolder": "/workspace",
-          "postCreateCommand": "echo diag-postcreate"
-        }
-        JSON
-        # Live event stream for the whole up.
-        podman events --format '{{.Time}} type={{.Type}} status={{.Status}} name={{.Name}}' > /tmp/podman_events.log 2>&1 &
-        EVPID=$!
-        set +e
-        DEACON_CONTAINER_RUNTIME=podman RUST_LOG=deacon=debug,deacon_core=debug \
-          "$BIN" up --workspace-folder "$WS" --mount-workspace-git-root false
-        echo "=== deacon up exit: $? ==="
-        sleep 3   # let any teardown event flush before killing the stream
-        kill "$EVPID" 2>/dev/null
-        echo "=== podman ps -a (did the container survive?) ==="
-        podman ps -a --format '{{.ID}} {{.Names}} {{.Status}}'
-        echo "=== ALL container lifecycle events (look for died/remove/cleanup/stop) ==="
-        grep -iE "type=container" /tmp/podman_events.log | tail -80
-        podman rm -f -a 2>&1 | tail -2 || true
 
     - name: Acquire GHCR bearer token (read-only)
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,19 +228,19 @@ jobs:
         path: artifacts/nextest/mvp-integration-timing.json
         if-no-files-found: warn
 
-  # Experimental Podman parity lane. deacon's PodmanRuntime is trait-complete but
-  # had no execution coverage; this runs the integration suite against a real
-  # `podman` (via DEACON_CONTAINER_RUNTIME=podman) to surface parity gaps
-  # (rootless userns, image-ref defaults, networking, compose). Non-blocking
-  # (continue-on-error) while the gaps are burned down; promote to required when
-  # green. Tracks 1.1 Podman support.
+  # Podman parity lane. deacon's PodmanRuntime drives the `podman` CLI directly;
+  # this runs the full integration suite against a real rootless `podman` (via
+  # DEACON_CONTAINER_RUNTIME=podman). Promoted from experimental to REQUIRED once
+  # the lane reached 163/163 — the image-ref qualification, runtime selection
+  # across the consumer surface, and podman `ps`-JSON parsing fixes landed
+  # (issue #30). Remaining 1.1 items (rootless userns/uidmap, label=disable,
+  # podman-aware GPU info) are non-blocking polish, tracked on #30.
   test-podman:
-    name: Test (Podman, experimental)
+    name: Test (Podman)
     if: github.event_name != 'schedule'
     needs: test-fast
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     env:
       DEACON_CONTAINER_RUNTIME: podman
       DEACON_NETWORK_TESTS: "1"
@@ -293,5 +293,5 @@ jobs:
         TOKEN=$(curl -fsSL "$TOKEN_URL" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')
         echo "DEACON_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
-    - name: Run integration suite against Podman (non-blocking, full failure set)
+    - name: Run integration suite against Podman (full failure set)
       run: cargo nextest run --profile mvp-integration --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,3 +227,71 @@ jobs:
         name: nextest-mvp-integration-timing
         path: artifacts/nextest/mvp-integration-timing.json
         if-no-files-found: warn
+
+  # Experimental Podman parity lane. deacon's PodmanRuntime is trait-complete but
+  # had no execution coverage; this runs the integration suite against a real
+  # `podman` (via DEACON_CONTAINER_RUNTIME=podman) to surface parity gaps
+  # (rootless userns, image-ref defaults, networking, compose). Non-blocking
+  # (continue-on-error) while the gaps are burned down; promote to required when
+  # green. Tracks 1.1 Podman support.
+  test-podman:
+    name: Test (Podman, experimental)
+    if: github.event_name != 'schedule'
+    needs: test-fast
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    env:
+      DEACON_CONTAINER_RUNTIME: podman
+      DEACON_NETWORK_TESTS: "1"
+    steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry and target
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-nextest-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-nextest-
+          ${{ runner.os }}-cargo-
+
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest
+
+    - name: Set up Podman (rootless)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+        podman version
+        # deacon's PodmanRuntime drives the `podman` CLI directly (no socket).
+        # Sanity-check rootless pull + run before the suite.
+        podman run --rm docker.io/library/alpine:3.18 echo "podman-ok"
+
+    - name: Acquire GHCR bearer token (read-only)
+      run: |
+        set -euo pipefail
+        TOKEN_URL="https://ghcr.io/token?service=ghcr.io\
+        &scope=repository:devcontainers/features/node:pull\
+        &scope=repository:devcontainers/features/common-utils:pull\
+        &scope=repository:devcontainers/features/docker-in-docker:pull\
+        &scope=repository:devcontainers/features/python:pull\
+        &scope=repository:devcontainers/features/git:pull"
+        TOKEN=$(curl -fsSL "$TOKEN_URL" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("token",""))')
+        echo "DEACON_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+    - name: Run integration suite against Podman (non-blocking, full failure set)
+      run: cargo nextest run --profile mvp-integration --no-fail-fast

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -1096,15 +1096,26 @@ impl CliRuntime {
         let mut result = Vec::new();
         for container in containers {
             let container_info = ContainerInfo {
+                // Accept both docker (`ID`) and podman (`Id`) key casing.
                 id: container
                     .get("ID")
+                    .or_else(|| container.get("Id"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown")
                     .to_string(),
+                // docker: comma-joined string; podman: array of names.
                 names: container
                     .get("Names")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.split(',').map(|name| name.trim().to_string()).collect())
+                    .map(|v| match v {
+                        serde_json::Value::String(s) => {
+                            s.split(',').map(|name| name.trim().to_string()).collect()
+                        }
+                        serde_json::Value::Array(items) => items
+                            .iter()
+                            .filter_map(|n| n.as_str().map(|s| s.to_string()))
+                            .collect(),
+                        _ => vec![],
+                    })
                     .unwrap_or_default(),
                 image: container
                     .get("Image")
@@ -1423,16 +1434,30 @@ impl Docker for CliRuntime {
                 DockerError::CLIError(format!("Failed to parse container JSON: {}", e))
             })?;
 
+            // Field shapes differ between docker and podman `ps --format "{{json .}}"`:
+            // docker emits `"ID"` + `"Names"` (comma-joined string); podman emits
+            // `"Id"` + `"Names"` (array of strings). Accept both so container
+            // discovery (start/exec/down) resolves a real ID under podman instead
+            // of falling back to "unknown".
             let container_info = ContainerInfo {
                 id: container
                     .get("ID")
+                    .or_else(|| container.get("Id"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown")
                     .to_string(),
                 names: container
                     .get("Names")
-                    .and_then(|v| v.as_str())
-                    .map(|s| vec![s.to_string()])
+                    .map(|v| match v {
+                        serde_json::Value::String(s) => {
+                            s.split(',').map(|n| n.trim().to_string()).collect()
+                        }
+                        serde_json::Value::Array(items) => items
+                            .iter()
+                            .filter_map(|n| n.as_str().map(|s| s.to_string()))
+                            .collect(),
+                        _ => vec![],
+                    })
                     .unwrap_or_default(),
                 image: container
                     .get("Image")
@@ -3285,6 +3310,25 @@ mod tests {
         let docker = CliDocker::new();
         let result = docker.parse_container_list("").unwrap();
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_container_list_docker_and_podman_shapes() {
+        let docker = CliDocker::new();
+        // docker `ps --format "{{json .}}"`: "ID" + comma-joined "Names" string.
+        let docker_line = r#"{"ID":"abc123","Names":"my-ctr","Image":"alpine:3.19","Status":"Up","State":"running"}"#;
+        let parsed = docker.parse_container_list(docker_line).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "abc123");
+        assert_eq!(parsed[0].names, vec!["my-ctr".to_string()]);
+
+        // podman `ps --format "{{json .}}"`: "Id" + "Names" array. Must NOT
+        // fall back to "unknown" (regression: every podman container did).
+        let podman_line = r#"{"Id":"def456","Names":["pod-ctr"],"Image":"alpine:3.19","Status":"Up","State":"running"}"#;
+        let parsed = docker.parse_container_list(podman_line).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "def456");
+        assert_eq!(parsed[0].names, vec!["pod-ctr".to_string()]);
     }
 
     #[test]

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -750,6 +750,20 @@ impl<T: Docker> Docker for &T {
     }
 }
 
+/// Which container runtime a `CliRuntime` is driving.
+///
+/// Lives here (rather than reusing `runtime::RuntimeKind`) so the low-level
+/// `docker.rs` module does not depend on the higher-level `runtime.rs`. It
+/// gates podman-specific command construction (e.g. image-ref qualification).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RuntimeFlavor {
+    /// Docker (or a Docker-compatible CLI).
+    #[default]
+    Docker,
+    /// Podman.
+    Podman,
+}
+
 /// Generic CLI-based container runtime implementation
 ///
 /// This can be used for both Docker and Podman runtimes since they share
@@ -758,6 +772,8 @@ impl<T: Docker> Docker for &T {
 pub struct CliRuntime {
     /// Container runtime CLI binary path (e.g., "docker" or "podman")
     runtime_path: String,
+    /// Which runtime this drives — gates podman-specific behavior.
+    flavor: RuntimeFlavor,
 }
 
 impl CliRuntime {
@@ -765,6 +781,7 @@ impl CliRuntime {
     pub fn docker() -> Self {
         Self {
             runtime_path: "docker".to_string(),
+            flavor: RuntimeFlavor::Docker,
         }
     }
 
@@ -772,12 +789,38 @@ impl CliRuntime {
     pub fn podman() -> Self {
         Self {
             runtime_path: "podman".to_string(),
+            flavor: RuntimeFlavor::Podman,
         }
     }
 
-    /// Create a new CliRuntime with custom runtime binary path
+    /// Create a new CliRuntime with a custom runtime binary path.
+    ///
+    /// The flavor is inferred from the binary basename (`*podman*` → Podman,
+    /// otherwise Docker). Use [`CliRuntime::with_runtime_path_and_flavor`] when
+    /// the flavor is known and the path is non-standard.
     pub fn with_runtime_path(runtime_path: String) -> Self {
-        Self { runtime_path }
+        let flavor = if std::path::Path::new(&runtime_path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|name| name.contains("podman"))
+            .unwrap_or(false)
+        {
+            RuntimeFlavor::Podman
+        } else {
+            RuntimeFlavor::Docker
+        };
+        Self {
+            runtime_path,
+            flavor,
+        }
+    }
+
+    /// Create a new CliRuntime with an explicit binary path and flavor.
+    pub fn with_runtime_path_and_flavor(runtime_path: String, flavor: RuntimeFlavor) -> Self {
+        Self {
+            runtime_path,
+            flavor,
+        }
     }
 
     /// Create a new CliRuntime instance (defaults to Docker)
@@ -793,6 +836,88 @@ impl CliRuntime {
     /// This is an alias for `CliRuntime::with_runtime_path()` provided for backward compatibility.
     pub fn with_path(runtime_path: String) -> Self {
         Self::with_runtime_path(runtime_path)
+    }
+
+    /// Whether this runtime is podman (gates podman-specific command construction).
+    pub fn is_podman(&self) -> bool {
+        self.flavor == RuntimeFlavor::Podman
+    }
+
+    /// The runtime CLI binary path (e.g. "docker" or "podman").
+    pub fn runtime_path(&self) -> &str {
+        &self.runtime_path
+    }
+
+    /// Whether an image reference is already fully qualified (carries an
+    /// explicit registry, the `localhost/` repository, or is a bare digest).
+    ///
+    /// Bare short names like `alpine:3.19`, `node:18`, `deacon-build:abc`, and
+    /// even `library/alpine` are NOT qualified — under podman these need
+    /// rewriting (see [`CliRuntime::qualify_image_ref`]).
+    fn is_already_qualified(image_ref: &str) -> bool {
+        if image_ref.starts_with("localhost/") {
+            return true;
+        }
+        // Bare digest reference (e.g. `sha256:deadbeef…`).
+        if image_ref.starts_with("sha256:") {
+            return true;
+        }
+        // A registry-qualified ref has a first path segment that looks like a
+        // host (`ghcr.io/…`, `mcr.microsoft.com/…`, `localhost:5000/…`,
+        // `docker.io/…`).
+        if let Some((first, _rest)) = image_ref.split_once('/') {
+            return crate::registry_parser::looks_like_registry(first);
+        }
+        false
+    }
+
+    /// Qualify a short remote image name to its Docker Hub canonical form
+    /// (`docker.io/library/<name>` for single-segment names, `docker.io/<ns>/<name>`
+    /// otherwise) so podman resolves it without short-name ambiguity.
+    fn qualify_short_remote(image_ref: &str) -> String {
+        if image_ref.contains('/') {
+            format!("docker.io/{image_ref}")
+        } else {
+            format!("docker.io/library/{image_ref}")
+        }
+    }
+
+    /// Whether an image is present in the local image store.
+    ///
+    /// Uses `<runtime> image exists <ref>` (exit-code only — podman's
+    /// purpose-built check). Docker lacks `image exists`, but this is only
+    /// called on the podman path.
+    async fn image_exists_local(&self, image_ref: &str) -> bool {
+        Command::new(&self.runtime_path)
+            .args(["image", "exists", image_ref])
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Rewrite an image reference so podman can resolve it.
+    ///
+    /// Docker is a no-op (it auto-pulls short names and resolves locally-built
+    /// bare tags natively). Under podman:
+    /// - already-qualified refs pass through unchanged;
+    /// - a bare name that exists locally (a deacon-built tag like
+    ///   `deacon-build:<hash>`) is referenced as `localhost/<ref>` — podman
+    ///   stores locally-built images under the `localhost/` repository and
+    ///   would otherwise treat the bare name as a remote pull target;
+    /// - a bare name that is NOT local (a base image like `alpine:3.19`) is
+    ///   qualified to `docker.io/library/<ref>` so the implicit pull during
+    ///   `create` resolves unambiguously (rootless podman won't resolve bare
+    ///   short names non-interactively).
+    async fn qualify_image_ref(&self, image_ref: &str) -> String {
+        if self.flavor != RuntimeFlavor::Podman || Self::is_already_qualified(image_ref) {
+            return image_ref.to_string();
+        }
+        if self.image_exists_local(image_ref).await {
+            format!("localhost/{image_ref}")
+        } else {
+            Self::qualify_short_remote(image_ref)
+        }
     }
 }
 
@@ -1484,13 +1609,18 @@ impl Docker for CliRuntime {
     async fn inspect_image(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
         debug!("Inspecting image: {}", image_ref);
 
+        // Match the ref form `create_container` uses under podman (locally
+        // built images live under `localhost/…`). A wrong guess is non-fatal:
+        // the "No such image" branch below returns Ok(None).
+        let qualified = self.qualify_image_ref(image_ref).await;
+
         // Use the default array-of-objects output (no --format). With
         // `--format "{{json .}}"` Docker emits a single bare object per
         // image, which the array parser below would reject; this surfaced
         // when image-metadata merging started actually consuming the
         // labels (#70).
         let output = Command::new(&self.runtime_path)
-            .args(["image", "inspect", image_ref])
+            .args(["image", "inspect", &qualified])
             .output()
             .await
             .map_err(|e| {
@@ -2041,7 +2171,10 @@ impl ContainerOps for CliRuntime {
         let image = config.image.as_ref().ok_or_else(|| {
             DockerError::CLIError("No image specified in configuration".to_string())
         })?;
-        args.push(image.clone());
+        // Under podman, rewrite bare refs so `create` resolves them: locally
+        // built tags -> `localhost/…`, short base images -> `docker.io/library/…`.
+        // No-op under docker.
+        args.push(self.qualify_image_ref(image).await);
 
         // Respect overrideCommand semantics (default: true)
         // When enabled, ensure the container stays running so lifecycle commands can execute.
@@ -3047,6 +3180,97 @@ mod tests {
         let custom_path = "/usr/local/bin/docker";
         let docker = CliDocker::with_path(custom_path.to_string());
         assert_eq!(docker.runtime_path, custom_path);
+    }
+
+    #[test]
+    fn test_runtime_flavor_constructors() {
+        assert!(!CliRuntime::docker().is_podman());
+        assert!(CliRuntime::podman().is_podman());
+        // basename inference
+        assert!(CliRuntime::with_runtime_path("/usr/bin/podman".to_string()).is_podman());
+        assert!(CliRuntime::with_runtime_path("podman".to_string()).is_podman());
+        assert!(!CliRuntime::with_runtime_path("/usr/local/bin/docker".to_string()).is_podman());
+        // explicit flavor wins over a non-standard path
+        assert!(
+            CliRuntime::with_runtime_path_and_flavor(
+                "/opt/pod/run".to_string(),
+                RuntimeFlavor::Podman
+            )
+            .is_podman()
+        );
+    }
+
+    #[test]
+    fn test_is_already_qualified() {
+        // Qualified: explicit registry, localhost repo, or bare digest.
+        for r in [
+            "localhost/deacon-build:abc",
+            "localhost:5000/x:1",
+            "ghcr.io/owner/name:tag",
+            "mcr.microsoft.com/devcontainers/base:ubuntu",
+            "docker.io/library/alpine:3.19",
+            "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        ] {
+            assert!(
+                CliRuntime::is_already_qualified(r),
+                "expected qualified: {r}"
+            );
+        }
+        // Short / bare: need rewriting under podman.
+        for r in [
+            "alpine:3.19",
+            "node:18",
+            "deacon-build:abc123",
+            "deacon-devcontainer-features:hash",
+            "library/alpine", // namespaced but no registry host
+        ] {
+            assert!(
+                !CliRuntime::is_already_qualified(r),
+                "expected NOT qualified: {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_qualify_short_remote() {
+        assert_eq!(
+            CliRuntime::qualify_short_remote("alpine:3.19"),
+            "docker.io/library/alpine:3.19"
+        );
+        assert_eq!(
+            CliRuntime::qualify_short_remote("library/alpine"),
+            "docker.io/library/alpine"
+        );
+        assert_eq!(
+            CliRuntime::qualify_short_remote("user/repo:tag"),
+            "docker.io/user/repo:tag"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_qualify_image_ref_docker_is_noop() {
+        let docker = CliRuntime::docker();
+        for r in ["alpine:3.19", "deacon-build:abc", "ghcr.io/o/n:t"] {
+            assert_eq!(
+                docker.qualify_image_ref(r).await,
+                r,
+                "docker must not rewrite {r}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_qualify_image_ref_podman_passes_through_qualified() {
+        // Already-qualified refs are untouched even under podman; this path
+        // does not shell out to `podman image exists`.
+        let podman = CliRuntime::podman();
+        for r in [
+            "localhost/deacon-build:abc",
+            "ghcr.io/o/n:t",
+            "docker.io/library/alpine:3.19",
+        ] {
+            assert_eq!(podman.qualify_image_ref(r).await, r);
+        }
     }
 
     #[test]

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -901,20 +901,27 @@ impl CliRuntime {
     /// Docker is a no-op (it auto-pulls short names and resolves locally-built
     /// bare tags natively). Under podman:
     /// - already-qualified refs pass through unchanged;
-    /// - a bare name that exists locally (a deacon-built tag like
-    ///   `deacon-build:<hash>`) is referenced as `localhost/<ref>` — podman
-    ///   stores locally-built images under the `localhost/` repository and
-    ///   would otherwise treat the bare name as a remote pull target;
-    /// - a bare name that is NOT local (a base image like `alpine:3.19`) is
-    ///   qualified to `docker.io/library/<ref>` so the implicit pull during
-    ///   `create` resolves unambiguously (rootless podman won't resolve bare
-    ///   short names non-interactively).
+    /// - a bare name whose **`localhost/`-qualified** form exists (a deacon-built
+    ///   tag like `deacon-build:<hash>`) is referenced as `localhost/<ref>` —
+    ///   podman stores locally-built images under the `localhost/` repository
+    ///   and would otherwise treat the bare name as a remote pull target;
+    /// - any other bare name (a base image like `alpine:3.19`) is qualified to
+    ///   `docker.io/library/<ref>` so the implicit pull during `create` resolves
+    ///   unambiguously (rootless podman won't resolve bare short names
+    ///   non-interactively).
+    ///
+    /// The existence probe is on the `localhost/`-qualified form, NOT the bare
+    /// name: a base image pulled from a registry (`docker.io/library/alpine`)
+    /// also satisfies `podman image exists alpine:3.19` via short-name
+    /// resolution, but must NOT be rewritten to `localhost/` (which has no
+    /// registry and would force a doomed pull from `localhost`).
     async fn qualify_image_ref(&self, image_ref: &str) -> String {
         if self.flavor != RuntimeFlavor::Podman || Self::is_already_qualified(image_ref) {
             return image_ref.to_string();
         }
-        if self.image_exists_local(image_ref).await {
-            format!("localhost/{image_ref}")
+        let localhost_ref = format!("localhost/{image_ref}");
+        if self.image_exists_local(&localhost_ref).await {
+            localhost_ref
         } else {
             Self::qualify_short_remote(image_ref)
         }

--- a/crates/core/src/registry_parser.rs
+++ b/crates/core/src/registry_parser.rs
@@ -88,7 +88,7 @@ pub fn parse_registry_reference(
 
 /// Check if a string looks like a registry hostname.
 /// A registry has a dot (e.g. ghcr.io) or a colon followed by digits (e.g. localhost:5000).
-fn looks_like_registry(s: &str) -> bool {
+pub(crate) fn looks_like_registry(s: &str) -> bool {
     if s.contains('.') {
         return true;
     }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -535,7 +535,10 @@ impl PodmanRuntime {
     /// Create new Podman runtime with custom path
     pub fn with_path(podman_path: String) -> Self {
         Self {
-            runtime: CliRuntime::with_runtime_path(podman_path),
+            runtime: CliRuntime::with_runtime_path_and_flavor(
+                podman_path,
+                crate::docker::RuntimeFlavor::Podman,
+            ),
         }
     }
 }

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -1535,7 +1535,7 @@ impl Cli {
                     terminal_dimensions,
                 };
 
-                execute_exec(args).await
+                execute_exec(args, self.runtime.map(|r| r.into())).await
             }
             Some(Commands::ReadConfiguration {
                 include_merged_configuration,
@@ -1714,12 +1714,13 @@ impl Cli {
                     docker_path: self.docker_path.clone(),
                     docker_compose_path: self.docker_compose_path.clone(),
                 };
+                let down_runtime = self.runtime.map(|r| r.into());
 
                 // If spinner is eligible, wrap the down execution with a plain spinner
                 if spinner_eligible {
                     if stderr_is_tty {
                         let sp = PlainSpinner::start("Stopping environment…");
-                        let res = execute_down(args).await;
+                        let res = execute_down(args, down_runtime).await;
                         match res {
                             Ok(()) => {
                                 sp.finish_with_message("Shutdown completed");
@@ -1731,10 +1732,10 @@ impl Cli {
                             }
                         }
                     } else {
-                        execute_down(args).await
+                        execute_down(args, down_runtime).await
                     }
                 } else {
-                    execute_down(args).await
+                    execute_down(args, down_runtime).await
                 }
             }
             Some(Commands::Outdated {

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1397,6 +1397,9 @@ async fn execute_compose_build_with_features(
         config_path,
         &workspace_hash,
         host_ca_set,
+        // `deacon build` is docker-only today; podman parity for the build
+        // command is tracked separately (issue #30 deferred items).
+        &deacon_core::docker::CliDocker::new(),
     )
     .await?
     .ok_or_else(|| anyhow!("Compose feature build produced no image (no features declared?)"))?;
@@ -1612,6 +1615,9 @@ async fn apply_features_and_lockfile(
         config_path,
         None,
         host_ca_set,
+        // `deacon build` is docker-only today; podman parity for the build
+        // command is tracked separately (issue #30 deferred items).
+        &deacon_core::docker::CliDocker::new(),
     )
     .await
     .context("Failed to build feature-extended image from build output")?;

--- a/crates/deacon/src/commands/down.rs
+++ b/crates/deacon/src/commands/down.rs
@@ -43,7 +43,10 @@ pub struct DownArgs {
 
 /// Execute the down command
 #[instrument(skip(args))]
-pub async fn execute_down(args: DownArgs) -> Result<()> {
+pub async fn execute_down(
+    args: DownArgs,
+    runtime: Option<deacon_core::runtime::RuntimeKind>,
+) -> Result<()> {
     debug!("Starting down command execution");
     debug!("Down args: {:?}", args);
 
@@ -82,7 +85,7 @@ pub async fn execute_down(args: DownArgs) -> Result<()> {
             }
             DiscoveryResult::None(_) => {
                 debug!("No configuration found, attempting auto-discovery from state");
-                return execute_down_with_auto_discovery(workspace_folder, &args).await;
+                return execute_down_with_auto_discovery(workspace_folder, &args, runtime).await;
             }
         }
     };
@@ -94,7 +97,7 @@ pub async fn execute_down(args: DownArgs) -> Result<()> {
                 "Failed to load configuration: {}, attempting auto-discovery",
                 e
             );
-            return execute_down_with_auto_discovery(workspace_folder, &args).await;
+            return execute_down_with_auto_discovery(workspace_folder, &args, runtime).await;
         }
     };
 
@@ -109,7 +112,7 @@ pub async fn execute_down(args: DownArgs) -> Result<()> {
 
     // If --all flag is set, find and remove all containers with matching labels
     if args.all {
-        return execute_down_all(&identity, &args).await;
+        return execute_down_all(&identity, &args, runtime).await;
     }
 
     // Load saved state
@@ -137,6 +140,7 @@ pub async fn execute_down(args: DownArgs) -> Result<()> {
                 &args,
                 &mut state_manager,
                 workspace_hash,
+                runtime,
             )
             .await
         }
@@ -159,10 +163,14 @@ pub async fn execute_down(args: DownArgs) -> Result<()> {
 
 /// Execute down for all containers with matching labels
 #[instrument(skip(identity, args))]
-async fn execute_down_all(identity: &ContainerIdentity, args: &DownArgs) -> Result<()> {
+async fn execute_down_all(
+    identity: &ContainerIdentity,
+    args: &DownArgs,
+    runtime: Option<deacon_core::runtime::RuntimeKind>,
+) -> Result<()> {
     debug!("Finding all containers with matching labels");
 
-    let docker = CliDocker::new();
+    let docker = crate::commands::shared::resolve_runtime(runtime, &args.docker_path).cli_docker();
 
     // `--all` sweeps *every* container for this workspace, including stale
     // ones created under an older/different config. Match on the durable,
@@ -281,12 +289,14 @@ fn is_already_gone(err: &impl std::fmt::Display) -> bool {
 
 /// Execute down for single container configurations
 #[instrument(skip(config, container_state, state_manager, args))]
+#[allow(clippy::too_many_arguments)]
 async fn execute_container_down(
     config: &DevContainerConfig,
     container_state: &deacon_core::state::ContainerState,
     args: &DownArgs,
     state_manager: &mut StateManager,
     workspace_hash: &str,
+    runtime: Option<deacon_core::runtime::RuntimeKind>,
 ) -> Result<()> {
     debug!("Shutting down container: {}", container_state.container_id);
 
@@ -303,7 +313,7 @@ async fn execute_container_down(
         );
     }
 
-    let docker = CliDocker::new();
+    let docker = crate::commands::shared::resolve_runtime(runtime, &args.docker_path).cli_docker();
 
     // Determine if we should remove based on flags
     let should_remove = args.remove || args.force;
@@ -504,7 +514,11 @@ async fn execute_compose_down(
 
 /// Execute down with auto-discovery when config is not available
 #[instrument]
-async fn execute_down_with_auto_discovery(workspace_folder: &Path, args: &DownArgs) -> Result<()> {
+async fn execute_down_with_auto_discovery(
+    workspace_folder: &Path,
+    args: &DownArgs,
+    runtime: Option<deacon_core::runtime::RuntimeKind>,
+) -> Result<()> {
     debug!("Attempting auto-discovery of running containers/projects");
 
     // Create a minimal identity just for workspace hash generation (no config
@@ -528,6 +542,7 @@ async fn execute_down_with_auto_discovery(workspace_folder: &Path, args: &DownAr
                 args,
                 &mut state_manager,
                 workspace_hash,
+                runtime,
             )
             .await
         }

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -459,9 +459,12 @@ fn apply_container_substitution(
 
 /// Execute the exec command
 #[instrument]
-pub async fn execute_exec(args: ExecArgs) -> Result<()> {
-    let docker_path = args.docker_path.clone();
-    execute_exec_with_docker(args, &CliDocker::with_path(docker_path)).await
+pub async fn execute_exec(
+    args: ExecArgs,
+    runtime: Option<deacon_core::runtime::RuntimeKind>,
+) -> Result<()> {
+    let docker = crate::commands::shared::resolve_runtime(runtime, &args.docker_path);
+    execute_exec_with_docker(args, &docker).await
 }
 
 /// Execute the exec command with a custom Docker implementation

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -1,5 +1,30 @@
 //! Shared helpers for command implementations.
 
+use deacon_core::runtime::{
+    ContainerRuntimeImpl, DockerRuntime, PodmanRuntime, RuntimeFactory, RuntimeKind,
+};
+
+/// Select the container runtime for a consumer command, honoring
+/// `--runtime`/`DEACON_CONTAINER_RUNTIME` (via [`RuntimeFactory::detect_runtime`])
+/// and the `--docker-path` override for the docker runtime.
+///
+/// Every command that talks to a container (`up`, `exec`, `down`,
+/// `run-user-commands`, `set-up`) MUST select its runtime this way. Hardcoding
+/// `CliDocker::new()` silently ignores a podman selection, so the command talks
+/// to docker while the container lives in podman → "No such container" /
+/// "No running container found".
+pub(crate) fn resolve_runtime(
+    cli_runtime: Option<RuntimeKind>,
+    docker_path: &str,
+) -> ContainerRuntimeImpl {
+    match RuntimeFactory::detect_runtime(cli_runtime) {
+        RuntimeKind::Podman => ContainerRuntimeImpl::Podman(PodmanRuntime::new()),
+        RuntimeKind::Docker => {
+            ContainerRuntimeImpl::Docker(DockerRuntime::with_path(docker_path.to_string()))
+        }
+    }
+}
+
 pub(crate) mod build_resolution;
 pub mod config_loader;
 pub mod env_user;

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -350,6 +350,7 @@ pub(crate) async fn execute_compose_up(
         config_path,
         workspace_hash,
         host_ca_set,
+        &runtime.cli_docker(),
     )
     .await?;
 
@@ -640,6 +641,7 @@ pub(crate) async fn execute_compose_post_create(
 /// 4. In both cases, set `project.service_image_override` so the existing
 ///    injection override rewrites the target service's `image:` line to point
 ///    at the extended tag.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip(config, compose_manager, project, workspace_folder))]
 async fn install_features_for_compose(
     config: &DevContainerConfig,
@@ -649,6 +651,7 @@ async fn install_features_for_compose(
     config_path: &Path,
     workspace_hash: &str,
     host_ca_set: Option<&CorporateCaSet>,
+    cli: &deacon_core::docker::CliRuntime,
 ) -> Result<Option<FeatureBuildOutput>> {
     let output = match resolve_compose_feature_image(
         config,
@@ -658,6 +661,7 @@ async fn install_features_for_compose(
         config_path,
         workspace_hash,
         host_ca_set,
+        cli,
     )
     .await?
     {
@@ -676,6 +680,7 @@ async fn install_features_for_compose(
 /// `service_image_override` to run the extended image) and `build` (which tags
 /// the produced image for the user and writes the lockfile). Returns `None` when
 /// the config declares no features.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip(config, compose_manager, project, workspace_folder))]
 pub(crate) async fn resolve_compose_feature_image(
     config: &DevContainerConfig,
@@ -685,6 +690,7 @@ pub(crate) async fn resolve_compose_feature_image(
     config_path: &Path,
     workspace_hash: &str,
     host_ca_set: Option<&CorporateCaSet>,
+    cli: &deacon_core::docker::CliRuntime,
 ) -> Result<Option<FeatureBuildOutput>> {
     // Nothing to install when features is missing or an empty object.
     let features_obj = match config.features.as_object() {
@@ -737,6 +743,7 @@ pub(crate) async fn resolve_compose_feature_image(
                 config_path,
                 None,
                 host_ca_set,
+                cli,
             )
             .await
             .with_context(|| {
@@ -813,6 +820,7 @@ pub(crate) async fn resolve_compose_feature_image(
                 target.as_deref(),
                 None,
                 host_ca_set,
+                cli,
             )
             .await
             .with_context(|| {

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -723,6 +723,7 @@ pub(crate) async fn execute_container_up(
         resolved_features.as_deref().unwrap_or(&[]),
         prior_markers,
         Some(&identity.config_hash),
+        runtime,
     )
     .await?;
 

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -268,6 +268,7 @@ pub(crate) async fn execute_container_up(
             config_path,
             Some(build_options),
             host_ca_set,
+            &runtime.cli_docker(),
         )
         .await
         .with_context(|| "Failed to build feature-extended image")?;

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -90,7 +90,7 @@ struct StagedFeatures {
 /// When `build_options` is provided and not default, cache arguments are included
 /// in the generated build command. This enables cache-from/cache-to/no-cache/builder
 /// options to propagate to feature builds per spec (data-model.md).
-#[instrument(skip(config, identity, build_options))]
+#[instrument(skip(config, identity, build_options, cli))]
 pub(crate) async fn build_image_with_features(
     config: &DevContainerConfig,
     identity: &ContainerIdentity,
@@ -98,9 +98,8 @@ pub(crate) async fn build_image_with_features(
     config_path: &Path,
     build_options: Option<&BuildOptions>,
     host_ca_set: Option<&CorporateCaSet>,
+    cli: &deacon_core::docker::CliRuntime,
 ) -> Result<FeatureBuildOutput> {
-    use deacon_core::docker::CliDocker;
-
     info!("Building extended image with features");
 
     // Get base image
@@ -180,9 +179,8 @@ pub(crate) async fn build_image_with_features(
     let build_args =
         generator.generate_build_args(&dockerfile_path, &extended_image_tag, build_options);
 
-    let cli_docker = CliDocker::new();
     debug!("Building image with args: {:?}", build_args);
-    let _image_id = cli_docker.build_image(&build_args).await?;
+    let _image_id = cli.build_image(&build_args).await?;
 
     info!("Successfully built extended image: {}", extended_image_tag);
 
@@ -240,9 +238,8 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
     target: Option<&str>,
     build_options: Option<&BuildOptions>,
     host_ca_set: Option<&CorporateCaSet>,
+    cli: &deacon_core::docker::CliRuntime,
 ) -> Result<FeatureBuildOutput> {
-    use deacon_core::docker::CliDocker;
-
     // Optional `build.target` is honored as the upstream stage we extend. The
     // reference CLI rewrites the FROM matching `target`; we accomplish the
     // same outcome by trusting the caller to pre-process via
@@ -375,9 +372,8 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
         base_context_dir.display().to_string(),
     ]);
 
-    let cli_docker = CliDocker::new();
     debug!("Building image with args: {:?}", build_args);
-    let _image_id = cli_docker.build_image(&build_args).await.with_context(|| {
+    let _image_id = cli.build_image(&build_args).await.with_context(|| {
         format!(
             "Failed to build feature-extended image from Dockerfile {} (context {})",
             dockerfile_path.display(),

--- a/crates/deacon/src/commands/up/image_build.rs
+++ b/crates/deacon/src/commands/up/image_build.rs
@@ -61,10 +61,11 @@ pub(crate) fn extract_build_config_from_devcontainer(
 /// When `build_options.is_default()` is true, no extra arguments are added,
 /// preserving existing behavior. When cache-from/cache-to/builder options
 /// are set, they are passed to the docker build command via `to_docker_args()`.
-#[instrument(skip(build_config, build_options))]
+#[instrument(skip(build_config, build_options, cli))]
 pub(crate) async fn build_image_from_config(
     build_config: &BuildConfig,
     build_options: &BuildOptions,
+    cli: &deacon_core::docker::CliRuntime,
 ) -> Result<String> {
     debug!(
         "Building image from Dockerfile: {}",
@@ -134,18 +135,19 @@ pub(crate) async fn build_image_from_config(
             .to_string(),
     );
 
-    debug!("Docker build command: docker {}", build_args.join(" "));
+    let runtime_path = cli.runtime_path();
+    debug!("Build command: {} {}", runtime_path, build_args.join(" "));
 
-    // Execute docker build with retry-on-transient (network blips, 429,
+    // Execute the build with retry-on-transient (network blips, 429,
     // 5xx from registry). Terminal failures (Dockerfile syntax, RUN failure,
     // 401/403) fail on the first attempt — see classifier in
     // deacon_core::docker_retry.
     let output = deacon_core::docker_retry::run_build_with_retry(
-        std::path::Path::new("docker"),
+        std::path::Path::new(runtime_path),
         &build_args,
     )
     .await
-    .context("docker build failed")?;
+    .context("image build failed")?;
 
     let image_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
     debug!("Built image with ID: {}", image_id);
@@ -159,7 +161,7 @@ pub(crate) async fn build_image_from_config(
     // image — mirroring `deacon build`'s `deacon-build:<hash>` base tag. The
     // digest is content-addressed, so the derived tag is stable across rebuilds.
     let tag = derive_local_build_tag(&image_id);
-    tag_built_image(&image_id, &tag).await?;
+    tag_built_image(runtime_path, &image_id, &tag).await?;
     debug!("Tagged built image {} as {}", image_id, tag);
 
     Ok(tag)
@@ -175,13 +177,13 @@ fn derive_local_build_tag(image_id: &str) -> String {
     format!("deacon-build:{}", short)
 }
 
-/// Apply `tag` to the locally-built image `image_id` (`docker tag`).
-async fn tag_built_image(image_id: &str, tag: &str) -> Result<()> {
-    let output = tokio::process::Command::new("docker")
+/// Apply `tag` to the locally-built image `image_id` (`<runtime> tag`).
+async fn tag_built_image(runtime_path: &str, image_id: &str, tag: &str) -> Result<()> {
+    let output = tokio::process::Command::new(runtime_path)
         .args(["tag", image_id, tag])
         .output()
         .await
-        .with_context(|| format!("Failed to run 'docker tag {} {}'", image_id, tag))?;
+        .with_context(|| format!("Failed to run '{} tag {} {}'", runtime_path, image_id, tag))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -148,10 +148,11 @@ pub(crate) async fn execute_lifecycle_commands(
     resolved_features: &[ResolvedFeature],
     prior_markers: Vec<LifecyclePhaseState>,
     config_hash: Option<&str>,
+    runtime: &deacon_core::runtime::ContainerRuntimeImpl,
 ) -> Result<()> {
     use deacon_core::container_lifecycle::{
         ContainerLifecycleCommands, ContainerLifecycleConfig,
-        execute_container_lifecycle_with_progress_callback,
+        execute_container_lifecycle_with_progress_callback_and_docker,
     };
     use deacon_core::variable::SubstitutionContext;
 
@@ -322,11 +323,15 @@ pub(crate) async fn execute_lifecycle_commands(
 
     let lifecycle_start_time = std::time::Instant::now();
 
-    // Execute lifecycle commands with progress callback
-    let result = execute_container_lifecycle_with_progress_callback(
+    // Execute lifecycle commands with progress callback, using the SELECTED
+    // runtime (docker or podman). The plain wrapper hardcodes a docker client,
+    // which under podman cannot see the podman-created container ("No such
+    // container") — so every lifecycle exec must go through `runtime`.
+    let result = execute_container_lifecycle_with_progress_callback_and_docker(
         &lifecycle_config,
         &commands,
         &substitution_context,
+        &runtime.cli_docker(),
         Some(crate::commands::shared::progress::make_progress_callback(
             &args.progress_tracker,
         )),
@@ -362,14 +367,13 @@ pub(crate) async fn execute_lifecycle_commands(
     // Execute non-blocking phases (postStart, postAttach) synchronously
     // This ensures they run before the up command returns
     if !result.non_blocking_phases.is_empty() {
-        use deacon_core::docker::CliDocker;
-
         debug!(
             "Executing {} non-blocking phases synchronously",
             result.non_blocking_phases.len()
         );
 
-        let docker = CliDocker::new();
+        // Use the selected runtime (see blocking-phase note above).
+        let docker = runtime.cli_docker();
 
         let _final_result = result
             .execute_non_blocking_phases_sync_with_callback(

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -485,7 +485,9 @@ pub(crate) async fn execute_up_with_runtime(
     if config.image.is_none() && !config.uses_compose() {
         if let Some(build_config) = extract_build_config_from_devcontainer(&config, &config_path)? {
             info!("Building image from Dockerfile configuration");
-            let built_image_id = build_image_from_config(&build_config, &build_options).await?;
+            let built_image_id =
+                build_image_from_config(&build_config, &build_options, &runtime.cli_docker())
+                    .await?;
 
             // Update config to use the built image
             config.image = Some(built_image_id.clone());

--- a/crates/deacon/tests/integration_custom_container_name.rs
+++ b/crates/deacon/tests/integration_custom_container_name.rs
@@ -3,26 +3,20 @@
 use assert_cmd::Command;
 use serde_json::json;
 use std::fs;
-use std::process::{Command as StdCommand, Stdio};
+use std::process::Command as StdCommand;
 use tempfile::TempDir;
 
 mod support;
-use support::unique_name;
+use support::{is_runtime_available, runtime_bin, unique_name};
 
-/// Helper to check if Docker is available
+/// Helper to check if the active container runtime is available
 fn is_docker_available() -> bool {
-    StdCommand::new("docker")
-        .arg("info")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    is_runtime_available()
 }
 
-/// Helper to check if a container exists by name
+/// Helper to check if a container exists by name (in the active runtime's store)
 fn container_exists(name: &str) -> bool {
-    StdCommand::new("docker")
+    StdCommand::new(runtime_bin())
         .args([
             "ps",
             "-a",
@@ -39,9 +33,11 @@ fn container_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Helper to cleanup a container by name
+/// Helper to cleanup a container by name (in the active runtime's store)
 fn cleanup_container(name: &str) {
-    let _ = StdCommand::new("docker").args(["rm", "-f", name]).output();
+    let _ = StdCommand::new(runtime_bin())
+        .args(["rm", "-f", name])
+        .output();
 }
 
 #[test]

--- a/crates/deacon/tests/integration_exec_id_label.rs
+++ b/crates/deacon/tests/integration_exec_id_label.rs
@@ -6,11 +6,14 @@ use testcontainers::runners::AsyncRunner;
 mod support;
 mod testcontainers_helpers;
 use support::unique_name;
-use testcontainers_helpers::alpine_sleep_with_labels;
+use testcontainers_helpers::{alpine_sleep_with_labels, skip_if_not_docker_runtime};
 
 #[tokio::test]
 async fn test_exec_id_label_successful_unique_match() {
     // Test successful execution with a uniquely matched container
+    if skip_if_not_docker_runtime() {
+        return;
+    }
     // Use a unique label value to ensure we match only our container
     let unique_value = unique_name("unique-match");
 
@@ -51,6 +54,9 @@ async fn test_exec_id_label_successful_unique_match() {
 #[tokio::test]
 async fn test_exec_id_label_ambiguous_match_lists_candidates() {
     // Test that when multiple containers match, we use the first one (deterministic behavior)
+    if skip_if_not_docker_runtime() {
+        return;
+    }
     // Use a unique label value to ensure we match only our containers
     let unique_value = unique_name("ambiguous-match");
 

--- a/crates/deacon/tests/integration_exec_selection.rs
+++ b/crates/deacon/tests/integration_exec_selection.rs
@@ -8,11 +8,14 @@ use tempfile::TempDir;
 use testcontainers::runners::AsyncRunner;
 
 mod testcontainers_helpers;
-use testcontainers_helpers::{alpine_sleep_image, container_id};
+use testcontainers_helpers::{alpine_sleep_image, container_id, skip_if_not_docker_runtime};
 
 #[tokio::test]
 async fn test_exec_with_container_id_selection() {
     // T008: Integration: direct ID selection
+    if skip_if_not_docker_runtime() {
+        return;
+    }
     // Start a container using testcontainers (auto-cleanup on drop)
     let container = alpine_sleep_image().start().await.unwrap();
     let id = container_id(&container);

--- a/crates/deacon/tests/integration_up_exec_identity.rs
+++ b/crates/deacon/tests/integration_up_exec_identity.rs
@@ -22,8 +22,15 @@ use std::path::Path;
 use std::process::{Command as StdCommand, Stdio};
 use tempfile::TempDir;
 
+/// The container runtime binary under test (honors `DEACON_CONTAINER_RUNTIME`,
+/// the same env var deacon reads). Setup/cleanup that bypasses deacon must use
+/// this so images/containers land in the store deacon-under-podman actually reads.
+fn runtime_bin() -> String {
+    std::env::var("DEACON_CONTAINER_RUNTIME").unwrap_or_else(|_| "docker".to_string())
+}
+
 fn is_docker_available() -> bool {
-    StdCommand::new("docker")
+    StdCommand::new(runtime_bin())
         .arg("info")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -174,7 +181,7 @@ fn exec_honors_remote_user_from_image_metadata() {
          LABEL devcontainer.metadata='[{\"remoteUser\":\"appuser\"}]'\n",
     )
     .unwrap();
-    let built = StdCommand::new("docker")
+    let built = StdCommand::new(runtime_bin())
         .args(["build", "-t", tag, "."])
         .current_dir(build_dir.path())
         .stdout(Stdio::null())
@@ -207,7 +214,7 @@ fn exec_honors_remote_user_from_image_metadata() {
 
     let got = exec_cmd(ws.path(), &["sh", "-lc", "id -un"]);
     down(ws.path());
-    let _ = StdCommand::new("docker")
+    let _ = StdCommand::new(runtime_bin())
         .args(["rmi", "-f", tag])
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/crates/deacon/tests/smoke_down.rs
+++ b/crates/deacon/tests/smoke_down.rs
@@ -12,8 +12,15 @@ use assert_cmd::Command;
 use std::fs;
 use tempfile::TempDir;
 
+/// The container runtime binary under test (honors `DEACON_CONTAINER_RUNTIME`,
+/// the same env var deacon reads). Stale-container setup must use this so it
+/// lands in the store deacon-under-podman actually sweeps.
+fn runtime_bin() -> String {
+    std::env::var("DEACON_CONTAINER_RUNTIME").unwrap_or_else(|_| "docker".to_string())
+}
+
 fn is_docker_available() -> bool {
-    std::process::Command::new("docker")
+    std::process::Command::new(runtime_bin())
         .arg("info")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -196,7 +203,7 @@ fn test_down_all_sweeps_stale_by_local_folder() {
     // local_folder label (simulating a container from an older deacon run
     // whose state file / config no longer matches).
     let local_folder_label = format!("devcontainer.local_folder={}", workspace.display());
-    let stale = std::process::Command::new("docker")
+    let stale = std::process::Command::new(runtime_bin())
         .args([
             "run",
             "-d",
@@ -218,7 +225,7 @@ fn test_down_all_sweeps_stale_by_local_folder() {
 
     // Count containers with this workspace label before sweep (expect >= 2).
     let count_label = || -> usize {
-        let out = std::process::Command::new("docker")
+        let out = std::process::Command::new(runtime_bin())
             .args([
                 "ps",
                 "-a",
@@ -252,7 +259,7 @@ fn test_down_all_sweeps_stale_by_local_folder() {
 
     let remaining = count_label();
     // Best-effort cleanup of the stale container regardless of assertion outcome.
-    let _ = std::process::Command::new("docker")
+    let _ = std::process::Command::new(runtime_bin())
         .args(["rm", "-f", &stale_id])
         .output();
 

--- a/crates/deacon/tests/support/mod.rs
+++ b/crates/deacon/tests/support/mod.rs
@@ -26,6 +26,35 @@ pub fn skip_if_no_network_tests() -> bool {
     false
 }
 
+/// The container runtime binary under test, honoring `DEACON_CONTAINER_RUNTIME`
+/// (the same env var deacon reads). Defaults to `docker`.
+///
+/// Tests that create/query containers or images directly (bypassing deacon)
+/// MUST use this rather than hardcoding `"docker"`, otherwise they set up state
+/// in docker while deacon-under-podman looks in podman's separate store — the
+/// container/image is invisible and the test fails spuriously.
+pub fn runtime_bin() -> String {
+    std::env::var("DEACON_CONTAINER_RUNTIME").unwrap_or_else(|_| "docker".to_string())
+}
+
+/// Whether the active runtime ([`runtime_bin`]) is reachable.
+pub fn is_runtime_available() -> bool {
+    std::process::Command::new(runtime_bin())
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Whether the active runtime is docker (not podman). testcontainers-rs is a
+/// docker-API client and cannot drive rootless podman without a podman socket,
+/// so testcontainers-based tests skip when this is false.
+pub fn runtime_is_docker() -> bool {
+    runtime_bin() == "docker"
+}
+
 /// Helper function to extract JSON from mixed output (logs + JSON).
 ///
 /// When running CLI tests with logging enabled, the output may contain log lines

--- a/crates/deacon/tests/testcontainers_helpers.rs
+++ b/crates/deacon/tests/testcontainers_helpers.rs
@@ -9,6 +9,27 @@ use testcontainers::core::WaitFor;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, ContainerRequest, GenericImage, ImageExt};
 
+/// testcontainers-rs talks to the docker API socket; it cannot drive rootless
+/// podman (no podman socket is started in CI). Tests that spin up a container
+/// via testcontainers and then exec into it with deacon must therefore skip
+/// when the active runtime (`DEACON_CONTAINER_RUNTIME`) is not docker — under
+/// podman the testcontainers container lives in docker while deacon looks in
+/// podman's store, which is an invalid cross-runtime scenario, not a deacon bug.
+///
+/// Returns `true` (caller should `return` early) when running under non-docker.
+pub fn skip_if_not_docker_runtime() -> bool {
+    match std::env::var("DEACON_CONTAINER_RUNTIME") {
+        Ok(rt) if rt != "docker" => {
+            eprintln!(
+                "skipping testcontainers-based test: DEACON_CONTAINER_RUNTIME={rt} \
+                 (testcontainers requires the docker API)"
+            );
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Create a simple Alpine container request that sleeps forever.
 /// Useful for tests that need a running container to exec into.
 pub fn alpine_sleep_image() -> ContainerRequest<GenericImage> {


### PR DESCRIPTION
## What & why

The experimental podman CI lane (#236) first ran at **136/163 passing, 27 failing** — every failure in the `up`/`exec`/`down` lifecycle smoke + integration tests. Root cause: `CliRuntime::up` has **no pull step**, so `podman create alpine:3.19` is handed a bare short name that rootless podman cannot resolve (Docker auto-pulls it; podman does not, non-interactively). A related blocker hits feature/Dockerfile builds — locally-built bare tags (`deacon-build:<hash>`, `deacon-devcontainer-features:<hash>`) are treated by podman as remote pull targets and must be referenced as `localhost/<tag>`.

## Changes

- **Runtime-flavor awareness** (`crates/core/src/docker.rs`): `CliRuntime` gains a `RuntimeFlavor` field so command construction can branch docker-vs-podman. Set by `docker()`/`podman()`, inferred by binary basename in `with_runtime_path`, explicit via `with_runtime_path_and_flavor`. Adds `is_podman()` / `runtime_path()`.
- **Image-ref qualification**: `qualify_image_ref()` — under podman, a bare ref present locally → `localhost/<ref>`; a short remote name → `docker.io/library/<ref>`; already-qualified refs and **all** docker refs pass through unchanged. Applied at `create_container` and `inspect_image`. Reuses `registry_parser::looks_like_registry`.
- **Build-binary routing**: the `up` build path (base-image build, feature build, Dockerfile feature build, image tag) now runs the **selected** runtime binary instead of a hardcoded `"docker"`, so feature/Dockerfile builds land in podman's image store. `deacon build` stays docker-only (tracked under #30 deferred items).

## Scope

Green-the-lane burn-down only. Deferred (tracked on #30): rootless `label=disable`, `--userns=keep-id`/`--uidmap`, podman-aware GPU `info` query, docs/marker removal, and `deacon build` podman support.

## Tests

- New unit tests: qualification truth table (`is_already_qualified`, `qualify_short_remote`), docker no-op, podman pass-through, flavor constructors.
- Full `dev-fast` suite (2618) + doctests (130) green locally.
- The `test-podman` lane on this PR is the end-to-end check; once it reaches 163/163 a follow-up commit flips it from `continue-on-error` to required.

Refs #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)