### PR TITLE
chore(release): bump version to 0.2.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.7" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.8" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.7"
+version = "0.2.0-rc.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Release-prep bump to **0.2.0-rc.8**. Version updated in all four spots (root `deacon-core` dep, `crates/deacon/Cargo.toml`, `crates/core/Cargo.toml`, `Cargo.lock`) per the release process.

This rc carries the full **Part 1 build-output rendering** work:
- **B1** (#255) — BuildKit `--progress=plain` parser
- **B2** (#256) — streaming build executor + `--iidfile`
- **B3** (#257) — `BuildOutputMode` (Compact/Inherit/Plain) + live renderer
- **B4** (#258) — `deacon build` base/compose builds streamed + integration test

plus the earlier verbosity flags (`-v`/`-q`, default `warn`) and the feature `containerEnv` → build-time `ENV` fix (the `npm: command not found` fix).

Once merged, an annotated `v0.2.0-rc.8` tag on `main` triggers the release workflow (binaries for 8 targets, checksums, SBOMs, provenance, install-script deploy; flagged prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)