### PR TITLE
feat(cli): add -v/-q verbosity flags; default log level to warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,17 @@ The JSON format is useful for CI/CD systems and log aggregation tools that need 
 
 ### Quiet mode and spinner (TTY only)
 
-When running in a real terminal (stderr is a TTY) and using the default text output, deacon shows a small spinner during long-running operations like `up` and `down`. In these spinner sessions, if you haven't set `DEACON_LOG`, `RUST_LOG`, or `--log-level`, the default log level is temporarily set to `warn` so routine progress noise stays out of your way. JSON mode or non‑TTY environments (CI, redirections) do not render a spinner and keep the previous logging behavior.
+The default log level is `warn`, so routine `info` progress noise stays out of your way unless you ask for it. When running in a real terminal (stderr is a TTY) and using the default text output, deacon also shows a small spinner during long-running operations like `up` and `down`. JSON mode or non‑TTY environments (CI, redirections) do not render a spinner.
+
+Verbosity is a single axis (`error < warn < info < debug < trace`). Use the `-v`/`-q` shortcuts to shift it, or `--log-level` to set the baseline directly:
+
+- `-v`/`--verbose` raises verbosity one step (`-v`=info, `-vv`=debug, `-vvv`=trace); repeatable.
+- `-q`/`--quiet` lowers it (`-q`=error, silencing warnings).
+- `--log-level <level>` sets the baseline that `-v`/`-q` shift from.
+- `DEACON_LOG`/`RUST_LOG` take precedence over all of the above.
 
 Tips:
-- Want details with the spinner? Set `RUST_LOG=info` or use `--log-level info`.
+- Want details? Use `-v` (or `--log-level info`); `-vv` for debug.
 - Prefer structured logs? Use `--log-format json` (no spinner) and parse stderr.
 
 Color and accessibility:
@@ -431,9 +438,9 @@ becomes:
 
 Deacon uses the `tracing` ecosystem for structured logging.
 
-- Default log level: `info`
+- Default log level: `warn`
 - Default log format: text (human-readable)
-- CLI flag overrides: `--log-level` (`error|warn|info|debug|trace`), `--log-format` (`text|json`)
+- CLI flag overrides: `--log-level` (`error|warn|info|debug|trace`), `-v`/`--verbose` and `-q`/`--quiet` (repeatable shortcuts that shift the baseline), `--log-format` (`text|json`)
 - Environment overrides (take precedence before CLI flag processing sets `RUST_LOG`):
   - `DEACON_LOG`: Full filter specification (e.g. `DEACON_LOG=deacon=debug,deacon_core=debug`)
   - `RUST_LOG`: Standard Rust filter fallback if `DEACON_LOG` unset

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -143,6 +143,34 @@ pub enum LogLevel {
     Trace,
 }
 
+/// Resolve the effective tracing level from the `--log-level` baseline shifted
+/// by repeated `-v`/`-q`.
+///
+/// Verbosity is a single axis (`error < warn < info < debug < trace`). `-v`
+/// raises it one step, `-q` lowers it, and the net shift is applied to the
+/// `--log-level` baseline (default `warn`) then clamped to the valid range.
+/// This resolves only the *default* log directive — an explicit
+/// `DEACON_LOG`/`RUST_LOG` still wins (see [`Cli::dispatch`]).
+fn resolve_log_level(base: &LogLevel, verbose: u8, quiet: u8) -> &'static str {
+    let base_idx: i32 = match base {
+        LogLevel::Error => 0,
+        LogLevel::Warn => 1,
+        LogLevel::Info => 2,
+        LogLevel::Debug => 3,
+        LogLevel::Trace => 4,
+    };
+    // `-v` and `-q` are both u8 counts; widen to i32 so the difference can go
+    // negative before clamping.
+    let idx = (base_idx + i32::from(verbose) - i32::from(quiet)).clamp(0, 4);
+    match idx {
+        0 => "error",
+        1 => "warn",
+        2 => "info",
+        3 => "debug",
+        _ => "trace",
+    }
+}
+
 /// Progress format options
 #[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
 pub enum ProgressFormat {
@@ -613,7 +641,9 @@ pub enum Commands {
         feature: Option<String>,
         /// HIDDEN: target version for `--feature`. Must match
         /// `^\d+(\.\d+(\.\d+)?)?$`.
-        #[arg(long, short = 'v', hide = true)]
+        // No `-v` short: `-v` is the global `--verbose` flag. Dependabot uses
+        // the long `--target-version` form.
+        #[arg(long, hide = true)]
         target_version: Option<String>,
     },
 
@@ -850,9 +880,22 @@ pub struct Cli {
     #[arg(long, global = true, value_enum)]
     pub log_format: Option<LogFormat>,
 
-    /// Log level
-    #[arg(long, global = true, value_enum, default_value = "info")]
+    /// Log level (baseline verbosity). Shifted by repeated `-v`/`-q`.
+    #[arg(long, global = true, value_enum, default_value = "warn")]
     pub log_level: LogLevel,
+
+    /// Increase log verbosity, repeatable: `-v`=info, `-vv`=debug, `-vvv`=trace.
+    ///
+    /// Convenience shortcut that raises `--log-level` one step per `-v`. An
+    /// explicit `DEACON_LOG`/`RUST_LOG` still takes precedence over this.
+    #[arg(short = 'v', long, global = true, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Decrease log verbosity, repeatable: `-q`=error (silences warnings).
+    ///
+    /// Convenience shortcut that lowers `--log-level` one step per `-q`.
+    #[arg(short = 'q', long, global = true, action = clap::ArgAction::Count)]
+    pub quiet: u8,
 
     /// Workspace folder path
     #[arg(long, global = true, value_name = "PATH")]
@@ -1115,13 +1158,11 @@ impl Cli {
             None => None, // Let logging module check environment variable
         };
 
-        let mut log_level = match self.log_level {
-            LogLevel::Error => "error",
-            LogLevel::Warn => "warn",
-            LogLevel::Info => "info",
-            LogLevel::Debug => "debug",
-            LogLevel::Trace => "trace",
-        };
+        // Resolve the effective baseline level from `--log-level` (default
+        // `warn`) shifted by repeated `-v`/`-q`. The default is intentionally
+        // quiet: routine INFO chatter is hidden unless the user opts in with
+        // `-v`.
+        let log_level = resolve_log_level(&self.log_level, self.verbose, self.quiet);
 
         // Determine if spinner-friendly session: progress auto, no progress_file, stderr is TTY, non-JSON format.
         let stderr_is_tty = std::io::stderr().is_terminal();
@@ -1138,11 +1179,6 @@ impl Cli {
         // runtime's worker threads exist.
         let default_log_directive =
             if std::env::var_os("DEACON_LOG").is_none() && std::env::var_os("RUST_LOG").is_none() {
-                // In spinner sessions, prefer a quieter default unless the user
-                // overrode it via flag/env.
-                if spinner_eligible {
-                    log_level = "warn";
-                }
                 Some(format!(
                     "deacon={level},deacon_core={level}",
                     level = log_level
@@ -1824,6 +1860,52 @@ mod tests {
         assert_eq!(cli.docker_compose_path, "docker-compose");
         assert!(cli.terminal_columns.is_none());
         assert!(cli.terminal_rows.is_none());
+    }
+
+    #[test]
+    fn test_resolve_log_level_default_is_warn() {
+        // Default baseline (no -v/-q) is now warn, not info.
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 0, 0), "warn");
+    }
+
+    #[test]
+    fn test_resolve_log_level_verbose_raises() {
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 1, 0), "info");
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 2, 0), "debug");
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 3, 0), "trace");
+        // Clamp at the top; extra -v is a no-op past trace.
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 9, 0), "trace");
+    }
+
+    #[test]
+    fn test_resolve_log_level_quiet_lowers() {
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 0, 1), "error");
+        // Clamp at the bottom.
+        assert_eq!(resolve_log_level(&LogLevel::Warn, 0, 5), "error");
+    }
+
+    #[test]
+    fn test_resolve_log_level_shifts_from_explicit_baseline() {
+        // `--log-level` sets the baseline; -v/-q shift from it additively.
+        assert_eq!(resolve_log_level(&LogLevel::Info, 1, 0), "debug");
+        assert_eq!(resolve_log_level(&LogLevel::Info, 0, 1), "warn");
+        // -v and -q cancel out.
+        assert_eq!(resolve_log_level(&LogLevel::Info, 1, 1), "info");
+    }
+
+    #[test]
+    fn test_verbose_quiet_flags_parse_and_count() {
+        let cli = Cli::parse_from(["deacon"]);
+        assert_eq!(cli.verbose, 0);
+        assert_eq!(cli.quiet, 0);
+
+        let cli = Cli::parse_from(["deacon", "-vv"]);
+        assert_eq!(cli.verbose, 2);
+
+        // Global flags work after the subcommand too.
+        let cli = Cli::parse_from(["deacon", "doctor", "-v", "-q"]);
+        assert_eq!(cli.verbose, 1);
+        assert_eq!(cli.quiet, 1);
     }
 
     /// BEAD-11-T03: --log-format json must auto-force PTY allocation so the

--- a/crates/deacon/src/commands/templates.rs
+++ b/crates/deacon/src/commands/templates.rs
@@ -261,9 +261,12 @@ async fn execute_templates_apply(
     // Apply the template
     let result = apply_template(&template_dir, &output_dir, &apply_options)?;
 
-    // Report results
+    // Report results. A `--dry-run` preview is the output the user explicitly
+    // asked for, so it goes to stdout as a result (matching the config
+    // substitute dry-run) and stays visible at the quiet default log level. A
+    // live apply reports progress via `info!` (quiet by default, like `up`).
     if dry_run {
-        info!("DRY RUN: Would process {} files", result.files_processed);
+        println!("DRY RUN: Would process {} files", result.files_processed);
     } else {
         info!("Successfully processed {} files", result.files_processed);
     }
@@ -289,13 +292,23 @@ async fn execute_templates_apply(
                 } else {
                     ""
                 };
-                info!(
-                    "{} {} -> {}{}",
-                    action_str,
-                    src.display(),
-                    dest.display(),
-                    subst_str
-                );
+                if dry_run {
+                    println!(
+                        "{} {} -> {}{}",
+                        action_str,
+                        src.display(),
+                        dest.display(),
+                        subst_str
+                    );
+                } else {
+                    info!(
+                        "{} {} -> {}{}",
+                        action_str,
+                        src.display(),
+                        dest.display(),
+                        subst_str
+                    );
+                }
             }
             deacon_core::templates::PlannedAction::SkipExistingFile { dest } => {
                 info!("Skipped existing file: {}", dest.display());
@@ -315,13 +328,23 @@ async fn execute_templates_apply(
                 } else {
                     ""
                 };
-                info!(
-                    "{} {} -> {}{}",
-                    action_str,
-                    src.display(),
-                    dest.display(),
-                    subst_str
-                );
+                if dry_run {
+                    println!(
+                        "{} {} -> {}{}",
+                        action_str,
+                        src.display(),
+                        dest.display(),
+                        subst_str
+                    );
+                } else {
+                    info!(
+                        "{} {} -> {}{}",
+                        action_str,
+                        src.display(),
+                        dest.display(),
+                        subst_str
+                    );
+                }
             }
         }
     }

--- a/crates/deacon/tests/integration_down.rs
+++ b/crates/deacon/tests/integration_down.rs
@@ -12,11 +12,13 @@ fn test_down_command_basic() {
     // Create a temp directory for testing
     let temp_dir = TempDir::new().unwrap();
 
+    // Default log level is now `warn`; the "nothing to tear down" outcome is
+    // emitted at INFO, so opt into it via the global `-v` flag.
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
-        // .env("DEACON_LOG", "info") // Removed unnecessary env override
         .assert()
         .success();
 
@@ -42,11 +44,11 @@ fn test_down_command_with_remove() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--remove")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
-        // .env("DEACON_LOG", "info") // Removed unnecessary env override
         .assert()
         .success();
 
@@ -104,6 +106,7 @@ fn test_down_command_with_all() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--all")
         .arg("--workspace-folder")
@@ -132,6 +135,7 @@ fn test_down_command_with_volumes() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--volumes")
         .arg("--workspace-folder")
@@ -160,6 +164,7 @@ fn test_down_command_with_force() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--force")
         .arg("--workspace-folder")
@@ -188,6 +193,7 @@ fn test_down_command_with_timeout() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--timeout")
         .arg("60")
@@ -217,6 +223,7 @@ fn test_down_command_with_combined_flags() {
     let temp_dir = TempDir::new().unwrap();
 
     let assert = cmd
+        .arg("-v")
         .arg("down")
         .arg("--remove")
         .arg("--volumes")

--- a/crates/deacon/tests/smoke_compose_edges.rs
+++ b/crates/deacon/tests/smoke_compose_edges.rs
@@ -396,10 +396,14 @@ RUN echo "app service" > /tmp/app.txt
     )
     .unwrap();
 
-    // Test build command with compose configuration
+    // Test build command with compose configuration.
+    // The default log level is `warn`; the "Building Docker Compose service:
+    // <name>" status is emitted at INFO, so opt into it via the global `-v`
+    // flag to assert on the compose-service build indicators below.
     let mut build_cmd = Command::cargo_bin("deacon").unwrap();
     let build_output = build_cmd
         .current_dir(&temp_dir)
+        .arg("-v")
         .arg("build")
         .arg("--workspace-folder")
         .arg(temp_dir.path())


### PR DESCRIPTION
Phase A of the build-output UX work: establish the verbosity foundation that later gates build rendering (compact-by-default vs. verbose live streaming).

## What changed

Verbosity is now a **single axis** (`error < warn < info < debug < trace`):

- **Default log level is now `warn`** (was `info`) — routine INFO progress noise is hidden unless requested.
- **`-v`/`--verbose`** (repeatable): raises one step per `-v` — `-v`=info, `-vv`=debug, `-vvv`=trace.
- **`-q`/`--quiet`** (repeatable): lowers one step — `-q`=error (silences warnings).
- **`--log-level <level>`** sets the baseline that `-v`/`-q` shift from.
- **`DEACON_LOG`/`RUST_LOG`** still take precedence over all of the above.

`-v`/`-q` are **additive** over `--log-level`, which sidesteps the classic "was `--log-level` explicitly set or defaulted?" ambiguity: `--log-level info -v` → debug. The core is a pure, unit-tested `resolve_log_level(base, verbose, quiet)` (clamped to `error..=trace`).

## Notes

- Removed the previous spinner-only "force `warn`" special case — `warn` is now the global default, so it's redundant.
- **Reclaimed the `-v` short flag**: it was a hidden alias for `upgrade --target-version`. `upgrade` is an internal (non-user-surface) command and nothing in-repo invokes `upgrade -v` (Dependabot uses the long `--target-version`); the long form is unchanged. ⚠️ If any external Dependabot config relies on `upgrade -v`, flag it and I'll pick a different short for verbose.
- README logging section updated.

## Tests

Unit tests for `resolve_log_level` (default warn, verbose raises + clamps, quiet lowers + clamps, additive-from-baseline, `-v`/`-q` cancel) and clap parsing of `-vv` / post-subcommand `-v -q`. Existing GPU stderr assertions are guarded by `if stderr.contains("GPU")` and check a `warn!` message, so they stay green; `--log-level` tests pass explicit values; `--help` tests use substring matches.

> No local Rust toolchain on the authoring machine — relying on CI for fmt/clippy/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)