### PR TITLE
refactor(logging): downgrade expected feature/GPU detect noise

### DIFF
--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument};
 
 /// Canonicalize a feature ID by trimming whitespace
 ///
@@ -1018,8 +1018,13 @@ impl FeatureDependencyResolver {
                         dependencies.insert(canonical);
                     }
                     None => {
-                        warn!(
-                            "Feature '{}' depends on '{}' which is not in the feature set",
+                        // `installsAfter` is a soft ordering hint, not a dependency:
+                        // per spec it only orders features already in the set and never
+                        // pulls in missing ones. An unresolved entry is expected, common
+                        // (e.g. every feature's installsAfter on common-utils), and not
+                        // actionable by the user — pure ordering bookkeeping, so debug.
+                        debug!(
+                            "Feature '{}' lists 'installsAfter' '{}', which is not in the feature set; ignoring for ordering",
                             feature.id, after_id
                         );
                     }

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -160,7 +160,13 @@ pub async fn execute_up(args: UpArgs) -> Result<UpContainerInfo> {
                     error
                 );
             } else {
-                warn!(
+                // `detect` is best-effort by design ("use a GPU if one is
+                // present, otherwise proceed without"). Finding none is the
+                // expected outcome on a GPU-less host, not a problem the user
+                // must act on, so this is informational rather than a warning.
+                // (A probe *error* above stays at warn — that's an actual
+                // malfunction, not a clean negative result.)
+                info!(
                     "GPU mode 'detect' specified but no GPU runtime found. Proceeding without GPU acceleration."
                 );
             }


### PR DESCRIPTION
## Context

On a normal `up`, deacon emits WARN lines that read as problems when nothing is wrong:

```
WARN deacon::commands::up: GPU mode 'detect' specified but no GPU runtime found. Proceeding without GPU acceleration.
WARN deacon_core::features: Feature 'ghcr.io/devcontainers/features/node' depends on 'ghcr.io/devcontainers/features/common-utils' which is not in the feature set
WARN deacon_core::features: Feature 'ghcr.io/devcontainers/features/docker-in-docker' depends on 'ghcr.io/devcontainers/features/common-utils' which is not in the feature set
... (one per installsAfter entry, several per up)
```

Both describe **expected, non-actionable outcomes**. Downgrade them.

## Changes

**1. `installsAfter` referencing a feature not in the set → `debug!`** (`crates/core/src/features.rs`)

`installsAfter` is a soft ordering hint: per the [containers.dev spec](https://containers.dev/implementors/features/#installsafter) it only orders features already in the set and never pulls in missing ones (unlike `dependsOn`, which deacon treats as a hard error). An unresolved entry is expected, extremely common (nearly every feature lists `installsAfter` on `common-utils`), and pure ordering bookkeeping the user can't act on — so this is `debug`. Also reworded: it's an ignored ordering hint, not something the feature "depends on" (the old wording conflated `installsAfter` with `dependsOn`).

**2. GPU mode `detect` finding no runtime → `info!`** (`crates/deacon/src/commands/up/mod.rs`)

`detect` is best-effort by design ("use a GPU if one is present, otherwise proceed without"). A GPU-less host is the expected outcome, not a problem the user must act on. The probe-*error* branch (detection actually malfunctioned) stays at `warn!` — that's a real failure, not a clean negative result.

## Import hygiene

- `features.rs`: drop now-unused `warn` (remaining calls are fully qualified `tracing::warn!`).
- `up/mod.rs`: `warn` stays (still used by the probe-error branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)