### PR TITLE
chore(release): bump version to 0.2.0-rc.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.10"
+version = "0.2.0-rc.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.10"
+version = "0.2.0-rc.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.10" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.11" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.10"
+version = "0.2.0-rc.11"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.10"
+version = "0.2.0-rc.11"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Bumps the crate version to `0.2.0-rc.11` in all four spots (`Cargo.toml`, `crates/core/Cargo.toml`, `crates/deacon/Cargo.toml`, `Cargo.lock`), preparing the next release candidate.

Ships since `v0.2.0-rc.10`:
- #264/#268 — OCI lockfile writes the manifest digest, not the layer digest
- #266/#269 — `devcontainer.json` `mounts` applied on the compose path
- #265/#270 — deacon-namespaced compose project name, isolated from the reference CLI
- #267/#271 — observable-state parity suite
- #275 — normalized observable-state parity differ
- #272/#274/#276 — `containerUser` applied at container-create time (`Config.User`); compose feature-contributed `mounts` fixed (plus the compose named-volume declaration bug it surfaced)
- #273 — investigated and closed as an intentional, documented divergence (not a code change)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --workspace` clean
- [x] CI (fmt/clippy/tests across all lanes) — see checks below

After merge, an annotated tag `v0.2.0-rc.11` will be pushed on the merge commit to trigger the release workflow (binary builds, SBOMs, provenance, install-script deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)