### PR TITLE
chore(release): bump version to 0.2.0-rc.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.12"
+version = "0.2.0-rc.13"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.12"
+version = "0.2.0-rc.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.12" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.13" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.12"
+version = "0.2.0-rc.13"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.12"
+version = "0.2.0-rc.13"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Version bump to `0.2.0-rc.13` across the four sync spots (root `Cargo.toml` dep, `crates/deacon`, `crates/core`, `Cargo.lock`).

This release includes the user-scoped profiles feature and the `--override-config` / `--merge-config` split (#286, closes #285).

Once merged, an annotated `v0.2.0-rc.13` tag on the merge commit triggers the release workflow (8-target binaries + SHA256SUMS + SBOMs + SLSA provenance; flagged prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)