### PR TITLE
chore: enforce 7-day supply-chain cooldown on dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    # Supply-chain cooldown: hold newly published crate versions for 7 days so a
+    # compromised release can be detected/yanked before it's proposed. (cargo
+    # has no install-time cooldown, so this Dependabot gate is the only layer.)
+    cooldown:
+      default-days: 7
     groups:
       rust-minor-patch:
         update-types:
@@ -33,6 +38,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    cooldown:
+      default-days: 7
     groups:
       actions-minor-patch:
         update-types:


### PR DESCRIPTION
## Supply-chain cooldown (7-day minimum release age)

Part of an org-wide rollout hardening get2knowio repos against supply-chain attacks. A newly published dependency version must age **7 days** before it can be installed/resolved or proposed by Dependabot — giving time for a malicious release to be detected and yanked. Security updates are never delayed (Dependabot cooldown applies to *version* updates only).

Config schema verified against current official docs (not training data).

### Changes
- **Dependabot** — `cooldown: { default-days: 7 }` on the `cargo` and `github-actions` entries.

⚠️ **cargo has no native install-time cooldown** — there is no package-manager layer to apply, so the Dependabot gate is the only cooldown layer for Rust crates here. Existing `ignore` rules (reqwest major, dtolnay/rust-toolchain) are preserved.
