### PR TITLE
fix(up): apply containerUser at create time and compose feature mounts

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -1411,12 +1411,36 @@ impl ComposeProject {
             }
         }
 
+        // Named-volume mounts (e.g. a feature-contributed `type=volume`
+        // mount, #272) must be declared under the compose file's top-level
+        // `volumes:` key, or `docker compose up` rejects the project with
+        // "refers to undefined volume …: invalid compose project". Compose
+        // deep-merges `volumes:` across override files, so declaring an
+        // already-known volume here as an empty mapping is a harmless no-op
+        // (the base file's `external`/driver settings win); for a genuinely
+        // new volume, this is what makes the reference valid. This is a
+        // top-level (not per-service) YAML key, so it must sit outside the
+        // `services:` block built above.
+        let mut new_volume_names: Vec<&str> = Vec::new();
+        for mount in &self.additional_mounts {
+            if mount.mount_type == "volume" && !new_volume_names.contains(&mount.source.as_str()) {
+                new_volume_names.push(&mount.source);
+            }
+        }
+        if !new_volume_names.is_empty() {
+            yaml.push_str("volumes:\n");
+            for name in &new_volume_names {
+                yaml.push_str(&format!("  {}: {{}}\n", name));
+            }
+        }
+
         debug!(
-            "Generated compose injection override for service '{}': {} env vars, {} mounts, {} labels, override_command={}",
+            "Generated compose injection override for service '{}': {} env vars, {} mounts, {} labels, {} volumes, override_command={}",
             self.service,
             self.additional_env.len(),
             self.additional_mounts.len(),
             self.deacon_labels.len(),
+            new_volume_names.len(),
             override_cmd,
         );
 
@@ -2142,6 +2166,58 @@ mod tests {
         assert!(override_yaml.contains("volumes:"));
         assert!(override_yaml.contains("/host/path:/container/path"));
         assert!(override_yaml.contains("/another/host:/another/container:ro"));
+    }
+
+    #[test]
+    fn test_generate_injection_override_declares_new_named_volumes() {
+        // #272 follow-up: a `type=volume` additional mount (e.g. a
+        // feature-contributed mount) must be declared under a top-level
+        // `volumes:` key, or `docker compose up` rejects the project with
+        // "refers to undefined volume …: invalid compose project".
+        let project = ComposeProject {
+            name: "test".to_string(),
+            base_path: PathBuf::from("/test"),
+            compose_files: vec![PathBuf::from("docker-compose.yml")],
+            service: "app".to_string(),
+            run_services: Vec::new(),
+            env_files: Vec::new(),
+            additional_mounts: vec![
+                ComposeMount {
+                    mount_type: "volume".to_string(),
+                    source: "feat-probe-vol".to_string(),
+                    target: "/feat-mnt".to_string(),
+                    read_only: false,
+                    consistency: None,
+                },
+                ComposeMount {
+                    mount_type: "bind".to_string(),
+                    source: "/host/ws".to_string(),
+                    target: "/workspace".to_string(),
+                    read_only: false,
+                    consistency: None,
+                },
+            ],
+            profiles: Vec::new(),
+            additional_env: IndexMap::new(),
+            external_volumes: Vec::new(),
+            override_command: Some(false),
+            service_image_override: None,
+            deacon_labels: IndexMap::new(),
+        };
+
+        let override_yaml = project.generate_injection_override().unwrap();
+
+        // The per-service `volumes:` list still gets the short-form mount…
+        assert!(override_yaml.contains("feat-probe-vol:/feat-mnt"));
+        // …and a SIBLING top-level `volumes:` key declares the named volume
+        // (not nested under `services:`), so compose accepts the reference.
+        let top_level_volumes_idx = override_yaml
+            .find("\nvolumes:\n")
+            .expect("expected a top-level `volumes:` key");
+        let declaration = &override_yaml[top_level_volumes_idx..];
+        assert!(declaration.contains("  feat-probe-vol: {}"));
+        // The bind mount's source must NOT be declared as a named volume.
+        assert!(!declaration.contains("/host/ws"));
     }
 
     #[test]

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -2225,6 +2225,20 @@ impl ContainerOps for CliRuntime {
         // Add security options from merged security (config + features)
         args.extend(merged_security.to_docker_args());
 
+        // Apply `containerUser` to the container's start user (`Config.User`).
+        // Per containers.dev, `containerUser` is "the user the container will
+        // be started as" — the reference CLI passes it straight to `docker run
+        // -u <containerUser>` (unset falls through to the image's own default
+        // user). `remoteUser` is intentionally NOT consulted here: it only
+        // resolves the user for exec/lifecycle time (`resolve_env_and_user`),
+        // defaulting to `containerUser` when unset — never the other way
+        // around. Pushed before `runArgs` below so a user-supplied `--user` in
+        // `runArgs` still wins (Docker CLI honors the last `--user` flag).
+        if let Some(ref container_user) = config.container_user {
+            args.push("--user".to_string());
+            args.push(container_user.clone());
+        }
+
         // Apply entrypoint from chain (features + config)
         match entrypoint_chain {
             crate::features::EntrypointChain::None => {

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -152,53 +152,11 @@ pub(crate) async fn execute_compose_up(
         );
     }
 
-    // Apply `devcontainer.json` `mounts` to the compose project (#266). The
-    // single-container path applies these via `merge_mounts`
-    // (up/container.rs); the compose path never read `config.mounts` at all.
-    // Feature-contributed mounts are out of scope here (compose feature
-    // dispatch doesn't yet resolve `ResolvedFeature` mounts the same way) —
-    // pass an empty feature slice so `merge_mounts` only substitutes +
-    // normalizes `config.mounts`.
-    if !config.mounts.is_empty() {
-        let mount_substitution_context = {
-            let mut ctx = deacon_core::variable::SubstitutionContext::new(workspace_folder)?;
-            let id_labels: Vec<(String, String)> = identity.labels().into_iter().collect();
-            ctx.devcontainer_id = deacon_core::container::compute_dev_container_id(&id_labels);
-            ctx
-        };
-        let merged_config_mounts = deacon_core::mount::merge_mounts(
-            &config.mounts,
-            &[],
-            Some(&mount_substitution_context),
-        )
-        .with_context(|| "Failed to merge devcontainer.json mounts for compose")?;
-        for mount_str in &merged_config_mounts.mounts {
-            let mount = NormalizedMount::parse(mount_str).with_context(|| {
-                format!(
-                    "Invalid mount specification in devcontainer.json: {}",
-                    mount_str
-                )
-            })?;
-            additional_mounts.push(normalized_mount_to_compose_mount(&mount));
-        }
-    }
-
-    // Apply CLI mounts to compose project
-    // Per CLAUDE.md: No silent fallbacks - fail fast on invalid mounts
-    for mount_str in &args.mount {
-        let mount = NormalizedMount::parse(mount_str)
-            .with_context(|| format!("Invalid mount specification: {}", mount_str))?;
-        additional_mounts.push(normalized_mount_to_compose_mount(&mount));
-    }
-
-    // Dedupe by target, last-wins, so later sources (config, then CLI) can
-    // override the workspace-consistency mount or each other for the same
-    // target path — mirrors `merge_mounts`' union-by-target semantics
-    // (`mount.rs`), which `generate_injection_override` does NOT do on its
-    // own; it renders every `additional_mounts` entry verbatim.
-    if !additional_mounts.is_empty() {
-        project.additional_mounts = dedupe_compose_mounts_by_target(additional_mounts);
-    }
+    // `devcontainer.json` `mounts` (#266) and feature-contributed `mounts`
+    // (#272) are folded into `additional_mounts` further below, AFTER
+    // features are resolved (`feature_build`) — `merge_mounts` needs the
+    // resolved features to fold their `mounts` in, mirroring the
+    // single-container path (up/container.rs).
 
     // Apply `containerEnv` (config) + remote env (CLI, higher precedence) to
     // compose services. `config.container_env` was never read here at all —
@@ -421,6 +379,57 @@ pub(crate) async fn execute_compose_up(
     // `None` when no features are declared).
     if let Some(ref fb) = feature_build {
         handle_lockfile_post_build(args, config_path, &fb.lockfile).await?;
+    }
+
+    // Apply `devcontainer.json` `mounts` (#266) and feature-contributed
+    // `mounts` (#272) to the compose project. Run through `merge_mounts` in a
+    // single call — same as the single-container path (up/container.rs) —
+    // so config-vs-feature precedence and target-based dedup happen exactly
+    // once. Must run here (after `feature_build`) so `resolved_features` is
+    // available. Precedence overall: workspace < feature < config < CLI.
+    let resolved_features_for_mounts: &[deacon_core::features::ResolvedFeature] = feature_build
+        .as_ref()
+        .map(|fb| fb.resolved_features.as_slice())
+        .unwrap_or(&[]);
+    if !config.mounts.is_empty() || !resolved_features_for_mounts.is_empty() {
+        let mount_substitution_context = {
+            let mut ctx = deacon_core::variable::SubstitutionContext::new(workspace_folder)?;
+            let id_labels: Vec<(String, String)> = identity.labels().into_iter().collect();
+            ctx.devcontainer_id = deacon_core::container::compute_dev_container_id(&id_labels);
+            ctx
+        };
+        let merged_config_mounts = deacon_core::mount::merge_mounts(
+            &config.mounts,
+            resolved_features_for_mounts,
+            Some(&mount_substitution_context),
+        )
+        .with_context(|| "Failed to merge devcontainer.json + feature mounts for compose")?;
+        for mount_str in &merged_config_mounts.mounts {
+            let mount = NormalizedMount::parse(mount_str).with_context(|| {
+                format!(
+                    "Invalid mount specification in devcontainer.json/feature: {}",
+                    mount_str
+                )
+            })?;
+            additional_mounts.push(normalized_mount_to_compose_mount(&mount));
+        }
+    }
+
+    // Apply CLI mounts to compose project
+    // Per CLAUDE.md: No silent fallbacks - fail fast on invalid mounts
+    for mount_str in &args.mount {
+        let mount = NormalizedMount::parse(mount_str)
+            .with_context(|| format!("Invalid mount specification: {}", mount_str))?;
+        additional_mounts.push(normalized_mount_to_compose_mount(&mount));
+    }
+
+    // Dedupe by target, last-wins, so later sources (feature, config, then
+    // CLI) can override the workspace-consistency mount or each other for the
+    // same target path — mirrors `merge_mounts`' union-by-target semantics
+    // (`mount.rs`), which `generate_injection_override` does NOT do on its
+    // own; it renders every `additional_mounts` entry verbatim.
+    if !additional_mounts.is_empty() {
+        project.additional_mounts = dedupe_compose_mounts_by_target(additional_mounts);
     }
 
     // Start the compose project

--- a/crates/deacon/tests/integration_state_diff.rs
+++ b/crates/deacon/tests/integration_state_diff.rs
@@ -9,9 +9,18 @@ use serde_json::json;
 
 mod parity_utils;
 use parity_utils::{
-    DivergenceClass, StateSnapshot, assert_snapshots_parity, classify_divergence, diff_states,
-    snapshot_from_inspect,
+    DivergenceClass, KnownGap, StateSnapshot, assert_snapshots_parity,
+    assert_snapshots_parity_with_gaps, classify_divergence, classify_divergence_with_gaps,
+    diff_states, snapshot_from_inspect,
 };
+
+/// Synthetic gap used only to exercise the `KnownGap` classification branch
+/// (production `KNOWN_GAPS` is empty — every tracked gap has been fixed).
+const SYNTHETIC_GAP: &[KnownGap] = &[KnownGap {
+    field_matcher: "mount:/feat-mnt",
+    issue: "#TEST",
+    note: "synthetic gap for classifier unit tests",
+}];
 
 /// A minimal single-container `docker inspect` object with the given env,
 /// mounts, and labels.
@@ -136,12 +145,18 @@ fn missing_env_is_detected() {
 }
 
 #[test]
-fn feature_mount_gap_classifies_as_known_gap_272() {
-    // The #272 gap: upstream has the feature volume at /feat-mnt, deacon lacks it.
-    match classify_divergence("mount:/feat-mnt", &[]) {
-        DivergenceClass::KnownGap(gap) => assert_eq!(gap.issue, "#272"),
-        _ => panic!("mount:/feat-mnt should classify as the #272 known gap"),
+fn known_gap_classifies_via_gaps_list() {
+    // #272 (the original real-world example of this mechanism) is fixed and
+    // KNOWN_GAPS is empty; exercise the KnownGap branch with a synthetic gap.
+    match classify_divergence_with_gaps("mount:/feat-mnt", &[], SYNTHETIC_GAP) {
+        DivergenceClass::KnownGap(gap) => assert_eq!(gap.issue, "#TEST"),
+        _ => panic!("mount:/feat-mnt should classify as the synthetic known gap"),
     }
+    // Absent a matching gaps list, the same field is unexplained.
+    assert!(matches!(
+        classify_divergence("mount:/feat-mnt", &[]),
+        DivergenceClass::Unexpected
+    ));
 }
 
 #[test]
@@ -161,13 +176,14 @@ fn unlisted_divergence_classifies_as_unexpected() {
 fn assert_snapshots_parity_passes_on_known_gap_but_fails_on_new_divergence() {
     let base = snapshot_from_inspect(&inspect(&["FOO=bar"], json!([]), json!({})));
 
-    // Only a known-gap divergence (/feat-mnt) → passes.
+    // Only a known-gap divergence (/feat-mnt) → passes, against a synthetic
+    // gaps list (production KNOWN_GAPS is currently empty).
     let with_gap = snapshot_from_inspect(&inspect(
         &["FOO=bar"],
         json!([volume("/feat-mnt", "up_feat-probe-vol")]),
         json!({}),
     ));
-    assert_snapshots_parity(&base, &with_gap, &[]);
+    assert_snapshots_parity_with_gaps(&base, &with_gap, &[], SYNTHETIC_GAP);
 
     // A NEW, unlisted divergence → must panic (teeth).
     let with_new = snapshot_from_inspect(&inspect(

--- a/crates/deacon/tests/parity_state_diff.rs
+++ b/crates/deacon/tests/parity_state_diff.rs
@@ -239,11 +239,12 @@ fn state_diff_single_container_parity() {
 }
 
 // ===========================================================================
-// Test 2: compose outcome parity — exercises the #272 feature-mount gap. The
-// gap classifies as a tracked KNOWN_GAP (passes today); any OTHER compose
-// divergence fails. The positive control (feature `containerEnv`, baked into
-// the image) proves the Feature installed on deacon's compose path, so a
-// missing /feat-mnt is specifically the runtime mount being dropped.
+// Test 2: compose outcome parity — covers the (fixed) #272 feature-mount gap.
+// `execute_compose_up` now resolves features before folding their `mounts`
+// into `additional_mounts` (mirrors the single-container path), so the
+// feature mount must now match upstream exactly; any compose divergence
+// fails. The positive control (feature `containerEnv`, baked into the image)
+// proves the Feature installed on deacon's compose path.
 // ===========================================================================
 
 #[test]
@@ -281,21 +282,19 @@ fn state_diff_compose_parity_with_feature_mount_gap() {
         "upstream compose snapshot missing baked feature env: {:?}",
         up_snap.env
     );
-    // The #272 gap itself: upstream has the feature mount, deacon does not.
-    // Asserting this shape keeps the KNOWN_GAP honest — if deacon starts
-    // applying it, this assertion flips and the gap entry should be removed.
+    // #272 fixed: deacon now applies the feature-contributed mount, matching
+    // upstream, on the compose path.
     assert!(
         up_snap.mounts.contains_key("/feat-mnt"),
         "upstream should apply the feature mount /feat-mnt: {:?}",
         up_snap.mounts
     );
     assert!(
-        !d_snap.mounts.contains_key("/feat-mnt"),
-        "deacon unexpectedly applied /feat-mnt — #272 may be FIXED; remove the KNOWN_GAP entry and drop this assertion: {:?}",
+        d_snap.mounts.contains_key("/feat-mnt"),
+        "deacon should now apply the feature mount /feat-mnt (#272 fix): {:?}",
         d_snap.mounts
     );
 
-    // Everything except the tracked #272 gap must match.
     assert_snapshots_parity(&d_snap, &up_snap, &[]);
 }
 
@@ -516,22 +515,19 @@ fn state_diff_dockerfile_build_and_nonroot_user() {
         );
     }
 
-    // #274: deacon does not apply `containerUser` to the created container's
-    // `Config.User` (it runs as root, applying the user only at exec time),
-    // whereas the reference sets `Config.User=dev`. Assert the gap's shape so
-    // this test flips red when #274 is fixed, then allow `user` in the diff.
+    // #274 fixed: deacon now passes `--user <containerUser>` at container
+    // create time, so `Config.User` matches the reference.
     assert_eq!(
         up_snap.user, "dev",
         "reference should set Config.User=dev from containerUser: {:?}",
         up_snap.user
     );
-    assert!(
-        d_snap.user.is_empty() || d_snap.user == "root",
-        "deacon unexpectedly set Config.User ({:?}) — #274 may be FIXED; drop \
-         the `user` allowance and this shape assertion",
+    assert_eq!(
+        d_snap.user, "dev",
+        "deacon should now set Config.User=dev from containerUser (#274 fix): {:?}",
         d_snap.user
     );
-    assert_snapshots_parity(&d_snap, &up_snap, &["user"]);
+    assert_snapshots_parity(&d_snap, &up_snap, &[]);
 }
 
 // ===========================================================================

--- a/crates/deacon/tests/parity_utils.rs
+++ b/crates/deacon/tests/parity_utils.rs
@@ -537,11 +537,11 @@ pub struct KnownGap {
     pub note: &'static str,
 }
 
-pub const KNOWN_GAPS: &[KnownGap] = &[KnownGap {
-    field_matcher: "mount:/feat-mnt",
-    issue: "#272",
-    note: "feature-contributed mounts dropped on deacon compose path",
-}];
+// Currently empty: #272 (feature-contributed mounts dropped on compose) was
+// fixed by resolving features before folding their `mounts` into
+// `additional_mounts` (see `execute_compose_up` in
+// `commands/up/compose.rs`). New entries go here only for genuinely open bugs.
+pub const KNOWN_GAPS: &[KnownGap] = &[];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MountState {
@@ -897,6 +897,18 @@ fn field_matches(field: &str, matcher: &str) -> bool {
 }
 
 pub fn classify_divergence(field: &str, extra_allowed: &[&str]) -> DivergenceClass {
+    classify_divergence_with_gaps(field, extra_allowed, KNOWN_GAPS)
+}
+
+/// As `classify_divergence`, but against an explicit gaps list rather than the
+/// production `KNOWN_GAPS`. Lets unit tests exercise the `KnownGap` branch of
+/// the classifier mechanism with a synthetic entry, independent of whatever
+/// real open bugs `KNOWN_GAPS` currently holds (ideally none).
+pub fn classify_divergence_with_gaps(
+    field: &str,
+    extra_allowed: &[&str],
+    gaps: &'static [KnownGap],
+) -> DivergenceClass {
     if let Some(m) = extra_allowed.iter().find(|m| field_matches(field, m)) {
         return DivergenceClass::Intentional(format!("caller-allowed ({m})"));
     }
@@ -906,10 +918,7 @@ pub fn classify_divergence(field: &str, extra_allowed: &[&str]) -> DivergenceCla
     {
         return DivergenceClass::Intentional((*why).to_string());
     }
-    if let Some(gap) = KNOWN_GAPS
-        .iter()
-        .find(|g| field_matches(field, g.field_matcher))
-    {
+    if let Some(gap) = gaps.iter().find(|g| field_matches(field, g.field_matcher)) {
         return DivergenceClass::KnownGap(gap);
     }
     DivergenceClass::Unexpected
@@ -932,10 +941,21 @@ pub fn assert_snapshots_parity(
     upstream: &StateSnapshot,
     extra_allowed: &[&str],
 ) {
+    assert_snapshots_parity_with_gaps(deacon, upstream, extra_allowed, KNOWN_GAPS)
+}
+
+/// As `assert_snapshots_parity`, but against an explicit gaps list. See
+/// `classify_divergence_with_gaps`.
+pub fn assert_snapshots_parity_with_gaps(
+    deacon: &StateSnapshot,
+    upstream: &StateSnapshot,
+    extra_allowed: &[&str],
+    gaps: &'static [KnownGap],
+) {
     let divs = diff_states(deacon, upstream);
     let mut unexpected = Vec::new();
     for div in &divs {
-        match classify_divergence(&div.field, extra_allowed) {
+        match classify_divergence_with_gaps(&div.field, extra_allowed, gaps) {
             DivergenceClass::Intentional(why) => {
                 eprintln!(
                     "[state-diff] intentional: {} — {} ({})",

--- a/docs/parity-state-diff.md
+++ b/docs/parity-state-diff.md
@@ -67,40 +67,59 @@ knowingly different.
 
 ## Known gaps (`KNOWN_GAPS`) — open bugs, reported but not failing
 
-| Field | Issue | Note |
-|---|---|---|
-| `mount:/feat-mnt` | [#272](https://github.com/get2knowio/deacon/issues/272) | Feature-contributed `mounts` dropped on deacon's compose path. |
+Currently **empty**. [#272](https://github.com/get2knowio/deacon/issues/272)
+(feature-contributed `mounts` dropped on deacon's compose path) was the only
+global entry and is now **fixed**: `execute_compose_up` resolves features
+before folding their `mounts` into `additional_mounts` (same `merge_mounts`
+call the single-container path uses), so compose feature mounts now match
+upstream (`crates/deacon/src/commands/up/compose.rs`).
 
-Additional tracked gaps asserted per-fixture (not in the global `KNOWN_GAPS`
-because they only surface for one fixture shape):
+[#274](https://github.com/get2knowio/deacon/issues/274) (`containerUser` not
+reflected in `Config.User`) is also **fixed**: `create_container`
+(`crates/core/src/docker.rs`) now passes `--user <containerUser>` at container
+create time when `containerUser` is configured, mirroring the reference CLI's
+`PV()`/`getContainerUser` resolution (`containerUser` alone — `remoteUser` is
+never consulted for `Config.User`, only for exec/lifecycle time). Both fixtures
+(`state_diff_compose_parity_with_feature_mount_gap`,
+`state_diff_dockerfile_build_and_nonroot_user`) now assert full parity instead
+of a tracked gap shape.
 
-- [#273](https://github.com/get2knowio/deacon/issues/273) — default
-  workspace-mount target (`state_diff_default_workspace_mount_target_divergence`).
-- [#274](https://github.com/get2knowio/deacon/issues/274) — `containerUser` not
-  reflected in `Config.User` (`state_diff_dockerfile_build_and_nonroot_user`
-  allows `user` and asserts the gap's shape).
-
-Each gap-tracking test asserts the divergence's **shape**, so it flips red when
-the gap is fixed — forcing the tracking entry to be removed rather than silently
-lingering.
+[#273](https://github.com/get2knowio/deacon/issues/273) (default
+workspace-mount target) was **investigated and closed as an intentional,
+characterized divergence** — see below; it never used a KNOWN_GAP tracking
+entry (`state_diff_default_workspace_mount_target_divergence` characterizes
+both CLIs' behavior independently rather than diffing them).
 
 ## Divergences discovered while building the differ
 
 The differ surfaced these on its first runs (as test *failures*, before any
 allowlisting):
 
-1. **Default workspace-mount target — real divergence, filed as
-   [#273](https://github.com/get2knowio/deacon/issues/273).** On the
+1. **Default workspace-mount target — investigated, closed as intentional
+   ([#273](https://github.com/get2knowio/deacon/issues/273)).** On the
    single-container path, with `workspaceFolder` set and no explicit
    `workspaceMount`, deacon mounts the workspace **at `workspaceFolder`**
    (`/workspace`), while the reference CLI mounts it at the spec default
    **`/workspaces/<basename>`** and uses `workspaceFolder` only as the working
-   directory (`crates/core/src/docker.rs:2150-2162`). Characterized and tracked
-   by `state_diff_default_workspace_mount_target_divergence`.
+   directory (`crates/core/src/docker.rs:2150-2162`).
+
+   **Why deacon does NOT align to the reference here:** empirically, the
+   reference CLI's own behavior in this exact shape is broken — mounting at
+   `/workspaces/<basename>` while defaulting `remoteWorkspaceFolder` (and thus
+   the exec/lifecycle working directory) to `workspaceFolder` means `/workspace`
+   never exists in the container. Verified with `@devcontainers/cli` 0.87.0
+   against `{"image": "debian:bookworm-slim", "workspaceFolder": "/workspace"}`
+   (no `workspaceMount`): `devcontainer exec … pwd` fails with `OCI runtime exec
+   failed: … chdir to cwd ("/workspace") set in config.json failed: no such
+   file or directory`. Aligning deacon to the reference default would import
+   this footgun. deacon's behavior — mounting at `workspaceFolder` so it
+   actually exists — is the more robust choice and is kept as a deliberate,
+   tested characterization (`state_diff_default_workspace_mount_target_divergence`),
+   not a bug to fix.
 2. **Compose workspace mount — NOT a parity gap (verified).** deacon's compose
    path only mounts the workspace root when `--workspace-mount-consistency` is
    passed, and ignores `workspaceMount` on compose
-   (`crates/deacon/src/commands/up/compose.rs:117-153`) — but the **reference
+   (`crates/deacon/src/commands/up/compose.rs`) — but the **reference
    CLI behaves the same on compose**: a plain compose devcontainer yields *zero*
    workspace binds on both CLIs (the compose file is responsible for mounting the
    workspace). The differ's intra-deacon single-vs-compose fixture surfaces the
@@ -108,5 +127,4 @@ allowlisting):
    allowed (`mount:/workspace`) there with a comment, not filed.
 
 The differ's own fixtures pin `workspaceMount` explicitly (single-container) so
-divergence (1) does not mask real findings (e.g. #272) in the cross-CLI
-comparison.
+divergence (1) does not mask real findings in the cross-CLI comparison.


### PR DESCRIPTION
## Summary

Fixes two outcome-parity gaps surfaced by the normalized observable-state differ (`crates/deacon/tests/parity_state_diff.rs`), and investigates/closes a third.

- **#274** — `containerUser` was never applied to the created container's `Config.User` (deacon only applied it post-create via `apply_user_mapping`, exec-time only). `create_container` (`crates/core/src/docker.rs`) now passes `--user <containerUser>` at `docker create` time, matching the reference CLI's resolution (verified against its own bundled source: `containerUser` is resolved independently of `remoteUser`, never falling back to it — `remoteUser` only affects exec/lifecycle time).

- **#272** — the compose path dropped feature-contributed `mounts` because mount assembly ran *before* features were resolved. `execute_compose_up` (`crates/deacon/src/commands/up/compose.rs`) now builds `additional_mounts` (config `mounts` + feature `mounts`, via one `merge_mounts` call) *after* feature resolution, mirroring the single-container path. This uncovered a **second, previously-latent bug**: a `type=volume` additional mount (e.g. the feature's volume) was never declared under the compose override's top-level `volumes:` key, so `docker compose up` rejected the project with `refers to undefined volume …: invalid compose project`. Fixed in `ComposeProject::generate_injection_override` (`crates/core/src/compose.rs`), which now emits a sibling top-level `volumes:` declaration for every distinct `type=volume` source — a no-op for already-declared volumes (compose deep-merges), and what makes a genuinely new one valid.

- **#273** — investigated, **not code-changed**, closed as an intentional divergence. Empirically reproduced the reference CLI's own behavior for `workspaceFolder` set + `workspaceMount` unset: it mounts the workspace at `/workspaces/<basename>` but still defaults the exec/lifecycle working directory to `workspaceFolder`, which was never mounted — `devcontainer exec … pwd` fails with `chdir to cwd ("/workspace") … no such file or directory` on the reference CLI itself. Aligning deacon to that default would import this footgun, so deacon's divergent (more robust) behavior is documented in `docs/parity-state-diff.md` instead.

Both previously gap-tracking Docker fixtures (`state_diff_compose_parity_with_feature_mount_gap`, `state_diff_dockerfile_build_and_nonroot_user`) now assert full parity instead of a tracked-gap shape, and `KNOWN_GAPS` is empty.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p deacon-core --lib` — 1308 passed
- [x] `cargo test -p deacon --lib` — 385 passed
- [x] `cargo test --test integration_state_diff` — 12 passed (fast-loop differ unit tests, updated for the fixed gaps)
- [x] `DEACON_PARITY=1 cargo test --test parity_state_diff -- --test-threads=1` — 8/8 passed against real Docker + `@devcontainers/cli` 0.87.0, including the two fixtures that now assert full parity

Closes #274, closes #272. Investigates and closes #273 (as intentional, documented, not fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)