### PR TITLE
chore(release): bump version to 0.2.0-rc.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.9" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.10" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.9"
+version = "0.2.0-rc.10"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Release rc.10.

Bumps the version in all four sync'd spots (root `deacon-core` dep, both crate manifests, `Cargo.lock`).

Ships on top of rc.9:
- **#262** feat(up): compact lifecycle-command output in Compact mode — `postCreate`/etc. output is buffered behind the per-phase spinner in Compact mode (replayed on failure), matching the build-output UX; verbose/non-TTY/JSON keep streaming.

After merge, an annotated `v0.2.0-rc.10` tag triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)