### PR TITLE
feat(build-output): stream deacon build base + compose builds, integration test (Part 1 / B4)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -114,7 +114,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.default.overrides]]
-filter = 'binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build)'
+filter = 'binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build)'
 test-group = 'docker-slow-shared'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
@@ -149,7 +149,7 @@ test-group = 'fs-heavy'
 slow-timeout = "2m"
 
 [[profile.default.overrides]]
-filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
 # Fast feedback loop profile: skip smoke/parity suites, Docker tests, and testcontainers tests
@@ -157,7 +157,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -217,7 +217,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build)'
+filter = 'binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build)'
 test-group = 'docker-slow-shared'
 
 [[profile.dev-fast.overrides]]
@@ -248,7 +248,7 @@ test-group = 'fs-heavy'
 slow-timeout = "2m"
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
 # Full profile: Run all tests with appropriate grouping
@@ -263,7 +263,7 @@ status-level = "none"
 retries = 0
 slow-timeout = { period = "30m", terminate-after = 1 }
 status-level = "pass"
-default-filter = 'binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_vulnerability_scan)'
+default-filter = 'binary(=integration_build) | binary(=integration_build_output) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_vulnerability_scan)'
 
 # integration_up_build_options tests are CLI-only (no actual Docker container operations)
 [[profile.long-running.overrides]]
@@ -272,7 +272,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.long-running.overrides]]
-filter = 'binary(=integration_build) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_vulnerability_scan)'
+filter = 'binary(=integration_build) | binary(=integration_build_output) | binary(#integration_up_*) | binary(=integration_progress) | binary(=integration_vulnerability_scan)'
 test-group = 'docker-slow-shared'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
@@ -325,7 +325,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.docker.overrides]]
-filter = 'binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress)'
+filter = 'binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress)'
 test-group = 'docker-slow-shared'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
@@ -363,7 +363,7 @@ test-group = 'fs-heavy'
 slow-timeout = "2m"
 
 [[profile.docker.overrides]]
-filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
 # Apply all default overrides
@@ -409,7 +409,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.full.overrides]]
-filter = 'binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(#integration_compose_*)  | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(#integration_compose_*)  | binary(=integration_progress) | binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
@@ -441,7 +441,7 @@ test-group = 'fs-heavy'
 slow-timeout = "2m"
 
 [[profile.full.overrides]]
-filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
 # CI profile: Conservative settings for deterministic CI execution
@@ -495,7 +495,7 @@ test-group = 'smoke-cli'
 slow-timeout = "60s"
 
 [[profile.ci.overrides]]
-filter = 'binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(#integration_compose_*)  | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(#integration_compose_*)  | binary(=integration_progress) | binary(=up_dotfiles)'
 test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
@@ -529,7 +529,7 @@ test-group = 'fs-heavy'
 slow-timeout = "2m"
 
 [[profile.ci.overrides]]
-filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
+filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(=up_dotfiles)'
 priority = 100
 
 # MVP Integration profile: Consolidated smoke + parity + core Docker integration tests

--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -306,6 +306,49 @@ impl ComposeCommand {
         Ok(stdout)
     }
 
+    /// Execute a compose command, streaming its stderr (where `docker compose
+    /// build` writes BuildKit progress) line-by-line to `sink` as it arrives.
+    ///
+    /// Mirrors [`Self::execute`] for the no-stdin case but reuses the shared
+    /// build-output streaming path ([`crate::docker_retry::stream_captured_child`])
+    /// so `deacon build`'s compose-service build renders like the other build
+    /// paths. Returns captured stdout on success.
+    #[instrument(skip(self, sink))]
+    pub async fn execute_streamed(
+        &self,
+        args: &[&str],
+        sink: Option<&dyn crate::docker_retry::BuildLineSink>,
+    ) -> Result<String> {
+        use std::process::Stdio;
+
+        if let Some(sink) = sink {
+            sink.reset();
+        }
+
+        let mut command = self.build_command(args);
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let child = command.spawn().map_err(|e| {
+            DockerError::CLIError(format!("Failed to execute docker compose command: {}", e))
+        })?;
+
+        let output = crate::docker_retry::stream_captured_child(child, sink)
+            .await
+            .map_err(|e| DockerError::CLIError(format!("docker compose I/O error: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(DockerError::CLIError(format!(
+                "Docker compose command failed: {}",
+                stderr
+            ))
+            .into());
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
     /// Start services
     #[instrument(skip(self))]
     pub async fn up(
@@ -1073,13 +1116,18 @@ impl ComposeManager {
     ///     deacon_labels: IndexMap::new(),
     /// };
     ///
-    /// let output = manager.build_service(&project, "web").await?;
+    /// let output = manager.build_service(&project, "web", None).await?;
     /// println!("Build output: {}", output);
     /// # Ok(())
     /// # }
     /// ```
-    #[instrument(skip(self))]
-    pub async fn build_service(&self, project: &ComposeProject, service: &str) -> Result<String> {
+    #[instrument(skip(self, sink))]
+    pub async fn build_service(
+        &self,
+        project: &ComposeProject,
+        service: &str,
+        sink: Option<&dyn crate::docker_retry::BuildLineSink>,
+    ) -> Result<String> {
         let command = self.get_command(project);
 
         debug!(
@@ -1087,7 +1135,7 @@ impl ComposeManager {
             project.name, service
         );
 
-        let output = command.execute(&["build", service]).await?;
+        let output = command.execute_streamed(&["build", service], sink).await?;
 
         debug!(
             "Compose project {} service {} built successfully",

--- a/crates/core/src/docker_retry.rs
+++ b/crates/core/src/docker_retry.rs
@@ -419,7 +419,7 @@ async fn stream_build_once(
     args: &[String],
     sink: Option<&dyn BuildLineSink>,
 ) -> std::result::Result<Output, DockerSubprocessError> {
-    let mut child = tokio::process::Command::new(runtime_path)
+    let child = tokio::process::Command::new(runtime_path)
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -429,11 +429,33 @@ async fn stream_build_once(
             exit_code: -1,
         })?;
 
+    stream_captured_child(child, sink)
+        .await
+        .map_err(|e| DockerSubprocessError::Other {
+            stderr: format!("docker build I/O error: {}", e),
+            exit_code: -1,
+        })
+}
+
+/// Drain an already-spawned child that has **piped** stdout/stderr: forward each
+/// stderr line to `sink` (BuildKit progress is on stderr) while capturing both
+/// streams into the returned [`Output`].
+///
+/// stdout is drained concurrently in a spawned task — required to avoid a pipe
+/// deadlock where the child blocks writing stdout while we only read stderr.
+/// The child's stdout handle is `Send`, so the drain task needs no bound on the
+/// (possibly `!Send`) sink; stdout is captured but not forwarded because BuildKit
+/// emits no progress there.
+///
+/// `pub(crate)` so the compose executor can reuse the same streaming behavior for
+/// `docker compose build` (which also emits BuildKit progress on stderr).
+pub(crate) async fn stream_captured_child(
+    mut child: tokio::process::Child,
+    sink: Option<&dyn BuildLineSink>,
+) -> std::io::Result<Output> {
     let child_stdout = child.stdout.take();
     let child_stderr = child.stderr.take();
 
-    // Drain stdout in a background task so a full stdout pipe can't stall the
-    // child while we're forwarding stderr.
     let stdout_task = tokio::spawn(async move {
         let mut buf = Vec::new();
         if let Some(mut out) = child_stdout {
@@ -442,8 +464,6 @@ async fn stream_build_once(
         buf
     });
 
-    // Forward stderr lines to the sink in this task; also capture verbatim so
-    // classification and error text see exactly what the process emitted.
     let mut err_buf: Vec<u8> = Vec::new();
     if let Some(err) = child_stderr {
         let mut lines = BufReader::new(err).lines();
@@ -465,20 +485,63 @@ async fn stream_build_once(
     }
 
     let out_buf = stdout_task.await.unwrap_or_default();
-
-    let status = child
-        .wait()
-        .await
-        .map_err(|e| DockerSubprocessError::Other {
-            stderr: format!("Failed to wait for docker build: {}", e),
-            exit_code: -1,
-        })?;
+    let status = child.wait().await?;
 
     Ok(Output {
         status,
         stdout: out_buf,
         stderr: err_buf,
     })
+}
+
+/// Run a **single** pre-configured build command (env/cwd/args already set by the
+/// caller) with the given [`BuildIo`], returning its [`Output`] — like
+/// `Command::output()` but honoring the output mode. Unlike
+/// [`run_build_with_retry`], there is **no** retry: this is for callers that own
+/// a bespoke command (e.g. `deacon build`'s base Dockerfile build, which sets
+/// `DOCKER_BUILDKIT`, a working directory, and secret mounts).
+///
+/// The returned `Output` always carries the real exit status; the caller decides
+/// how to treat a non-zero exit (a spawn/wait failure is the only `Err`). For
+/// [`BuildIo::Inherited`] the stdout/stderr buffers are empty (stdio was handed
+/// to the terminal); for [`BuildIo::Captured`] they hold the full capture.
+pub async fn run_build_once(
+    mut command: tokio::process::Command,
+    io: BuildIo<'_>,
+) -> Result<Output> {
+    match io {
+        BuildIo::Inherited => {
+            let status = command
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status()
+                .await
+                .map_err(|e| {
+                    DockerError::CLIError(format!("Failed to execute docker build: {}", e))
+                })?;
+            Ok(Output {
+                status,
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            })
+        }
+        BuildIo::Captured(sink) => {
+            if let Some(sink) = sink {
+                sink.reset();
+            }
+            let child = command
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|e| {
+                    DockerError::CLIError(format!("Failed to execute docker build: {}", e))
+                })?;
+            stream_captured_child(child, sink)
+                .await
+                .map_err(|e| DockerError::CLIError(format!("docker build I/O error: {}", e)).into())
+        }
+    }
 }
 
 /// Pull-and-decrement the test-hook counter. Returns `Some(stderr)` if a

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1315,8 +1315,21 @@ async fn execute_compose_build(
         ));
     }
 
-    // Build the service
-    let _build_output = compose_manager.build_service(&project, service).await?;
+    // Build the service, rendering its BuildKit output per the resolved mode.
+    // This is the base compose-service build (no feature-install steps — feature
+    // layering renders separately), so there are no feature ids to register.
+    let renderer = crate::ui::build_render::BuildRenderer::for_mode(
+        args.build_output_mode,
+        Vec::<&str>::new(),
+    );
+    let sink = renderer
+        .as_ref()
+        .map(|r| r as &dyn deacon_core::docker_retry::BuildLineSink);
+    let build_result = compose_manager.build_service(&project, service, sink).await;
+    if let Some(r) = &renderer {
+        r.finish(build_result.is_ok());
+    }
+    let _build_output = build_result?;
 
     let build_duration = build_start.elapsed().as_secs_f64();
 
@@ -1989,17 +2002,36 @@ async fn execute_docker_build(
 
         debug!("Docker build command: docker {}", build_args.join(" "));
 
-        // Execute docker build (async) using the prepared command with env vars
-        let output = cmd
-            .args(&build_args) // Pass all args including "build" subcommand
-            .current_dir(workspace_folder)
-            .output()
-            .await
-            .map_err(|e| DockerError::CLIError(format!("Failed to execute docker build: {}", e)))?;
+        // Execute the base Dockerfile build through the streaming executor so its
+        // output honors the resolved mode (Compact/Inherit/Plain). No features are
+        // installed in this pass — feature layering renders separately — so there
+        // are no feature ids to register. `run_build_once` runs a single attempt
+        // (no retry) on our pre-configured command (env vars + working dir).
+        cmd.args(&build_args) // Pass all args including "build" subcommand
+            .current_dir(workspace_folder);
+        let renderer = crate::ui::build_render::BuildRenderer::for_mode(
+            args.build_output_mode,
+            Vec::<&str>::new(),
+        );
+        let output = deacon_core::docker_retry::run_build_once(
+            cmd,
+            crate::ui::build_render::io_for(&renderer),
+        )
+        .await?;
+        if let Some(r) = &renderer {
+            r.finish(output.status.success());
+        }
 
         if !output.status.success() {
+            // In Inherit mode stderr wasn't captured (it went to the terminal);
+            // fall back to a generic message so we never print an empty error.
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(DockerError::CLIError(format!("Docker build failed: {}", stderr)).into());
+            let detail = if stderr.trim().is_empty() {
+                format!("exited with {}", output.status)
+            } else {
+                stderr.to_string()
+            };
+            return Err(DockerError::CLIError(format!("Docker build failed: {}", detail)).into());
         }
 
         // When using --push or --output, we may not get a local image ID; use a

--- a/crates/deacon/tests/integration_build_output.rs
+++ b/crates/deacon/tests/integration_build_output.rs
@@ -1,0 +1,118 @@
+//! Integration tests for build-output rendering (`deacon build`).
+//!
+//! These run through the streaming build executor (`run_build_once` / the
+//! `BuildIo` path). In CI stderr is not a TTY, so the resolved mode is **Plain**:
+//! build output is streamed verbatim to stderr. The key guarantees verified here:
+//!
+//! * a **failing** build surfaces the failing step's output on stderr (it is not
+//!   swallowed) and exits non-zero, and
+//! * a **successful** build still produces the expected JSON result on stdout.
+//!
+//! Both tolerate a Docker-less environment (they assert the Docker-unavailable
+//! error instead), mirroring `integration_build.rs`.
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::TempDir;
+
+/// Whether the failure is just "Docker isn't available here" (so the test's real
+/// assertion doesn't apply).
+fn is_docker_unavailable(stderr: &str) -> bool {
+    let lc = stderr.to_lowercase();
+    stderr.contains("Docker is not installed")
+        || stderr.contains("Docker daemon is not")
+        || lc.contains("permission denied")
+        || lc.contains("cannot connect to the docker daemon")
+}
+
+fn write_devcontainer(temp_dir: &TempDir, dockerfile: &str) {
+    fs::create_dir_all(temp_dir.path().join(".devcontainer")).unwrap();
+    fs::write(temp_dir.path().join(".devcontainer/Dockerfile"), dockerfile).unwrap();
+    let config = r#"{
+    "name": "Build Output Test",
+    "dockerFile": "Dockerfile",
+    "build": { "context": "." }
+}
+"#;
+    fs::write(
+        temp_dir.path().join(".devcontainer/devcontainer.json"),
+        config,
+    )
+    .unwrap();
+}
+
+/// A failing `RUN` must surface its output on stderr (Plain mode streams it, and
+/// the build error carries the captured stderr) and the command must exit
+/// non-zero — i.e. the failure is not silently swallowed.
+#[test]
+fn build_failure_surfaces_failing_step_output() {
+    let temp_dir = TempDir::new().unwrap();
+    // A unique marker printed by the failing RUN step. `--no-cache` guarantees the
+    // step actually executes (not served from a prior layer cache).
+    let marker = "DEACON_BUILD_OUTPUT_FAIL_MARKER";
+    let dockerfile =
+        format!("FROM alpine:3.19\nLABEL deacon.test=build-output\nRUN echo {marker} && exit 7\n");
+    write_devcontainer(&temp_dir, &dockerfile);
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let assert = cmd
+        .current_dir(&temp_dir)
+        .arg("build")
+        .arg("--no-cache")
+        .assert();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if is_docker_unavailable(&stderr) {
+        eprintln!("skipping: docker unavailable ({})", stderr.trim());
+        return;
+    }
+
+    assert!(
+        !output.status.success(),
+        "a failing RUN must produce a non-zero exit; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(marker),
+        "the failing step's output must be surfaced on stderr, not swallowed; stderr:\n{stderr}"
+    );
+}
+
+/// A successful build still emits the JSON result on stdout (stdout stays
+/// reserved for the result; build progress goes to stderr).
+#[test]
+fn build_success_emits_json_result_on_stdout() {
+    let temp_dir = TempDir::new().unwrap();
+    let dockerfile = "FROM alpine:3.19\nLABEL deacon.test=build-output\nRUN echo DEACON_BUILD_OK\n";
+    write_devcontainer(&temp_dir, dockerfile);
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let assert = cmd
+        .current_dir(&temp_dir)
+        .arg("build")
+        .arg("--output-format")
+        .arg("json")
+        .assert();
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        assert!(
+            is_docker_unavailable(&stderr),
+            "unexpected build failure (docker available): {stderr}"
+        );
+        eprintln!("skipping: docker unavailable ({})", stderr.trim());
+        return;
+    }
+
+    // stdout carries only the JSON result.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(r#""outcome":"success"#),
+        "stdout should carry the success JSON result; stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(r#""imageName""#),
+        "stdout JSON should include the built image name; stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Part 1 / B4 — complete the build-output rollout + Docker integration test

Final stage of the build-output work. Extends B3's renderer to the remaining build paths and adds Docker integration coverage. Builds on #255/#256/#257.

### `deacon build` base Dockerfile build
- Extracted the streaming inner loop into a reusable `stream_captured_child`, and added **`run_build_once(command, io)`** — a single-attempt (no-retry) executor for callers that own a pre-configured `Command` (env vars, working dir, secret mounts).
- `execute_docker_build` now runs through it (with a renderer) instead of buffering via `.output()`, so `deacon build`'s base build honors the resolved mode. (`--iidfile` from B2 unchanged.)

### Compose
- Added `ComposeCommand::execute_streamed` (reuses `stream_captured_child`, **without** touching the shared `execute` path) and threaded a sink through `ComposeManager::build_service`, so `deacon build`'s compose-service build renders like the others. `up`'s compose *feature* build already rendered via B3's `build_image_with_features`.

### Integration test (`integration_build_output.rs`, `docker-slow-shared`)
- A **failing** `RUN` must surface its output on stderr and exit non-zero (not swallowed).
- A **successful** build still emits the JSON result on stdout (stdout stays reserved for the result).
- Both tolerate a Docker-less env (assert the Docker-unavailable error), mirroring `integration_build.rs`.
- Wired into **all** nextest profiles mirroring `binary(=integration_build)` (13 spots).

> In CI (non-TTY) the resolved mode is **Plain**, so the integration test exercises Plain-mode streaming + failure surfacing. Compact's `MultiProgress`/failure-trim is unit-tested (it needs a real TTY, which CI can't provide).

### Gates
fmt, clippy `--all-targets --all-features -D warnings`, core lib (1302, single-threaded — see note) + deacon lib/bins (380/377) + doctests (130) all green.

**Note on `cargo test --lib`:** a pre-existing shared-global-state race in the *plugins* tests (`PLUGIN_REGISTRY` static) surfaces only under `cargo test`'s single-process parallelism; it passes single-threaded and under **nextest** (process-per-test, which CI uses). Unrelated to this change.

---

This closes out **Part 1** (build-output rendering): B1 parser (#255) → B2 streaming + `--iidfile` (#256) → B3 modes + renderer (#257) → **B4 remaining paths + tests (this)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)