### PR TITLE
chore(tests): add normalized observable-state parity differ

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -97,6 +97,13 @@ filter = 'binary(=parity_observable_state)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.default.overrides]]
+filter = 'binary(=parity_state_diff)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
 [[profile.default.overrides]]
 filter = 'binary(=parity_read_configuration)'
 test-group = 'parity-cli'
@@ -206,6 +213,13 @@ test-group = 'parity'
 # matrix), longer-running than the other parity_* binaries.
 [[profile.dev-fast.overrides]]
 filter = 'binary(=parity_observable_state)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.dev-fast.overrides]]
+filter = 'binary(=parity_state_diff)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 
@@ -325,6 +339,13 @@ filter = 'binary(=parity_observable_state)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.docker.overrides]]
+filter = 'binary(=parity_state_diff)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
 [[profile.docker.overrides]]
 filter = 'binary(=parity_read_configuration)'
 test-group = 'parity-cli'
@@ -414,6 +435,13 @@ test-group = 'parity'
 # matrix), longer-running than the other parity_* binaries.
 [[profile.full.overrides]]
 filter = 'binary(=parity_observable_state)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.full.overrides]]
+filter = 'binary(=parity_state_diff)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 
@@ -508,6 +536,13 @@ test-group = 'parity'
 # matrix), longer-running than the other parity_* binaries.
 [[profile.ci.overrides]]
 filter = 'binary(=parity_observable_state)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.ci.overrides]]
+filter = 'binary(=parity_state_diff)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 
@@ -606,6 +641,13 @@ test-group = 'parity'
 # matrix), longer-running than the other parity_* binaries.
 [[profile.mvp-integration.overrides]]
 filter = 'binary(=parity_observable_state)'
+test-group = 'parity'
+slow-timeout = { period = "15m", terminate-after = 1 }
+
+# parity_state_diff brings each fixture up with BOTH CLIs (including an OCI
+# feature build on the compose fixture) to diff normalized container state.
+[[profile.mvp-integration.overrides]]
+filter = 'binary(=parity_state_diff)'
 test-group = 'parity'
 slow-timeout = { period = "15m", terminate-after = 1 }
 

--- a/crates/deacon/tests/integration_state_diff.rs
+++ b/crates/deacon/tests/integration_state_diff.rs
@@ -1,0 +1,258 @@
+//! Pure-logic unit tests for the normalized observable-state differ
+//! (`parity_utils::{snapshot_from_inspect, diff_states, classify_divergence,
+//! assert_snapshots_parity}`). No Docker, no upstream CLI — feeds fixed
+//! `docker inspect` JSON through the differ so its correctness (and teeth) are
+//! covered in the fast test loop, independent of the gated Docker fixtures in
+//! `parity_state_diff.rs`.
+
+use serde_json::json;
+
+mod parity_utils;
+use parity_utils::{
+    DivergenceClass, StateSnapshot, assert_snapshots_parity, classify_divergence, diff_states,
+    snapshot_from_inspect,
+};
+
+/// A minimal single-container `docker inspect` object with the given env,
+/// mounts, and labels.
+fn inspect(
+    env: &[&str],
+    mounts: serde_json::Value,
+    labels: serde_json::Value,
+) -> serde_json::Value {
+    json!({
+        "Config": {
+            "Env": env,
+            "Labels": labels,
+            "User": "",
+            "WorkingDir": "/workspace",
+            "ExposedPorts": {},
+            "Entrypoint": null,
+            "Cmd": ["sleep", "infinity"],
+        },
+        "Mounts": mounts,
+        "NetworkSettings": { "Networks": { "bridge": {} } },
+    })
+}
+
+fn bind(dest: &str, source: &str) -> serde_json::Value {
+    json!({ "Type": "bind", "Source": source, "Destination": dest, "RW": true })
+}
+
+fn volume(dest: &str, name: &str) -> serde_json::Value {
+    json!({ "Type": "volume", "Name": name, "Source": "/var/lib/docker/volumes/x/_data", "Destination": dest, "RW": true })
+}
+
+#[test]
+fn snapshot_strips_noise_env_and_cli_labels() {
+    let raw = inspect(
+        &["PATH=/usr/bin", "HOSTNAME=abc", "FOO=bar", "BAZ=qux"],
+        json!([bind("/workspace", "/tmp/ws-a")]),
+        json!({
+            "devcontainer.source": "deacon",
+            "devcontainer.metadata": "[...]",
+            "com.docker.compose.project": "deacon_1_2",
+            "org.opencontainers.image.title": "debian",
+        }),
+    );
+    let snap = snapshot_from_inspect(&raw);
+    // Noise env removed; real env kept.
+    assert!(snap.env.contains("FOO=bar"));
+    assert!(snap.env.contains("BAZ=qux"));
+    assert!(!snap.env.iter().any(|e| e.starts_with("PATH=")));
+    assert!(!snap.env.iter().any(|e| e.starts_with("HOSTNAME=")));
+    // CLI-namespaced labels stripped; semantic image label kept.
+    assert!(!snap.labels.contains_key("devcontainer.source"));
+    assert!(!snap.labels.contains_key("com.docker.compose.project"));
+    assert_eq!(
+        snap.labels
+            .get("org.opencontainers.image.title")
+            .map(String::as_str),
+        Some("debian")
+    );
+    // Mount captured by destination.
+    assert_eq!(
+        snap.mounts.get("/workspace").map(|m| m.mount_type.as_str()),
+        Some("bind")
+    );
+}
+
+#[test]
+fn snapshot_normalizes_compose_project_prefix_on_volumes() {
+    let raw = inspect(
+        &["FOO=bar"],
+        json!([volume("/feat-mnt", "deacon_1_2_feat-probe-vol")]),
+        json!({ "com.docker.compose.project": "deacon_1_2" }),
+    );
+    let snap = snapshot_from_inspect(&raw);
+    // The project prefix is stripped from the reporting source tail so it is
+    // comparable to upstream's differently-prefixed volume name.
+    assert_eq!(
+        snap.mounts.get("/feat-mnt").map(|m| m.source_tail.as_str()),
+        Some("feat-probe-vol")
+    );
+}
+
+#[test]
+fn identical_snapshots_have_no_divergences() {
+    let a = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        json!([bind("/workspace", "/tmp/ws-a")]),
+        json!({}),
+    ));
+    let b = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        // Different bind SOURCE (per-workspace temp path) must NOT be a divergence.
+        json!([bind("/workspace", "/tmp/ws-b")]),
+        json!({}),
+    ));
+    assert!(diff_states(&a, &b).is_empty(), "{:?}", diff_states(&a, &b));
+}
+
+#[test]
+fn missing_mount_is_detected() {
+    let deacon = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        json!([bind("/workspace", "/tmp/ws-a")]),
+        json!({}),
+    ));
+    let upstream = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        json!([bind("/workspace", "/tmp/ws-b"), volume("/data", "up_data")]),
+        json!({}),
+    ));
+    let divs = diff_states(&deacon, &upstream);
+    assert_eq!(divs.len(), 1, "{divs:?}");
+    assert_eq!(divs[0].field, "mount:/data");
+    assert!(divs[0].detail.contains("absent deacon"));
+}
+
+#[test]
+fn missing_env_is_detected() {
+    let deacon = snapshot_from_inspect(&inspect(&["FOO=bar"], json!([]), json!({})));
+    let upstream = snapshot_from_inspect(&inspect(&["FOO=bar", "SECRET=1"], json!([]), json!({})));
+    let divs = diff_states(&deacon, &upstream);
+    assert!(divs.iter().any(|d| d.field == "env:SECRET"));
+}
+
+#[test]
+fn feature_mount_gap_classifies_as_known_gap_272() {
+    // The #272 gap: upstream has the feature volume at /feat-mnt, deacon lacks it.
+    match classify_divergence("mount:/feat-mnt", &[]) {
+        DivergenceClass::KnownGap(gap) => assert_eq!(gap.issue, "#272"),
+        _ => panic!("mount:/feat-mnt should classify as the #272 known gap"),
+    }
+}
+
+#[test]
+fn unlisted_divergence_classifies_as_unexpected() {
+    assert!(matches!(
+        classify_divergence("mount:/some-other", &[]),
+        DivergenceClass::Unexpected
+    ));
+    // ...unless the caller explicitly allows it.
+    assert!(matches!(
+        classify_divergence("mount:/some-other", &["mount:/some-other"]),
+        DivergenceClass::Intentional(_)
+    ));
+}
+
+#[test]
+fn assert_snapshots_parity_passes_on_known_gap_but_fails_on_new_divergence() {
+    let base = snapshot_from_inspect(&inspect(&["FOO=bar"], json!([]), json!({})));
+
+    // Only a known-gap divergence (/feat-mnt) → passes.
+    let with_gap = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        json!([volume("/feat-mnt", "up_feat-probe-vol")]),
+        json!({}),
+    ));
+    assert_snapshots_parity(&base, &with_gap, &[]);
+
+    // A NEW, unlisted divergence → must panic (teeth).
+    let with_new = snapshot_from_inspect(&inspect(
+        &["FOO=bar"],
+        json!([volume("/unexpected", "up_vol")]),
+        json!({}),
+    ));
+    let res = std::panic::catch_unwind(|| assert_snapshots_parity(&base, &with_new, &[]));
+    assert!(
+        res.is_err(),
+        "an unlisted divergence must fail the parity assertion"
+    );
+
+    // ...but the caller can allow it explicitly.
+    assert_snapshots_parity(&base, &with_new, &["mount:/unexpected"]);
+}
+
+#[test]
+fn allowlist_matcher_is_exact_by_default_and_prefix_with_star() {
+    // Exact matcher must NOT swallow a longer path that shares its prefix:
+    // allowing `mount:/workspace` must not also allow `mount:/workspaces/sib`.
+    assert!(matches!(
+        classify_divergence("mount:/workspaces/sib", &["mount:/workspace"]),
+        DivergenceClass::Unexpected
+    ));
+    assert!(matches!(
+        classify_divergence("mount:/workspace", &["mount:/workspace"]),
+        DivergenceClass::Intentional(_)
+    ));
+    // A trailing `*` opts into prefix matching.
+    assert!(matches!(
+        classify_divergence("mount:/workspaces/sib", &["mount:/workspaces*"]),
+        DivergenceClass::Intentional(_)
+    ));
+}
+
+#[test]
+fn empty_user_equals_root() {
+    let a = snapshot_from_inspect(&json!({
+        "Config": { "Env": ["FOO=bar"], "User": "" },
+        "Mounts": [], "NetworkSettings": { "Networks": {} }
+    }));
+    let b = snapshot_from_inspect(&json!({
+        "Config": { "Env": ["FOO=bar"], "User": "root" },
+        "Mounts": [], "NetworkSettings": { "Networks": {} }
+    }));
+    assert!(
+        diff_states(&a, &b).is_empty(),
+        "empty User and root must be equivalent: {:?}",
+        diff_states(&a, &b)
+    );
+    // ...but a real non-root user still diverges.
+    let c = snapshot_from_inspect(&json!({
+        "Config": { "Env": ["FOO=bar"], "User": "node" },
+        "Mounts": [], "NetworkSettings": { "Networks": {} }
+    }));
+    assert!(diff_states(&a, &c).iter().any(|d| d.field == "user"));
+}
+
+#[test]
+fn published_ports_are_captured_and_diffed() {
+    let with_port = json!({
+        "Config": { "Env": ["FOO=bar"], "ExposedPorts": {} },
+        "Mounts": [], "NetworkSettings": { "Networks": {} },
+        "HostConfig": { "PortBindings": { "3000/tcp": [{ "HostIp": "", "HostPort": "3000" }] } }
+    });
+    let no_port = json!({
+        "Config": { "Env": ["FOO=bar"], "ExposedPorts": {} },
+        "Mounts": [], "NetworkSettings": { "Networks": {} },
+        "HostConfig": { "PortBindings": {} }
+    });
+    let a = snapshot_from_inspect(&with_port);
+    assert!(a.published_ports.contains("3000/tcp"));
+    let b = snapshot_from_inspect(&no_port);
+    let divs = diff_states(&a, &b);
+    assert!(
+        divs.iter().any(|d| d.field == "pubport:3000/tcp"),
+        "a published-port difference must be detected: {divs:?}"
+    );
+    // Same ports on both → no divergence.
+    assert!(diff_states(&a, &a).is_empty());
+}
+
+#[test]
+fn default_snapshot_yields_no_divergences_against_itself() {
+    let s = StateSnapshot::default();
+    assert!(diff_states(&s, &s).is_empty());
+}

--- a/crates/deacon/tests/parity_state_diff.rs
+++ b/crates/deacon/tests/parity_state_diff.rs
@@ -1,0 +1,739 @@
+//! #267 follow-up: normalized observable-state parity between deacon and the
+//! reference `@devcontainers/cli`.
+//!
+//! Unlike the launch-parity checks (both CLIs exit 0) and the per-bug field
+//! probes in `parity_observable_state.rs`, this binary brings a fixture up with
+//! BOTH CLIs and diffs the resulting container's NORMALIZED observable state
+//! (`docker inspect`: mounts, env, labels, user, working dir, ports) field by
+//! field via the differ in `parity_utils`. Any divergence that is not an
+//! explicit intentional divergence or a tracked known gap (`KNOWN_GAPS`, e.g.
+//! #272) fails the test — catching outcome drift that a launch check misses.
+//!
+//! Triple-gated like the rest of the `parity_*` suite (`DEACON_PARITY=1`,
+//! Docker, `devcontainer` CLI). Cleanly skips when any gate is unmet. Lives in
+//! the `parity` nextest group (15m slow-timeout) via `.config/nextest.toml`.
+
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+mod parity_utils;
+use parity_utils::{
+    StateSnapshot, WsCleanup, assert_snapshots_parity, deacon_down, docker_out_allow_fail, gated,
+    json_field, normalized_state, run_deacon, run_upstream, sweep_ws_containers,
+    upstream_container_id,
+};
+
+// ---------------------------------------------------------------------------
+// Fixture writers
+// ---------------------------------------------------------------------------
+
+/// Single-container fixture: `containerEnv` + a `devcontainer.json` bind mount.
+fn write_single_fixture(ws: &Path, label: &str) {
+    let sib = ws.join("sib");
+    fs::create_dir_all(&sib).unwrap();
+    fs::write(sib.join("marker.txt"), "from-sib").unwrap();
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffSingle-{label}",
+  "image": "debian:bookworm-slim",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "containerEnv": {{ "SC_ENV": "yes" }},
+  "mounts": [
+    "source=${{localWorkspaceFolder}}/sib,target=/workspaces/sib,type=bind"
+  ]
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+/// Compose fixture with `containerEnv`, a `devcontainer.json` bind mount, and a
+/// local Feature declaring BOTH a `containerEnv` (positive control — baked into
+/// the feature image, so present on both CLIs) and a volume `mount` (the #272
+/// gap — dropped by deacon's compose path).
+fn write_compose_feature_fixture(ws: &Path, label: &str) {
+    let sib = ws.join("sib");
+    fs::create_dir_all(&sib).unwrap();
+    fs::write(sib.join("marker.txt"), "from-sib").unwrap();
+    fs::write(
+        ws.join("docker-compose.yml"),
+        "services:\n  app:\n    image: debian:bookworm-slim\n    command: [\"sleep\", \"infinity\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(ws.join(".devcontainer/mountprobe")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffCompose-{label}",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "containerEnv": {{ "CE_ENV": "yes" }},
+  "mounts": [
+    "source=${{localWorkspaceFolder}}/sib,target=/workspaces/sib,type=bind"
+  ],
+  "features": {{ "./mountprobe": {{}} }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        ws.join(".devcontainer/mountprobe/devcontainer-feature.json"),
+        r#"{
+  "id": "mountprobe",
+  "version": "1.0.0",
+  "name": "Mount Probe",
+  "containerEnv": { "FEATURE_ENV_CONTROL": "yes" },
+  "mounts": [ { "source": "feat-probe-vol", "target": "/feat-mnt", "type": "volume" } ]
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        ws.join(".devcontainer/mountprobe/install.sh"),
+        "#!/bin/sh\nset -e\necho \"mountprobe feature installed\"\n",
+    )
+    .unwrap();
+}
+
+/// Compose fixture (feature-free) mirroring `write_single_fixture`'s
+/// `containerEnv` + bind mount, for the intra-deacon single-vs-compose diff.
+fn write_compose_plain_fixture(ws: &Path, label: &str) {
+    let sib = ws.join("sib");
+    fs::create_dir_all(&sib).unwrap();
+    fs::write(sib.join("marker.txt"), "from-sib").unwrap();
+    fs::write(
+        ws.join("docker-compose.yml"),
+        "services:\n  app:\n    image: debian:bookworm-slim\n    command: [\"sleep\", \"infinity\"]\n",
+    )
+    .unwrap();
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffIntra-{label}",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "containerEnv": {{ "IX_ENV": "yes" }},
+  "mounts": [
+    "source=${{localWorkspaceFolder}}/sib,target=/workspaces/sib,type=bind"
+  ]
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+/// Single-container fixture with `workspaceFolder` set but NO explicit
+/// `workspaceMount`, to characterize the default-workspace-mount-target
+/// divergence the differ surfaced (see
+/// `state_diff_default_workspace_mount_target_divergence`).
+fn write_default_mount_fixture(ws: &Path, label: &str) {
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffDefaultMount-{label}",
+  "image": "debian:bookworm-slim",
+  "workspaceFolder": "/workspace",
+  "containerEnv": {{ "DM_ENV": "yes" }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Bring-up helpers
+// ---------------------------------------------------------------------------
+
+fn deacon_up_snapshot(ws: &Path) -> (std::process::Output, String, StateSnapshot) {
+    let out = run_deacon(ws, &["up", "--workspace-folder", &ws.to_string_lossy()]).unwrap();
+    assert!(
+        out.status.success(),
+        "deacon up failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let id = json_field(&out, "containerId").expect("deacon up should report a containerId");
+    let snap = normalized_state(&id);
+    (out, id, snap)
+}
+
+fn upstream_up_snapshot(ws: &Path) -> (String, StateSnapshot) {
+    let out = run_upstream(ws, &["up", "--workspace-folder", &ws.to_string_lossy()]).unwrap();
+    assert!(
+        out.status.success(),
+        "upstream up failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let id = upstream_container_id(ws).expect("no upstream container found by label");
+    let snap = normalized_state(&id);
+    (id, snap)
+}
+
+// ===========================================================================
+// Test 1: single-container outcome parity.
+// ===========================================================================
+
+#[test]
+fn state_diff_single_container_parity() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_single_fixture(up_ws, "upstream");
+    let (up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_single_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    // Tear down BEFORE asserting so a failed assertion never leaks state.
+    let _ = docker_out_allow_fail(&["rm", "-f", &up_id]);
+    deacon_down(d_ws);
+
+    // Vacuity guards: the fixture's own markers must be captured, or the diff
+    // would be comparing empty/incomplete snapshots.
+    assert!(
+        d_snap.env.contains("SC_ENV=yes"),
+        "deacon snapshot missing fixture marker SC_ENV: {:?}",
+        d_snap.env
+    );
+    assert!(
+        up_snap.env.contains("SC_ENV=yes"),
+        "upstream snapshot missing fixture marker SC_ENV: {:?}",
+        up_snap.env
+    );
+    assert!(
+        d_snap.mounts.contains_key("/workspaces/sib"),
+        "deacon snapshot missing config mount /workspaces/sib: {:?}",
+        d_snap.mounts
+    );
+    assert!(
+        up_snap.mounts.contains_key("/workspaces/sib"),
+        "upstream snapshot missing config mount /workspaces/sib: {:?}",
+        up_snap.mounts
+    );
+
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
+}
+
+// ===========================================================================
+// Test 2: compose outcome parity — exercises the #272 feature-mount gap. The
+// gap classifies as a tracked KNOWN_GAP (passes today); any OTHER compose
+// divergence fails. The positive control (feature `containerEnv`, baked into
+// the image) proves the Feature installed on deacon's compose path, so a
+// missing /feat-mnt is specifically the runtime mount being dropped.
+// ===========================================================================
+
+#[test]
+fn state_diff_compose_parity_with_feature_mount_gap() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_compose_feature_fixture(up_ws, "upstream");
+    let (_up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_compose_feature_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    // Tear down BEFORE asserting (compose projects + the shared feature volume).
+    sweep_ws_containers(up_ws);
+    sweep_ws_containers(d_ws);
+    let _ = docker_out_allow_fail(&["volume", "rm", "-f", "feat-probe-vol"]);
+
+    // Positive control: feature containerEnv baked into the image → present on
+    // BOTH CLIs, proving the feature installed on deacon's compose path.
+    assert!(
+        d_snap.env.contains("FEATURE_ENV_CONTROL=yes"),
+        "deacon compose snapshot missing baked feature env (feature did not install?): {:?}",
+        d_snap.env
+    );
+    assert!(
+        up_snap.env.contains("FEATURE_ENV_CONTROL=yes"),
+        "upstream compose snapshot missing baked feature env: {:?}",
+        up_snap.env
+    );
+    // The #272 gap itself: upstream has the feature mount, deacon does not.
+    // Asserting this shape keeps the KNOWN_GAP honest — if deacon starts
+    // applying it, this assertion flips and the gap entry should be removed.
+    assert!(
+        up_snap.mounts.contains_key("/feat-mnt"),
+        "upstream should apply the feature mount /feat-mnt: {:?}",
+        up_snap.mounts
+    );
+    assert!(
+        !d_snap.mounts.contains_key("/feat-mnt"),
+        "deacon unexpectedly applied /feat-mnt — #272 may be FIXED; remove the KNOWN_GAP entry and drop this assertion: {:?}",
+        d_snap.mounts
+    );
+
+    // Everything except the tracked #272 gap must match.
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
+}
+
+// ===========================================================================
+// Test 3: intra-deacon single-vs-compose parity. No upstream needed — diffs
+// deacon's OWN single-container state against its compose state for the same
+// logical config. This catches "compose drops X that single-container applies"
+// bugs (the #266 / #272 class) directly, and would have caught #266.
+// ===========================================================================
+
+#[test]
+fn state_diff_intra_deacon_single_vs_compose() {
+    if !gated() {
+        return;
+    }
+
+    let single_tmp = TempDir::new().unwrap();
+    let single_ws = single_tmp.path();
+    let _single_clean = WsCleanup(single_ws);
+    write_single_fixture(single_ws, "intra");
+    // Reuse SC_ENV marker name is fine; single fixture already sets SC_ENV.
+    let (_s_out, _s_id, single_snap) = deacon_up_snapshot(single_ws);
+
+    let compose_tmp = TempDir::new().unwrap();
+    let compose_ws = compose_tmp.path();
+    let _compose_clean = WsCleanup(compose_ws);
+    write_compose_plain_fixture(compose_ws, "intra");
+    let (_c_out, _c_id, compose_snap) = deacon_up_snapshot(compose_ws);
+
+    // Tear down BEFORE asserting.
+    deacon_down(single_ws);
+    sweep_ws_containers(compose_ws);
+
+    // Vacuity guards + normalize the differently-named env markers: the two
+    // fixtures intentionally use different containerEnv KEYS (SC_ENV vs IX_ENV)
+    // because they are distinct fixtures; allow those two so the diff focuses
+    // on STRUCTURAL parity (mounts) rather than the deliberately-different key.
+    assert!(
+        single_snap.env.contains("SC_ENV=yes"),
+        "single snapshot missing SC_ENV: {:?}",
+        single_snap.env
+    );
+    assert!(
+        compose_snap.env.contains("IX_ENV=yes"),
+        "compose snapshot missing IX_ENV: {:?}",
+        compose_snap.env
+    );
+    assert!(
+        single_snap.mounts.contains_key("/workspaces/sib"),
+        "single snapshot missing config mount: {:?}",
+        single_snap.mounts
+    );
+    assert!(
+        compose_snap.mounts.contains_key("/workspaces/sib"),
+        "compose snapshot missing config mount (compose dropped it — #266 class regression): {:?}",
+        compose_snap.mounts
+    );
+
+    // Allowed divergences:
+    //  * env:SC_ENV / env:IX_ENV — the two fixtures deliberately use different
+    //    containerEnv KEYS, so the diff focuses on STRUCTURAL parity (mounts).
+    //  * mount:/workspace — deacon's compose path does not mount the workspace
+    //    folder by default (only with `--workspace-mount-consistency`, and it
+    //    ignores `workspaceMount`), whereas the single-container path honors the
+    //    pinned `workspaceMount`. This single-vs-compose difference MIRRORS the
+    //    reference CLI (verified: a plain compose devcontainer yields zero
+    //    workspace binds on BOTH CLIs — the compose file owns the workspace
+    //    mount), so it is the compose model, NOT a deacon parity gap.
+    assert_snapshots_parity(
+        &single_snap,
+        &compose_snap,
+        &["env:SC_ENV", "env:IX_ENV", "mount:/workspace"],
+    );
+}
+
+// ===========================================================================
+// Test 4: default-workspace-mount-target divergence (surfaced by this differ
+// on its first run). With `workspaceFolder` set but no explicit
+// `workspaceMount`, deacon mounts the workspace AT `workspaceFolder`
+// (`/workspace`), while the reference CLI mounts it at the spec default
+// `/workspaces/<basename>` and uses `workspaceFolder` only as the working
+// directory (containers.dev: `workspaceMount` overrides the mount; its default
+// is `/workspaces/${localWorkspaceFolderBasename}`, independent of
+// `workspaceFolder`). See `crates/core/src/docker.rs:2150-2162`.
+//
+// This test CHARACTERIZES the divergence so it is tracked, not silently
+// allowlisted: if deacon changes its default to match the spec (mounting at
+// `/workspaces/<basename>`), this test flips red and forces the decision to be
+// made deliberately. The differ's other fixtures pin `workspaceMount`
+// explicitly so both CLIs agree and the divergence does not mask real findings.
+// ===========================================================================
+
+#[test]
+fn state_diff_default_workspace_mount_target_divergence() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_default_mount_fixture(up_ws, "upstream");
+    let (up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_default_mount_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    let _ = docker_out_allow_fail(&["rm", "-f", &up_id]);
+    deacon_down(d_ws);
+
+    // Vacuity guard: both fixtures actually launched with the marker env.
+    assert!(
+        d_snap.env.contains("DM_ENV=yes") && up_snap.env.contains("DM_ENV=yes"),
+        "fixture marker DM_ENV missing (deacon={:?} upstream={:?})",
+        d_snap.env,
+        up_snap.env
+    );
+
+    let is_workspace_bind = |snap: &StateSnapshot, dest: &str| {
+        snap.mounts
+            .get(dest)
+            .is_some_and(|m| m.mount_type == "bind")
+    };
+
+    // deacon: workspace mounted AT workspaceFolder.
+    assert!(
+        is_workspace_bind(&d_snap, "/workspace"),
+        "deacon should mount the workspace at workspaceFolder (/workspace): {:?}",
+        d_snap.mounts
+    );
+    // upstream: workspace mounted at the spec default /workspaces/<basename>,
+    // NOT at workspaceFolder.
+    assert!(
+        !up_snap.mounts.contains_key("/workspace"),
+        "reference CLI unexpectedly mounted the workspace at /workspace; the \
+         default-mount-target divergence may be gone — reconcile deacon's \
+         default (docker.rs) and update this test: {:?}",
+        up_snap.mounts
+    );
+    assert!(
+        up_snap
+            .mounts
+            .keys()
+            .any(|d| d.starts_with("/workspaces/") && is_workspace_bind(&up_snap, d)),
+        "reference CLI should mount the workspace under /workspaces/<basename>: {:?}",
+        up_snap.mounts
+    );
+}
+
+// ===========================================================================
+// Test 5: Dockerfile build + non-root containerUser/remoteUser + Dockerfile ENV
+// + containerEnv. Exercises the image-BUILD path (deacon `deacon-build:*` vs
+// upstream `vsc-*`) and user parity beyond the empty≡root normalization.
+// ===========================================================================
+
+fn write_dockerfile_user_fixture(ws: &Path, label: &str) {
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/Dockerfile"),
+        "FROM debian:bookworm-slim\n\
+         RUN useradd -m -u 1000 dev\n\
+         ENV DOCKERFILE_ENV=yes\n",
+    )
+    .unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffDockerfile-{label}",
+  "build": {{ "dockerfile": "Dockerfile" }},
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "containerUser": "dev",
+  "remoteUser": "dev",
+  "containerEnv": {{ "DF_ENV": "yes" }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn state_diff_dockerfile_build_and_nonroot_user() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_dockerfile_user_fixture(up_ws, "upstream");
+    let (up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_dockerfile_user_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    let _ = docker_out_allow_fail(&["rm", "-f", &up_id]);
+    deacon_down(d_ws);
+
+    // Vacuity guards: Dockerfile ENV + containerEnv actually landed.
+    for (who, snap) in [("deacon", &d_snap), ("upstream", &up_snap)] {
+        assert!(
+            snap.env.contains("DOCKERFILE_ENV=yes"),
+            "{who} missing Dockerfile ENV: {:?}",
+            snap.env
+        );
+        assert!(
+            snap.env.contains("DF_ENV=yes"),
+            "{who} missing containerEnv DF_ENV: {:?}",
+            snap.env
+        );
+    }
+
+    // #274: deacon does not apply `containerUser` to the created container's
+    // `Config.User` (it runs as root, applying the user only at exec time),
+    // whereas the reference sets `Config.User=dev`. Assert the gap's shape so
+    // this test flips red when #274 is fixed, then allow `user` in the diff.
+    assert_eq!(
+        up_snap.user, "dev",
+        "reference should set Config.User=dev from containerUser: {:?}",
+        up_snap.user
+    );
+    assert!(
+        d_snap.user.is_empty() || d_snap.user == "root",
+        "deacon unexpectedly set Config.User ({:?}) — #274 may be FIXED; drop \
+         the `user` allowance and this shape assertion",
+        d_snap.user
+    );
+    assert_snapshots_parity(&d_snap, &up_snap, &["user"]);
+}
+
+// ===========================================================================
+// Test 6: appPort → PUBLISHED ports. Exercises `HostConfig.PortBindings`
+// parity (a container port published to the host).
+// ===========================================================================
+
+fn write_appport_fixture(ws: &Path, label: &str) {
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffAppPort-{label}",
+  "image": "debian:bookworm-slim",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "appPort": [3000],
+  "containerEnv": {{ "AP_ENV": "yes" }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn state_diff_appport_published_ports() {
+    if !gated() {
+        return;
+    }
+
+    // `appPort: [3000]` publishes to the FIXED host port 3000 on BOTH CLIs (per
+    // spec), so the two containers cannot coexist — bring up upstream, snapshot,
+    // TEAR IT DOWN to free host:3000, then bring up deacon. (This is not a
+    // parity difference; it is the shared host-port resource.)
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_appport_fixture(up_ws, "upstream");
+    let (up_id, up_snap) = upstream_up_snapshot(up_ws);
+    let _ = docker_out_allow_fail(&["rm", "-f", &up_id]);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_appport_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+    deacon_down(d_ws);
+
+    // Vacuity guard: the appPort actually published on at least one side, or the
+    // test proves nothing about port parity.
+    assert!(
+        d_snap.published_ports.contains("3000/tcp") || up_snap.published_ports.contains("3000/tcp"),
+        "neither CLI published appPort 3000/tcp (deacon={:?} upstream={:?}) — fixture broken?",
+        d_snap.published_ports,
+        up_snap.published_ports
+    );
+
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
+}
+
+// ===========================================================================
+// Test 7: mount variety — a read-only bind and a tmpfs mount. Exercises the
+// mount read-only flag and the tmpfs mount type.
+// ===========================================================================
+
+fn write_mounts_variety_fixture(ws: &Path, label: &str) {
+    let ro = ws.join("ro");
+    fs::create_dir_all(&ro).unwrap();
+    fs::write(ro.join("marker.txt"), "ro").unwrap();
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffMounts-{label}",
+  "image": "debian:bookworm-slim",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
+  "containerEnv": {{ "MV_ENV": "yes" }},
+  "mounts": [
+    "source=${{localWorkspaceFolder}}/ro,target=/ro,type=bind,readonly",
+    "type=tmpfs,target=/tmpmnt"
+  ]
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn state_diff_mount_variety_readonly_and_tmpfs() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_mounts_variety_fixture(up_ws, "upstream");
+    let (up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_mounts_variety_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    let _ = docker_out_allow_fail(&["rm", "-f", &up_id]);
+    deacon_down(d_ws);
+
+    // Vacuity guard: the read-only bind landed and is actually read-only on at
+    // least one side (so the ro-flag comparison is meaningful).
+    assert!(
+        d_snap.mounts.get("/ro").is_some_and(|m| m.ro)
+            || up_snap.mounts.get("/ro").is_some_and(|m| m.ro),
+        "neither CLI produced a read-only /ro bind (deacon={:?} upstream={:?})",
+        d_snap.mounts.get("/ro"),
+        up_snap.mounts.get("/ro")
+    );
+
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
+}
+
+// ===========================================================================
+// Test 8: compose with a db sidecar + a compose-declared named volume mounted
+// into the primary service. Exercises multi-service compose and volume
+// pass-through parity on the inspected (primary) container.
+// ===========================================================================
+
+fn write_compose_volume_fixture(ws: &Path, label: &str) {
+    fs::write(
+        ws.join("docker-compose.yml"),
+        "services:\n  \
+           app:\n    \
+             image: debian:bookworm-slim\n    \
+             command: [\"sleep\", \"infinity\"]\n    \
+             volumes:\n      \
+               - appdata:/data\n  \
+           db:\n    \
+             image: debian:bookworm-slim\n    \
+             command: [\"sleep\", \"infinity\"]\n\
+         volumes:\n  \
+           appdata:\n",
+    )
+    .unwrap();
+    fs::create_dir_all(ws.join(".devcontainer")).unwrap();
+    fs::write(
+        ws.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "StateDiffComposeVol-{label}",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "containerEnv": {{ "CV_ENV": "yes" }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn state_diff_compose_sidecar_and_named_volume() {
+    if !gated() {
+        return;
+    }
+
+    let up_tmp = TempDir::new().unwrap();
+    let up_ws = up_tmp.path();
+    let _up_clean = WsCleanup(up_ws);
+    write_compose_volume_fixture(up_ws, "upstream");
+    let (_up_id, up_snap) = upstream_up_snapshot(up_ws);
+
+    let d_tmp = TempDir::new().unwrap();
+    let d_ws = d_tmp.path();
+    let _d_clean = WsCleanup(d_ws);
+    write_compose_volume_fixture(d_ws, "deacon");
+    let (_d_out, _d_id, d_snap) = deacon_up_snapshot(d_ws);
+
+    sweep_ws_containers(up_ws);
+    sweep_ws_containers(d_ws);
+
+    // Vacuity guards: the compose-declared named volume + containerEnv landed on
+    // the inspected (primary) container.
+    for (who, snap) in [("deacon", &d_snap), ("upstream", &up_snap)] {
+        assert!(
+            snap.mounts
+                .get("/data")
+                .is_some_and(|m| m.mount_type == "volume"),
+            "{who} missing compose-declared named volume at /data: {:?}",
+            snap.mounts
+        );
+        assert!(
+            snap.env.contains("CV_ENV=yes"),
+            "{who} missing containerEnv CV_ENV: {:?}",
+            snap.env
+        );
+    }
+
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
+}

--- a/crates/deacon/tests/parity_utils.rs
+++ b/crates/deacon/tests/parity_utils.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::Command;
 use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 /// Environment gate: set to `1` to enable parity tests.
@@ -320,4 +321,641 @@ pub fn run_deacon(ws: &Path, args: &[&str]) -> anyhow::Result<std::process::Outp
 /// Extract stdout as trimmed string
 pub fn stdout_str(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+// ===========================================================================
+// Shared Docker discovery / cleanup helpers (used by the observable-state
+// parity binaries). Mirrors the private copies in
+// `parity_observable_state.rs`; centralized here so the state differ
+// (`parity_state_diff.rs`) can reuse them.
+// ===========================================================================
+
+/// Triple-gate a docker+upstream parity test. Returns `true` only when
+/// `DEACON_PARITY=1`, Docker is reachable, and the `devcontainer` CLI is
+/// available. Prints a skip reason and returns `false` otherwise (tests then
+/// early-return — never panic-skip).
+pub fn gated() -> bool {
+    if !parity_enabled() {
+        eprintln!("Skipping parity test: {}", skip_reason());
+        return false;
+    }
+    if !docker_available() {
+        eprintln!("Skipping parity test: Docker not available");
+        return false;
+    }
+    if !upstream_available() {
+        eprintln!("Skipping parity test: {}", skip_reason());
+        return false;
+    }
+    true
+}
+
+/// Run `docker <args>`, returning (success, stdout, stderr) without panicking
+/// on failure (for best-effort cleanup / discovery).
+pub fn docker_out_allow_fail(args: &[&str]) -> (bool, String, String) {
+    let out = std::process::Command::new("docker")
+        .args(args)
+        .output()
+        .expect("docker should run");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+    )
+}
+
+/// Extract a top-level string field from a `deacon up`/`deacon build` JSON
+/// result on stdout (tolerant of leading log lines before the JSON object).
+pub fn json_field(output: &std::process::Output, field: &str) -> Option<String> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    let value: Value = serde_json::from_str(trimmed).ok().or_else(|| {
+        trimmed
+            .rfind('{')
+            .and_then(|i| serde_json::from_str(&trimmed[i..]).ok())
+    })?;
+    value
+        .get(field)?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// The canonicalized workspace path, matching the value both CLIs stamp into
+/// the `devcontainer.local_folder` label. Filtering `docker ps` by the raw
+/// (un-canonicalized) temp path misses the container where the temp dir is
+/// symlinked (e.g. macOS `/tmp` -> `/private/tmp`).
+pub fn canonical_ws_display(ws: &Path) -> String {
+    ws.canonicalize()
+        .unwrap_or_else(|_| ws.to_path_buf())
+        .display()
+        .to_string()
+}
+
+/// Discover the first running container for `ws` by its canonicalized
+/// `devcontainer.local_folder` label (both CLIs stamp it). Used to locate the
+/// upstream CLI's container, which does not report a container id on stdout.
+pub fn upstream_container_id(ws: &Path) -> Option<String> {
+    let (ok, out, _) = docker_out_allow_fail(&[
+        "ps",
+        "--filter",
+        &format!(
+            "label=devcontainer.local_folder={}",
+            canonical_ws_display(ws)
+        ),
+        "--format",
+        "{{.ID}}",
+    ]);
+    if !ok {
+        return None;
+    }
+    out.lines().find(|s| !s.is_empty()).map(|s| s.to_string())
+}
+
+/// `docker compose -p <project> down` (best-effort, volumes + local images).
+pub fn deacon_compose_down_by_project(project_name: &str) {
+    let _ = std::process::Command::new("docker")
+        .args([
+            "compose",
+            "-p",
+            project_name,
+            "down",
+            "--remove-orphans",
+            "-v",
+            "--rmi",
+            "local",
+        ])
+        .output();
+}
+
+/// `deacon down --remove` for a workspace (best-effort).
+pub fn deacon_down(ws: &Path) {
+    let _ = run_deacon(
+        ws,
+        &[
+            "down",
+            "--workspace-folder",
+            &ws.to_string_lossy(),
+            "--remove",
+        ],
+    );
+}
+
+/// Best-effort teardown of every container stamped with this workspace's
+/// `devcontainer.local_folder` label (both CLIs stamp it), plus each
+/// container's compose project read from its actual
+/// `com.docker.compose.project` label.
+pub fn sweep_ws_containers(ws: &Path) {
+    let (ok, out, _) = docker_out_allow_fail(&[
+        "ps",
+        "-a",
+        "--filter",
+        &format!(
+            "label=devcontainer.local_folder={}",
+            canonical_ws_display(ws)
+        ),
+        "--format",
+        "{{.ID}}",
+    ]);
+    if !ok {
+        return;
+    }
+    for id in out.lines().filter(|s| !s.is_empty()) {
+        let (_, project, _) = docker_out_allow_fail(&[
+            "inspect",
+            "--format",
+            "{{ index .Config.Labels \"com.docker.compose.project\" }}",
+            id,
+        ]);
+        if !project.is_empty() {
+            deacon_compose_down_by_project(&project);
+        }
+        let _ = docker_out_allow_fail(&["rm", "-f", id]);
+    }
+}
+
+/// RAII cleanup: sweeps every container (and its compose project) for this
+/// workspace when dropped — including during panic unwinding, so a failed
+/// assertion can never leak Docker state. Declare it right after the workspace
+/// path so it drops before the `TempDir`.
+pub struct WsCleanup<'a>(pub &'a Path);
+impl Drop for WsCleanup<'_> {
+    fn drop(&mut self) {
+        sweep_ws_containers(self.0);
+    }
+}
+
+// ===========================================================================
+// Normalized observable-state differ (#267 follow-up)
+//
+// The parity_* suites historically asserted "both CLIs launched" or checked a
+// single hand-picked field. The bugs that actually bite are OUTCOME
+// divergences on a successful launch: a missing mount (#266, #272), a missing
+// env var, a colliding project name (#265). This differ snapshots the
+// normalized observable state of a container (`docker inspect`) for each CLI
+// and diffs it field-by-field, subtracting only:
+//   * volatile-but-equivalent values (container ids, per-workspace temp paths,
+//     compose-project-prefixed volume/network names),
+//   * an explicit, documented allowlist of INTENTIONAL deacon divergences, and
+//   * a documented KNOWN_GAPS list (open bugs, each tied to an issue).
+// Anything left over is a real parity finding and fails the test.
+// ===========================================================================
+
+/// Env keys present in every container and/or runtime-injected; not meaningful
+/// for cross-CLI outcome parity. Subtracted before diffing env.
+pub const NOISE_ENV_KEYS: &[&str] = &["PATH", "HOME", "HOSTNAME", "TERM", "container"];
+
+/// Label namespaces both CLIs stamp by design and differently (identity,
+/// per-CLI metadata blob, compose bookkeeping, Docker Desktop). Subtracted
+/// before diffing labels so only semantic image/config labels remain.
+pub const INTENTIONAL_LABEL_PREFIXES: &[&str] = &[
+    "devcontainer.",
+    "com.docker.",
+    "desktop.",
+    "dev.containers.",
+];
+
+/// INTENTIONAL divergences deacon deliberately makes vs the reference CLI.
+/// A raw divergence whose `field` starts with one of these matchers is dropped
+/// (logged, never fails). Keep this list SMALL and each entry justified — it
+/// is the reviewable record of where deacon is knowingly different. (Most
+/// intentional divergences — project name, identity labels, keep-alive
+/// command, project-prefixed networks — are already handled by normalization
+/// or by fields the differ does not compare; entries here are only for
+/// divergences that survive normalization.)
+pub const KNOWN_INTENTIONAL_DIVERGENCES: &[(&str, &str)] = &[
+    // (field-matcher, rationale)
+];
+
+/// A known, OPEN parity gap: deacon does not yet match the reference CLI here.
+/// The differ reports it (so it stays visible) but does not fail, until the
+/// bug is fixed — at which point the entry is removed and the divergence must
+/// disappear (or the test flips red, catching a widened gap).
+pub struct KnownGap {
+    pub field_matcher: &'static str,
+    pub issue: &'static str,
+    pub note: &'static str,
+}
+
+pub const KNOWN_GAPS: &[KnownGap] = &[KnownGap {
+    field_matcher: "mount:/feat-mnt",
+    issue: "#272",
+    note: "feature-contributed mounts dropped on deacon compose path",
+}];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountState {
+    pub mount_type: String,
+    pub ro: bool,
+    /// Normalized source descriptor for REPORTING only (bind: leaf component;
+    /// volume: name with compose-project prefix stripped). NOT compared — bind
+    /// sources are per-workspace temp paths that legitimately differ between
+    /// the two CLIs' independent workspaces.
+    pub source_tail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StateSnapshot {
+    /// destination -> mount state
+    pub mounts: BTreeMap<String, MountState>,
+    /// `KEY=VALUE` entries, noise keys removed
+    pub env: BTreeSet<String>,
+    /// labels with CLI-namespaced keys stripped
+    pub labels: BTreeMap<String, String>,
+    pub user: String,
+    pub working_dir: String,
+    /// `Config.ExposedPorts` keys (image `EXPOSE` + declared), e.g. `3000/tcp`.
+    pub exposed_ports: BTreeSet<String>,
+    /// `HostConfig.PortBindings` keys — container ports actually PUBLISHED to
+    /// the host (e.g. via `appPort`), e.g. `3000/tcp`. (`forwardPorts` is a
+    /// runtime forward, not a publish, and does not appear here.)
+    pub published_ports: BTreeSet<String>,
+    /// Captured for debugging; NOT diffed (keep-alive strategy differs by CLI).
+    pub entrypoint: Vec<String>,
+    /// Captured for debugging; NOT diffed (keep-alive strategy differs by CLI).
+    pub cmd: Vec<String>,
+    /// Captured (compose-project-prefix-normalized) for debugging; NOT diffed.
+    pub networks: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Divergence {
+    /// Stable field identifier, e.g. `mount:/feat-mnt`, `env:FOO`, `user`.
+    pub field: String,
+    pub detail: String,
+}
+
+/// Snapshot a running container by id (`docker inspect`), normalized.
+pub fn normalized_state(container_id: &str) -> StateSnapshot {
+    let raw = docker_inspect_one(container_id);
+    assert!(
+        raw.get("Config").is_some(),
+        "docker inspect for {} has no Config object; unexpected shape: {}",
+        container_id,
+        raw
+    );
+    snapshot_from_inspect(&raw)
+}
+
+fn docker_inspect_one(container_id: &str) -> Value {
+    let out = std::process::Command::new("docker")
+        .args(["inspect", container_id])
+        .output()
+        .expect("docker inspect should run");
+    assert!(
+        out.status.success(),
+        "docker inspect {} failed: {}",
+        container_id,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let arr: Vec<Value> = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .expect("docker inspect returns a JSON array");
+    arr.into_iter()
+        .next()
+        .expect("docker inspect returns at least one entry")
+}
+
+/// Build a normalized snapshot from a single `docker inspect` object. Pure —
+/// unit-testable without Docker.
+pub fn snapshot_from_inspect(raw: &Value) -> StateSnapshot {
+    let project = raw["Config"]["Labels"]["com.docker.compose.project"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    let mut mounts = BTreeMap::new();
+    if let Some(arr) = raw["Mounts"].as_array() {
+        for m in arr {
+            let dest = m["Destination"].as_str().unwrap_or("").to_string();
+            if dest.is_empty() {
+                continue;
+            }
+            let mount_type = m["Type"].as_str().unwrap_or("").to_string();
+            let ro = !m["RW"].as_bool().unwrap_or(true);
+            let source_tail = if mount_type == "volume" {
+                strip_project_prefix(m["Name"].as_str().unwrap_or(""), &project)
+            } else if mount_type == "bind" {
+                Path::new(m["Source"].as_str().unwrap_or(""))
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_string()
+            } else {
+                String::new()
+            };
+            mounts.insert(
+                dest,
+                MountState {
+                    mount_type,
+                    ro,
+                    source_tail,
+                },
+            );
+        }
+    }
+
+    let env = str_array(&raw["Config"]["Env"])
+        .into_iter()
+        .filter(|e| {
+            let key = e.split_once('=').map(|(k, _)| k).unwrap_or(e.as_str());
+            !NOISE_ENV_KEYS.contains(&key)
+        })
+        .collect();
+
+    let labels = raw["Config"]["Labels"]
+        .as_object()
+        .map(|o| {
+            o.iter()
+                .filter(|(k, _)| !INTENTIONAL_LABEL_PREFIXES.iter().any(|p| k.starts_with(p)))
+                .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let exposed_ports = raw["Config"]["ExposedPorts"]
+        .as_object()
+        .map(|o| o.keys().cloned().collect())
+        .unwrap_or_default();
+
+    let published_ports = raw["HostConfig"]["PortBindings"]
+        .as_object()
+        .map(|o| {
+            o.iter()
+                // A key maps to a non-null bindings array when actually published.
+                .filter(|(_, v)| v.as_array().is_some_and(|a| !a.is_empty()))
+                .map(|(k, _)| k.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let networks = raw["NetworkSettings"]["Networks"]
+        .as_object()
+        .map(|o| {
+            o.keys()
+                .map(|k| strip_project_prefix(k, &project))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    StateSnapshot {
+        mounts,
+        env,
+        labels,
+        user: raw["Config"]["User"].as_str().unwrap_or("").to_string(),
+        working_dir: raw["Config"]["WorkingDir"]
+            .as_str()
+            .unwrap_or("")
+            .to_string(),
+        exposed_ports,
+        published_ports,
+        entrypoint: str_array(&raw["Config"]["Entrypoint"]),
+        cmd: str_array(&raw["Config"]["Cmd"]),
+        networks,
+    }
+}
+
+fn str_array(v: &Value) -> Vec<String> {
+    v.as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn strip_project_prefix(name: &str, project: &str) -> String {
+    if !project.is_empty() {
+        if let Some(rest) = name.strip_prefix(&format!("{project}_")) {
+            return rest.to_string();
+        }
+    }
+    name.to_string()
+}
+
+/// Field-by-field diff of two normalized snapshots. Compares mounts (by
+/// destination + type + read-only), env (by key), labels (by key), exposed
+/// ports (set), and the scalar `user` / `working_dir`. Deliberately does NOT
+/// compare mount SOURCES (per-workspace temp paths), cmd/entrypoint (keep-alive
+/// strategy differs), or networks (compose-project-prefixed) — see the
+/// `StateSnapshot` field docs.
+pub fn diff_states(deacon: &StateSnapshot, upstream: &StateSnapshot) -> Vec<Divergence> {
+    let mut out = Vec::new();
+
+    let dests: BTreeSet<&String> = deacon.mounts.keys().chain(upstream.mounts.keys()).collect();
+    for dest in dests {
+        match (deacon.mounts.get(dest), upstream.mounts.get(dest)) {
+            (Some(d), Some(u)) => {
+                if d.mount_type != u.mount_type {
+                    out.push(Divergence {
+                        field: format!("mount:{dest}"),
+                        detail: format!(
+                            "type differs: deacon={} upstream={}",
+                            d.mount_type, u.mount_type
+                        ),
+                    });
+                }
+                if d.ro != u.ro {
+                    out.push(Divergence {
+                        field: format!("mount:{dest}"),
+                        detail: format!("read-only differs: deacon={} upstream={}", d.ro, u.ro),
+                    });
+                }
+            }
+            (Some(d), None) => out.push(Divergence {
+                field: format!("mount:{dest}"),
+                detail: format!("present on deacon ({}), absent upstream", d.mount_type),
+            }),
+            (None, Some(u)) => out.push(Divergence {
+                field: format!("mount:{dest}"),
+                detail: format!("present upstream ({}), absent deacon", u.mount_type),
+            }),
+            (None, None) => unreachable!(),
+        }
+    }
+
+    diff_kv(
+        "env",
+        &env_map(&deacon.env),
+        &env_map(&upstream.env),
+        &mut out,
+    );
+    diff_kv("label", &deacon.labels, &upstream.labels, &mut out);
+
+    for p in deacon.exposed_ports.difference(&upstream.exposed_ports) {
+        out.push(Divergence {
+            field: format!("port:{p}"),
+            detail: "exposed on deacon, not upstream".to_string(),
+        });
+    }
+    for p in upstream.exposed_ports.difference(&deacon.exposed_ports) {
+        out.push(Divergence {
+            field: format!("port:{p}"),
+            detail: "exposed upstream, not deacon".to_string(),
+        });
+    }
+
+    for p in deacon.published_ports.difference(&upstream.published_ports) {
+        out.push(Divergence {
+            field: format!("pubport:{p}"),
+            detail: "published on deacon, not upstream".to_string(),
+        });
+    }
+    for p in upstream.published_ports.difference(&deacon.published_ports) {
+        out.push(Divergence {
+            field: format!("pubport:{p}"),
+            detail: "published upstream, not deacon".to_string(),
+        });
+    }
+
+    if norm_user(&deacon.user) != norm_user(&upstream.user) {
+        out.push(Divergence {
+            field: "user".to_string(),
+            detail: format!("deacon={:?} upstream={:?}", deacon.user, upstream.user),
+        });
+    }
+    if deacon.working_dir != upstream.working_dir {
+        out.push(Divergence {
+            field: "workingdir".to_string(),
+            detail: format!(
+                "deacon={:?} upstream={:?}",
+                deacon.working_dir, upstream.working_dir
+            ),
+        });
+    }
+
+    out
+}
+
+/// An empty `Config.User` means "image default", which for the Linux base
+/// images used here is root. Treat "" and "root" as equivalent so the cosmetic
+/// difference (deacon leaves it empty; the reference CLI stamps "root" on its
+/// feature-image build) is not flagged, while a real `remoteUser` /
+/// `containerUser` (a specific non-root user) still diverges.
+fn norm_user(u: &str) -> &str {
+    if u.is_empty() { "root" } else { u }
+}
+
+fn env_map(set: &BTreeSet<String>) -> BTreeMap<String, String> {
+    set.iter()
+        .map(|e| match e.split_once('=') {
+            Some((k, v)) => (k.to_string(), v.to_string()),
+            None => (e.clone(), String::new()),
+        })
+        .collect()
+}
+
+fn diff_kv(
+    kind: &str,
+    deacon: &BTreeMap<String, String>,
+    upstream: &BTreeMap<String, String>,
+    out: &mut Vec<Divergence>,
+) {
+    let keys: BTreeSet<&String> = deacon.keys().chain(upstream.keys()).collect();
+    for k in keys {
+        match (deacon.get(k), upstream.get(k)) {
+            (Some(dv), Some(uv)) => {
+                if dv != uv {
+                    out.push(Divergence {
+                        field: format!("{kind}:{k}"),
+                        detail: format!("value differs: deacon={dv:?} upstream={uv:?}"),
+                    });
+                }
+            }
+            (Some(dv), None) => out.push(Divergence {
+                field: format!("{kind}:{k}"),
+                detail: format!("present on deacon ({dv:?}), absent upstream"),
+            }),
+            (None, Some(uv)) => out.push(Divergence {
+                field: format!("{kind}:{k}"),
+                detail: format!("present upstream ({uv:?}), absent deacon"),
+            }),
+            (None, None) => unreachable!(),
+        }
+    }
+}
+
+/// Classification of a raw divergence.
+pub enum DivergenceClass {
+    /// Matches `KNOWN_INTENTIONAL_DIVERGENCES` or the caller's `extra_allowed`.
+    Intentional(String),
+    /// Matches a `KNOWN_GAPS` entry (open bug).
+    KnownGap(&'static KnownGap),
+    /// A real, unexplained parity divergence — fails the test.
+    Unexpected,
+}
+
+/// Match a divergence `field` against an allowlist/gap `matcher`. Matchers are
+/// EXACT by default; a trailing `*` makes it a prefix match. Exact-by-default
+/// matters for path-like fields where one destination is a string prefix of
+/// another — e.g. `mount:/workspace` must NOT match `mount:/workspaces/sib`.
+fn field_matches(field: &str, matcher: &str) -> bool {
+    match matcher.strip_suffix('*') {
+        Some(prefix) => field.starts_with(prefix),
+        None => field == matcher,
+    }
+}
+
+pub fn classify_divergence(field: &str, extra_allowed: &[&str]) -> DivergenceClass {
+    if let Some(m) = extra_allowed.iter().find(|m| field_matches(field, m)) {
+        return DivergenceClass::Intentional(format!("caller-allowed ({m})"));
+    }
+    if let Some((_, why)) = KNOWN_INTENTIONAL_DIVERGENCES
+        .iter()
+        .find(|(m, _)| field_matches(field, m))
+    {
+        return DivergenceClass::Intentional((*why).to_string());
+    }
+    if let Some(gap) = KNOWN_GAPS
+        .iter()
+        .find(|g| field_matches(field, g.field_matcher))
+    {
+        return DivergenceClass::KnownGap(gap);
+    }
+    DivergenceClass::Unexpected
+}
+
+/// Snapshot both containers and assert outcome parity. Fails with a readable
+/// per-field report unless every divergence is intentional / caller-allowed /
+/// a tracked known gap.
+pub fn assert_state_parity(deacon_id: &str, upstream_id: &str, extra_allowed: &[&str]) {
+    let deacon = normalized_state(deacon_id);
+    let upstream = normalized_state(upstream_id);
+    assert_snapshots_parity(&deacon, &upstream, extra_allowed);
+}
+
+/// As `assert_state_parity`, but on already-captured snapshots (so a test can
+/// assert fixture-specific markers on the snapshot first — guarding against a
+/// vacuous pass over empty state).
+pub fn assert_snapshots_parity(
+    deacon: &StateSnapshot,
+    upstream: &StateSnapshot,
+    extra_allowed: &[&str],
+) {
+    let divs = diff_states(deacon, upstream);
+    let mut unexpected = Vec::new();
+    for div in &divs {
+        match classify_divergence(&div.field, extra_allowed) {
+            DivergenceClass::Intentional(why) => {
+                eprintln!(
+                    "[state-diff] intentional: {} — {} ({})",
+                    div.field, div.detail, why
+                );
+            }
+            DivergenceClass::KnownGap(gap) => {
+                eprintln!(
+                    "[state-diff] KNOWN GAP {}: {} — {} ({})",
+                    gap.issue, div.field, div.detail, gap.note
+                );
+            }
+            DivergenceClass::Unexpected => unexpected.push(div),
+        }
+    }
+    if !unexpected.is_empty() {
+        let mut msg = String::from("observable-state parity divergence(s) deacon vs upstream:\n");
+        for div in &unexpected {
+            msg.push_str(&format!("  - {}: {}\n", div.field, div.detail));
+        }
+        panic!("{msg}");
+    }
 }

--- a/docs/parity-state-diff.md
+++ b/docs/parity-state-diff.md
@@ -1,0 +1,112 @@
+# Normalized observable-state parity differ
+
+The `parity_state_diff` test binary compares the **resulting container state**
+of `deacon up` against `@devcontainers/cli up` for the same input — not merely
+that both launched. The bugs that bite are outcome divergences on a *successful*
+launch: a missing mount (#266, #272), a dropped env var, a colliding project
+name (#265). The differ snapshots each CLI's container via `docker inspect`,
+normalizes away legitimate differences, and fails on anything left over.
+
+- Differ implementation: `crates/deacon/tests/parity_utils.rs`
+  (`StateSnapshot`, `snapshot_from_inspect`, `diff_states`,
+  `classify_divergence`, `assert_state_parity` / `assert_snapshots_parity`).
+- Pure-logic unit tests (fast loop, no Docker):
+  `crates/deacon/tests/integration_state_diff.rs`.
+- Docker fixtures (opt-in, gated): `crates/deacon/tests/parity_state_diff.rs`.
+
+Run (triple-gated on `DEACON_PARITY=1` + Docker + `devcontainer` in PATH):
+
+```bash
+DEACON_PARITY=1 cargo test --test parity_state_diff -- --test-threads=1 --nocapture
+```
+
+Every subtracted divergence is printed as a `[state-diff]` line so the
+normalization/allowlist is visible on each run.
+
+## Fields compared
+
+`mounts` (by destination → type + read-only), `env` (by key), `labels` (by key,
+after namespace filtering), `exposed_ports` (set), `published_ports`
+(`HostConfig.PortBindings`, set), `user`, `working_dir`.
+
+Captured for debugging but **not** diffed: `entrypoint` / `cmd` (keep-alive
+strategy differs by CLI), `networks` (compose-project-prefixed).
+
+## Fixture matrix
+
+`crates/deacon/tests/parity_state_diff.rs` exercises the differ across:
+
+| Fixture | Axis exercised |
+|---|---|
+| single-container (image) | config bind mount, `containerEnv` |
+| compose + local Feature | feature `containerEnv` (baked) + feature `mounts` (#272) |
+| intra-deacon single-vs-compose | compose-drops-X vs single (no upstream needed) |
+| default workspace mount | `workspaceFolder` mount-target default (#273) |
+| Dockerfile build + `containerUser`/`remoteUser` | image-build path + non-root user (#274) |
+| `appPort` | published-port parity (`HostConfig.PortBindings`) |
+| mount variety | read-only bind + `tmpfs` mount |
+| compose db sidecar + named volume | multi-service compose + compose-declared volume |
+
+## Normalization (legitimate differences subtracted before diffing)
+
+| What | Why it is not a divergence |
+|---|---|
+| Mount **sources** (bind host paths) | Each CLI runs in its own workspace temp dir; sources legitimately differ. Mounts are compared by destination + type + read-only. |
+| Env noise keys: `PATH`, `HOME`, `HOSTNAME`, `TERM`, `container` | Present in every container / runtime-injected. |
+| Label namespaces: `devcontainer.*`, `com.docker.*`, `desktop.*`, `dev.containers.*` | Per-CLI identity, metadata blob, compose bookkeeping, Docker Desktop. |
+| Compose-project prefix on volume/network names | Volumes/networks are named after the (deliberately different) project name (#265). |
+| `Config.User` empty vs `"root"` | Empty means "image default", which is root for these bases. A real non-root `remoteUser`/`containerUser` still diverges. |
+
+## Intentional divergences (`KNOWN_INTENTIONAL_DIVERGENCES`)
+
+Currently **empty** — every intentional deacon divergence (project name,
+identity labels, keep-alive command, project-prefixed networks) is already
+handled by normalization or by a field the differ does not compare. New entries
+here must be justified; they are the reviewable record of where deacon is
+knowingly different.
+
+## Known gaps (`KNOWN_GAPS`) — open bugs, reported but not failing
+
+| Field | Issue | Note |
+|---|---|---|
+| `mount:/feat-mnt` | [#272](https://github.com/get2knowio/deacon/issues/272) | Feature-contributed `mounts` dropped on deacon's compose path. |
+
+Additional tracked gaps asserted per-fixture (not in the global `KNOWN_GAPS`
+because they only surface for one fixture shape):
+
+- [#273](https://github.com/get2knowio/deacon/issues/273) — default
+  workspace-mount target (`state_diff_default_workspace_mount_target_divergence`).
+- [#274](https://github.com/get2knowio/deacon/issues/274) — `containerUser` not
+  reflected in `Config.User` (`state_diff_dockerfile_build_and_nonroot_user`
+  allows `user` and asserts the gap's shape).
+
+Each gap-tracking test asserts the divergence's **shape**, so it flips red when
+the gap is fixed — forcing the tracking entry to be removed rather than silently
+lingering.
+
+## Divergences discovered while building the differ
+
+The differ surfaced these on its first runs (as test *failures*, before any
+allowlisting):
+
+1. **Default workspace-mount target — real divergence, filed as
+   [#273](https://github.com/get2knowio/deacon/issues/273).** On the
+   single-container path, with `workspaceFolder` set and no explicit
+   `workspaceMount`, deacon mounts the workspace **at `workspaceFolder`**
+   (`/workspace`), while the reference CLI mounts it at the spec default
+   **`/workspaces/<basename>`** and uses `workspaceFolder` only as the working
+   directory (`crates/core/src/docker.rs:2150-2162`). Characterized and tracked
+   by `state_diff_default_workspace_mount_target_divergence`.
+2. **Compose workspace mount — NOT a parity gap (verified).** deacon's compose
+   path only mounts the workspace root when `--workspace-mount-consistency` is
+   passed, and ignores `workspaceMount` on compose
+   (`crates/deacon/src/commands/up/compose.rs:117-153`) — but the **reference
+   CLI behaves the same on compose**: a plain compose devcontainer yields *zero*
+   workspace binds on both CLIs (the compose file is responsible for mounting the
+   workspace). The differ's intra-deacon single-vs-compose fixture surfaces the
+   internal single-vs-compose difference, which mirrors upstream's own; it is
+   allowed (`mount:/workspace`) there with a comment, not filed.
+
+The differ's own fixtures pin `workspaceMount` explicitly (single-container) so
+divergence (1) does not mask real findings (e.g. #272) in the cross-CLI
+comparison.


### PR DESCRIPTION
## What

Adds an **outcome-parity** differ for the `parity_*` suite: it brings a fixture
up with **both** `deacon` and `@devcontainers/cli` and diffs the resulting
container's **normalized observable state** (`docker inspect`) field by field —
instead of only asserting both CLIs launch. The bugs that bite are outcome
divergences on a *successful* launch (a missing mount, a dropped env var, a
container running as the wrong user), which a launch check cannot see.

## How

- **`crates/deacon/tests/parity_utils.rs`** — `StateSnapshot`,
  `snapshot_from_inspect`, `diff_states`, `classify_divergence`,
  `assert_state_parity` / `assert_snapshots_parity`, plus shared Docker
  discovery/cleanup helpers (`WsCleanup`, label-based sweep). Compares mounts
  (destination → type + read-only), env, labels, exposed **and published**
  ports, user, working-dir. Normalizes legitimate differences: mount sources
  (per-workspace temp paths), noise env, CLI-namespaced labels,
  compose-project prefixes, and empty-`User` ≡ root.
- **`crates/deacon/tests/integration_state_diff.rs`** — 12 pure-logic unit
  tests (normalization, teeth, matcher precision), run in the **fast loop** (no
  Docker).
- **`crates/deacon/tests/parity_state_diff.rs`** — 8 gated Docker fixtures:
  single-container, compose+feature, Dockerfile + non-root `containerUser`,
  `appPort`, mount variety (read-only bind + tmpfs), compose db sidecar + named
  volume, intra-deacon single-vs-compose, and the default workspace-mount
  characterization.
- **`.config/nextest.toml`** — register `parity_state_diff` in the `parity`
  group (15m slow-timeout) across all six profiles.
- **`docs/parity-state-diff.md`** — normalization rules, intentional-divergence
  allowlist, and tracked known gaps.

## Findings surfaced (each as a test failure first)

- **#272** — feature-contributed `mounts` dropped on deacon's compose path
  (tracked in `KNOWN_GAPS`).
- **#273** — single-container default workspace-mount target diverges
  (`workspaceFolder` vs `/workspaces/<basename>`).
- **#274** — `containerUser` not applied to `Config.User` (container runs as
  root; reference sets it).

Each gap-tracking test asserts the divergence's **shape**, so it flips red when
the gap is fixed — forcing the tracking entry to be removed rather than
lingering. A suspected fourth gap (compose ignoring `workspaceMount`) was
verified to **match** the reference and is *not* filed.

## Gating / CI

Triple-gated: `DEACON_PARITY=1` + Docker + `devcontainer` CLI in PATH (or
`DEACON_PARITY_DEVCONTAINER`). Without the gates the Docker fixtures **cleanly
skip** (never panic-skip); the 12 unit tests always run in the fast loop.

Validated locally: `fmt --check`, `clippy --all-targets --all-features -D
warnings`, 12 unit + all 8 Docker fixtures green (`DEACON_PARITY=1`, Docker +
`@devcontainers/cli` 0.87.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
