### PR TITLE
feat(build-output): streaming build execution + --iidfile (Part 1 / B2)

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,6 +54,8 @@ fs2.workspace = true
 rustls-native-certs = "0.8"
 x509-parser = "0.18"
 webpki-roots = "1"
+# `--iidfile` temp files for capturing the built image digest (docker.rs::build_image).
+tempfile.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -61,7 +63,6 @@ libc = "0.2"
 nix.workspace = true
 
 [dev-dependencies]
-tempfile = "3.12"
 assert_cmd = "2.0"
 tokio-test = "0.4"
 wiremock = "0.6"

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -2539,74 +2539,44 @@ impl CliRuntime {
     pub async fn build_image(&self, args: &[String]) -> Result<String> {
         debug!("Building image with BuildKit: {:?}", args);
 
-        let output = crate::docker_retry::run_build_with_retry(
+        // Retrieve the built image ID via `--iidfile` rather than scraping
+        // BuildKit's progress output (which varies by version and is destined
+        // to become a live-rendered stream). A temp file the daemon writes the
+        // digest into is version-stable and unaffected by the progress format.
+        let iidfile = tempfile::NamedTempFile::new().map_err(|e| {
+            DockerError::CLIError(format!("Failed to create temp file for image ID: {}", e))
+        })?;
+        let mut args = args.to_vec();
+        args.push("--iidfile".to_string());
+        args.push(iidfile.path().display().to_string());
+
+        let _output = crate::docker_retry::run_build_with_retry(
             std::path::Path::new(&self.runtime_path),
-            args,
+            &args,
+            None,
         )
         .await?;
 
-        // Parse the image ID from the output
-        // BuildKit output format varies by version:
-        // - Older: "writing image sha256:<id>"
-        // - Newer: "exporting manifest sha256:<id> done" or "naming to moby-dangling@sha256:<id>"
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let combined = format!("{}\n{}", stdout, stderr);
+        let image_id = tokio::fs::read_to_string(iidfile.path())
+            .await
+            .map_err(|e| {
+                DockerError::CLIError(format!(
+                    "Build succeeded but the image ID file could not be read: {}",
+                    e
+                ))
+            })?
+            .trim()
+            .to_string();
 
-        // Extract sha256 hash from a line, handling various formats
-        let extract_sha256 = |line: &str| -> Option<String> {
-            if let Some(sha_start) = line.find("sha256:") {
-                let after_sha = &line[sha_start + 7..];
-                // Extract the 64-character hex hash (or until whitespace/non-hex)
-                let hash: String = after_sha
-                    .chars()
-                    .take_while(|c| c.is_ascii_hexdigit())
-                    .collect();
-                if hash.len() == 64 {
-                    return Some(hash);
-                }
-            }
-            None
-        };
-
-        // Look for the image ID in the output, trying multiple patterns
-        for line in combined.lines() {
-            // Pattern 1: Older BuildKit format
-            if line.contains("writing image sha256:") {
-                if let Some(image_id) = extract_sha256(line) {
-                    debug!("Built image ID (writing image): {}", image_id);
-                    return Ok(image_id);
-                }
-            }
-            // Pattern 2: Newer BuildKit format - exporting manifest
-            if line.contains("exporting manifest sha256:") && line.contains("done") {
-                if let Some(image_id) = extract_sha256(line) {
-                    debug!("Built image ID (exporting manifest): {}", image_id);
-                    return Ok(image_id);
-                }
-            }
+        if image_id.is_empty() {
+            return Err(DockerError::CLIError(
+                "Build succeeded but wrote an empty image ID file".to_string(),
+            )
+            .into());
         }
 
-        // Pattern 3: Fallback - naming to moby-dangling@sha256:
-        for line in combined.lines() {
-            if line.contains("naming to") && line.contains("@sha256:") {
-                if let Some(image_id) = extract_sha256(line) {
-                    debug!("Built image ID (naming): {}", image_id);
-                    return Ok(image_id);
-                }
-            }
-        }
-
-        // If we can't find the image ID in the output, return an error
-        // The image was likely built but we couldn't parse its ID from the output
-        debug!(
-            "Could not parse image ID from build output. Output was:\n{}",
-            combined
-        );
-        Err(DockerError::CLIError(
-            "Could not determine image ID from build output. Image may have been built successfully.".to_string(),
-        )
-        .into())
+        debug!("Built image ID (iidfile): {}", image_id);
+        Ok(image_id)
     }
 }
 

--- a/crates/core/src/docker_retry.rs
+++ b/crates/core/src/docker_retry.rs
@@ -27,12 +27,45 @@
 //!   than mask a real bug behind 3 retries.
 
 use std::path::Path;
-use std::process::Output;
+use std::process::{Output, Stdio};
 
 use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 
 use crate::errors::{DockerError, Result};
 use crate::retry::{RetryConfig, RetryDecision, retry_async};
+
+/// Which of the child process's standard streams a build-output line came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildStream {
+    /// The child's standard output.
+    Stdout,
+    /// The child's standard error. BuildKit (`docker buildx build`) writes all
+    /// `--progress=plain` output here, so this is the stream the build-progress
+    /// renderer consumes.
+    Stderr,
+}
+
+/// Sink for streamed `docker build` output lines.
+///
+/// [`run_build_with_retry`] forwards each output line to this sink as it is
+/// produced, so the build UI can render live progress instead of waiting for a
+/// buffered `.output()` to return. Passing `None` preserves the historical
+/// buffer-and-surface-on-failure behavior.
+///
+/// The methods take `&self` (not `&mut self`) because the retry loop drives the
+/// subprocess through [`retry_async`], whose operation closure is `Fn`; the sink
+/// is therefore shared across attempts by shared reference. Implementors that
+/// need to mutate state use interior mutability (e.g. `Mutex` / `RefCell`).
+pub trait BuildLineSink {
+    /// Called once per output line (newline stripped) as it streams from the
+    /// child process.
+    fn on_line(&self, line: &str, stream: BuildStream);
+
+    /// Called at the start of every attempt so stateful renderers can discard
+    /// output captured from a prior, failed-and-retried attempt. Default no-op.
+    fn reset(&self) {}
+}
 
 /// Classification of a failed `docker build` / `docker buildx build` invocation.
 ///
@@ -259,14 +292,25 @@ pub(crate) static FORCED_TRANSIENT_FAILURES: std::sync::atomic::AtomicU32 =
 /// terminal failure (auth, build-failed, unknown) or exhausted retries
 /// returns a `DockerError::CLIError` carrying the final stderr — preserving
 /// existing call-site error rendering.
-pub async fn run_build_with_retry(runtime_path: &Path, args: &[String]) -> Result<Output> {
+///
+/// When `sink` is `Some`, each output line is forwarded to it as the child
+/// produces it (live progress) and [`BuildLineSink::reset`] is called at the
+/// start of every attempt. When `sink` is `None`, output is captured but not
+/// forwarded — identical to the historical `.output()` behavior. Either way the
+/// full stdout/stderr is captured into the returned `Output` for retry
+/// classification and error rendering.
+pub async fn run_build_with_retry(
+    runtime_path: &Path,
+    args: &[String],
+    sink: Option<&dyn BuildLineSink>,
+) -> Result<Output> {
     let config = RetryConfig::network();
 
     let result = retry_async(
         &config,
         || {
-            // Re-borrow per attempt so the async block can `move` references
-            // without consuming the outer FnMut closure state.
+            // Re-borrow per attempt so the async block can `move` the shared
+            // references (all `Copy`) without consuming the outer closure state.
             async move {
                 // Test hook: synthesize a transient failure for the first N calls.
                 if let Some(forced) = take_forced_failure() {
@@ -276,14 +320,13 @@ pub async fn run_build_with_retry(runtime_path: &Path, args: &[String]) -> Resul
                     });
                 }
 
-                let output = tokio::process::Command::new(runtime_path)
-                    .args(args)
-                    .output()
-                    .await
-                    .map_err(|e| DockerSubprocessError::Other {
-                        stderr: format!("Failed to execute docker build: {}", e),
-                        exit_code: -1,
-                    })?;
+                // Fresh attempt: let a stateful sink drop any output it captured
+                // from a prior attempt that failed transiently and got retried.
+                if let Some(sink) = sink {
+                    sink.reset();
+                }
+
+                let output = stream_build_once(runtime_path, args, sink).await?;
 
                 if output.status.success() {
                     return Ok(output);
@@ -299,6 +342,82 @@ pub async fn run_build_with_retry(runtime_path: &Path, args: &[String]) -> Resul
     .await;
 
     result.map_err(|e| DockerError::CLIError(format!("Image build failed: {}", e.stderr())).into())
+}
+
+/// Spawn a single `docker build` attempt with piped stdio, streaming stderr
+/// line-by-line to `sink` (BuildKit writes `--progress=plain` to stderr) while
+/// capturing both streams into the returned [`Output`].
+///
+/// stdout is drained concurrently in a spawned task — required to avoid a pipe
+/// deadlock where the child blocks writing stdout while we only read stderr.
+/// The child's stdout handle is `Send`, so the drain task needs no bound on the
+/// (possibly `!Send`) sink; stdout is captured but not forwarded because BuildKit
+/// emits no progress there.
+async fn stream_build_once(
+    runtime_path: &Path,
+    args: &[String],
+    sink: Option<&dyn BuildLineSink>,
+) -> std::result::Result<Output, DockerSubprocessError> {
+    let mut child = tokio::process::Command::new(runtime_path)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| DockerSubprocessError::Other {
+            stderr: format!("Failed to execute docker build: {}", e),
+            exit_code: -1,
+        })?;
+
+    let child_stdout = child.stdout.take();
+    let child_stderr = child.stderr.take();
+
+    // Drain stdout in a background task so a full stdout pipe can't stall the
+    // child while we're forwarding stderr.
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut out) = child_stdout {
+            let _ = out.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
+    // Forward stderr lines to the sink in this task; also capture verbatim so
+    // classification and error text see exactly what the process emitted.
+    let mut err_buf: Vec<u8> = Vec::new();
+    if let Some(err) = child_stderr {
+        let mut lines = BufReader::new(err).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => {
+                    if let Some(sink) = sink {
+                        sink.on_line(&line, BuildStream::Stderr);
+                    }
+                    err_buf.extend_from_slice(line.as_bytes());
+                    err_buf.push(b'\n');
+                }
+                Ok(None) => break,
+                // A decode/IO error on the pipe shouldn't abort the build; stop
+                // reading and let `child.wait()` report the real exit status.
+                Err(_) => break,
+            }
+        }
+    }
+
+    let out_buf = stdout_task.await.unwrap_or_default();
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| DockerSubprocessError::Other {
+            stderr: format!("Failed to wait for docker build: {}", e),
+            exit_code: -1,
+        })?;
+
+    Ok(Output {
+        status,
+        stdout: out_buf,
+        stderr: err_buf,
+    })
 }
 
 /// Pull-and-decrement the test-hook counter. Returns `Some(stderr)` if a
@@ -562,8 +681,12 @@ mod tests {
         // Two synthetic transient failures, then real subprocess succeeds.
         FORCED_TRANSIENT_FAILURES.store(2, Ordering::SeqCst);
 
-        let result =
-            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
+        let result = run_build_with_retry(
+            std::path::Path::new("/usr/bin/true"),
+            &[] as &[String],
+            None,
+        )
+        .await;
 
         assert!(
             result.is_ok(),
@@ -585,8 +708,12 @@ mod tests {
         // guarantees exhaustion.
         FORCED_TRANSIENT_FAILURES.store(10, Ordering::SeqCst);
 
-        let result =
-            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
+        let result = run_build_with_retry(
+            std::path::Path::new("/usr/bin/true"),
+            &[] as &[String],
+            None,
+        )
+        .await;
 
         assert!(
             result.is_err(),
@@ -612,9 +739,123 @@ mod tests {
         let _guard = HOOK_LOCK.lock().await;
         clear_fail_hook();
 
-        let result =
-            run_build_with_retry(std::path::Path::new("/usr/bin/true"), &[] as &[String]).await;
+        let result = run_build_with_retry(
+            std::path::Path::new("/usr/bin/true"),
+            &[] as &[String],
+            None,
+        )
+        .await;
 
         assert!(result.is_ok(), "expected success, got {:?}", result);
+    }
+
+    // ------------------------------------------------------------------
+    // Streaming sink — verifies stderr lines are forwarded live and both
+    // streams are still captured into the returned `Output`. Uses `/bin/sh`
+    // so no Docker daemon is needed. BuildKit writes progress to stderr, so
+    // the sink is fed from stderr.
+    // ------------------------------------------------------------------
+
+    /// A test sink that records every forwarded line (interior mutability, as
+    /// the trait requires `&self`), plus how many times `reset` fired.
+    #[cfg(unix)]
+    #[derive(Default)]
+    struct RecordingSink {
+        lines: std::sync::Mutex<Vec<(BuildStream, String)>>,
+        resets: std::sync::atomic::AtomicUsize,
+    }
+
+    #[cfg(unix)]
+    impl BuildLineSink for RecordingSink {
+        fn on_line(&self, line: &str, stream: BuildStream) {
+            self.lines.lock().unwrap().push((stream, line.to_string()));
+        }
+        fn reset(&self) {
+            self.resets.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// The sink receives each stderr line as it streams, `reset` is called once
+    /// for the single (successful) attempt, and the returned `Output` still
+    /// carries the full captured stderr for classification/error text.
+    // Unix-only: drives `/bin/sh`, absent on Windows.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn streaming_sink_receives_stderr_lines_and_output_is_captured() {
+        let _guard = HOOK_LOCK.lock().await;
+        clear_fail_hook();
+
+        let sink = RecordingSink::default();
+        // Emit two stderr lines and one stdout line, then exit 0.
+        let script = "echo err-one 1>&2; echo out-one; echo err-two 1>&2";
+        let args = vec!["-c".to_string(), script.to_string()];
+
+        let result = run_build_with_retry(
+            std::path::Path::new("/bin/sh"),
+            &args,
+            Some(&sink as &dyn BuildLineSink),
+        )
+        .await;
+
+        let output = result.expect("sh script should succeed");
+        assert!(output.status.success());
+
+        // Sink saw exactly the two stderr lines, in order.
+        let seen = sink.lines.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![
+                (BuildStream::Stderr, "err-one".to_string()),
+                (BuildStream::Stderr, "err-two".to_string()),
+            ],
+            "sink should receive stderr lines live and in order"
+        );
+        // reset() fired once for the single attempt.
+        assert_eq!(sink.resets.load(Ordering::SeqCst), 1);
+
+        // Full capture is preserved for classification / error rendering.
+        let captured_stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(captured_stderr.contains("err-one") && captured_stderr.contains("err-two"));
+        let captured_stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            captured_stdout.contains("out-one"),
+            "stdout should be captured even though it is not forwarded to the sink"
+        );
+    }
+
+    /// A failing streamed build classifies from the captured stderr just like
+    /// the buffered path did, and the sink still saw the failing line.
+    // Unix-only: drives `/bin/sh`, absent on Windows.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn streaming_sink_failure_still_classifies_from_captured_stderr() {
+        let _guard = HOOK_LOCK.lock().await;
+        clear_fail_hook();
+
+        let sink = RecordingSink::default();
+        // A terminal (non-retryable) build failure phrase, then exit 1.
+        let script =
+            "echo 'Dockerfile parse error on line 5: unknown instruction: FOOBAR' 1>&2; exit 1";
+        let args = vec!["-c".to_string(), script.to_string()];
+
+        let result = run_build_with_retry(
+            std::path::Path::new("/bin/sh"),
+            &args,
+            Some(&sink as &dyn BuildLineSink),
+        )
+        .await;
+
+        let err = result.expect_err("non-zero exit should surface an error");
+        assert!(err.to_string().contains("Image build failed"));
+        // Terminal failure → exactly one attempt → exactly one reset.
+        assert_eq!(sink.resets.load(Ordering::SeqCst), 1);
+        assert!(
+            sink.lines
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|(_, l)| l.contains("unknown instruction")),
+            "sink should have received the failing stderr line"
+        );
     }
 }

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1948,10 +1948,20 @@ async fn execute_docker_build(
             build_args.push("--load".to_string());
         }
 
-        // Add quiet flag to reduce output noise (only if not pushing/exporting)
-        if !args.push && args.output.is_none() {
-            build_args.push("-q".to_string());
-        }
+        // Retrieve the image ID via `--iidfile` instead of `docker build -q`
+        // stdout scraping (only when building locally — push/export may not
+        // produce a local image). Dropping `-q` lets BuildKit progress stream
+        // to stderr for the build-output UI while the digest still arrives
+        // reliably. The temp file must outlive the build invocation below.
+        let iidfile = if !args.push && args.output.is_none() {
+            let f =
+                tempfile::NamedTempFile::new().context("Failed to create image ID temp file")?;
+            build_args.push("--iidfile".to_string());
+            build_args.push(f.path().display().to_string());
+            Some(f)
+        } else {
+            None
+        };
 
         // Finally add build context (must be last)
         build_args.push(
@@ -1978,17 +1988,32 @@ async fn execute_docker_build(
             return Err(DockerError::CLIError(format!("Docker build failed: {}", stderr)).into());
         }
 
-        // When using --push or --output, we may not get an image ID on stdout
-        let image_id = if args.push || args.output.is_some() {
-            // For push/export, the image may not be available locally
-            // Use the first user-specified tag or the deterministic tag as a reference
-            if !args.image_names.is_empty() {
-                args.image_names[0].clone()
-            } else {
-                tag.clone()
+        // When using --push or --output, we may not get a local image ID; use a
+        // tag reference. Otherwise read the digest from the `--iidfile` the
+        // daemon wrote (replaces the former `-q` stdout scrape).
+        let image_id = match iidfile {
+            None => {
+                // push/export path — the image may not be available locally
+                if !args.image_names.is_empty() {
+                    args.image_names[0].clone()
+                } else {
+                    tag.clone()
+                }
             }
-        } else {
-            String::from_utf8_lossy(&output.stdout).trim().to_string()
+            Some(f) => {
+                let id = tokio::fs::read_to_string(f.path())
+                    .await
+                    .context("Build succeeded but the image ID file could not be read")?
+                    .trim()
+                    .to_string();
+                if id.is_empty() {
+                    return Err(DockerError::CLIError(
+                        "Build succeeded but wrote an empty image ID file".to_string(),
+                    )
+                    .into());
+                }
+                id
+            }
         };
 
         // Extract image metadata (skip if pushing or exporting as image may not be local)
@@ -2665,8 +2690,9 @@ mod tests {
         build_args.push("--label".to_string());
         build_args.push(label);
 
-        // Add quiet flag
-        build_args.push("-q".to_string());
+        // Capture the image ID via --iidfile (replaces the former `-q` scrape)
+        build_args.push("--iidfile".to_string());
+        build_args.push("/tmp/deacon-iid".to_string());
 
         // Finally add context (PATH last)
         build_args.push(context_path.to_str().unwrap().to_string());
@@ -2684,8 +2710,9 @@ mod tests {
         assert_eq!(build_args[9], "deacon-build:abcd12345678");
         assert_eq!(build_args[10], "--label");
         assert_eq!(build_args[11], "org.deacon.configHash=abcd1234567890");
-        assert_eq!(build_args[12], "-q");
-        assert_eq!(build_args[13], context_path.to_str().unwrap());
+        assert_eq!(build_args[12], "--iidfile");
+        assert_eq!(build_args[13], "/tmp/deacon-iid");
+        assert_eq!(build_args[14], context_path.to_str().unwrap());
 
         // Verify that when passed to Command::new("docker").args(&build_args),
         // it will correctly execute "docker build ..." not "docker -f ..."
@@ -2757,8 +2784,9 @@ mod tests {
         build_args.push("--label".to_string());
         build_args.push(label);
 
-        // Add quiet flag
-        build_args.push("-q".to_string());
+        // Capture the image ID via --iidfile (replaces the former `-q` scrape)
+        build_args.push("--iidfile".to_string());
+        build_args.push("/tmp/deacon-iid".to_string());
 
         // Finally add context (PATH last)
         build_args.push(context_path.to_str().unwrap().to_string());

--- a/crates/deacon/src/commands/up/image_build.rs
+++ b/crates/deacon/src/commands/up/image_build.rs
@@ -122,8 +122,13 @@ pub(crate) async fn build_image_from_config(
         build_args.push(format!("{}={}", key, value));
     }
 
-    // Add quiet flag to reduce output noise and get just the image ID
-    build_args.push("-q".to_string());
+    // Retrieve the image ID via `--iidfile` instead of `docker build -q`
+    // stdout scraping. Dropping `-q` lets BuildKit progress stream to stderr
+    // (rendered by the build-output UI); the digest still arrives reliably via
+    // the file the daemon writes. The temp file must outlive the build call.
+    let iidfile = tempfile::NamedTempFile::new().context("Failed to create image ID temp file")?;
+    build_args.push("--iidfile".to_string());
+    build_args.push(iidfile.path().display().to_string());
 
     // Finally add build context (must be last)
     build_args.push(
@@ -142,17 +147,28 @@ pub(crate) async fn build_image_from_config(
     // 5xx from registry). Terminal failures (Dockerfile syntax, RUN failure,
     // 401/403) fail on the first attempt — see classifier in
     // deacon_core::docker_retry.
-    let output = deacon_core::docker_retry::run_build_with_retry(
+    deacon_core::docker_retry::run_build_with_retry(
         std::path::Path::new(runtime_path),
         &build_args,
+        None,
     )
     .await
     .context("image build failed")?;
 
-    let image_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let image_id = tokio::fs::read_to_string(iidfile.path())
+        .await
+        .context("Build succeeded but the image ID file could not be read")?
+        .trim()
+        .to_string();
+    if image_id.is_empty() {
+        return Err(DeaconError::Docker(DockerError::CLIError(
+            "Build succeeded but wrote an empty image ID file".to_string(),
+        ))
+        .into());
+    }
     debug!("Built image with ID: {}", image_id);
 
-    // `docker build -q` returns a bare `sha256:<digest>` image ID. Returning
+    // The `--iidfile` digest is a bare `sha256:<digest>` image ID. Returning
     // that as the resolved `config.image` works for `docker create`, but when
     // features are layered on top the generated `FROM ${base}` makes BuildKit
     // treat a bare digest as a `docker.io/library/sha256:...` repository


### PR DESCRIPTION
## Part 1 / B2 — streaming build execution + `--iidfile`

Second stage of the build-output rendering work ([plan](docs/plans/build-output-and-verbosity.md), §B2). Builds on B1 (#255). Makes the docker-build executor **streaming-capable** and retires fragile stdout image-ID scraping — the two prerequisites for B3's live per-feature progress renderer.

**No user-visible behavior change.** Every caller passes a `None` sink, so output is still buffered and surfaced on failure exactly as before; the image ID now comes from `--iidfile` instead of stdout. B2 is invisible until B3 wires modes and passes a real sink.

### Streaming
- `run_build_with_retry` gains an `Option<&dyn BuildLineSink>` parameter. When set, the child's **stderr** (where BuildKit writes `--progress=plain`) is streamed line-by-line to the sink as it arrives; both streams are still captured into the returned `Output` for retry classification and error text.
- stdout is drained concurrently in a spawned task to avoid a pipe-buffer deadlock (child blocks writing stdout while we read stderr).
- `BuildLineSink::reset()` fires at the start of every attempt so a retried, stateful renderer discards prior-attempt output.
- The sink is `&self` + shared-ref (not `&mut`) because `retry_async`'s operation closure is `Fn`.

### Image ID via `--iidfile` (all build paths)
- **`docker.rs::build_image`**: owns a temp `--iidfile`, reads the digest back, and **deletes the ~55-line multi-pattern `extract_sha256` scraper**. Both callers already discarded the parsed ID (they use a pre-chosen tag), so this is a pure simplification that also yields a correct, version-stable digest.
- **`up`'s `image_build.rs`** and **`deacon build`'s `execute_docker_build`**: drop the `-q` reliance, inject `--iidfile <tmp>`, read the digest from the file. Dropping `-q` lets progress stream to stderr for B3 while the ID stays exact.
- `tempfile` promoted from dev- to a regular dependency of `crates/core`.

### Tests
- Two new streaming unit tests over `/bin/sh` (**no Docker**): stderr lines forwarded live and in order, `reset()` fires once per attempt, both streams still captured, non-zero exit still classifies from captured stderr.
- Existing `run_build_with_retry` retry tests + the `deacon build` arg-ordering simulations updated for the new signature / `--iidfile`.
- Local: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, core lib (1300) + deacon lib/bins (368) + doctests all green. (Docker-path behavior is covered end-to-end by B4's integration test.)

### Deviations from the plan (scoped, noted)
- **iidfile ownership**: the plan suggested injecting `--iidfile` in `generate_build_args`, but that fn is pure and doesn't own a tempfile lifecycle. `build_image` owns the iidfile instead — cleaner, and its callers need no change.
- **Deferred to B3** (no consumer until the renderer exists): threading the sink through the compose build path, and routing `execute_docker_build` through the streaming executor.

Staged after #255 (B1). Next: **B3 + B4** — `BuildOutputMode` resolution/threading, the MultiProgress renderer that passes a real sink, failure-trim, integration tests, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)