### PR TITLE
chore(release): bump version to 0.2.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.6"
+version = "0.2.0-rc.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.6"
+version = "0.2.0-rc.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.6" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.7" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.6"
+version = "0.2.0-rc.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.6"
+version = "0.2.0-rc.7"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Cuts the next prerelease, `v0.2.0-rc.7`.

Bumps the version in all four required spots (root `Cargo.toml` `deacon-core`
dep, `crates/deacon/Cargo.toml`, `crates/core/Cargo.toml`, `Cargo.lock`).

## What's new since rc.6

- **Podman 1.1 polish (#238)** — rootless `--security-opt label=disable` +
  `--userns=keep-id` (skipped for root and when the user supplies their own
  `--uidmap`/`--gidmap`), podman-aware GPU detection (clean "no GPU" instead of
  a spurious WARN), runtime threading through `run-user-commands`/`set-up`, and
  removal of the "experimental" markers. Podman promoted to **supported**.
- **Non-required nightly Windows + Podman smoke lane (#242, #240, #241)** —
  proves a `windows-latest` runner can host `podman machine` (WSL2) and run a
  full `deacon up → exec → down`, gathering reliability data ahead of a
  promote-to-required decision (#239).

After merge, push the annotated `v0.2.0-rc.7` tag on the merged `main` commit to
trigger the Release workflow (it validates the tag equals
`crates/deacon/Cargo.toml`'s version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)