### PR TITLE
fix(up): resolve _REMOTE_USER from image metadata before feature build

### DIFF
--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -303,6 +303,11 @@ pub struct ImageInfo {
     pub id: String,
     /// Image labels (from Config.Labels)
     pub labels: HashMap<String, String>,
+    /// The image's baked-in `USER` (from `Config.User`). `None` when the image
+    /// declares no `USER` (Docker reports an empty string), which per the
+    /// features spec means the effective user is `root`. Callers resolving
+    /// `_CONTAINER_USER` use this as the lowest-precedence fallback (#89).
+    pub user: Option<String>,
 }
 
 /// Represents an exposed port from a container
@@ -647,6 +652,27 @@ pub trait Docker {
 
     /// Inspect a specific image by reference and return its info including labels
     async fn inspect_image(&self, image_ref: &str) -> Result<Option<ImageInfo>>;
+
+    /// Like [`inspect_image`](Self::inspect_image), but pulls the image first if
+    /// it isn't present locally.
+    ///
+    /// Needed when a caller must read image metadata (`devcontainer.metadata`
+    /// LABEL, `Config.User`) *before* the image would otherwise materialize —
+    /// notably the feature build, which bakes `_REMOTE_USER` into the generated
+    /// Dockerfile and therefore cannot wait for BuildKit to pull the base
+    /// itself. Mirrors upstream's `inspectDockerImage(…, pullImageOnError)`.
+    ///
+    /// A pull failure is NOT fatal here: the image may be local-only (e.g. a
+    /// just-built tag) or the registry may be unreachable while a cached copy
+    /// exists. Errors are logged and the post-pull inspect decides the outcome,
+    /// so a genuinely absent image still surfaces as `Ok(None)` to the caller.
+    ///
+    /// The default implementation ignores the pull and delegates to
+    /// `inspect_image`, which is correct for mocks and for runtimes with no
+    /// registry access.
+    async fn ensure_image_available(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
+        self.inspect_image(image_ref).await
+    }
 
     /// Execute a command in a running container
     async fn exec(
@@ -1781,7 +1807,45 @@ impl Docker for CliRuntime {
             })
             .unwrap_or_default();
 
-        Ok(Some(ImageInfo { id, labels }))
+        // `Config.User` is an empty string when the image declares no USER;
+        // normalize that to None so callers can distinguish "unset" from a
+        // real user name rather than propagating "" into `_CONTAINER_USER`.
+        let user = image
+            .get("Config")
+            .and_then(|c| c.get("User"))
+            .and_then(|u| u.as_str())
+            .filter(|u| !u.is_empty())
+            .map(|u| u.to_string());
+
+        Ok(Some(ImageInfo { id, labels, user }))
+    }
+
+    #[instrument(skip(self))]
+    async fn ensure_image_available(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
+        if let Some(info) = self.inspect_image(image_ref).await? {
+            debug!("Image '{}' already present locally", image_ref);
+            return Ok(Some(info));
+        }
+
+        debug!("Image '{}' not present locally; pulling", image_ref);
+        let qualified = self.qualify_image_ref(image_ref).await;
+        let output = Command::new(&self.runtime_path)
+            .args(["pull", &qualified])
+            .output()
+            .await
+            .map_err(|e| DockerError::CLIError(format!("Failed to run image pull: {}", e)))?;
+
+        if !output.status.success() {
+            // Best-effort: fall through to the inspect below rather than
+            // failing. See the trait docs for why a pull failure is not fatal.
+            tracing::warn!(
+                "Failed to pull image '{}': {}",
+                image_ref,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        self.inspect_image(image_ref).await
     }
 
     #[instrument(skip(self))]
@@ -2935,6 +2999,7 @@ pub mod mock {
             Ok(Some(ImageInfo {
                 id: format!("sha256:mock_{}", image_ref.replace(':', "_")),
                 labels: HashMap::new(),
+                user: None,
             }))
         }
 

--- a/crates/core/src/dockerfile_generator.rs
+++ b/crates/core/src/dockerfile_generator.rs
@@ -693,6 +693,86 @@ mod tests {
         assert!(dockerfile.contains("./install.sh"));
     }
 
+    /// Spec parity (#89): `FeatureInstallEnv::resolve` implements the
+    /// `_REMOTE_USER` → `_CONTAINER_USER` → image `USER` fallback chain.
+    #[test]
+    fn test_feature_install_env_resolution_rules() {
+        // remoteUser defaults to containerUser.
+        let env = FeatureInstallEnv::resolve(None, Some("builder"), Some("root"));
+        assert_eq!(env.remote_user.as_deref(), Some("builder"));
+        assert_eq!(env.container_user.as_deref(), Some("builder"));
+
+        // containerUser defaults to the image's USER.
+        let env = FeatureInstallEnv::resolve(None, None, Some("node"));
+        assert_eq!(env.remote_user.as_deref(), Some("node"));
+        assert_eq!(env.container_user.as_deref(), Some("node"));
+
+        // An explicit remoteUser does not leak into containerUser.
+        let env = FeatureInstallEnv::resolve(Some("vscode"), None, Some("root"));
+        assert_eq!(env.remote_user.as_deref(), Some("vscode"));
+        assert_eq!(env.container_user.as_deref(), Some("root"));
+
+        // Home dirs: root is /root, everyone else /home/<user>.
+        assert_eq!(env.remote_user_home.as_deref(), Some("/home/vscode"));
+        assert_eq!(env.container_user_home.as_deref(), Some("/root"));
+
+        // Nothing known: stays None so the caller can surface the gap.
+        let env = FeatureInstallEnv::resolve(None, None, None);
+        assert_eq!(env.remote_user, None);
+        assert_eq!(env.container_user_home, None);
+    }
+
+    /// Spec parity (#89): the resolved users must actually reach the generated
+    /// `install.sh` invocation. Features commonly do `su - "$_REMOTE_USER" -c`,
+    /// which fails outright on an empty value — so assert the exported values,
+    /// not merely that the variable names appear.
+    #[test]
+    fn test_feature_install_env_is_exported_into_install_command() {
+        let feature = create_test_feature("ai-clis", HashMap::new());
+        let plan = InstallationPlan::new(vec![feature]);
+
+        let config = DockerfileConfig {
+            base_image: "mcr.microsoft.com/devcontainers/base:ubuntu-24.04".to_string(),
+            features_source_dir: "/tmp/features".to_string(),
+            feature_install_env: FeatureInstallEnv::resolve(Some("vscode"), None, Some("root")),
+            ..Default::default()
+        };
+
+        let dockerfile = DockerfileGenerator::new(config).generate(&plan).unwrap();
+
+        assert!(
+            dockerfile.contains(r#"export _REMOTE_USER="vscode""#),
+            "resolved _REMOTE_USER must be exported, got:\n{}",
+            dockerfile
+        );
+        assert!(dockerfile.contains(r#"export _REMOTE_USER_HOME="/home/vscode""#));
+        assert!(dockerfile.contains(r#"export _CONTAINER_USER="root""#));
+        assert!(dockerfile.contains(r#"export _CONTAINER_USER_HOME="/root""#));
+        assert!(
+            !dockerfile.contains(r#"export _REMOTE_USER="""#),
+            "an empty _REMOTE_USER breaks `su - \"$_REMOTE_USER\"` in feature install scripts"
+        );
+    }
+
+    /// Unresolvable users still emit the variables (as empty strings) so that
+    /// `${_REMOTE_USER:-}` resolves to "" rather than `<unset>`.
+    #[test]
+    fn test_unresolved_feature_install_env_still_exports_empty_values() {
+        let feature = create_test_feature("node", HashMap::new());
+        let plan = InstallationPlan::new(vec![feature]);
+
+        let config = DockerfileConfig {
+            base_image: "ubuntu:22.04".to_string(),
+            features_source_dir: "/tmp/features".to_string(),
+            feature_install_env: FeatureInstallEnv::resolve(None, None, None),
+            ..Default::default()
+        };
+
+        let dockerfile = DockerfileGenerator::new(config).generate(&plan).unwrap();
+        assert!(dockerfile.contains(r#"export _REMOTE_USER="""#));
+        assert!(dockerfile.contains(r#"export _CONTAINER_USER="""#));
+    }
+
     /// 016 / T034: the host-CA install RUN step is emitted after the features
     /// mkdir and BEFORE the first feature RUN-mount, only when injection is on,
     /// and is byte-stable for the same CA set (FR-017).

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -144,6 +144,13 @@ impl Docker for ContainerRuntimeImpl {
         }
     }
 
+    async fn ensure_image_available(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
+        match self {
+            Self::Docker(runtime) => runtime.ensure_image_available(image_ref).await,
+            Self::Podman(runtime) => runtime.ensure_image_available(image_ref).await,
+        }
+    }
+
     async fn exec(
         &self,
         container_id: &str,
@@ -376,6 +383,10 @@ impl Docker for DockerRuntime {
         self.docker.inspect_image(image_ref).await
     }
 
+    async fn ensure_image_available(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
+        self.docker.ensure_image_available(image_ref).await
+    }
+
     async fn exec(
         &self,
         container_id: &str,
@@ -541,6 +552,10 @@ impl Docker for PodmanRuntime {
 
     async fn inspect_image(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
         self.runtime.inspect_image(image_ref).await
+    }
+
+    async fn ensure_image_available(&self, image_ref: &str) -> Result<Option<ImageInfo>> {
+        self.runtime.ensure_image_available(image_ref).await
     }
 
     async fn exec(

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -131,16 +131,14 @@ pub(crate) async fn build_image_with_features(
     //
     // Spec parity (#89): surface `_REMOTE_USER`, `_REMOTE_USER_HOME`,
     // `_CONTAINER_USER`, `_CONTAINER_USER_HOME` to every feature's
-    // `install.sh`. Resolved from the user config; we don't currently
-    // probe the image for its baked-in USER, so callers relying on that
-    // fallback should set `containerUser` explicitly. Empty values are
-    // still emitted so `${_REMOTE_USER:-}` resolves to "" rather than
-    // `<unset>`.
-    let feature_install_env = FeatureInstallEnv::resolve(
-        config.remote_user.as_deref(),
-        config.container_user.as_deref(),
-        None,
-    );
+    // `install.sh`. These are resolved from the base image's
+    // `devcontainer.metadata` LABEL + baked-in `USER` folded under the user
+    // config — NOT from the user config alone, since `remoteUser` is commonly
+    // declared by the base image. Empty values are still emitted so
+    // `${_REMOTE_USER:-}` resolves to "" rather than `<unset>`.
+    let feature_install_env =
+        crate::commands::up::merged_config::resolve_feature_install_env(cli, base_image, config)
+            .await;
 
     // Build-time host-CA injection (016, T038/T039): stage the bundle + script
     // when a non-empty corporate set was supplied.
@@ -294,6 +292,12 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
     // window is closed. The literal `FROM <stage>` form sidesteps that and
     // resolves directly to the previous stage in the same Dockerfile.
     let target_stage_name = "dev_containers_target_stage";
+    // Unlike the `image:` path, the "base" here is a *stage name* inside the
+    // user's Dockerfile, not a registry ref — there is nothing to inspect for a
+    // `devcontainer.metadata` LABEL or baked-in `USER` until that stage has been
+    // built. So `_REMOTE_USER` / `_CONTAINER_USER` come from the user config
+    // alone; set `remoteUser` / `containerUser` explicitly if a feature needs
+    // them on this path (#89).
     let feature_install_env = FeatureInstallEnv::resolve(
         config.remote_user.as_deref(),
         config.container_user.as_deref(),

--- a/crates/deacon/src/commands/up/merged_config.rs
+++ b/crates/deacon/src/commands/up/merged_config.rs
@@ -10,6 +10,7 @@
 use anyhow::Result;
 use deacon_core::config::DevContainerConfig;
 use deacon_core::docker::Docker;
+use deacon_core::dockerfile_generator::FeatureInstallEnv;
 use std::collections::HashMap;
 use std::path::Path;
 use tracing::debug;
@@ -277,6 +278,115 @@ pub(crate) async fn merge_image_metadata_after_image_ready(
         image_ref,
         info.labels.get("devcontainer.metadata"),
         user_config,
+    )
+}
+
+/// Resolve the four spec-mandated feature-install env vars (`_REMOTE_USER`,
+/// `_REMOTE_USER_HOME`, `_CONTAINER_USER`, `_CONTAINER_USER_HOME`) for a
+/// feature build on top of `base_image`.
+///
+/// Why this exists (#89): the feature build bakes these values into the
+/// generated Dockerfile, so they must be known *before* the build runs. But
+/// `remoteUser` frequently comes from the base image's `devcontainer.metadata`
+/// LABEL rather than the user's devcontainer.json — e.g.
+/// `mcr.microsoft.com/devcontainers/base` declares `{"remoteUser": "vscode"}` —
+/// and [`merge_image_metadata_after_image_ready`] only folds that in *after*
+/// the build. Resolving from the user config alone therefore emitted
+/// `_REMOTE_USER=""`, which silently breaks any feature that does
+/// `su - "$_REMOTE_USER" -c ...`.
+///
+/// Precedence (mirrors upstream `@devcontainers/cli`):
+/// `remoteUser` → user config, else image metadata, else `containerUser`;
+/// `containerUser` → user config, else image metadata, else the image's
+/// baked-in `USER`, else `root`.
+///
+/// The metadata is applied to a **clone** of the config purely to derive the
+/// effective users; the clone is discarded. The real merge stays where it is,
+/// post-build. This is deliberate — the feature-extended image inherits the
+/// base's `devcontainer.metadata` LABEL verbatim (deacon emits no LABEL of its
+/// own), so merging here *and* post-build would fold the same entries twice and
+/// duplicate concatenated fields like `runArgs`. Sharing
+/// [`apply_image_metadata_label`] keeps this resolution byte-identical to the
+/// post-build merge.
+///
+/// Best-effort: if the image can't be inspected or pulled we warn and fall back
+/// to the user config alone. We don't fail the build — configs whose features
+/// never read `_REMOTE_USER` are unaffected — but the warning makes the gap
+/// visible instead of silent.
+pub(crate) async fn resolve_feature_install_env(
+    docker: &impl Docker,
+    base_image: &str,
+    config: &DevContainerConfig,
+) -> FeatureInstallEnv {
+    let info = match docker.ensure_image_available(base_image).await {
+        Ok(Some(info)) => Some(info),
+        Ok(None) => {
+            tracing::warn!(
+                "Image '{}' is unavailable locally and could not be pulled; resolving \
+                 feature install env (_REMOTE_USER, _CONTAINER_USER) from devcontainer.json \
+                 alone. Features that depend on these may misbehave — set \"remoteUser\" / \
+                 \"containerUser\" explicitly to be sure (#89).",
+                base_image
+            );
+            None
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to inspect image '{}' while resolving feature install env \
+                 (_REMOTE_USER, _CONTAINER_USER); falling back to devcontainer.json alone: {}",
+                base_image,
+                e
+            );
+            None
+        }
+    };
+
+    let Some(info) = info else {
+        return resolve_feature_install_env_from_image(base_image, None, None, config);
+    };
+
+    // The image was inspected successfully, so an absent `Config.User` really
+    // does mean `root` (upstream: `imageDetails.Config.User || 'root'`).
+    let image_user = info.user.as_deref().unwrap_or("root");
+
+    let env = resolve_feature_install_env_from_image(
+        base_image,
+        info.labels.get("devcontainer.metadata"),
+        Some(image_user),
+        config,
+    );
+
+    debug!(
+        remote_user = ?env.remote_user,
+        container_user = ?env.container_user,
+        image_user = %image_user,
+        "Resolved feature install env from image metadata + config (#89)"
+    );
+
+    env
+}
+
+/// Pure helper behind [`resolve_feature_install_env`]. Extracted so the
+/// precedence rules can be unit-tested without a Docker mock (mirrors
+/// [`apply_image_metadata_label`]).
+///
+/// `image_user` is `None` when the image could not be inspected at all — in
+/// which case there is no metadata label either and resolution degrades to the
+/// user config alone.
+fn resolve_feature_install_env_from_image(
+    base_image: &str,
+    label: Option<&String>,
+    image_user: Option<&str>,
+    config: &DevContainerConfig,
+) -> FeatureInstallEnv {
+    // Fold the image's metadata in at lower precedence than the user config,
+    // then read the effective users back off the result.
+    let effective = apply_image_metadata_label(base_image, label, config.clone());
+
+    FeatureInstallEnv::resolve(
+        effective.remote_user.as_deref(),
+        effective.container_user.as_deref(),
+        image_user,
     )
 }
 
@@ -721,5 +831,132 @@ mod image_metadata_merge_tests {
         let label = r#"[]"#.to_string();
         let merged = apply_image_metadata_label("alpine:3.18", Some(&label), user);
         assert_eq!(merged.container_env, user_clone.container_env);
+    }
+}
+
+#[cfg(test)]
+mod feature_install_env_tests {
+    //! Spec parity (#89): the four `_*_USER` env vars handed to every feature's
+    //! `install.sh` must be resolved from the base image's
+    //! `devcontainer.metadata` LABEL and baked-in `USER` folded *under* the
+    //! user's devcontainer.json — not from the user config alone.
+
+    use super::resolve_feature_install_env_from_image;
+    use deacon_core::config::DevContainerConfig;
+
+    /// The `mcr.microsoft.com/devcontainers/base` family declares its
+    /// `remoteUser` via the image label rather than the user's config.
+    fn base_image_label() -> String {
+        r#"[
+            { "id": "ghcr.io/devcontainers/features/common-utils:2" },
+            { "remoteUser": "vscode" }
+        ]"#
+        .to_string()
+    }
+
+    #[test]
+    fn remote_user_comes_from_image_metadata_when_config_is_silent() {
+        // The regression that motivated this (#89): devcontainer.json sets
+        // neither remoteUser nor containerUser, the base image declares
+        // remoteUser=vscode, and features doing `su - "$_REMOTE_USER"` were
+        // handed an empty string and silently failed to install.
+        let env = resolve_feature_install_env_from_image(
+            "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+            Some(&base_image_label()),
+            Some("root"),
+            &DevContainerConfig::default(),
+        );
+
+        assert_eq!(
+            env.remote_user.as_deref(),
+            Some("vscode"),
+            "_REMOTE_USER must come from the image's devcontainer.metadata label"
+        );
+        assert_eq!(
+            env.remote_user_home.as_deref(),
+            Some("/home/vscode"),
+            "_REMOTE_USER_HOME must follow the resolved remote user"
+        );
+        // containerUser is unset in both config and label, so it falls back to
+        // the image's baked-in USER.
+        assert_eq!(env.container_user.as_deref(), Some("root"));
+        assert_eq!(env.container_user_home.as_deref(), Some("/root"));
+    }
+
+    #[test]
+    fn user_config_wins_over_image_metadata() {
+        let user = DevContainerConfig {
+            remote_user: Some("devuser".to_string()),
+            ..DevContainerConfig::default()
+        };
+        let env = resolve_feature_install_env_from_image(
+            "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+            Some(&base_image_label()),
+            Some("root"),
+            &user,
+        );
+        assert_eq!(env.remote_user.as_deref(), Some("devuser"));
+        assert_eq!(env.remote_user_home.as_deref(), Some("/home/devuser"));
+    }
+
+    #[test]
+    fn remote_user_falls_back_to_container_user_then_image_user() {
+        // No remoteUser anywhere, but containerUser is set: _REMOTE_USER
+        // defaults to _CONTAINER_USER per the features spec.
+        let user = DevContainerConfig {
+            container_user: Some("builder".to_string()),
+            ..DevContainerConfig::default()
+        };
+        let env = resolve_feature_install_env_from_image("img", None, Some("root"), &user);
+        assert_eq!(env.remote_user.as_deref(), Some("builder"));
+        assert_eq!(env.container_user.as_deref(), Some("builder"));
+
+        // Nothing set anywhere: both fall through to the image's USER.
+        let env = resolve_feature_install_env_from_image(
+            "img",
+            None,
+            Some("node"),
+            &DevContainerConfig::default(),
+        );
+        assert_eq!(env.remote_user.as_deref(), Some("node"));
+        assert_eq!(env.container_user.as_deref(), Some("node"));
+        assert_eq!(env.remote_user_home.as_deref(), Some("/home/node"));
+    }
+
+    #[test]
+    fn uninspectable_image_degrades_to_user_config() {
+        // Image could not be pulled/inspected (image_user = None). We still
+        // honor whatever the config states rather than inventing a user.
+        let user = DevContainerConfig {
+            remote_user: Some("devuser".to_string()),
+            ..DevContainerConfig::default()
+        };
+        let env = resolve_feature_install_env_from_image("img", None, None, &user);
+        assert_eq!(env.remote_user.as_deref(), Some("devuser"));
+
+        // With nothing to go on, everything stays None — the generator emits
+        // empty strings and the caller has already warned.
+        let env = resolve_feature_install_env_from_image(
+            "img",
+            None,
+            None,
+            &DevContainerConfig::default(),
+        );
+        assert_eq!(env.remote_user, None);
+        assert_eq!(env.container_user, None);
+    }
+
+    #[test]
+    fn malformed_label_does_not_break_resolution() {
+        let bad = "{ not a json array }".to_string();
+        let env = resolve_feature_install_env_from_image(
+            "img",
+            Some(&bad),
+            Some("root"),
+            &DevContainerConfig::default(),
+        );
+        // Falls back to the image USER rather than failing the build.
+        assert_eq!(env.remote_user.as_deref(), Some("root"));
+        assert_eq!(env.container_user.as_deref(), Some("root"));
     }
 }


### PR DESCRIPTION
## The bug

Features that install as the remote user are **silently skipped** when `devcontainer.json` doesn't set `remoteUser`. Reported against a config using `ghcr.io/get2knowio/devcontainer-features/ai-clis:2` with `install: "claudeCode,specifyCli"` — `deacon up` reported success, but neither CLI was in the container.

The generated feature-install layer looked like this:

```
export INSTALL="claudeCode,specifyCli" && export OMIT="" && \
export _REMOTE_USER="" && export _REMOTE_USER_HOME="" && \
export _CONTAINER_USER="" && export _CONTAINER_USER_HOME="" && \
cd .../ai-clis_1 && chmod +x install.sh && ./install.sh
```

The option was passed correctly; `_REMOTE_USER` was empty. ai-clis does:

```sh
su - "$_REMOTE_USER" -c 'curl -fsSL https://claude.ai/install.sh | bash' || echo "Warning: Claude Code installation failed"
```

`su - ""` exits 1 (*"user does not exist"*), the `||` swallows it, the build succeeds, and the CLI is simply absent. Other features in the same config (act, eza, jj, ruff, poetry) installed fine — they don't read `_REMOTE_USER`.

## Root cause

An ordering bug. The config set no `remoteUser`, so it had to come from the base image: `mcr.microsoft.com/devcontainers/base:ubuntu-24.04` ships `devcontainer.metadata: [… {"remoteUser": "vscode"}]`.

deacon reads that label, but only in `merge_image_metadata_after_image_ready` (`container.rs:324`) — *after* `build_image_with_features` (`container.rs:279`). By then the Dockerfile has already been generated, so `FeatureInstallEnv::resolve` (`features_build.rs:139`) saw `config.remote_user == None` and `dockerfile_generator.rs:317` turned it into `""` via `unwrap_or("")`.

`resolve` already accepted an `image_user` fallback, but both call sites hardcoded `None`, and `ImageInfo` had no `Config.User` field — so it was dead code.

## The fix

Resolve the four vars before the build, mirroring upstream's `inspectDockerImage(…, pullImageOnError)` → `imageUser = Config.User || 'root'`:

- **`ImageInfo.user`** — exposes `Config.User`, activating the `image_user` fallback.
- **`Docker::ensure_image_available`** — inspect → pull if absent → re-inspect. Default impl delegates to `inspect_image` (per the trait-extension pattern in `CLAUDE.md`); forwarded through the wrapper runtimes. **The pull is load-bearing:** on a cold cache the base image isn't local until BuildKit pulls it mid-build, so without it the fix would only work on a warm cache.
- **`resolve_feature_install_env`** — folds image metadata under the user config through the existing `apply_image_metadata_label`, so precedence stays identical to the post-build merge.

### Two decisions worth reviewing

**Discarded clone instead of an early merge.** The feature-extended image *inherits* the base's `devcontainer.metadata` label verbatim (deacon emits no `LABEL` of its own), so the post-build merge already reads exactly this label — just too late. Merging both pre- and post-build would fold the same entries twice and duplicate concatenated fields like `runArgs` (`concat_string_arrays`). So the clone is used purely to derive the effective users and thrown away; the real merge stays where it is.

**Dockerfile path unchanged.** Its "base" is a stage name inside the user's Dockerfile, not an inspectable ref — nothing to inspect until it's built. Behavior is as before, but the constraint is now documented rather than implicit.

Best-effort by design: if the image can't be inspected or pulled we warn and fall back to the user config. Failing the build would break configs whose features never read these vars — but the warning makes the gap visible instead of silent.

## Tests

These four vars had **zero** test coverage, which is how this shipped. Adds 9 unit tests: the resolution/precedence chain, image-metadata-vs-user-config precedence, malformed labels, uninspectable images, and assertions on the emitted `export` lines (including that `_REMOTE_USER=""` is *not* emitted when resolvable). No new test binaries, so no `nextest.toml` changes.

## Verification

A/B'd real binaries (this branch vs unmodified `main`) against an isolated workspace using the reported config — the real ai-clis feature on `base:ubuntu-24.04` with `install: "claudeCode,specifyCli"`:

| | `main` | this branch |
|---|---|---|
| `_REMOTE_USER` | `[]` | `[vscode]` |
| `su - "$_REMOTE_USER"` | `FAILED` | `ok` |
| `claude` / `specify` | **MISSING** | **FOUND** at `/home/vscode/.local/bin/` |

Both reported `"outcome": "success"` — the failure was entirely silent, which is the part worth fixing.

`cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean; 410 + 407 lib/bin tests pass.

> [!NOTE]
> Verification ran in a `rust:slim` container against the host Docker daemon (no local Rust toolchain), so CI is the authority on the full suite. Two tests (`oci::fetcher::test_install_script_*`, intermittently `plugins::test_config_augmentation`) fail in that container — but they fail identically on unmodified `main`. They're env-sensitive (`ReqwestClient::new()` reads the host trust store and `~/.docker/config.json`) and look like pre-existing env-var pollution between tests. Untouched here; worth a separate issue.

Context: #89 (original implementation of these vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)