### PR TITLE
fix(install): read overwrite prompt from /dev/tty

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -378,8 +378,20 @@ main() {
 
         if [[ "${DEACON_FORCE:-false}" != "true" ]]; then
             warn "Deacon is already installed: $existing_version"
-            echo -n "Do you want to overwrite? [y/N] "
-            read -r response
+            # When invoked via `curl ... | bash`, stdin is the pipe (already at
+            # EOF), not the keyboard — so `read` from stdin would auto-answer
+            # with an empty string and cancel. Read from the controlling
+            # terminal instead. If there's no terminal (truly non-interactive,
+            # e.g. CI), fail fast with guidance rather than silently cancelling.
+            local response=""
+            if [[ -r /dev/tty ]]; then
+                echo -n "Do you want to overwrite? [y/N] " > /dev/tty
+                read -r response < /dev/tty || response=""
+            else
+                error "Deacon is already installed ($existing_version) and no terminal is available to confirm overwrite."
+                error "Re-run with DEACON_FORCE=true to overwrite non-interactively."
+                exit 1
+            fi
             if [[ ! "$response" =~ ^[Yy]$ ]]; then
                 info "Installation cancelled"
                 exit 0


### PR DESCRIPTION
## Problem

Running the piped install with an existing install present auto-answers its own overwrite prompt and cancels:

```
$ curl -fsSL https://get2knowio.github.io/deacon/install.sh | bash -s -- --prerelease
...
warn: Deacon is already installed: deacon 0.2.0-rc.1
Do you want to overwrite? [y/N]     # never waits — cancels immediately
```

When invoked via `curl ... | bash`, the script itself arrives on bash's **stdin** through the pipe. By the time execution reaches the overwrite prompt, curl has closed that pipe, so stdin is at EOF. `read -r response` then returns an empty answer immediately, the `^[Yy]$` test fails, and the install cancels without ever waiting for a keypress.

## Fix

Prompt and read from the controlling terminal (`/dev/tty`) instead of stdin, so the prompt actually waits for user input. When no terminal is attached (truly non-interactive, e.g. CI), fail fast with guidance to set `DEACON_FORCE=true` rather than silently cancelling.

## Notes

- `scripts/install.sh` is deployed to Pages by the release workflow, so the live `get2knowio.github.io/deacon/install.sh` picks this up on the next release deploy.
- Workaround until then: `curl -fsSL .../install.sh | DEACON_FORCE=true bash -s -- --prerelease`
- Verified with `bash -n` (syntax check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)