### PR TITLE
fix(up): compose build output mode, spinner/stream conflict, and lifecycle cwd

### DIFF
--- a/crates/core/src/progress.rs
+++ b/crates/core/src/progress.rs
@@ -752,6 +752,22 @@ impl ProgressTracker {
         Ok(())
     }
 
+    /// Suspend the emitter's terminal drawing (e.g. an interactive spinner) so a
+    /// streaming build renderer can own stderr without the two clobbering each
+    /// other. No-op for non-interactive emitters. Pair with [`Self::resume`].
+    pub fn suspend(&mut self) {
+        if let Some(ref mut emitter) = self.emitter {
+            emitter.suspend();
+        }
+    }
+
+    /// Resume terminal drawing after [`Self::suspend`].
+    pub fn resume(&mut self) {
+        if let Some(ref mut emitter) = self.emitter {
+            emitter.resume();
+        }
+    }
+
     /// Records a duration for an operation into the tracker's in-memory metrics.
     ///
     /// The `operation` string is used as the histogram key; the duration is added to
@@ -828,6 +844,14 @@ impl ProgressTracker {
 pub trait ProgressEmitter: Send + Sync + std::fmt::Debug {
     /// Emit a progress event
     fn emit(&mut self, event: &ProgressEvent) -> Result<()>;
+
+    /// Temporarily stop drawing to the terminal so another component can own
+    /// stderr (e.g. the streaming build-output renderer, which draws its own
+    /// progress). Default no-op — only the interactive spinner overrides this.
+    fn suspend(&mut self) {}
+
+    /// Resume drawing after a [`Self::suspend`]. Default no-op.
+    fn resume(&mut self) {}
 }
 
 /// JSON line emitter that writes to a file

--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -1318,6 +1318,8 @@ async fn execute_compose_build(
     // Build the service, rendering its BuildKit output per the resolved mode.
     // This is the base compose-service build (no feature-install steps — feature
     // layering renders separately), so there are no feature ids to register.
+    // Pause the spinner so the build's streaming renderer owns stderr.
+    let _pause = crate::commands::shared::progress::SpinnerPause::new(&args.progress_tracker);
     let renderer = crate::ui::build_render::BuildRenderer::for_mode(
         args.build_output_mode,
         Vec::<&str>::new(),
@@ -1407,6 +1409,12 @@ async fn execute_compose_build_with_features(
     let identity = ContainerIdentity::new(workspace_folder, config);
     let workspace_hash = format!("{}-build", identity.workspace_hash);
 
+    // Carry the resolved build-output mode into the feature build so it renders
+    // like the other build paths (cache/builder options stay default here).
+    let build_options = deacon_core::build::BuildOptions {
+        output_mode: args.build_output_mode,
+        ..Default::default()
+    };
     let feature_build = resolve_compose_feature_image(
         config,
         &compose_manager,
@@ -1414,6 +1422,7 @@ async fn execute_compose_build_with_features(
         workspace_folder,
         config_path,
         &workspace_hash,
+        Some(&build_options),
         host_ca_set,
         // `deacon build` is docker-only today; podman parity for the build
         // command is tracked separately (issue #30 deferred items).
@@ -2009,6 +2018,8 @@ async fn execute_docker_build(
         // (no retry) on our pre-configured command (env vars + working dir).
         cmd.args(&build_args) // Pass all args including "build" subcommand
             .current_dir(workspace_folder);
+        // Pause the spinner so the build's streaming renderer owns stderr.
+        let _pause = crate::commands::shared::progress::SpinnerPause::new(&args.progress_tracker);
         let renderer = crate::ui::build_render::BuildRenderer::for_mode(
             args.build_output_mode,
             Vec::<&str>::new(),

--- a/crates/deacon/src/commands/shared/progress.rs
+++ b/crates/deacon/src/commands/shared/progress.rs
@@ -5,6 +5,54 @@ use deacon_core::progress::{ProgressEvent, ProgressTracker};
 use std::sync::{Arc, Mutex};
 use tracing::warn;
 
+/// RAII guard that suspends the interactive progress spinner for its lifetime,
+/// resuming it on drop.
+///
+/// The streaming build-output renderer (`ui::build_render`) draws its own
+/// progress to stderr; if the general `up` spinner keeps its steady-tick going
+/// at the same time, the two clobber each other. Wrap a build call in one of
+/// these so the spinner yields stderr for the duration of the build:
+///
+/// ```ignore
+/// let _pause = SpinnerPause::new(&args.progress_tracker);
+/// let result = build_image_with_features(...).await;
+/// drop(_pause); // (or let it drop at end of scope)
+/// ```
+///
+/// A non-interactive tracker (JSON/none/no emitter) suspends to a no-op, so this
+/// is always safe to acquire.
+pub struct SpinnerPause<'a> {
+    tracker: &'a Arc<Mutex<Option<ProgressTracker>>>,
+}
+
+impl<'a> SpinnerPause<'a> {
+    /// Suspend the spinner now; it resumes when the returned guard drops.
+    pub fn new(tracker: &'a Arc<Mutex<Option<ProgressTracker>>>) -> Self {
+        match tracker.lock() {
+            Ok(mut guard) => {
+                if let Some(t) = guard.as_mut() {
+                    t.suspend();
+                }
+            }
+            Err(e) => warn!("Progress tracker mutex poisoned (suspend): {}", e),
+        }
+        Self { tracker }
+    }
+}
+
+impl Drop for SpinnerPause<'_> {
+    fn drop(&mut self) {
+        match self.tracker.lock() {
+            Ok(mut guard) => {
+                if let Some(t) = guard.as_mut() {
+                    t.resume();
+                }
+            }
+            Err(e) => warn!("Progress tracker mutex poisoned (resume): {}", e),
+        }
+    }
+}
+
 /// Create a progress event callback that emits events through the shared progress tracker.
 ///
 /// Returns a closure suitable for passing to lifecycle execution functions as a progress callback.
@@ -24,5 +72,61 @@ pub fn make_progress_callback(
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_core::progress::{ProgressEmitter, ProgressEvent};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A ProgressEmitter that counts suspend/resume calls so we can assert the
+    /// `SpinnerPause` guard actually drives them through the tracker.
+    #[derive(Debug, Default)]
+    struct CountingEmitter {
+        suspends: Arc<AtomicUsize>,
+        resumes: Arc<AtomicUsize>,
+    }
+
+    impl ProgressEmitter for CountingEmitter {
+        fn emit(&mut self, _event: &ProgressEvent) -> deacon_core::progress::Result<()> {
+            Ok(())
+        }
+        fn suspend(&mut self) {
+            self.suspends.fetch_add(1, Ordering::SeqCst);
+        }
+        fn resume(&mut self) {
+            self.resumes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn spinner_pause_suspends_on_new_and_resumes_on_drop() {
+        let suspends = Arc::new(AtomicUsize::new(0));
+        let resumes = Arc::new(AtomicUsize::new(0));
+        let emitter = CountingEmitter {
+            suspends: suspends.clone(),
+            resumes: resumes.clone(),
+        };
+        let tracker = ProgressTracker::new(Some(Box::new(emitter)), None, Default::default())
+            .expect("tracker");
+        let tracker = Arc::new(Mutex::new(Some(tracker)));
+
+        {
+            let _pause = SpinnerPause::new(&tracker);
+            assert_eq!(suspends.load(Ordering::SeqCst), 1, "suspend on new");
+            assert_eq!(resumes.load(Ordering::SeqCst), 0, "no resume yet");
+        }
+        assert_eq!(resumes.load(Ordering::SeqCst), 1, "resume on drop");
+    }
+
+    #[test]
+    fn spinner_pause_is_safe_with_no_tracker() {
+        // A `None` tracker (non-interactive) must not panic.
+        let tracker = Arc::new(Mutex::new(None));
+        {
+            let _pause = SpinnerPause::new(&tracker);
+        }
     }
 }

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -85,6 +85,14 @@ pub(crate) async fn execute_compose_up(
 ) -> Result<UpContainerInfo> {
     debug!("Starting Docker Compose project");
 
+    // Build options (cache flags + the resolved build-output mode) for the
+    // feature-extended image builds below. Previously this path passed `None`,
+    // which (a) ignored cache-from/cache-to/no-cache and (b) defaulted the build
+    // output to Plain — so on a TTY the compose feature build dumped the raw
+    // BuildKit firehose instead of the compact per-step view. Mirror the
+    // single-container path (container.rs), which threads these through.
+    let build_options = super::args::build_options_from_args(args);
+
     let compose_manager = ComposeManager::with_docker_path(args.docker_path.clone());
     // Compose files resolve relative to the directory containing devcontainer.json
     // (the `.devcontainer` dir for the standard layout), not the workspace folder.
@@ -342,17 +350,24 @@ pub(crate) async fn execute_compose_up(
     // the existing injection override. Both the `image:` shape (14a) and the
     // `build:` shape (14b — user-authored Dockerfile + context) are supported.
     // Future work (per spec): thread resolved_features into merged_configuration.
-    let feature_build = install_features_for_compose(
-        config,
-        &compose_manager,
-        &mut project,
-        workspace_folder,
-        config_path,
-        workspace_hash,
-        host_ca_set,
-        &runtime.cli_docker(),
-    )
-    .await?;
+    // Pause the interactive spinner around the feature build so the build's
+    // streaming renderer owns stderr (otherwise the steady-tick spinner clobbers
+    // the build progress).
+    let feature_build = {
+        let _pause = crate::commands::shared::progress::SpinnerPause::new(&args.progress_tracker);
+        install_features_for_compose(
+            config,
+            &compose_manager,
+            &mut project,
+            workspace_folder,
+            config_path,
+            workspace_hash,
+            Some(&build_options),
+            host_ca_set,
+            &runtime.cli_docker(),
+        )
+        .await?
+    };
 
     // Lockfile graduation (PR-4b): mirror the single-container flow — write
     // the lockfile to disk, or byte-compare it in `--frozen-lockfile` mode.
@@ -410,7 +425,14 @@ pub(crate) async fn execute_compose_up(
             .map(|v| v == "json")
             .unwrap_or(false);
         let force_pty = resolve_force_pty(args.force_tty_if_json, json_mode);
-        execute_compose_post_create(&project, config, &args.docker_path, force_pty).await?;
+        execute_compose_post_create(
+            &project,
+            config,
+            workspace_folder,
+            &args.docker_path,
+            force_pty,
+        )
+        .await?;
     }
 
     // Handle port forwarding and events
@@ -571,10 +593,18 @@ pub(crate) async fn execute_compose_up(
 pub(crate) async fn execute_compose_post_create(
     project: &ComposeProject,
     config: &DevContainerConfig,
+    workspace_folder: &Path,
     docker_path: &str,
     force_pty: bool,
 ) -> Result<()> {
     debug!("Executing post-create lifecycle for compose project");
+
+    // Run lifecycle commands from the container's workspace folder, matching the
+    // single-container path (container_lifecycle.rs). Without this the exec
+    // inherits the image's default WORKDIR (often `/`), so a workspace-relative
+    // command like `.devcontainer/setup.sh` fails with "No such file or directory".
+    let container_workspace_folder =
+        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder);
 
     // Get the primary container ID
     let compose_manager = ComposeManager::with_docker_path(docker_path.to_string());
@@ -603,7 +633,7 @@ pub(crate) async fn execute_compose_post_create(
                     &["sh".to_string(), "-c".to_string(), cmd_str.to_string()],
                     ExecConfig {
                         user: None,
-                        working_dir: None,
+                        working_dir: Some(container_workspace_folder.clone()),
                         env: std::collections::HashMap::new(),
                         tty: force_pty,
                         interactive: false,
@@ -650,6 +680,7 @@ async fn install_features_for_compose(
     workspace_folder: &Path,
     config_path: &Path,
     workspace_hash: &str,
+    build_options: Option<&deacon_core::build::BuildOptions>,
     host_ca_set: Option<&CorporateCaSet>,
     cli: &deacon_core::docker::CliRuntime,
 ) -> Result<Option<FeatureBuildOutput>> {
@@ -660,6 +691,7 @@ async fn install_features_for_compose(
         workspace_folder,
         config_path,
         workspace_hash,
+        build_options,
         host_ca_set,
         cli,
     )
@@ -689,6 +721,7 @@ pub(crate) async fn resolve_compose_feature_image(
     workspace_folder: &Path,
     config_path: &Path,
     workspace_hash: &str,
+    build_options: Option<&deacon_core::build::BuildOptions>,
     host_ca_set: Option<&CorporateCaSet>,
     cli: &deacon_core::docker::CliRuntime,
 ) -> Result<Option<FeatureBuildOutput>> {
@@ -741,7 +774,7 @@ pub(crate) async fn resolve_compose_feature_image(
                 &identity,
                 workspace_folder,
                 config_path,
-                None,
+                build_options,
                 host_ca_set,
                 cli,
             )
@@ -818,7 +851,7 @@ pub(crate) async fn resolve_compose_feature_image(
                 &context_path,
                 config_path,
                 target.as_deref(),
-                None,
+                build_options,
                 host_ca_set,
                 cli,
             )

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -600,9 +600,18 @@ pub(crate) async fn execute_compose_post_create(
     debug!("Executing post-create lifecycle for compose project");
 
     // Run lifecycle commands from the container's workspace folder, matching the
-    // single-container path (container_lifecycle.rs). Without this the exec
-    // inherits the image's default WORKDIR (often `/`), so a workspace-relative
-    // command like `.devcontainer/setup.sh` fails with "No such file or directory".
+    // single-container path. Without this the exec inherits the image's default
+    // WORKDIR (often `/`), so a workspace-relative command like
+    // `.devcontainer/setup.sh` fails with "No such file or directory".
+    //
+    // We do NOT set `docker exec -w <dir>` (ExecConfig.working_dir): deacon does
+    // not inject a workspace bind mount for compose (the user's compose file
+    // provides it), so `<workspaceFolder>` may not exist in the container — and
+    // `-w` to a missing dir makes the exec hard-fail
+    // ("chdir to cwd … no such file or directory"). Instead we `cd` into it from
+    // inside the shell and fall through to the default dir if it is absent. This
+    // matches the reference CLI (run lifecycle from workspaceFolder) when the
+    // workspace is mounted, and stays graceful when it is not.
     let container_workspace_folder =
         crate::commands::shared::derive_container_workspace_folder(config, workspace_folder);
 
@@ -626,14 +635,22 @@ pub(crate) async fn execute_compose_post_create(
         if let Some(cmd_str) = post_create_cmd.as_str() {
             debug!("Executing postCreateCommand: {}", cmd_str);
 
+            // Run from the container workspace folder if it exists, else fall
+            // through (see the note above). Single-quote the path defensively;
+            // container workspace paths do not contain single quotes in practice.
+            let wrapped_cmd = format!(
+                "cd '{}' 2>/dev/null; {}",
+                container_workspace_folder, cmd_str
+            );
+
             let docker = deacon_core::docker::CliDocker::new();
             let result = docker
                 .exec(
                     &container_id,
-                    &["sh".to_string(), "-c".to_string(), cmd_str.to_string()],
+                    &["sh".to_string(), "-c".to_string(), wrapped_cmd],
                     ExecConfig {
                         user: None,
-                        working_dir: Some(container_workspace_folder.clone()),
+                        working_dir: None,
                         env: std::collections::HashMap::new(),
                         tty: force_pty,
                         interactive: false,

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -260,18 +260,24 @@ pub(crate) async fn execute_container_up(
         info!("Features detected in configuration - building feature-extended image with BuildKit");
 
         // Pass build_options to propagate cache-from/cache-to/buildx settings per spec (data-model.md).
-        // `config_path` anchors local feature references (#69).
-        let feature_build = build_image_with_features(
-            &config,
-            identity,
-            workspace_folder,
-            config_path,
-            Some(build_options),
-            host_ca_set,
-            &runtime.cli_docker(),
-        )
-        .await
-        .with_context(|| "Failed to build feature-extended image")?;
+        // `config_path` anchors local feature references (#69). Pause the
+        // interactive spinner for the build so its streaming renderer owns stderr
+        // (otherwise the steady-tick spinner clobbers the build progress).
+        let feature_build = {
+            let _pause =
+                crate::commands::shared::progress::SpinnerPause::new(&args.progress_tracker);
+            build_image_with_features(
+                &config,
+                identity,
+                workspace_folder,
+                config_path,
+                Some(build_options),
+                host_ca_set,
+                &runtime.cli_docker(),
+            )
+            .await
+            .with_context(|| "Failed to build feature-extended image")?
+        };
 
         if !feature_build.combined_env.is_empty() {
             config

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -491,9 +491,13 @@ pub(crate) async fn execute_up_with_runtime(
     if config.image.is_none() && !config.uses_compose() {
         if let Some(build_config) = extract_build_config_from_devcontainer(&config, &config_path)? {
             info!("Building image from Dockerfile configuration");
-            let built_image_id =
+            let built_image_id = {
+                // Pause the spinner so the build's streaming renderer owns stderr.
+                let _pause =
+                    crate::commands::shared::progress::SpinnerPause::new(&args.progress_tracker);
                 build_image_from_config(&build_config, &build_options, &runtime.cli_docker())
-                    .await?;
+                    .await?
+            };
 
             // Update config to use the built image
             config.image = Some(built_image_id.clone());

--- a/crates/deacon/src/ui/spinner.rs
+++ b/crates/deacon/src/ui/spinner.rs
@@ -1,6 +1,6 @@
 use console::style;
 use deacon_core::progress::{ProgressEmitter, ProgressEvent, Result};
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::time::Duration;
 
 // (no-op) TTY helpers live in CLI; UI module remains pure
@@ -153,6 +153,17 @@ impl ProgressEmitter for SpinnerEmitter {
             _ => {}
         }
         Ok(())
+    }
+
+    fn suspend(&mut self) {
+        // Clear the current spinner line and stop drawing so the streaming
+        // build-output renderer can own stderr. The steady-tick thread keeps
+        // running but draws to a hidden target (a no-op) until `resume`.
+        self.pb.set_draw_target(ProgressDrawTarget::hidden());
+    }
+
+    fn resume(&mut self) {
+        self.pb.set_draw_target(ProgressDrawTarget::stderr());
     }
 }
 


### PR DESCRIPTION
Three issues surfaced by running **rc.8 `deacon up`** on a Docker Compose devcontainer (thanks @paulofallon for the repro).

### 1. Compose feature build dumped the raw BuildKit firehose on a TTY
The compose path passed `None` for `build_options` into `build_image_with_features`, so `BuildOutputMode` fell back to **Plain** (verbatim stream) even on an interactive terminal — and it also silently ignored `--cache-from`/`--cache-to`/`--no-cache`. Now the real `BuildOptions` (with the resolved output mode) is threaded through `install_features_for_compose` → `resolve_compose_feature_image`, so the compose feature build renders **Compact** on a TTY like the single-container path. `deacon build`'s compose path passes the mode too.

### 2. The general `up` spinner fought the streaming build output
Before B2 the build was buffered, so the steady-tick `SpinnerEmitter` never overlapped it. Now that builds **stream**, the two clobber each other on stderr (the reported "spinner + firehose interleaving"). Added `suspend()`/`resume()` to `ProgressEmitter` (no-op default; `SpinnerEmitter` hides/shows its draw target), a `SpinnerPause` RAII guard, and wrapped **every** build call (up: image/feature/compose; `deacon build`: base/compose) so the build renderer owns stderr for the build's duration.

### 3. Compose lifecycle ran with the wrong working directory
`execute_compose_post_create` exec'd `postCreateCommand` with `working_dir: None`, so a workspace-relative command like `.devcontainer/setup.sh` resolved against the image's default `WORKDIR` (`/`) → `bash: .devcontainer/setup.sh: No such file or directory`. Now set to the container workspace folder (`derive_container_workspace_folder`), matching the single-container path (`container_lifecycle.rs:1432`).

### Tests
New `SpinnerPause` unit tests (suspend-on-new / resume-on-drop, and no-tracker safety). fmt + clippy `--all-targets --all-features -D warnings`, 1302 core + 380/377 deacon lib/bins green.

### Known, tracked separately (not in this PR)
- deacon does **not** auto-inject a workspace bind mount for compose — the user's compose file must mount the workspace at `workspaceFolder` (per reference-CLI convention). If that mount is missing, files are absent regardless of cwd.
- The compose post-create stub still only handles the **string** form of `postCreateCommand` and doesn't run `onCreate`/`updateContent`/`postStart`/`postAttach` or feature lifecycle commands — a broader gap worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)