### PR TITLE
fix(install): stop install.sh spurious errors, sign macOS binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,14 +206,30 @@ jobs:
           AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --release --target ${{ matrix.target }}
+      - name: Ad-hoc codesign (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          # Apple Silicon requires every executable to carry a valid code
+          # signature (even an ad-hoc one) or the kernel's AMFI check refuses
+          # to exec it (SIGKILL, immediately, on every attempt). `strip = true`
+          # in [profile.release] strips the binary via an external tool AFTER
+          # ld64 already applied its automatic ad-hoc signature at link time,
+          # which invalidates that signature. Re-sign ad-hoc after stripping
+          # so the shipped binary actually runs on arm64 macOS.
+          codesign --sign - --force target/${{ matrix.target }}/release/deacon
+          codesign --verify --verbose target/${{ matrix.target }}/release/deacon
       - name: Smoke run (Unix native)
-        if: runner.os != 'Windows' && !contains(matrix.target, 'aarch64') && !contains(matrix.target, 'arm')
+        # `aarch64-apple-darwin` is NATIVE here: GitHub's `macos-latest` runners
+        # are Apple Silicon (arm64), so that build can and should be exercised
+        # too — only genuinely cross-compiled Linux aarch64/arm targets (built
+        # on an x86_64 ubuntu-latest runner) cannot run their own binary.
+        if: runner.os != 'Windows' && (runner.os == 'macOS' || (!contains(matrix.target, 'aarch64') && !contains(matrix.target, 'arm')))
         run: |
           BIN=target/${{ matrix.target }}/release/deacon
           "$BIN" --version
           "$BIN" --help | head -n 20
       - name: Skip note (cross-compiled ARM64 on x86 runner)
-        if: runner.os != 'Windows' && (contains(matrix.target, 'aarch64') || contains(matrix.target, 'arm'))
+        if: runner.os == 'Linux' && (contains(matrix.target, 'aarch64') || contains(matrix.target, 'arm'))
         run: echo "Skipping runtime smoke test for ${{ matrix.target }} (cross-compiled binary cannot execute on x86 runner)."
       - name: Smoke run (Windows)
         if: runner.os == 'Windows' && matrix.target == 'x86_64-pc-windows-msvc'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -402,9 +402,17 @@ main() {
     fi
 
     # Create temporary directory
+    #
+    # The trap body is double-quoted so `$tmp_dir` is expanded NOW, not when
+    # the trap fires. `main` is the script's last statement, so the EXIT trap
+    # actually runs after `main` has already returned — at which point the
+    # `local tmp_dir` is out of scope. A single-quoted trap defers `$tmp_dir`
+    # lookup to that later, out-of-scope point, and `set -u` turns the
+    # now-unset reference into a spurious "tmp_dir: unbound variable" error
+    # right as the script exits (even though installation already succeeded).
     local tmp_dir
     tmp_dir=$(mktemp -d)
-    trap 'rm -rf "$tmp_dir"' EXIT
+    trap "rm -rf '$tmp_dir'" EXIT
 
     # Construct download URLs
     local archive_name="deacon-${version}-${target}.${ext}"
@@ -463,8 +471,26 @@ main() {
     success "Deacon $version has been installed successfully!"
     echo ""
 
-    # Verify installation
-    if "$binary_path" --version >/dev/null 2>&1; then
+    # Verify installation.
+    #
+    # On macOS a freshly-written binary can occasionally be killed (SIGKILL)
+    # on its very first execution — Gatekeeper's on-demand scan racing the
+    # exec — even though every later invocation succeeds once the scan
+    # completes. Retry once after a brief pause so a one-shot hiccup here
+    # doesn't just silently skip the version report.
+    #
+    # The check itself runs inside a nested `bash -c` that captures the exit
+    # code and exits explicitly (`exit "$ec"`) rather than letting the killed
+    # command sit in tail position: bash re-raises a signal that kills the
+    # last command in a script's own tail position, which would otherwise
+    # propagate the raw SIGKILL up to this script and print an alarming,
+    # unsuppressable "Killed: 9" line to the terminal — confusing given the
+    # install itself already succeeded and this check is non-fatal.
+    check_version() {
+        bash -c '"$1" --version >/dev/null 2>&1; ec=$?; exit "$ec"' _ "$binary_path" \
+            >/dev/null 2>&1
+    }
+    if check_version || { sleep 1; check_version; }; then
         info "Installed version: $("$binary_path" --version)"
     fi
 


### PR DESCRIPTION
## Summary

Fixes two real-world `curl | bash` install-time bugs, plus hardens the release pipeline against the class of macOS issue behind one of them.

- **`tmp_dir: unbound variable`** — `main`'s `EXIT` trap referenced `$tmp_dir` (a `local`) with deferred (single-quoted) expansion. Since `main` is the script's last statement, the trap fires after `main` returns and `tmp_dir` is out of scope, so `set -u` throws "unbound variable" right as the script exits — even though installation already succeeded. Fixed by expanding `$tmp_dir` eagerly into the trap string.

- **Alarming `Killed: 9` line** — the internal `--version` smoke check printed an unsuppressable "Killed: 9" line when the freshly-installed binary's first execution got SIGKILL'd. Confirmed empirically this is bash's own signal-propagation behavior for a command in tail position (not something redirecting the command's own stdout/stderr can suppress). Wrapped the check in a nested `bash -c` that captures the exit code and exits explicitly instead of leaving the killed command in tail position, and retry once after a brief pause — the underlying trigger (a freshly-extracted macOS arm64 binary racing Gatekeeper's on-demand scan on its very first exec) is a one-shot hiccup that succeeds on every later invocation.

- **Release pipeline hardening** — `[profile.release] strip = true` runs an external strip pass *after* `ld64` has already applied its automatic ad-hoc code signature to arm64 macOS binaries, invalidating that signature; Apple Silicon's kernel refuses to exec an invalidly-signed binary at all. Added an ad-hoc `codesign --sign -` step after each macOS build. Also fixed the release workflow's smoke-test skip condition, which unconditionally skipped aarch64 targets on the (now stale) assumption they're always cross-compiled — `macos-latest` GitHub runners are native Apple Silicon, so `aarch64-apple-darwin` can and should be smoke-tested there; only genuinely cross-compiled Linux aarch64/arm targets are skipped now.

## Test plan

- [x] Reproduced both `install.sh` bugs with minimal standalone repros before fixing, and verified each fix independently
- [x] Full end-to-end dry run of the actual modified script (stubbing only network calls) using a binary that self-`SIGKILL`s on its first invocation then succeeds — confirms no spurious error output and the retry recovers the version report
- [x] `bash -n scripts/install.sh` — syntax OK
- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `cargo fmt --all -- --check` clean (unaffected files, part of the standing gate)

After merge, will re-run the release workflow via `workflow_dispatch` for the existing `v0.2.0-rc.11` tag (no version bump — only the build/signing pipeline changes) to publish a correctly signed macOS binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)