### PR TITLE
fix(up): apply devcontainer.json mounts on compose path

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -119,7 +119,7 @@ test-group = 'docker-slow-shared'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
 test-group = 'docker-shared'
 
 [[profile.default.overrides]]
@@ -157,7 +157,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build))'
+default-filter = 'not (binary(#smoke_*) | binary(#parity_*) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -221,7 +221,7 @@ filter = 'binary(=integration_build) | binary(=integration_build_output) | binar
 test-group = 'docker-slow-shared'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
 test-group = 'docker-shared'
 
 [[profile.dev-fast.overrides]]
@@ -340,7 +340,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.docker.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
 test-group = 'docker-shared'
 
 [[profile.docker.overrides]]
@@ -414,7 +414,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.full.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
 test-group = 'docker-shared'
 
 [[profile.full.overrides]]
@@ -500,7 +500,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.ci.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
 test-group = 'docker-shared'
 threads-required = 1
 

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -152,24 +152,52 @@ pub(crate) async fn execute_compose_up(
         );
     }
 
+    // Apply `devcontainer.json` `mounts` to the compose project (#266). The
+    // single-container path applies these via `merge_mounts`
+    // (up/container.rs); the compose path never read `config.mounts` at all.
+    // Feature-contributed mounts are out of scope here (compose feature
+    // dispatch doesn't yet resolve `ResolvedFeature` mounts the same way) —
+    // pass an empty feature slice so `merge_mounts` only substitutes +
+    // normalizes `config.mounts`.
+    if !config.mounts.is_empty() {
+        let mount_substitution_context = {
+            let mut ctx = deacon_core::variable::SubstitutionContext::new(workspace_folder)?;
+            let id_labels: Vec<(String, String)> = identity.labels().into_iter().collect();
+            ctx.devcontainer_id = deacon_core::container::compute_dev_container_id(&id_labels);
+            ctx
+        };
+        let merged_config_mounts = deacon_core::mount::merge_mounts(
+            &config.mounts,
+            &[],
+            Some(&mount_substitution_context),
+        )
+        .with_context(|| "Failed to merge devcontainer.json mounts for compose")?;
+        for mount_str in &merged_config_mounts.mounts {
+            let mount = NormalizedMount::parse(mount_str).with_context(|| {
+                format!(
+                    "Invalid mount specification in devcontainer.json: {}",
+                    mount_str
+                )
+            })?;
+            additional_mounts.push(normalized_mount_to_compose_mount(&mount));
+        }
+    }
+
     // Apply CLI mounts to compose project
     // Per CLAUDE.md: No silent fallbacks - fail fast on invalid mounts
     for mount_str in &args.mount {
         let mount = NormalizedMount::parse(mount_str)
             .with_context(|| format!("Invalid mount specification: {}", mount_str))?;
-        additional_mounts.push(deacon_core::compose::ComposeMount {
-            mount_type: match mount.mount_type {
-                MountType::Bind => "bind".to_string(),
-                MountType::Volume => "volume".to_string(),
-            },
-            source: mount.source.clone(),
-            target: mount.target.clone(),
-            read_only: mount.read_only,
-            consistency: mount.consistency.clone(),
-        });
+        additional_mounts.push(normalized_mount_to_compose_mount(&mount));
     }
+
+    // Dedupe by target, last-wins, so later sources (config, then CLI) can
+    // override the workspace-consistency mount or each other for the same
+    // target path — mirrors `merge_mounts`' union-by-target semantics
+    // (`mount.rs`), which `generate_injection_override` does NOT do on its
+    // own; it renders every `additional_mounts` entry verbatim.
     if !additional_mounts.is_empty() {
-        project.additional_mounts = additional_mounts;
+        project.additional_mounts = dedupe_compose_mounts_by_target(additional_mounts);
     }
 
     // Apply remote env to compose services
@@ -922,6 +950,40 @@ fn resolve_compose_path(base: &Path, candidate: &str) -> std::path::PathBuf {
     }
 }
 
+/// Map a validated CLI/config mount into the compose project's mount shape.
+/// Shared by the `devcontainer.json` `mounts` (#266) and CLI `--mount` loops
+/// in [`execute_compose_up`] so both normalize identically.
+fn normalized_mount_to_compose_mount(
+    mount: &NormalizedMount,
+) -> deacon_core::compose::ComposeMount {
+    deacon_core::compose::ComposeMount {
+        mount_type: match mount.mount_type {
+            MountType::Bind => "bind".to_string(),
+            MountType::Volume => "volume".to_string(),
+        },
+        source: mount.source.clone(),
+        target: mount.target.clone(),
+        read_only: mount.read_only,
+        consistency: mount.consistency.clone(),
+    }
+}
+
+/// Dedupe compose mounts by target path, last-wins, preserving each target's
+/// original position. Mirrors `merge_mounts`' union-by-target semantics
+/// (`deacon_core::mount`), which `generate_injection_override` does NOT apply
+/// on its own — it renders every `additional_mounts` entry verbatim. Without
+/// this, a later mount source (config, then CLI) for the same target would be
+/// appended alongside the earlier one instead of overriding it.
+fn dedupe_compose_mounts_by_target(
+    mounts: Vec<deacon_core::compose::ComposeMount>,
+) -> Vec<deacon_core::compose::ComposeMount> {
+    let mut by_target: IndexMap<String, deacon_core::compose::ComposeMount> = IndexMap::new();
+    for mount in mounts {
+        by_target.insert(mount.target.clone(), mount);
+    }
+    by_target.into_values().collect()
+}
+
 /// Handle shutdown for compose configurations
 #[instrument(skip(config, state_manager, docker_path))]
 pub(crate) async fn handle_compose_shutdown(
@@ -1011,5 +1073,100 @@ mod tests {
         let base = std::path::Path::new("/repo/compose-dir");
         let p = resolve_compose_path(base, "../sibling");
         assert_eq!(p, std::path::PathBuf::from("/repo/compose-dir/../sibling"));
+    }
+
+    /// #266: `merge_mounts` normalizes both string and object `config.mounts`
+    /// forms to Docker CLI mount-string format; `normalized_mount_to_compose_mount`
+    /// must map either form's parsed result into `ComposeMount` identically.
+    #[test]
+    fn config_mounts_string_and_object_forms_normalize_identically() {
+        let string_mount =
+            serde_json::json!("source=/host/a,target=/container/a,type=bind,readonly");
+        let object_mount = serde_json::json!({
+            "source": "/host/b",
+            "target": "/container/b",
+            "type": "volume"
+        });
+
+        let merged = deacon_core::mount::merge_mounts(&[string_mount, object_mount], &[], None)
+            .expect("merge_mounts should accept both string and object config mount forms");
+
+        let compose_mounts: Vec<_> = merged
+            .mounts
+            .iter()
+            .map(|s| {
+                let parsed = NormalizedMount::parse(s).expect("normalized mount string reparses");
+                normalized_mount_to_compose_mount(&parsed)
+            })
+            .collect();
+
+        let a = compose_mounts
+            .iter()
+            .find(|m| m.target == "/container/a")
+            .expect("string-form mount present");
+        assert_eq!(a.mount_type, "bind");
+        assert_eq!(a.source, "/host/a");
+        assert!(a.read_only);
+
+        let b = compose_mounts
+            .iter()
+            .find(|m| m.target == "/container/b")
+            .expect("object-form mount present");
+        assert_eq!(b.mount_type, "volume");
+        assert_eq!(b.source, "/host/b");
+        assert!(!b.read_only);
+    }
+
+    /// #266: when config and CLI mounts target the same path, the later
+    /// source (CLI, appended after config) must win — matching
+    /// `merge_mounts`' "config overrides features" precedence extended one
+    /// level further ("CLI overrides config").
+    #[test]
+    fn dedupe_compose_mounts_by_target_last_wins() {
+        let workspace_mount = deacon_core::compose::ComposeMount {
+            mount_type: "bind".to_string(),
+            source: "/host/workspace".to_string(),
+            target: "/workspaces/app".to_string(),
+            read_only: false,
+            consistency: None,
+        };
+        let config_mount = deacon_core::compose::ComposeMount {
+            mount_type: "bind".to_string(),
+            source: "/host/config-src".to_string(),
+            target: "/data".to_string(),
+            read_only: false,
+            consistency: None,
+        };
+        let cli_mount = deacon_core::compose::ComposeMount {
+            mount_type: "volume".to_string(),
+            source: "cli-vol".to_string(),
+            target: "/data".to_string(),
+            read_only: true,
+            consistency: None,
+        };
+
+        let deduped = dedupe_compose_mounts_by_target(vec![
+            workspace_mount.clone(),
+            config_mount,
+            cli_mount.clone(),
+        ]);
+
+        assert_eq!(deduped.len(), 2, "targets /workspaces/app and /data only");
+        let workspace_result = deduped
+            .iter()
+            .find(|m| m.target == "/workspaces/app")
+            .expect("workspace mount preserved");
+        assert_eq!(workspace_result.source, workspace_mount.source);
+
+        let data_result = deduped
+            .iter()
+            .find(|m| m.target == "/data")
+            .expect("deduped /data mount present");
+        assert_eq!(
+            data_result.source, cli_mount.source,
+            "CLI mount must win over config mount for the same target"
+        );
+        assert_eq!(data_result.mount_type, "volume");
+        assert!(data_result.read_only);
     }
 }

--- a/crates/deacon/tests/integration_compose_config_mounts.rs
+++ b/crates/deacon/tests/integration_compose_config_mounts.rs
@@ -34,6 +34,16 @@ fn deacon_down(workspace: &Path) {
         .output();
 }
 
+/// RAII cleanup: tears the compose project down when dropped — including
+/// during panic unwinding, so a failed `expect`/assertion after `up` never
+/// leaks the container. Declare it right after the workspace path.
+struct DeaconDownGuard<'a>(&'a Path);
+impl Drop for DeaconDownGuard<'_> {
+    fn drop(&mut self) {
+        deacon_down(self.0);
+    }
+}
+
 /// Extract the primary service container id from `deacon up`'s JSON result.
 fn up_container_id(up_output: &std::process::Output) -> Option<String> {
     let stdout = String::from_utf8_lossy(&up_output.stdout);
@@ -88,6 +98,7 @@ fn test_compose_config_mounts_applied_to_container() {
 
     let temp_dir = TempDir::new().unwrap();
     let workspace = temp_dir.path();
+    let _down = DeaconDownGuard(workspace);
 
     // Bind-mount source lives inside the workspace so `${localWorkspaceFolder}/sib`
     // resolves to a real, known host path without exercising `/../` traversal.
@@ -142,7 +153,6 @@ volumes:
 
     let stderr = String::from_utf8_lossy(&up_output.stderr).to_string();
     if !up_output.status.success() {
-        deacon_down(workspace);
         panic!("deacon up failed: {}", stderr);
     }
 
@@ -150,11 +160,11 @@ volumes:
     let inspect = inspect_container(&container_id);
 
     // Config mount present, `${localWorkspaceFolder}` resolved to the real host path.
+    // Teardown is handled unconditionally by the `DeaconDownGuard` on scope
+    // exit / panic, so the assertions below can never leak the container.
     let sib_mount = find_mount(&inspect, "/workspaces/sib");
     let cli_mount = find_mount(&inspect, "/mnt/cli");
     let compose_volume = find_mount(&inspect, "/data");
-
-    deacon_down(workspace);
 
     let sib_mount = sib_mount.expect("config mount at /workspaces/sib should be present");
     assert_eq!(sib_mount["Type"].as_str(), Some("bind"));

--- a/crates/deacon/tests/integration_compose_config_mounts.rs
+++ b/crates/deacon/tests/integration_compose_config_mounts.rs
@@ -1,0 +1,187 @@
+//! Integration test for #266: `devcontainer.json` `mounts` applied on the compose `up` path.
+//!
+//! The single-container path applies `config.mounts` via `merge_mounts`
+//! (up/container.rs); the compose path never read `config.mounts` at all.
+//! This test brings up a real compose project with a `mounts` entry that uses
+//! `${localWorkspaceFolder}` and verifies: the config mount lands on the
+//! primary service container with the token resolved, the original compose
+//! service volume is untouched, and a CLI `--mount` is applied alongside it.
+
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Best-effort cleanup; ignore failures since the project may already be torn down.
+fn deacon_down(workspace: &Path) {
+    let _ = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(workspace)
+        .arg("down")
+        .arg("--workspace-folder")
+        .arg(workspace)
+        .output();
+}
+
+/// Extract the primary service container id from `deacon up`'s JSON result.
+fn up_container_id(up_output: &std::process::Output) -> Option<String> {
+    let stdout = String::from_utf8_lossy(&up_output.stdout);
+    let trimmed = stdout.trim();
+    let value: Value = serde_json::from_str(trimmed).ok().or_else(|| {
+        trimmed
+            .rfind('{')
+            .and_then(|i| serde_json::from_str(&trimmed[i..]).ok())
+    })?;
+    value
+        .get("containerId")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+fn inspect_container(container_id: &str) -> Value {
+    let output = std::process::Command::new("docker")
+        .args(["inspect", container_id])
+        .output()
+        .expect("docker inspect should run");
+    assert!(
+        output.status.success(),
+        "docker inspect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let inspect_json = String::from_utf8_lossy(&output.stdout);
+    let inspect_array: Vec<Value> =
+        serde_json::from_str(&inspect_json).expect("docker inspect output should be valid JSON");
+    inspect_array
+        .into_iter()
+        .next()
+        .expect("docker inspect should return one entry")
+}
+
+fn find_mount<'a>(inspect: &'a Value, target: &str) -> Option<&'a Value> {
+    inspect["Mounts"]
+        .as_array()?
+        .iter()
+        .find(|m| m["Destination"].as_str() == Some(target))
+}
+
+/// #266: a `devcontainer.json` `mounts` entry using `${localWorkspaceFolder}`
+/// is applied to the compose primary service container, alongside the
+/// existing compose-declared volume and a CLI `--mount`.
+#[test]
+fn test_compose_config_mounts_applied_to_container() {
+    if !is_docker_available() {
+        eprintln!("Skipping test_compose_config_mounts_applied_to_container: Docker not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let workspace = temp_dir.path();
+
+    // Bind-mount source lives inside the workspace so `${localWorkspaceFolder}/sib`
+    // resolves to a real, known host path without exercising `/../` traversal.
+    let sib_dir = workspace.join("sib");
+    fs::create_dir_all(&sib_dir).unwrap();
+    fs::write(sib_dir.join("marker.txt"), "from-sib").unwrap();
+
+    let compose_yml = r#"services:
+  app:
+    image: alpine:3.18
+    command: ["sleep", "infinity"]
+    volumes:
+      - compose-named-vol:/data
+volumes:
+  compose-named-vol:
+"#;
+    let devcontainer_json = r#"{
+  "name": "Compose Config Mounts",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "mounts": [
+    "source=${localWorkspaceFolder}/sib,target=/workspaces/sib,type=bind"
+  ]
+}"#;
+
+    fs::write(workspace.join("docker-compose.yml"), compose_yml).unwrap();
+    fs::create_dir(workspace.join(".devcontainer")).unwrap();
+    fs::write(
+        workspace.join(".devcontainer/devcontainer.json"),
+        devcontainer_json,
+    )
+    .unwrap();
+
+    // A CLI-supplied mount should still apply alongside the config mount.
+    let cli_mount_source = workspace.join("cli-data");
+    fs::create_dir_all(&cli_mount_source).unwrap();
+
+    let up_output = Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(workspace)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(workspace)
+        .arg("--mount")
+        .arg(format!(
+            "type=bind,source={},target=/mnt/cli",
+            cli_mount_source.display()
+        ))
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&up_output.stderr).to_string();
+    if !up_output.status.success() {
+        deacon_down(workspace);
+        panic!("deacon up failed: {}", stderr);
+    }
+
+    let container_id = up_container_id(&up_output).expect("deacon up should report a containerId");
+    let inspect = inspect_container(&container_id);
+
+    // Config mount present, `${localWorkspaceFolder}` resolved to the real host path.
+    let sib_mount = find_mount(&inspect, "/workspaces/sib");
+    let cli_mount = find_mount(&inspect, "/mnt/cli");
+    let compose_volume = find_mount(&inspect, "/data");
+
+    deacon_down(workspace);
+
+    let sib_mount = sib_mount.expect("config mount at /workspaces/sib should be present");
+    assert_eq!(sib_mount["Type"].as_str(), Some("bind"));
+    let source = sib_mount["Source"]
+        .as_str()
+        .expect("bind mount should report a Source path");
+    assert!(
+        source.ends_with("/sib") && !source.contains("${localWorkspaceFolder}"),
+        "config mount source '{}' should resolve ${{localWorkspaceFolder}} to the real workspace path",
+        source
+    );
+
+    // Original compose-declared named volume is untouched. Compose prefixes
+    // named volumes with the project name, so check by suffix rather than
+    // exact match.
+    let compose_volume = compose_volume.expect("compose-declared volume at /data should survive");
+    assert_eq!(compose_volume["Type"].as_str(), Some("volume"));
+    let volume_name = compose_volume["Name"]
+        .as_str()
+        .expect("volume mount should report a Name");
+    assert!(
+        volume_name.ends_with("compose-named-vol"),
+        "expected the compose-declared volume, got '{}'",
+        volume_name
+    );
+
+    // CLI --mount still applies alongside the config mount.
+    let cli_mount = cli_mount.expect("CLI --mount at /mnt/cli should be present");
+    assert_eq!(cli_mount["Type"].as_str(), Some("bind"));
+}

--- a/crates/deacon/tests/integration_compose_features_build.rs
+++ b/crates/deacon/tests/integration_compose_features_build.rs
@@ -36,6 +36,11 @@ fn is_docker_available() -> bool {
 /// drop any containers, networks, or volumes left behind by a failed test.
 /// Always best-effort — we ignore the exit code so cleanup never masks a
 /// real test failure.
+///
+/// This is only useful as a best-effort *pre*-test sweep (before we have a
+/// `deacon up` result to read the real project name from): deacon's compose
+/// project name does not necessarily match the directory-basename default
+/// `docker compose` would infer here (see [`compose_down_by_project`]).
 fn compose_cleanup(project_dir: &std::path::Path) {
     let _ = StdCommand::new("docker")
         .current_dir(project_dir)
@@ -48,6 +53,46 @@ fn compose_cleanup(project_dir: &std::path::Path) {
             "local",
         ])
         .output();
+}
+
+/// Tear down a compose project by the exact name `deacon up` reported.
+///
+/// `docker compose` run bare (or with `--project-directory`) derives its
+/// default project name from a directory basename, which does NOT match
+/// deacon's compose project naming — so `docker compose exec`/`down` invoked
+/// without `-p <name>` silently targets a different (usually nonexistent)
+/// project and reports "service is not running" even though deacon's
+/// container is alive. `docker compose -p <name> down` works purely from the
+/// project label, no compose file needed. Always best-effort.
+fn compose_down_by_project(project_name: &str) {
+    let _ = StdCommand::new("docker")
+        .args([
+            "compose",
+            "-p",
+            project_name,
+            "down",
+            "--remove-orphans",
+            "-v",
+            "--rmi",
+            "local",
+        ])
+        .output();
+}
+
+/// Extract the compose project name `deacon up` reported in its JSON result.
+fn up_project_name(up_output: &std::process::Output) -> Option<String> {
+    let stdout = String::from_utf8_lossy(&up_output.stdout);
+    let trimmed = stdout.trim();
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok().or_else(|| {
+        trimmed
+            .rfind('{')
+            .and_then(|i| serde_json::from_str(&trimmed[i..]).ok())
+    })?;
+    value
+        .get("composeProjectName")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }
 
 /// Bead 14a regression: a compose service that declares `image:` plus
@@ -125,11 +170,17 @@ fn compose_features_image_shape_installs_feature() {
         );
     }
 
+    // Read back the exact project name deacon used — a bare `docker compose`
+    // here would derive a different default from the directory basename and
+    // silently miss the running project (see `compose_down_by_project`).
+    let project_name = up_project_name(&up).expect("deacon up should report a composeProjectName");
+
     // The common-utils feature drops a marker file at this canonical path.
     let exec = StdCommand::new("docker")
-        .current_dir(workspace)
         .args([
             "compose",
+            "-p",
+            &project_name,
             "exec",
             "-T",
             "app",
@@ -142,7 +193,7 @@ fn compose_features_image_shape_installs_feature() {
 
     let exec_ok = exec.status.success();
     // Always tear down before any assertions to avoid leaking resources.
-    compose_cleanup(workspace);
+    compose_down_by_project(&project_name);
 
     assert!(
         exec_ok,
@@ -244,20 +295,17 @@ fn compose_features_build_shape_installs_feature() {
     }
 
     // Compose project name is derived from the workspace folder (not the
-    // compose file's directory), so we must invoke `docker compose` with
-    // `-f <compose-file>` and `--project-directory <workspace>` to attach to
-    // the same project deacon brought up. Running from `compose_dir` would
-    // address a different project and report "service is not running".
-    let compose_file = compose_dir.join("docker-compose.yml");
+    // compose file's directory) and does not match the directory-basename
+    // default `docker compose` would otherwise infer — read back the exact
+    // name deacon used and address the project by `-p`, not by directory or
+    // `--project-directory` (neither reproduces deacon's naming).
+    let project_name = up_project_name(&up).expect("deacon up should report a composeProjectName");
     let docker_compose = |cmd: &str| -> std::process::Output {
         StdCommand::new("docker")
-            .current_dir(workspace)
             .args([
                 "compose",
-                "-f",
-                compose_file.to_str().unwrap(),
-                "--project-directory",
-                workspace.to_str().unwrap(),
+                "-p",
+                &project_name,
                 "exec",
                 "-T",
                 "app",
@@ -278,7 +326,7 @@ fn compose_features_build_shape_installs_feature() {
     let base_ok = base_exec.status.success();
     let feature_ok = feature_exec.status.success();
 
-    compose_cleanup(workspace);
+    compose_down_by_project(&project_name);
 
     assert!(
         base_ok,


### PR DESCRIPTION
## Summary
- `execute_compose_up` built `additional_mounts` from only the workspace-consistency mount and CLI `--mount` args — `config.mounts` (`devcontainer.json`'s `mounts` field) was never read at all on the compose path, unlike the single-container path (which applies it via `merge_mounts`).
- Fixes #266.

## Changes
- Reuse `deacon_core::mount::merge_mounts` (already substitutes `${localWorkspaceFolder}` etc. and normalizes string/object mount forms into Docker CLI mount strings) to process `config.mounts` on the compose path, scoped to config mounts only (feature-contributed mounts on compose are a separate, pre-existing gap — not expanded here).
- Added `normalized_mount_to_compose_mount` (shared by both the new config-mounts loop and the existing CLI `--mount` loop) and `dedupe_compose_mounts_by_target` (last-wins) helpers in `compose.rs`. Precedence: workspace mount < config mounts < CLI mounts. This was needed because the compose override renderer (`generate_injection_override`) emits `additional_mounts` verbatim with no dedupe of its own, unlike `merge_mounts`.
- Unit tests: `config_mounts_string_and_object_forms_normalize_identically`, `dedupe_compose_mounts_by_target_last_wins`.
- New docker-shared integration test `integration_compose_config_mounts.rs`: brings up a real compose project with a `mounts` entry using `${localWorkspaceFolder}`, and verifies the config mount lands with the token resolved, the original compose-declared volume is untouched, and a CLI `--mount` still applies alongside it. Registered in `.config/nextest.toml`'s `docker-shared` group across all profiles.

## Incidental fix
While testing against a real Docker daemon, discovered `integration_compose_features_build.rs`'s two Docker-backed tests were failing on `main` already (pre-existing, unrelated to this change): both called bare `docker compose exec`/`down`, which derives its default project name from the current directory's basename — not deacon's actual `<dir>_devcontainer` compose project name. So on a real daemon they silently exec'd/tore down the wrong (usually nonexistent) project and reported `service "app" is not running`, even though deacon's container was alive and the feature had installed correctly (verified via direct `docker exec` and `docker compose -p <correct-name> exec`). Fixed by reading the real `composeProjectName` back from `deacon up`'s JSON result and addressing `docker compose` by `-p <name>` instead of directory context.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --lib -- --test-threads=1` (1307 passed)
- [x] `cargo test --test integration_compose_config_mounts` (new test, passes against real Docker)
- [x] `cargo test --test integration_compose_features_build -- --test-threads=1` (all 3 pass now; 2 were failing on `main` before this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)