### PR TITLE
chore(release): bump version to 0.2.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.11" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.12" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.11"
+version = "0.2.0-rc.12"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Release bump to **0.2.0-rc.12**.

Bumps the version in all four required spots (root `Cargo.toml` `deacon-core` dep, `crates/deacon/Cargo.toml`, `crates/core/Cargo.toml`, `Cargo.lock`).

### Included since rc.11
- #283 — filesystem-artifact relocation (#280): lifecycle markers, build cache, feature entrypoint wrappers, the image-reference temp build context, and the CWD-relative OCI cache all move to the host user-data folder (`~/.deacon/`). Only the spec-mandated `devcontainer-lock.json` is written into the project now, matching the reference CLI.
- `outdated.rs` clippy `question_mark` fix (newer CI toolchain).

After merge, push the annotated tag `v0.2.0-rc.12` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)