### PR TITLE
chore(release): bump version to 0.2.0-rc.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.8" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.9" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.8"
+version = "0.2.0-rc.9"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Release-prep bump to **0.2.0-rc.9**. Version updated in all four spots (root `deacon-core` dep, both crate manifests, `Cargo.lock`).

Carries the compose `up` fixes (#260) on top of rc.8's build-output work (#255–#258):
- Compose feature build renders **Compact** on a TTY instead of the raw BuildKit firehose (it was defaulting to Plain).
- The general `up` spinner no longer clobbers the streamed build output (suspended during builds).
- Compose lifecycle commands run from the workspace folder, so a relative `.devcontainer/setup.sh` resolves (graceful `cd`, falls through if the workspace isn't mounted).

Once merged, an annotated `v0.2.0-rc.9` tag on `main` triggers the release workflow (8 targets, checksums, SBOMs, provenance, install-script deploy; prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)