### PR TITLE
feat(podman): 1.1 polish — rootless SELinux/userns, GPU skip, runtime threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ The 1.0 release is being assembled across a series of PRs tracked in
 
 ### Added
 
+- **Podman promoted from experimental to supported.** A required CI lane runs the
+  integration suite against rootless Podman. Beyond the parity fixes already
+  landed (local image-ref qualification, `podman ps` JSON shape, runtime
+  selection across `up`/`exec`/`down`), this adds the rootless-host arguments
+  mirroring upstream `getPodmanArgs`: `--security-opt label=disable` (so host
+  bind mounts are accessible without the destructive `:Z` relabel) and
+  `--userns=keep-id` for non-root users (skipped for root, and when the user
+  supplies their own `--uidmap`/`--gidmap`). `run-user-commands` and `set-up`
+  now honor `--runtime`/`DEACON_CONTAINER_RUNTIME` like the other commands, and
+  GPU detection no longer emits a spurious WARN under Podman (it cleanly reports
+  no GPU — CDI passthrough remains a follow-up). See
+  [#30](https://github.com/get2knowio/deacon/issues/30).
+
 - `DEACON_OVERRIDE_CONFIG` environment variable as an alternative to the
   `--override-config` flag (the explicit flag takes precedence). Uses clap-native
   `env` support, so `--help` advertises it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,7 +552,7 @@ echo "$OUTPUT" | jq '.configuration'
 
 **Container Runtimes:**
 - Docker (default, production-ready)
-- Podman (experimental in 1.0; trait-level support complete; parity items and test coverage targeted for 1.1)
+- Podman (supported; required CI lane runs the integration suite against rootless Podman). Podman-specific handling lives behind `CliRuntime::is_podman()` in `crates/core/src/docker.rs`: image-ref qualification (`localhost/…` / `docker.io/library/…`), `podman ps` JSON shape (`Id`+`Names` array), SELinux `--security-opt label=disable`, and rootless `--userns=keep-id` for non-root users (`podman_create_args`, mirroring upstream `getPodmanArgs`). Remaining gap: GPU passthrough is not wired for Podman (`detect_gpu_capability` short-circuits to "unavailable").
 
 ## CI/CD Requirements
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ see SECURITY.md for the manual `ARG`/`COPY` convention.
 
 | Limitation | Notes |
 |---|---|
-| **Podman runtime** | Ships as **experimental in 1.0**. Trait-level integration is complete and the happy path works, but rootless-Podman parity items (`label=disable`, `--userns=keep-id`, `--uidmap`/`--gidmap`) and dedicated test coverage are targeted for **1.1** — see [#30](https://github.com/get2knowio/deacon/issues/30). Using `--runtime podman` emits a one-time WARN. |
+| **Podman runtime** | **Supported.** A required CI lane runs the integration suite against rootless Podman, and `up`/`exec`/`down`/`run-user-commands`/`set-up` handle Podman's image-ref qualification, `ps`-JSON shape, SELinux `label=disable`, and rootless `--userns=keep-id`. Remaining gap: **GPU passthrough is not wired for Podman** (`--gpu detect` cleanly reports no GPU; CDI/`--device` support is a follow-up). See [#30](https://github.com/get2knowio/deacon/issues/30). |
 | **`build` features** | Feature installation during `build` is supported for **Dockerfile-based** configs only. Compose-build and image-reference configs still error out with features (different integration patterns; tracked as a post-1.0 follow-up). |
 
 For the full 1.0 roadmap, see [docs/ROADMAP_TO_1.0.md](docs/ROADMAP_TO_1.0.md). Post-1.0 hardening landed in May 2026 — redaction wiring into the tracing pipeline, a [workspace-trust gate](#workspace-trust) for host-side lifecycle hooks, async I/O conversion across `crates/core`, typed errors throughout `crates/core`, and the `json5`→`jsonc-parser` migration (see closed [#52](https://github.com/get2knowio/deacon/issues/52)).
@@ -222,22 +222,23 @@ See the full details and additional commands in `examples/README.md`.
 
 ## Runtime Selection
 
-Deacon uses Docker as its container runtime. Podman support ships in **1.0 as
-experimental**: the trait-level integration is complete, but rootless-Podman
-parity items (`label=disable`, `--userns=keep-id`, `--uidmap`/`--gidmap`) and
-dedicated test coverage are still required for full support, targeted for 1.1
-(tracked in [#30](https://github.com/get2knowio/deacon/issues/30)). Using
-`--runtime podman` emits a one-time WARN.
+Deacon supports **Docker** (default) and **Podman**. Podman is exercised by a
+required CI lane that runs the integration suite against rootless Podman, and
+the consumer commands handle Podman's specifics automatically: local image-ref
+qualification (`localhost/…`), the `podman ps` JSON shape, SELinux relabeling
+(`--security-opt label=disable`), and rootless UID mapping (`--userns=keep-id`
+for non-root users). The one remaining gap is GPU passthrough, which is not yet
+wired for Podman (tracked in [#30](https://github.com/get2knowio/deacon/issues/30)).
 
 ```bash
 # Explicitly select Docker (optional, it's the default)
 deacon --runtime docker up
 
-# Experimental: select Podman
+# Select Podman
 deacon --runtime podman up
 
 # Or via environment variable
-DEACON_CONTAINER_RUNTIME=docker deacon up
+DEACON_CONTAINER_RUNTIME=podman deacon up
 ```
 
 ## Runtime Configuration

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -926,6 +926,74 @@ impl CliRuntime {
             Self::qualify_short_remote(image_ref)
         }
     }
+
+    /// Extract the user named by a `--user`/`-u` flag in `run_args`, if any.
+    ///
+    /// Accepts both the split form (`--user`, `<value>`) and the joined form
+    /// (`--user=<value>` / `-u=<value>`). Mirrors upstream `findUserArg`.
+    fn find_user_arg(run_args: &[String]) -> Option<String> {
+        let mut iter = run_args.iter();
+        while let Some(arg) = iter.next() {
+            if let Some(value) = arg
+                .strip_prefix("--user=")
+                .or_else(|| arg.strip_prefix("-u="))
+            {
+                return Some(value.to_string());
+            }
+            if arg == "--user" || arg == "-u" {
+                if let Some(value) = iter.next() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    /// Podman-specific `create` arguments for rootless/SELinux Linux hosts,
+    /// mirroring upstream devcontainers/cli `getPodmanArgs`
+    /// (`src/spec-node/singleContainer.ts`):
+    ///
+    /// - `--security-opt label=disable` is added unconditionally so host bind
+    ///   mounts are accessible without the destructive `:Z` SELinux relabel
+    ///   (which rewrites labels on the host's own files). Harmless when SELinux
+    ///   is already disabled.
+    /// - `--userns=keep-id` maps the host UID/GID into the container so a
+    ///   non-root container user can read/write bind-mounted host files. It is
+    ///   added ONLY when the effective remote user is non-root AND the user has
+    ///   not supplied their own `--uidmap`/`--gidmap` in `runArgs` (the two are
+    ///   mutually exclusive in podman). Skipping it for root avoids the
+    ///   well-known breakage where keep-id makes root-owned mounts inaccessible
+    ///   (devcontainers/cli #1004).
+    ///
+    /// No-op under docker or on non-Linux hosts. `remote_user` is the resolved
+    /// effective user (config `remoteUser` → `--user` runArg → `containerUser`);
+    /// `None` is treated as root.
+    fn podman_create_args(
+        is_podman: bool,
+        remote_user: Option<&str>,
+        run_args: &[String],
+    ) -> Vec<String> {
+        // `cfg!` is a runtime boolean here (we only want this behavior on Linux
+        // hosts, where podman's userns/SELinux semantics apply); both branches
+        // still compile on every platform.
+        if !is_podman || !cfg!(target_os = "linux") {
+            return Vec::new();
+        }
+
+        let mut args = vec!["--security-opt".to_string(), "label=disable".to_string()];
+
+        let has_id_mapping = run_args
+            .iter()
+            .any(|a| a.starts_with("--uidmap") || a.starts_with("--gidmap"));
+        if !has_id_mapping {
+            let user = remote_user.unwrap_or("root");
+            if user != "root" && user != "0" {
+                args.push("--userns=keep-id".to_string());
+            }
+        }
+
+        args
+    }
 }
 
 impl Default for CliRuntime {
@@ -2196,6 +2264,21 @@ impl ContainerOps for CliRuntime {
             }
         }
 
+        // Podman rootless/SELinux args (no-op under docker / non-Linux):
+        // `--security-opt label=disable` always, and `--userns=keep-id` when the
+        // effective remote user is non-root. Resolve that user the way upstream
+        // does: config remoteUser → a `--user` runArg → containerUser.
+        let effective_user = config
+            .remote_user
+            .clone()
+            .or_else(|| Self::find_user_arg(&config.run_args))
+            .or_else(|| config.container_user.clone());
+        args.extend(Self::podman_create_args(
+            self.is_podman(),
+            effective_user.as_deref(),
+            &config.run_args,
+        ));
+
         // Add runArgs if present
         args.extend(config.run_args.iter().cloned());
 
@@ -3302,6 +3385,83 @@ mod tests {
             "docker.io/library/alpine:3.19",
         ] {
             assert_eq!(podman.qualify_image_ref(r).await, r);
+        }
+    }
+
+    #[test]
+    fn test_find_user_arg() {
+        // Split form.
+        assert_eq!(
+            CliRuntime::find_user_arg(&["--user".to_string(), "vscode".to_string()]).as_deref(),
+            Some("vscode")
+        );
+        assert_eq!(
+            CliRuntime::find_user_arg(&["-u".to_string(), "1000".to_string()]).as_deref(),
+            Some("1000")
+        );
+        // Joined form.
+        assert_eq!(
+            CliRuntime::find_user_arg(&["--user=node".to_string()]).as_deref(),
+            Some("node")
+        );
+        assert_eq!(
+            CliRuntime::find_user_arg(&["-u=node".to_string()]).as_deref(),
+            Some("node")
+        );
+        // Absent.
+        assert_eq!(
+            CliRuntime::find_user_arg(&["--privileged".to_string()]),
+            None
+        );
+        assert_eq!(CliRuntime::find_user_arg(&[]), None);
+    }
+
+    #[test]
+    fn test_podman_create_args_docker_is_noop() {
+        // Docker never gets podman args, regardless of user.
+        assert!(CliRuntime::podman_create_args(false, Some("vscode"), &[]).is_empty());
+        assert!(CliRuntime::podman_create_args(false, None, &[]).is_empty());
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_podman_create_args_linux() {
+        // Root (or unset) user: only the SELinux label-disable, no keep-id.
+        assert_eq!(
+            CliRuntime::podman_create_args(true, Some("root"), &[]),
+            vec!["--security-opt".to_string(), "label=disable".to_string()]
+        );
+        assert_eq!(
+            CliRuntime::podman_create_args(true, Some("0"), &[]),
+            vec!["--security-opt".to_string(), "label=disable".to_string()]
+        );
+        assert_eq!(
+            CliRuntime::podman_create_args(true, None, &[]),
+            vec!["--security-opt".to_string(), "label=disable".to_string()]
+        );
+
+        // Non-root user: keep-id is added on top of label-disable.
+        assert_eq!(
+            CliRuntime::podman_create_args(true, Some("vscode"), &[]),
+            vec![
+                "--security-opt".to_string(),
+                "label=disable".to_string(),
+                "--userns=keep-id".to_string()
+            ]
+        );
+
+        // User-supplied --uidmap/--gidmap suppresses keep-id (mutually exclusive),
+        // but label-disable still applies.
+        for mapping in ["--uidmap=0:1000:1", "--gidmap"] {
+            assert_eq!(
+                CliRuntime::podman_create_args(
+                    true,
+                    Some("vscode"),
+                    &[mapping.to_string(), "1".to_string()]
+                ),
+                vec!["--security-opt".to_string(), "label=disable".to_string()],
+                "id mapping {mapping} must suppress keep-id"
+            );
         }
     }
 

--- a/crates/core/src/gpu.rs
+++ b/crates/core/src/gpu.rs
@@ -146,6 +146,15 @@ impl UpGpuApplication {
     }
 }
 
+/// Whether a runtime binary path refers to podman, by basename (mirrors the flavor inference used by `CliRuntime::with_runtime_path` in `docker.rs`).
+fn runtime_path_is_podman(runtime_path: &str) -> bool {
+    std::path::Path::new(runtime_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|name| name.contains("podman"))
+        .unwrap_or(false)
+}
+
 /// Detect GPU capability on the host by checking for GPU-capable runtimes.
 ///
 /// This function queries the Docker daemon for available runtimes and checks
@@ -166,6 +175,20 @@ impl UpGpuApplication {
 #[instrument(skip(runtime_path))]
 pub async fn detect_gpu_capability(runtime_path: &str) -> HostGpuCapability {
     debug!("Detecting GPU capability using runtime: {}", runtime_path);
+
+    // Podman has no `.Runtimes` field in `podman info`, so the docker-shaped
+    // `--format {{json .Runtimes}}` query below errors ("can't evaluate field
+    // Runtimes in type *define.Info"). Podman exposes GPUs via CDI devices, not
+    // an OCI-runtime registry, so there is nothing equivalent to probe here.
+    // Treat it as "no GPU runtime detected" (a clean, non-error result) so
+    // `--gpu detect` proceeds without acceleration and without a noisy WARN.
+    if runtime_path_is_podman(runtime_path) {
+        debug!(
+            "GPU runtime detection is not supported on podman ({}); treating as unavailable",
+            runtime_path
+        );
+        return HostGpuCapability::unavailable();
+    }
 
     // Execute 'docker info --format {{json .Runtimes}}' to get runtime information
     let output = tokio::process::Command::new(runtime_path)
@@ -327,6 +350,29 @@ mod tests {
                 .probe_error
                 .unwrap()
                 .contains("Failed to execute runtime info command")
+        );
+    }
+
+    #[test]
+    fn test_runtime_path_is_podman() {
+        assert!(runtime_path_is_podman("podman"));
+        assert!(runtime_path_is_podman("/usr/bin/podman"));
+        assert!(runtime_path_is_podman("podman-remote"));
+        assert!(!runtime_path_is_podman("docker"));
+        assert!(!runtime_path_is_podman("/usr/local/bin/docker"));
+    }
+
+    #[tokio::test]
+    async fn test_detect_gpu_capability_podman_is_unavailable_not_error() {
+        // Podman short-circuits to a clean "unavailable" result without shelling
+        // out (the binary name need not exist) and without surfacing a probe
+        // error — so `--gpu detect` proceeds quietly without acceleration.
+        let result = detect_gpu_capability("/nonexistent/path/podman").await;
+        assert!(!result.available);
+        assert!(
+            result.probe_error.is_none(),
+            "podman GPU detection must not report a probe error: {:?}",
+            result.probe_error
         );
     }
 

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -10,23 +10,6 @@ use crate::docker::{
 };
 use crate::errors::{DeaconError, Result};
 use std::path::Path;
-use std::sync::Once;
-
-/// Emits the Podman experimental-status WARN at most once per process.
-static PODMAN_EXPERIMENTAL_WARN: Once = Once::new();
-
-/// Emit a one-time WARN when Podman is selected so users see the experimental
-/// status banner without spamming on every operation. Idempotent across calls.
-fn warn_podman_experimental_once() {
-    PODMAN_EXPERIMENTAL_WARN.call_once(|| {
-        tracing::warn!(
-            target: "deacon::runtime",
-            "Podman runtime is experimental in this release. Rootless-Podman parity \
-             items (label=disable, --userns=keep-id, --uidmap/--gidmap) and Podman \
-             test coverage are still required for full support, targeted for 1.1."
-        );
-    });
-}
 
 /// Container runtime abstraction that combines Docker and ContainerOps traits
 #[allow(async_fn_in_trait)]
@@ -82,9 +65,8 @@ impl RuntimeFactory {
     /// Detect runtime from CLI flag, environment variable, or default
     ///
     /// Precedence: CLI flag > `DEACON_CONTAINER_RUNTIME` env var > default (docker).
-    /// Selecting Podman emits a one-time experimental-status WARN.
     pub fn detect_runtime(cli_runtime: Option<RuntimeKind>) -> RuntimeKind {
-        let selected = if let Some(runtime) = cli_runtime {
+        if let Some(runtime) = cli_runtime {
             runtime
         } else if let Some(env_runtime) = std::env::var("DEACON_CONTAINER_RUNTIME")
             .ok()
@@ -93,13 +75,7 @@ impl RuntimeFactory {
             env_runtime
         } else {
             RuntimeKind::Docker
-        };
-
-        if selected == RuntimeKind::Podman {
-            warn_podman_experimental_once();
         }
-
-        selected
     }
 
     /// Create runtime instance based on RuntimeKind

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -97,7 +97,7 @@ use std::path::PathBuf;
 pub enum RuntimeOption {
     /// Docker runtime
     Docker,
-    /// Podman runtime (experimental in 1.0)
+    /// Podman runtime (rootless-aware: SELinux `label=disable` + `--userns=keep-id`)
     Podman,
 }
 
@@ -895,7 +895,7 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "NAME")]
     pub plugin: Vec<String>,
 
-    /// Container runtime to use (docker or podman [experimental]; can be set via DEACON_CONTAINER_RUNTIME env var)
+    /// Container runtime to use (docker or podman; can be set via DEACON_CONTAINER_RUNTIME env var)
     #[arg(long, global = true, value_enum)]
     pub runtime: Option<RuntimeOption>,
 
@@ -1653,7 +1653,7 @@ impl Cli {
                     container_data_folder: self.container_data_folder.clone(),
                 };
 
-                execute_run_user_commands(args).await
+                execute_run_user_commands(args, self.runtime.map(|r| r.into())).await
             }
             Some(Commands::SetUp {
                 container_id,
@@ -1691,7 +1691,7 @@ impl Cli {
                     progress_tracker: progress_tracker.clone(),
                 };
 
-                execute_set_up(args).await
+                execute_set_up(args, self.runtime.map(|r| r.into())).await
             }
             Some(Commands::Down {
                 remove,

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -3,14 +3,16 @@
 //! This module provides execution of lifecycle commands in an existing container
 //! without going through the full `up` workflow.
 
-use crate::commands::shared::{ConfigLoadArgs, ConfigLoadResult, load_config};
+use crate::commands::shared::{ConfigLoadArgs, ConfigLoadResult, load_config, resolve_runtime};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
     ContainerLifecycleCommands, ContainerLifecycleConfig, LifecycleCommandList,
-    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback,
+    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback_and_docker,
 };
+use deacon_core::docker::CliRuntime;
 use deacon_core::lifecycle::{LifecyclePhase, should_queue_phase_for_wait_for, wait_for_phase};
+use deacon_core::runtime::RuntimeKind;
 use deacon_core::variable::SubstitutionContext;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -43,9 +45,17 @@ pub struct RunUserCommandsArgs {
 }
 
 /// Execute the run-user-commands command
-#[instrument(skip(args))]
-pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> {
+#[instrument(skip(args, runtime))]
+pub async fn execute_run_user_commands(
+    args: RunUserCommandsArgs,
+    runtime: Option<RuntimeKind>,
+) -> Result<()> {
     info!("Starting run-user-commands execution");
+
+    // Select the runtime (docker/podman) honoring --runtime/DEACON_CONTAINER_RUNTIME.
+    // Hardcoding CliDocker::new() here would talk to docker while the container
+    // lives in podman → "Dev container not found" (mirrors the up/exec/down fix).
+    let cli = resolve_runtime(runtime, &args.docker_path).cli_docker();
 
     // Load configuration with override and secrets support via shared helper
     let ConfigLoadResult {
@@ -64,7 +74,7 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
     debug!("Loaded configuration with overrides and secrets support");
 
     let container_id = {
-        let docker_client = deacon_core::docker::CliDocker::new();
+        let docker_client = cli.clone();
 
         // Container selection precedence (matches `exec`):
         // 1. --container-id (direct lookup)
@@ -139,12 +149,8 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
     // no activation re-resolve) into containerEnv, insert-if-absent so user
     // values win. Mirrors `exec`.
     {
-        let docker_client = deacon_core::docker::CliDocker::new();
-        if let Some(bundle_path) = crate::commands::shared::host_ca::read_host_ca_bundle_path(
-            &docker_client,
-            &container_id,
-        )
-        .await
+        if let Some(bundle_path) =
+            crate::commands::shared::host_ca::read_host_ca_bundle_path(&cli, &container_id).await
         {
             for name in deacon_core::host_ca::CA_ENV_VARS {
                 config
@@ -157,7 +163,14 @@ pub async fn execute_run_user_commands(args: RunUserCommandsArgs) -> Result<()> 
     }
 
     // Execute lifecycle commands
-    execute_lifecycle_commands(&container_id, &config, workspace_folder.as_path(), &args).await?;
+    execute_lifecycle_commands(
+        &container_id,
+        &config,
+        workspace_folder.as_path(),
+        &args,
+        &cli,
+    )
+    .await?;
 
     info!("Run-user-commands execution completed successfully");
     Ok(())
@@ -170,6 +183,7 @@ async fn execute_lifecycle_commands(
     config: &DevContainerConfig,
     workspace_folder: &Path,
     args: &RunUserCommandsArgs,
+    cli: &CliRuntime,
 ) -> Result<()> {
     info!("Executing lifecycle commands in container");
 
@@ -322,11 +336,13 @@ async fn execute_lifecycle_commands(
         }
     }
 
-    // Execute lifecycle commands with progress callback
-    let result = execute_container_lifecycle_with_progress_callback(
+    // Execute lifecycle commands with progress callback, against the SELECTED
+    // runtime (docker/podman) rather than a hardcoded docker client.
+    let result = execute_container_lifecycle_with_progress_callback_and_docker(
         &lifecycle_config,
         &commands,
         &substitution_context,
+        cli,
         Some(crate::commands::shared::progress::make_progress_callback(
             &args.progress_tracker,
         )),
@@ -353,15 +369,13 @@ async fn execute_lifecycle_commands(
     // above), so an empty `non_blocking_phases` here means we have nothing
     // to do.
     if !result.non_blocking_phases.is_empty() {
-        use deacon_core::docker::CliDocker;
         debug!(
             "Executing {} non-blocking phase(s) synchronously",
             result.non_blocking_phases.len()
         );
-        let docker = CliDocker::new();
         result
             .execute_non_blocking_phases_sync_with_callback(
-                &docker,
+                cli,
                 Some(crate::commands::shared::progress::make_progress_callback(
                     &args.progress_tracker,
                 )),

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -32,14 +32,16 @@
 //!   (`${containerEnv:VAR}`) — current pass uses only the configured
 //!   `container_env`, not the live `docker exec` env probe
 
+use crate::commands::shared::resolve_runtime;
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
     AggregatedLifecycleCommand, ContainerLifecycleCommands, ContainerLifecycleConfig,
     DotfilesConfig, LifecycleCommandList, LifecycleCommandSource, LifecycleCommandValue,
-    execute_container_lifecycle_with_progress_callback,
+    execute_container_lifecycle_with_progress_callback_and_docker,
 };
-use deacon_core::docker::{CliDocker, ContainerInfo, Docker, ExecConfig};
+use deacon_core::docker::{CliRuntime, ContainerInfo, Docker, ExecConfig};
+use deacon_core::runtime::RuntimeKind;
 use deacon_core::variable::SubstitutionContext;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -88,10 +90,9 @@ pub struct SetUpArgs {
     /// `/var/devcontainer`. Spec §6 — `.patchEtcEnvironmentMarker` and
     /// `.patchEtcProfileMarker` live here.
     pub container_system_data_folder: Option<PathBuf>,
-    /// Docker CLI path; defaults to `"docker"`. Currently plumbed for shape
-    /// parity with `run-user-commands`; `CliDocker::new()` uses the binary
-    /// resolution baked into the runtime layer.
-    #[allow(dead_code)]
+    /// Docker CLI path; defaults to `"docker"`. Forwarded to
+    /// [`resolve_runtime`] so a `--docker-path` override reaches the selected
+    /// runtime (and, under docker, the binary it shells out to).
     pub docker_path: String,
     /// Progress tracker shared with the CLI shell.
     pub progress_tracker: Arc<Mutex<Option<deacon_core::progress::ProgressTracker>>>,
@@ -122,16 +123,20 @@ enum SetUpResult {
 /// `Ok(())`. On error: propagates the error so the binary boundary maps it
 /// to the spec's `{outcome: "error", ...}` JSON shape + exit code 1
 /// (handled in `crates/deacon/src/main.rs` via the existing error path).
-#[instrument(skip(args), fields(container_id = %args.container_id))]
-pub async fn execute_set_up(args: SetUpArgs) -> Result<()> {
+#[instrument(skip(args, runtime), fields(container_id = %args.container_id))]
+pub async fn execute_set_up(args: SetUpArgs, runtime: Option<RuntimeKind>) -> Result<()> {
     info!("Starting set-up execution");
 
     // Phase 1: Validate --remote-env early (fail-fast per spec §9).
     parse_remote_env(&args.remote_env)?;
 
+    // Select the runtime (docker/podman) honoring --runtime/DEACON_CONTAINER_RUNTIME.
+    // Hardcoding CliDocker::new() here would inspect/exec via docker while the
+    // container lives in podman → "Dev container not found" (mirrors up/exec/down).
+    let docker = resolve_runtime(runtime, &args.docker_path).cli_docker();
+
     // Phase 2: Inspect the target container. Per spec §9, a missing container
     // produces the upstream-aligned summary "Dev container not found."
-    let docker = CliDocker::new();
     let container = docker
         .inspect_container(&args.container_id)
         .await
@@ -195,6 +200,7 @@ pub async fn execute_set_up(args: SetUpArgs) -> Result<()> {
             &container,
             &substituted_merged,
             &substitution_context,
+            &docker,
         )
         .await?;
     } else {
@@ -351,6 +357,7 @@ async fn execute_lifecycle_hooks(
     container: &ContainerInfo,
     merged_config: &DevContainerConfig,
     substitution_context: &SubstitutionContext,
+    cli: &CliRuntime,
 ) -> Result<()> {
     let remote_env_pairs = parse_remote_env(&args.remote_env)?;
 
@@ -436,10 +443,11 @@ async fn execute_lifecycle_hooks(
     }
 
     debug!("Executing lifecycle hooks in container {}", container.id);
-    let result = execute_container_lifecycle_with_progress_callback(
+    let result = execute_container_lifecycle_with_progress_callback_and_docker(
         &lifecycle_config,
         &commands,
         substitution_context,
+        cli,
         Some(crate::commands::shared::progress::make_progress_callback(
             &args.progress_tracker,
         )),
@@ -469,15 +477,13 @@ async fn execute_lifecycle_hooks(
     // set-up previously stopped at the log line, so file side effects
     // (e.g. `/tmp/postStart.flag`) were never observable to callers.
     if !result.non_blocking_phases.is_empty() {
-        use deacon_core::docker::CliDocker;
         debug!(
             "Executing {} non-blocking phase(s) synchronously",
             result.non_blocking_phases.len()
         );
-        let docker = CliDocker::new();
         result
             .execute_non_blocking_phases_sync_with_callback(
-                &docker,
+                cli,
                 Some(crate::commands::shared::progress::make_progress_callback(
                     &args.progress_tracker,
                 )),


### PR DESCRIPTION
Wraps up the **1.1 Podman polish** tracked in #30, now that the parity burn-down (#237) made the **Test (Podman)** CI lane required and green.

## What's here

### 1 + 2. Rootless SELinux relabel + userns (`crates/core/src/docker.rs`)
`create_container` now emits podman-specific args on Linux, mirroring upstream `getPodmanArgs` (`devcontainers/cli` `src/spec-node/singleContainer.ts`):
- **`--security-opt label=disable`** — always (so host bind mounts are accessible without the destructive `:Z` relabel that rewrites labels on the host's own files; harmless when SELinux is already off).
- **`--userns=keep-id`** — only when the effective remote user is non-root **and** the user hasn't supplied their own `--uidmap`/`--gidmap` (mutually exclusive in podman). Skipping it for root avoids the well-known breakage in [devcontainers/cli#1004](https://github.com/devcontainers/cli/issues/1004).

> Note: upstream applies SELinux handling as a single `--security-opt label=disable` (not a per-mount `label=disable` as the issue framing suggested). Followed upstream per the constitution ("upstream wins"). Effective user is resolved the upstream way: `remoteUser` → a `--user` runArg → `containerUser`. Pure, unit-tested helpers (`podman_create_args`, `find_user_arg`).

### 3. Podman-aware GPU detection (`crates/core/src/gpu.rs`)
`podman info` has no `.Runtimes` field, so the docker-shaped `--format {{json .Runtimes}}` query errored into a noisy WARN. Now short-circuits under podman to a clean "unavailable" result — `--gpu detect` proceeds without acceleration, no WARN. (CDI/`--device` GPU passthrough for podman is a follow-up.)

### 4. Runtime threading for `run-user-commands` + `set-up`
Both hardcoded `CliDocker::new()` and ignored `--runtime`/`DEACON_CONTAINER_RUNTIME` (the same class of bug fixed for `up`/`exec`/`down` in #237). They now select via the shared `resolve_runtime()` and run lifecycle + non-blocking phases against the selected runtime.

### 5. Docs / marker removal
Podman is promoted from experimental to **supported**: removed the one-time experimental WARN, updated README "Known limitations" + "Runtime Selection", CLAUDE.md, `--runtime` help text + `RuntimeOption::Podman` doc, and added a CHANGELOG entry. README/CLAUDE call out GPU-on-podman as the one remaining gap.

## Testing
- New unit tests: `podman_create_args` (docker no-op; root vs non-root; uidmap/gidmap suppression), `find_user_arg` (split/joined/absent), `runtime_path_is_podman`, and podman GPU short-circuit.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `make test-nextest-fast` — 2624 passed, 31 skipped.
- The SELinux/userns args aren't exercised by the (non-SELinux) CI runner, so they're covered by targeted unit tests per the issue guidance.

Closes the remaining 1.1 checklist in #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)