### PR TITLE
chore(release): bump version to 0.2.0-rc.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.13" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.14" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.13"
+version = "0.2.0-rc.14"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Bumps the workspace to `0.2.0-rc.14` across all four spots that must stay in sync (root `Cargo.toml`'s `deacon-core` dep, both crate manifests, and `Cargo.lock`), so the `v0.2.0-rc.14` tag validates against `crates/deacon/Cargo.toml`.

## What's in this RC

**#299 — `fix(up): resolve _REMOTE_USER from image metadata before feature build`**

Features that install as the remote user were silently skipped when `devcontainer.json` didn't set `remoteUser`. The feature-install Dockerfile baked `_REMOTE_USER=""` because the base image's `devcontainer.metadata` label (e.g. `{"remoteUser": "vscode"}`) was only merged *after* the feature build. Any feature doing `su - "$_REMOTE_USER" -c ... || echo "Warning: ..."` failed and swallowed the error, so `up` reported success with the tools absent.

Verified end-to-end against the real ai-clis feature: `claude` and `specify` now install to `/home/vscode/.local/bin/`, where before both were missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)