### PR TITLE
feat(up): compact lifecycle-command output in Compact mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,22 @@ presented follows the same verbosity/TTY signals as logging:
 In all modes stdout stays reserved for the command's result (so `--output json`
 / piped output remain parseable); build progress and diagnostics go to stderr.
 
+### Lifecycle command output
+
+Lifecycle commands (`onCreate`, `postCreate`, `postStart`, …) follow the same
+signals:
+
+| Situation | What you see |
+|-----------|--------------|
+| Interactive terminal, default verbosity | **Compact**: output is buffered behind the per‑phase spinner (`Running postCreate…` → `postCreate completed in N ms`). On failure the captured output is replayed (redacted, tail‑capped to the last 100 lines) so you still see why it failed. |
+| `-v`/`--verbose`, non‑TTY (CI, redirection), or `--log-format json` | **Streamed**: each command's output is forwarded to stderr verbatim as it runs, exactly as before. |
+
+This keeps a verbose `postCreateCommand` (e.g. an installer that downloads
+hundreds of MB) from burying the progress spinner, while a failing hook still
+surfaces its log. It applies to string and array (`exec`) form commands; parallel
+(object‑form) and dotfiles installation still stream so their interleaved output
+stays attributable.
+
 ### PTY Allocation for JSON Log Mode
 
 When using JSON logging format (`--log-format json`), lifecycle commands (onCreate, postCreate, etc.) run without PTY (pseudo-terminal) allocation by default. This is ideal for non-interactive scripts and automated environments.

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -3,7 +3,7 @@
 //! This module provides container-specific lifecycle command execution with full
 //! variable substitution including containerEnv & containerWorkspaceFolder.
 
-use crate::docker::{CliDocker, Docker, ExecConfig};
+use crate::docker::{CliDocker, Docker, ExecConfig, ExecResult};
 use crate::errors::{ConfigError, DeaconError, Result};
 use crate::lifecycle::LifecyclePhase;
 use crate::progress::{ProgressEvent, ProgressTracker};
@@ -514,6 +514,79 @@ pub struct ContainerLifecycleConfig {
     /// rerun. `None` writes legacy markers (no hash) — compatible with
     /// older deacon installs.
     pub config_hash: Option<String>,
+    /// Capture lifecycle command output instead of streaming it live (Part 3
+    /// build-output-and-verbosity). When `true` (compact mode), each command's
+    /// stdout+stderr is buffered rather than forwarded to deacon's stderr, so
+    /// the per-phase progress spinner owns the terminal; on a non-zero exit the
+    /// captured log is replayed (redacted, tail-capped) so failures stay
+    /// diagnosable. When `false` (verbose/`-v`, non-TTY, or JSON), output
+    /// streams verbatim as before. Default `false` preserves legacy behavior.
+    pub capture_output: bool,
+}
+
+/// Maximum number of trailing lines of a failed command's captured output to
+/// replay, so a runaway log (e.g. a verbose installer) doesn't re-flood the
+/// terminal on failure.
+const MAX_REPLAY_LINES: usize = 100;
+
+/// Build the text to replay for a lifecycle command's captured output on failure
+/// (compact mode only), or `None` when nothing should be printed.
+///
+/// In compact mode (`ContainerLifecycleConfig::capture_output = true`) the
+/// command's stdout+stderr were buffered by the exec layer (`silent = true`)
+/// rather than streamed live, so on success nothing reaches the terminal and the
+/// per-phase spinner stays clean. When the command *fails* we still owe the user
+/// the output that explains why — so return it here (redacted, tail-capped to the
+/// last `MAX_REPLAY_LINES` lines).
+///
+/// Returns `None` when output was streamed live (`capture` is `false`), the
+/// command succeeded (`result.success`), or there is no output to show.
+fn build_lifecycle_failure_replay(capture: bool, result: &ExecResult) -> Option<String> {
+    if !capture || result.success {
+        return None;
+    }
+
+    let mut combined = result.stdout.clone();
+    if !result.stderr.is_empty() {
+        if !combined.is_empty() && !combined.ends_with('\n') {
+            combined.push('\n');
+        }
+        combined.push_str(&result.stderr);
+    }
+
+    let redacted = redact_if_enabled(&combined, &RedactionConfig::default());
+    let trimmed = redacted.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lines: Vec<&str> = trimmed.lines().collect();
+    let mut out = String::new();
+    if lines.len() > MAX_REPLAY_LINES {
+        let omitted = lines.len() - MAX_REPLAY_LINES;
+        out.push_str(&format!(
+            "  … {} earlier line(s) omitted (showing last {} of captured output)\n",
+            omitted, MAX_REPLAY_LINES
+        ));
+        for line in &lines[lines.len() - MAX_REPLAY_LINES..] {
+            out.push_str(line);
+            out.push('\n');
+        }
+    } else {
+        for line in &lines {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    Some(out)
+}
+
+/// Replay a failed lifecycle command's captured output to stderr (compact mode).
+/// No-op unless [`build_lifecycle_failure_replay`] yields text.
+fn replay_captured_lifecycle_output(capture: bool, result: &ExecResult) {
+    if let Some(text) = build_lifecycle_failure_replay(capture, result) {
+        eprint!("{}", text);
+    }
 }
 
 /// Execute lifecycle commands in a container with full variable substitution
@@ -1434,7 +1507,9 @@ where
                     tty: config.force_pty,
                     interactive: false,
                     detach: false,
-                    silent: false,
+                    // Compact mode buffers output (see `capture_output`); verbose/
+                    // non-TTY/JSON streams it live as before.
+                    silent: config.capture_output,
                     stdout_to_stderr: true,
                     terminal_size: None,
                 };
@@ -1472,6 +1547,9 @@ where
 
                 match exec_result {
                     Ok(exec_result) => {
+                        // Compact mode: replay the buffered output if the command
+                        // failed (no-op on success or when streamed live).
+                        replay_captured_lifecycle_output(config.capture_output, &exec_result);
                         debug!(
                             "Container command completed with exit code: {} in {:?}",
                             exec_result.exit_code, duration
@@ -1616,7 +1694,9 @@ where
                     tty: config.force_pty,
                     interactive: false,
                     detach: false,
-                    silent: false,
+                    // Compact mode buffers output (see `capture_output`); verbose/
+                    // non-TTY/JSON streams it live as before.
+                    silent: config.capture_output,
                     stdout_to_stderr: true,
                     terminal_size: None,
                 };
@@ -1630,6 +1710,9 @@ where
 
                 match exec_result {
                     Ok(exec_result) => {
+                        // Compact mode: replay the buffered output if the command
+                        // failed (no-op on success or when streamed live).
+                        replay_captured_lifecycle_output(config.capture_output, &exec_result);
                         debug!(
                             "Exec-style command completed with exit code: {} in {:?}",
                             exec_result.exit_code, duration
@@ -2730,6 +2813,60 @@ impl ContainerLifecycleResult {
 mod tests {
     use super::*;
 
+    fn exec_result(success: bool, stdout: &str, stderr: &str) -> ExecResult {
+        ExecResult {
+            exit_code: if success { 0 } else { 1 },
+            success,
+            stdout: stdout.to_string(),
+            stderr: stderr.to_string(),
+        }
+    }
+
+    #[test]
+    fn replay_is_none_when_not_capturing() {
+        // Streamed live (capture = false): output already went to the terminal,
+        // so there is nothing to replay even on failure.
+        let r = exec_result(false, "boom stdout", "boom stderr");
+        assert!(build_lifecycle_failure_replay(false, &r).is_none());
+    }
+
+    #[test]
+    fn replay_is_none_on_success() {
+        // Compact + success: the whole point is to stay quiet.
+        let r = exec_result(true, "lots of noise\n", "job control blah\n");
+        assert!(build_lifecycle_failure_replay(true, &r).is_none());
+    }
+
+    #[test]
+    fn replay_is_none_when_output_empty() {
+        let r = exec_result(false, "", "   \n  \n");
+        assert!(build_lifecycle_failure_replay(true, &r).is_none());
+    }
+
+    #[test]
+    fn replay_combines_stdout_and_stderr_on_failure() {
+        let r = exec_result(false, "line-out", "line-err");
+        let text = build_lifecycle_failure_replay(true, &r).expect("replay text");
+        assert!(text.contains("line-out"), "stdout present: {text:?}");
+        assert!(text.contains("line-err"), "stderr present: {text:?}");
+    }
+
+    #[test]
+    fn replay_tail_caps_long_output() {
+        // 250 lines of stdout; only the last MAX_REPLAY_LINES are shown, with a
+        // truncation notice for the remainder.
+        let stdout: String = (0..250).map(|i| format!("row{i}\n")).collect();
+        let r = exec_result(false, &stdout, "");
+        let text = build_lifecycle_failure_replay(true, &r).expect("replay text");
+        assert!(text.contains("earlier line(s) omitted"), "notice: {text:?}");
+        // Last line must be present, an early one must be dropped.
+        assert!(text.contains("row249"), "tail kept");
+        assert!(!text.contains("row0\n"), "head dropped");
+        // Count of content rows shown never exceeds the cap.
+        let shown = text.matches("row").count();
+        assert_eq!(shown, MAX_REPLAY_LINES, "exactly the cap of rows shown");
+    }
+
     /// Helper to convert string commands to AggregatedLifecycleCommand for tests
     fn make_config_commands(cmds: &[&str]) -> Vec<AggregatedLifecycleCommand> {
         cmds.iter()
@@ -2750,6 +2887,7 @@ mod tests {
     #[test]
     fn test_container_lifecycle_config_creation() {
         let config = ContainerLifecycleConfig {
+            capture_output: false,
             container_id: "test-container".to_string(),
             user: Some("root".to_string()),
             container_workspace_folder: "/workspaces/test".to_string(),
@@ -2900,6 +3038,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'test'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -2964,6 +3103,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'test'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3042,6 +3182,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'test'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3107,6 +3248,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'test'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3194,6 +3336,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'postStart'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3219,6 +3362,7 @@ mod tests {
             phase: LifecyclePhase::PostAttach,
             commands: make_config_commands(&["echo 'postAttach'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3296,6 +3440,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["exit 1"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3379,6 +3524,7 @@ mod tests {
             phase: LifecyclePhase::PostStart,
             commands: make_config_commands(&["echo 'postStart'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),
@@ -3404,6 +3550,7 @@ mod tests {
             phase: LifecyclePhase::PostAttach,
             commands: make_config_commands(&["echo 'postAttach'"]),
             config: ContainerLifecycleConfig {
+                capture_output: false,
                 container_id: "test".to_string(),
                 user: None,
                 container_workspace_folder: "/workspace".to_string(),

--- a/crates/core/tests/integration_container_lifecycle.rs
+++ b/crates/core/tests/integration_container_lifecycle.rs
@@ -28,6 +28,7 @@ async fn test_container_lifecycle_with_variable_substitution() {
     container_env.insert("DEBUG".to_string(), "true".to_string());
 
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container-123".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspaces/test".to_string(),
@@ -101,6 +102,7 @@ async fn test_container_lifecycle_with_skip_flags() {
 
     // Test with skip flags enabled
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container-456".to_string(),
         user: None, // Test without user specification
         container_workspace_folder: "/workspaces/test".to_string(),
@@ -158,6 +160,7 @@ fn test_container_lifecycle_config_validation() {
     container_env.insert("TEST_VAR".to_string(), "test_value".to_string());
 
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("testuser".to_string()),
         container_workspace_folder: "/workspaces/myproject".to_string(),
@@ -224,6 +227,7 @@ async fn test_all_lifecycle_phases_ordering() {
     let substitution_context = SubstitutionContext::new(workspace_path).unwrap();
 
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container-all-phases".to_string(),
         user: None,
         container_workspace_folder: "/workspaces/test".to_string(),

--- a/crates/core/tests/integration_mock_runtime.rs
+++ b/crates/core/tests/integration_mock_runtime.rs
@@ -331,6 +331,7 @@ async fn test_lifecycle_execution_with_mock_docker() -> Result<()> {
 
     // Create lifecycle configuration
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "lifecycle-test-container".to_string(),
         user: Some("node".to_string()),
         container_workspace_folder: "/workspace/app".to_string(),
@@ -434,6 +435,7 @@ async fn test_lifecycle_execution_with_skip_flags() -> Result<()> {
 
     // Create lifecycle configuration with skip flags
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "skip-test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -502,6 +504,7 @@ async fn test_lifecycle_execution_with_command_failure() -> Result<()> {
 
     // Create lifecycle configuration
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "failure-test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -610,6 +613,7 @@ async fn test_non_blocking_command_skip_behavior() -> Result<()> {
 
     // Create lifecycle configuration with non-blocking commands skipped
     let config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "non-blocking-test".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),

--- a/crates/core/tests/integration_non_blocking_lifecycle.rs
+++ b/crates/core/tests/integration_non_blocking_lifecycle.rs
@@ -33,6 +33,7 @@ async fn test_non_blocking_phases_are_deferred() {
 
     // Create lifecycle configuration with non-blocking commands enabled
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -140,6 +141,7 @@ async fn test_skip_non_blocking_commands_behavior() {
 
     // Create lifecycle configuration with non-blocking commands DISABLED
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -214,6 +216,7 @@ async fn test_non_blocking_phases_sync_execution() {
 
     // Create lifecycle configuration with non-blocking commands enabled
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -338,6 +341,7 @@ async fn test_non_blocking_phase_command_failures_are_handled() {
 
     // Create lifecycle configuration with non-blocking commands enabled
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -457,6 +461,7 @@ async fn test_non_blocking_phase_timeout_handling() {
 
     // Create lifecycle configuration with very short timeout
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),
@@ -538,6 +543,7 @@ async fn test_non_blocking_phases_with_progress_streaming() {
 
     // Create lifecycle configuration with non-blocking commands enabled
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspace".to_string(),

--- a/crates/core/tests/integration_per_command_events.rs
+++ b/crates/core/tests/integration_per_command_events.rs
@@ -64,6 +64,7 @@ async fn test_per_command_events_emitted() {
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "test-container".to_string(),
         user: Some("root".to_string()),
         container_workspace_folder: "/workspaces/test".to_string(),

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -196,6 +196,7 @@ async fn execute_lifecycle_commands(
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: container_id.to_string(),
         user: config
             .remote_user

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -376,6 +376,7 @@ async fn execute_lifecycle_hooks(
         .unwrap_or_else(|| "/".to_string());
 
     let lifecycle_config = ContainerLifecycleConfig {
+        capture_output: false,
         container_id: container.id.clone(),
         user: merged_config
             .remote_user

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -243,6 +243,9 @@ pub(crate) async fn execute_lifecycle_commands(
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {
+        // Part 3: buffer lifecycle output behind the per-phase spinner in compact
+        // mode; verbose/non-TTY/JSON keeps streaming it live.
+        capture_output: args.build_output_mode == deacon_core::build::BuildOutputMode::Compact,
         container_id: container_id.to_string(),
         user: effective_user,
         container_workspace_folder,
@@ -510,6 +513,7 @@ pub(crate) async fn execute_initialize_command(
 
     // Create a dummy lifecycle config (only needed for container phases, not host phases)
     let lifecycle_config = deacon_core::container_lifecycle::ContainerLifecycleConfig {
+        capture_output: false,
         container_id: "<host-only-no-container>".to_string(),
         user: None,
         container_workspace_folder: "<host-only-no-container>".to_string(),

--- a/docs/plans/build-output-and-verbosity.md
+++ b/docs/plans/build-output-and-verbosity.md
@@ -162,6 +162,30 @@ Staged, each independently CI-verifiable (user has no preference; this keeps rev
 
 ---
 
+## Part 3: Compact lifecycle-command output (follow-on from real-world `up`)
+
+Running the shipped Compact build UX on a real project surfaced the next layer of
+noise: the **build** output was compact, but `postCreate` (a verbose `setup.sh`:
+playwright browser downloads + a 94-package apt install) still streamed its full
+firehose over the per-phase spinner, and two `bash: … no job control` lines leaked
+from running the hook as an interactive login shell without a PTY.
+
+Fix (extends the same verbosity/TTY axis):
+- `ContainerLifecycleConfig::capture_output` (default `false`). When `true`
+  (Compact mode, set from `UpArgs::build_output_mode == Compact` in
+  `commands/up/lifecycle.rs`), the lifecycle exec runs with `silent: true` so
+  stdout+stderr are **buffered** instead of streamed — the `SpinnerEmitter`'s
+  existing `Running <phase>…` / `<phase> completed in N ms` line owns the terminal,
+  and the interactive-shell job-control noise is captured and discarded on success.
+- On a **non-zero exit**, `build_lifecycle_failure_replay` replays the captured
+  output (redacted, tail-capped to the last 100 lines) so failures stay
+  diagnosable. Unit-tested in `container_lifecycle.rs`.
+- Covers the String and `Exec` (array) command paths. Parallel (object-form) and
+  dotfiles installation intentionally keep streaming (prefixed / interleaved output
+  stays attributable) — noted as a follow-up.
+- Verbose (`-v`), non-TTY/CI, and `--log-format json` all keep streaming verbatim
+  (`capture_output` stays `false`).
+
 ## Part 2 (optional): `ai-clis` feature defensiveness
 
 Once PR #252 is merged and a new deacon is in use, `ai-clis` works unchanged. Independently


### PR DESCRIPTION
## Summary

Extends the build-output-and-verbosity work (Part 3) from **build** output to **lifecycle command** output.

Running the shipped Compact build UX on a real project surfaced the next layer of noise: the build output was compact, but a verbose `postCreate` (`setup.sh` doing playwright browser downloads + a 94-package apt install) still streamed its full firehose over the per-phase spinner, and two `bash: … no job control` lines leaked from running the hook as an interactive login shell without a PTY.

## What changed

- New `ContainerLifecycleConfig::capture_output` (default `false`, preserving legacy streaming for `run-user-commands`, `set-up`, host-only initialize, and all existing callers).
- In the `up` flow it's set from `UpArgs::build_output_mode == Compact`. When on, the lifecycle exec runs with `silent: true`, so stdout+stderr are **buffered** instead of streamed — the existing `SpinnerEmitter` line (`Running postCreate…` → `postCreate completed in N ms`) owns the terminal, and the interactive-shell job-control noise is captured and discarded on success.
- On a **non-zero exit**, `build_lifecycle_failure_replay` replays the captured output (redacted via the existing redaction path, tail-capped to the last 100 lines) so failures stay diagnosable.
- Covers the **String** and **Exec (array)** command paths. Parallel (object-form) and dotfiles installation intentionally keep streaming so their interleaved/prefixed output stays attributable — noted as a follow-up.
- Verbose (`-v`), non-TTY/CI, and `--log-format json` keep streaming verbatim (`capture_output` stays `false`).

## Behavior

| Situation | Before | After |
|-----------|--------|-------|
| Compact `up`, postCreate succeeds | full firehose over the spinner + `no job control` noise | just `Running postCreate…` → `postCreate completed in N ms` |
| Compact `up`, postCreate fails | firehose | captured output replayed (redacted, last 100 lines) then the error |
| `-v` / non-TTY / JSON | streamed | streamed (unchanged) |

## Tests

- Unit tests for `build_lifecycle_failure_replay` (no-op when not capturing / on success / empty output; combines stdout+stderr; tail-caps long output).
- Existing lifecycle lib + mock integration suites pass with the new field threaded through all construction sites.

README build/logging section and the plan doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)