### PR TITLE
fix(parity): resolve compose exec/workspace and entrypoint gaps

### DIFF
--- a/crates/core/src/compose.rs
+++ b/crates/core/src/compose.rs
@@ -852,7 +852,7 @@ impl ComposeManager {
 
         // Deacon-namespaced project name, unique per devcontainer (workspace +
         // config hash), so sibling devcontainers in one repo never collide.
-        let project_name = derive_project_name(base_path, config);
+        let project_name = derive_project_name(base_path, config, &resolved_files);
 
         Ok(ComposeProject {
             name: project_name,
@@ -1363,6 +1363,15 @@ impl ComposeProject {
         if !self.additional_mounts.is_empty() {
             yaml.push_str("    volumes:\n");
             for mount in &self.additional_mounts {
+                if mount.mount_type == "tmpfs" {
+                    yaml.push_str("      - type: tmpfs\n");
+                    yaml.push_str(&format!("        target: {}\n", mount.target));
+                    if mount.read_only {
+                        yaml.push_str("        read_only: true\n");
+                    }
+                    continue;
+                }
+
                 let mut mount_str = format!("{}:{}", mount.source, mount.target);
                 // Build options suffix: ro and/or consistency
                 // Docker Compose short-form: source:target:options
@@ -1598,7 +1607,61 @@ fn parse_env_file_for_project_name(env_file_path: &Path) -> Option<String> {
     None
 }
 
-fn derive_project_name(base_path: &Path, config: &DevContainerConfig) -> String {
+/// Parse compose file and extract top-level `name` if present.
+fn parse_compose_file_for_project_name(compose_file_path: &Path) -> Option<String> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    if !compose_file_path.exists() {
+        return None;
+    }
+
+    let file = File::open(compose_file_path).ok()?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line.ok()?;
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        // Top-level `name:` is unindented in compose files.
+        if line.starts_with(' ') || line.starts_with('\t') {
+            continue;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("name:") {
+            let value = value.trim();
+            let value = value
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .unwrap_or(value);
+            let value = value
+                .strip_prefix('\'')
+                .and_then(|v| v.strip_suffix('\''))
+                .unwrap_or(value);
+
+            if !value.is_empty() {
+                debug!(
+                    "Found compose top-level project name in {}: {}",
+                    compose_file_path.display(),
+                    value
+                );
+                return Some(value.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+fn derive_project_name(
+    base_path: &Path,
+    config: &DevContainerConfig,
+    compose_files: &[PathBuf],
+) -> String {
     // An explicit COMPOSE_PROJECT_NAME in a sibling `.env` is used verbatim
     // (no suffix) — this is a deliberate user override, so honor it exactly
     // as docker compose and the reference CLI would.
@@ -1606,6 +1669,16 @@ fn derive_project_name(base_path: &Path, config: &DevContainerConfig) -> String 
     if let Some(project_name) = parse_env_file_for_project_name(&env_file_path) {
         debug!("Using project name from .env file: {}", project_name);
         return project_name;
+    }
+
+    for compose_file in compose_files {
+        if let Some(project_name) = parse_compose_file_for_project_name(compose_file) {
+            debug!(
+                "Using project name from compose top-level `name`: {}",
+                project_name
+            );
+            return project_name;
+        }
     }
 
     // Auto-derived default: deacon-namespaced (#265) and unique per devcontainer.
@@ -1921,7 +1994,7 @@ mod tests {
     fn test_derive_project_name_is_deacon_namespaced_and_hash_based() {
         let path = Path::new("/tmp/my-workspace");
         let config = DevContainerConfig::default();
-        let name = derive_project_name(path, &config);
+        let name = derive_project_name(path, &config, &[]);
         assert!(
             name.starts_with("deacon_"),
             "expected deacon_<hash>, got {name}"
@@ -1941,8 +2014,8 @@ mod tests {
     fn test_derive_project_name_deterministic_and_not_reference_form() {
         let path = Path::new("/home/user/myapp");
         let config = DevContainerConfig::default();
-        let first = derive_project_name(path, &config);
-        let second = derive_project_name(path, &config);
+        let first = derive_project_name(path, &config, &[]);
+        let second = derive_project_name(path, &config, &[]);
         assert_eq!(first, second, "derivation must be deterministic");
         assert_ne!(
             first, "myapp_devcontainer",
@@ -1954,8 +2027,8 @@ mod tests {
     #[test]
     fn test_derive_project_name_differs_per_workspace() {
         let config = DevContainerConfig::default();
-        let a = derive_project_name(Path::new("/tmp/workspace-a"), &config);
-        let b = derive_project_name(Path::new("/tmp/workspace-b"), &config);
+        let a = derive_project_name(Path::new("/tmp/workspace-a"), &config, &[]);
+        let b = derive_project_name(Path::new("/tmp/workspace-b"), &config, &[]);
         assert_ne!(a, b);
     }
 
@@ -1977,8 +2050,8 @@ mod tests {
             name: Some("web".to_string()),
             ..DevContainerConfig::default()
         };
-        let a = derive_project_name(path, &config_a);
-        let b = derive_project_name(path, &config_b);
+        let a = derive_project_name(path, &config_a, &[]);
+        let b = derive_project_name(path, &config_b, &[]);
         assert_ne!(
             a, b,
             "sibling devcontainers under one workspace path must not share a compose project name"
@@ -1997,7 +2070,46 @@ mod tests {
         .unwrap();
         let config = DevContainerConfig::default();
         assert_eq!(
-            derive_project_name(temp_dir.path(), &config),
+            derive_project_name(temp_dir.path(), &config, &[]),
+            "my-custom-project"
+        );
+    }
+
+    #[test]
+    fn test_derive_project_name_compose_top_level_name_used_verbatim() {
+        let temp_dir = TempDir::new().unwrap();
+        let compose_file = temp_dir.path().join("docker-compose.yml");
+        std::fs::write(
+            &compose_file,
+            "name: r4-explicit-project\nservices:\n  app:\n    image: alpine:3.18\n",
+        )
+        .unwrap();
+        let config = DevContainerConfig::default();
+
+        assert_eq!(
+            derive_project_name(temp_dir.path(), &config, &[compose_file]),
+            "r4-explicit-project"
+        );
+    }
+
+    #[test]
+    fn test_derive_project_name_env_override_wins_over_compose_name() {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(
+            temp_dir.path().join(".env"),
+            "COMPOSE_PROJECT_NAME=my-custom-project\n",
+        )
+        .unwrap();
+        let compose_file = temp_dir.path().join("docker-compose.yml");
+        std::fs::write(
+            &compose_file,
+            "name: r4-explicit-project\nservices:\n  app:\n    image: alpine:3.18\n",
+        )
+        .unwrap();
+        let config = DevContainerConfig::default();
+
+        assert_eq!(
+            derive_project_name(temp_dir.path(), &config, &[compose_file]),
             "my-custom-project"
         );
     }
@@ -2166,6 +2278,36 @@ mod tests {
         assert!(override_yaml.contains("volumes:"));
         assert!(override_yaml.contains("/host/path:/container/path"));
         assert!(override_yaml.contains("/another/host:/another/container:ro"));
+    }
+
+    #[test]
+    fn test_generate_injection_override_with_tmpfs_mount() {
+        let project = ComposeProject {
+            name: "test".to_string(),
+            base_path: PathBuf::from("/test"),
+            compose_files: vec![PathBuf::from("docker-compose.yml")],
+            service: "myservice".to_string(),
+            run_services: Vec::new(),
+            env_files: Vec::new(),
+            additional_mounts: vec![ComposeMount {
+                mount_type: "tmpfs".to_string(),
+                source: String::new(),
+                target: "/mnt/config-tmp".to_string(),
+                read_only: false,
+                consistency: None,
+            }],
+            profiles: Vec::new(),
+            additional_env: IndexMap::new(),
+            external_volumes: Vec::new(),
+            override_command: Some(false),
+            service_image_override: None,
+            deacon_labels: IndexMap::new(),
+        };
+
+        let override_yaml = project.generate_injection_override().unwrap();
+        assert!(override_yaml.contains("volumes:"));
+        assert!(override_yaml.contains("- type: tmpfs"));
+        assert!(override_yaml.contains("target: /mnt/config-tmp"));
     }
 
     #[test]

--- a/crates/core/src/container.rs
+++ b/crates/core/src/container.rs
@@ -64,6 +64,9 @@ pub struct ContainerIdentity {
     /// Newline-joined subject DNs of the injected corporate CAs (016).
     /// Informational; emitted as `devcontainer.deacon.hostCaSubjects`.
     pub host_ca_subjects: Option<String>,
+    /// User-provided identification labels (for example, from `--id-label`)
+    /// that should be stamped onto created containers.
+    pub additional_labels: HashMap<String, String>,
 }
 
 /// Container creation result
@@ -153,6 +156,7 @@ impl ContainerIdentity {
             config_file: None,
             host_ca_bundle_path: None,
             host_ca_subjects: None,
+            additional_labels: HashMap::new(),
         }
     }
 
@@ -175,6 +179,16 @@ impl ContainerIdentity {
     pub fn with_host_ca(mut self, bundle_path: impl Into<String>, subjects: &[String]) -> Self {
         self.host_ca_bundle_path = Some(bundle_path.into());
         self.host_ca_subjects = Some(subjects.join("\n"));
+        self
+    }
+
+    /// Attach additional container labels.
+    ///
+    /// Keys are stored as-is and overwrite any existing key in this identity.
+    pub fn with_additional_labels(mut self, labels: &[(String, String)]) -> Self {
+        for (key, value) in labels {
+            self.additional_labels.insert(key.clone(), value.clone());
+        }
         self
     }
 
@@ -280,6 +294,10 @@ impl ContainerIdentity {
         }
         if let Some(ref subjects) = self.host_ca_subjects {
             labels.insert(LABEL_HOST_CA_SUBJECTS.to_string(), subjects.clone());
+        }
+
+        for (key, value) in &self.additional_labels {
+            labels.insert(key.clone(), value.clone());
         }
 
         labels
@@ -469,6 +487,30 @@ mod tests {
             "devcontainer.config_file must be the absolute path to the resolved devcontainer.json"
         );
         assert!(labels.contains_key(LABEL_LOCAL_FOLDER));
+    }
+
+    #[test]
+    fn test_labels_include_additional_labels_when_set() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+
+        let config = DevContainerConfig {
+            name: Some("extra-labels".to_string()),
+            image: Some("alpine:3.18".to_string()),
+            ..Default::default()
+        };
+
+        let identity = ContainerIdentity::new(workspace_path, &config).with_additional_labels(&[
+            ("devcontainer.conformance".to_string(), "case01".to_string()),
+            ("custom.scope".to_string(), "integration".to_string()),
+        ]);
+        let labels = identity.labels();
+
+        assert_eq!(
+            labels.get("devcontainer.conformance"),
+            Some(&"case01".to_string())
+        );
+        assert_eq!(labels.get("custom.scope"), Some(&"integration".to_string()));
     }
 
     #[test]

--- a/crates/core/src/container_env_probe.rs
+++ b/crates/core/src/container_env_probe.rs
@@ -593,6 +593,7 @@ impl ContainerEnvironmentProber {
     pub fn build_effective_env(
         &self,
         probed_env: &HashMap<String, String>,
+        container_env_for_substitution: &HashMap<String, String>,
         config_remote_env: Option<&HashMap<String, Option<String>>>,
         cli_env: &IndexMap<String, String>,
     ) -> HashMap<String, String> {
@@ -615,7 +616,7 @@ impl ContainerEnvironmentProber {
                 local_env: HashMap::new(),
                 devcontainer_id: String::new(),
                 container_workspace_folder: None,
-                container_env: Some(probed_env.clone()),
+                container_env: Some(container_env_for_substitution.clone()),
                 feature_vars: HashMap::new(),
                 template_options: None,
                 resolve_devcontainer_id: true,
@@ -1002,7 +1003,12 @@ mod tests {
         // CLI sets C to value -> should be present
         cli_env.insert("C".to_string(), "from_cli_c".to_string());
 
-        let result = prober.build_effective_env(&probed_env, Some(&config_remote_env), &cli_env);
+        let result = prober.build_effective_env(
+            &probed_env,
+            &probed_env,
+            Some(&config_remote_env),
+            &cli_env,
+        );
 
         // A should come from config (overrides probed)
         assert_eq!(result.get("A"), Some(&"from_config".to_string()));
@@ -1034,7 +1040,12 @@ mod tests {
         );
 
         let cli_env: IndexMap<String, String> = IndexMap::new();
-        let result = prober.build_effective_env(&probed_env, Some(&config_remote_env), &cli_env);
+        let result = prober.build_effective_env(
+            &probed_env,
+            &probed_env,
+            Some(&config_remote_env),
+            &cli_env,
+        );
 
         assert_eq!(
             result.get("PATH"),
@@ -1047,6 +1058,44 @@ mod tests {
         );
         // No unresolved template should remain.
         assert!(!result.get("PATH").unwrap().contains("${"));
+    }
+
+    #[test]
+    fn test_build_effective_env_uses_container_env_not_probed_for_container_substitute() {
+        // Parity (#298): ${containerEnv:PATH} should resolve from container env
+        // (Config.Env), not userEnvProbe-augmented PATH.
+        let prober = ContainerEnvironmentProber::new();
+
+        let mut probed_env = HashMap::new();
+        probed_env.insert(
+            "PATH".to_string(),
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/vscode/.local/bin"
+                .to_string(),
+        );
+        let mut container_env = HashMap::new();
+        container_env.insert(
+            "PATH".to_string(),
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
+        );
+
+        let mut config_remote_env: HashMap<String, Option<String>> = HashMap::new();
+        config_remote_env.insert(
+            "R2_PATH".to_string(),
+            Some("${containerEnv:PATH}".to_string()),
+        );
+
+        let cli_env: IndexMap<String, String> = IndexMap::new();
+        let result = prober.build_effective_env(
+            &probed_env,
+            &container_env,
+            Some(&config_remote_env),
+            &cli_env,
+        );
+
+        assert_eq!(
+            result.get("R2_PATH"),
+            Some(&"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string())
+        );
     }
 
     /// Spec parity: the `userEnvProbe` config field (deserialized via serde from

--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -32,6 +32,10 @@ fn is_pty_allocation_error(error_msg: &str) -> bool {
         || (lower.contains("tty") && (lower.contains("not a") || lower.contains("cannot")))
 }
 
+fn shell_quote_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 /// Resolve the exit code from a finished docker child process.
 ///
 /// Containerd encodes signal-killed inner processes into ExitCode as 128+N
@@ -741,6 +745,28 @@ pub trait DockerLifecycle: Docker + ContainerOps {
         merged_mounts: &crate::mount::MergedMounts,
         entrypoint_chain: &crate::features::EntrypointChain,
     ) -> Result<ContainerResult>;
+}
+
+async fn ensure_container_running<D: Docker + ?Sized>(
+    docker: &D,
+    container_id: &str,
+) -> Result<()> {
+    let info = docker
+        .inspect_container(container_id)
+        .await?
+        .ok_or_else(|| DockerError::ContainerNotFound {
+            id: container_id.to_string(),
+        })?;
+
+    if !info.state.eq_ignore_ascii_case("running") {
+        return Err(DockerError::CLIError(format!(
+            "Container '{}' is not running after start (state='{}', status='{}')",
+            container_id, info.state, info.status
+        ))
+        .into());
+    }
+
+    Ok(())
 }
 
 // Implement Docker trait for references to types that implement Docker
@@ -2303,18 +2329,29 @@ impl ContainerOps for CliRuntime {
             args.push(container_user.clone());
         }
 
-        // Apply entrypoint from chain (features + config)
-        match entrypoint_chain {
-            crate::features::EntrypointChain::None => {
-                // Use image default entrypoint
-            }
-            crate::features::EntrypointChain::Single(path) => {
-                args.push("--entrypoint".to_string());
-                args.push(path.clone());
-            }
-            crate::features::EntrypointChain::Chained { wrapper_path, .. } => {
-                args.push("--entrypoint".to_string());
-                args.push(wrapper_path.clone());
+        // Respect overrideCommand semantics (default: true)
+        let override_cmd = config.override_command.unwrap_or(true);
+
+        // Apply entrypoint from chain (features + config). When overrideCommand
+        // is enabled we mirror the reference process shape: /bin/sh entrypoint
+        // plus a command wrapper, and fold feature/config entrypoints into that
+        // wrapper command instead of Docker Config.Entrypoint.
+        if override_cmd {
+            args.push("--entrypoint".to_string());
+            args.push("/bin/sh".to_string());
+        } else {
+            match entrypoint_chain {
+                crate::features::EntrypointChain::None => {
+                    // Use image default entrypoint
+                }
+                crate::features::EntrypointChain::Single(path) => {
+                    args.push("--entrypoint".to_string());
+                    args.push(path.clone());
+                }
+                crate::features::EntrypointChain::Chained { wrapper_path, .. } => {
+                    args.push("--entrypoint".to_string());
+                    args.push(wrapper_path.clone());
+                }
             }
         }
 
@@ -2369,12 +2406,12 @@ impl ContainerOps for CliRuntime {
         // No-op under docker.
         args.push(self.qualify_image_ref(image).await);
 
-        // Respect overrideCommand semantics (default: true)
         // When enabled, ensure the container stays running so lifecycle commands can execute.
         // Use a minimal keep-alive command that is broadly available.
         // Reference: DevContainer spec "overrideCommand".
-        let override_cmd = config.override_command.unwrap_or(true);
         if override_cmd {
+            let keepalive_cmd = "export PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}\"; \
+                 sleep infinity || tail -f /dev/null";
             // Portable keep-alive: prefer `sleep infinity` (GNU coreutils), fall
             // back to `tail -f /dev/null` (BusyBox/Alpine, where `sleep infinity`
             // is rejected). Prepend a standard PATH first: some features (e.g.
@@ -2382,13 +2419,21 @@ impl ContainerOps for CliRuntime {
             // which would otherwise drop `/usr/bin`+`/bin` and make the bare
             // `sleep`/`tail` here resolve to "not found" (exit 127 → the
             // container dies before any lifecycle command can run).
-            args.push("/bin/sh".to_string());
+            let wrapped_cmd = match entrypoint_chain {
+                crate::features::EntrypointChain::None => keepalive_cmd.to_string(),
+                crate::features::EntrypointChain::Single(path) => format!(
+                    "{} /bin/sh -c {}",
+                    shell_quote_arg(path),
+                    shell_quote_arg(keepalive_cmd)
+                ),
+                crate::features::EntrypointChain::Chained { wrapper_path, .. } => format!(
+                    "{} /bin/sh -c {}",
+                    shell_quote_arg(wrapper_path),
+                    shell_quote_arg(keepalive_cmd)
+                ),
+            };
             args.push("-c".to_string());
-            args.push(
-                "export PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${PATH:-}\"; \
-                 sleep infinity || tail -f /dev/null"
-                    .to_string(),
-            );
+            args.push(wrapped_cmd);
         }
 
         // Execute container create command
@@ -2524,6 +2569,7 @@ impl DockerLifecycle for CliRuntime {
 
             // Start the container if it's not running
             self.start_container(&container_id).await?;
+            ensure_container_running(self, &container_id).await?;
 
             // Get the image ID
             let image_id = self.get_container_image(&container_id).await?;
@@ -2556,6 +2602,7 @@ impl DockerLifecycle for CliRuntime {
             )
             .await?;
         self.start_container(&container_id).await?;
+        ensure_container_running(self, &container_id).await?;
 
         // Get the image ID
         let image_id = self.get_container_image(&container_id).await?;
@@ -2774,6 +2821,10 @@ pub mod mock {
         pub capture_tty_flags: bool,
         /// Simulate Docker daemon unavailable
         pub daemon_unavailable: bool,
+        /// Container state reported after `start_container`
+        pub state_after_start: String,
+        /// Container status reported after `start_container`
+        pub status_after_start: String,
     }
 
     impl Default for MockDockerConfig {
@@ -2784,6 +2835,8 @@ pub mod mock {
                 exec_responses: HashMap::new(),
                 capture_tty_flags: true,
                 daemon_unavailable: false,
+                state_after_start: "running".to_string(),
+                status_after_start: "Up 1 second".to_string(),
             }
         }
     }
@@ -3166,13 +3219,16 @@ pub mod mock {
             if config.daemon_unavailable {
                 return Err(DockerError::NotInstalled.into());
             }
+            let state_after_start = config.state_after_start.clone();
+            let status_after_start = config.status_after_start.clone();
+            drop(config);
 
             // Update container state to running
             let mut containers = self.containers.lock().unwrap();
             for container in containers.iter_mut() {
                 if container.id == container_id {
-                    container.state = "running".to_string();
-                    container.status = "Up 1 second".to_string();
+                    container.state = state_after_start.clone();
+                    container.status = status_after_start.clone();
                     debug!("MockDocker container started");
                     return Ok(());
                 }
@@ -3283,6 +3339,7 @@ pub mod mock {
 
                 // Start the container if it's not running
                 self.start_container(&container_id).await?;
+                super::ensure_container_running(self, &container_id).await?;
 
                 // Get the image ID
                 let image_id = self.get_container_image(&container_id).await?;
@@ -3315,6 +3372,7 @@ pub mod mock {
                 )
                 .await?;
             self.start_container(&container_id).await?;
+            super::ensure_container_running(self, &container_id).await?;
 
             // Get the image ID
             let image_id = self.get_container_image(&container_id).await?;
@@ -3936,6 +3994,7 @@ mod tests {
             config_file: None,
             host_ca_bundle_path: None,
             host_ca_subjects: None,
+            additional_labels: HashMap::new(),
         };
 
         let config = DevContainerConfig {
@@ -3978,6 +4037,45 @@ mod tests {
         // Verify container is gone
         let result = mock_docker.get_container_image(&container_id).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_mock_docker_up_fails_if_container_not_running_after_start() {
+        let config = mock::MockDockerConfig {
+            state_after_start: "exited".to_string(),
+            status_after_start: "Exited (0)".to_string(),
+            ..Default::default()
+        };
+        let mock_docker = mock::MockDocker::with_config(config);
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let workspace_path = temp_dir.path();
+        let devcontainer = DevContainerConfig {
+            image: Some("ubuntu:20.04".to_string()),
+            ..Default::default()
+        };
+        let identity = ContainerIdentity::new(workspace_path, &devcontainer);
+        let merged_security = crate::features::MergedSecurityOptions::default();
+        let merged_mounts = crate::mount::MergedMounts::default();
+        let entrypoint_chain = crate::features::EntrypointChain::None;
+
+        let result = mock_docker
+            .up(
+                &identity,
+                &devcontainer,
+                workspace_path,
+                false,
+                crate::gpu::GpuMode::None,
+                &merged_security,
+                &merged_mounts,
+                &entrypoint_chain,
+            )
+            .await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("is not running after start"));
+        assert!(msg.contains("state='exited'"));
     }
 
     // Tests for derive_container_workspace_folder heuristic

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -170,6 +170,7 @@ where
     if config.uses_compose() {
         debug!("Configuration uses Docker Compose, resolving via compose manager");
         return resolve_compose_target_container(
+            docker_client,
             workspace_folder,
             config,
             config_dir,
@@ -327,8 +328,9 @@ fn create_compose_project_for_exec(
 }
 
 /// Resolve the target container for Docker Compose configurations
-#[instrument]
+#[instrument(skip(docker_client))]
 async fn resolve_compose_target_container(
+    docker_client: &impl Docker,
     workspace_folder: &Path,
     config: &DevContainerConfig,
     config_dir: &Path,
@@ -380,6 +382,32 @@ async fn resolve_compose_target_container(
             Ok(container_id.clone())
         }
         None => {
+            // Fallback parity path: if compose-project resolution fails, try the
+            // deacon identity labels + compose service label directly via `docker ps`.
+            // This recovers from project-name drift while still requiring a running
+            // container that matches this workspace/config identity.
+            let identity = canonical_reconnect_identity(workspace_folder, config, None, None);
+            let label_selector = format!(
+                "{},com.docker.compose.service={}",
+                identity.label_selector(),
+                service_name
+            );
+            let fallback_matches: Vec<_> = docker_client
+                .list_containers(Some(&label_selector))
+                .await?
+                .into_iter()
+                .filter(|c| c.state == "running")
+                .collect();
+
+            if fallback_matches.len() == 1 {
+                let container_id = fallback_matches[0].id.clone();
+                debug!(
+                    "Resolved compose service '{}' via label fallback: {}",
+                    service_name, container_id
+                );
+                return Ok(container_id);
+            }
+
             let workspace_path = workspace_folder.display();
             let config_name = config.name.as_deref().unwrap_or("unnamed");
             Err(anyhow::anyhow!(
@@ -722,18 +750,24 @@ where
         };
 
         // Pass 3 (`containerSubstitute`): resolve `${containerEnv:VAR}` tokens that
-        // pass 1 deliberately preserved in config-derived values. The probed env from
-        // resolve_env_and_user is the authoritative container env. Apply to working_dir
+        // pass 1 deliberately preserved in config-derived values. Use container inspect
+        // env (`Config.Env`) as canonical `containerEnv`, with probed env only as fallback.
+        // Apply to working_dir
         // and to every effective_env value, since either may carry tokens from
         // `workspaceFolder` / `remoteEnv` in the merged config.
         // See variableSubstitution.ts:41-44 in the reference CLI and BEAD-8.
-        let (working_dir, effective_env) = if env_user_resolution.probed_env.is_empty() {
+        let substitution_container_env = if env_user_resolution.container_env.is_empty() {
+            env_user_resolution.probed_env
+        } else {
+            env_user_resolution.container_env
+        };
+        let (working_dir, effective_env) = if substitution_container_env.is_empty() {
             (working_dir, env_user_resolution.effective_env)
         } else {
             apply_container_substitution(
                 working_dir,
                 env_user_resolution.effective_env,
-                env_user_resolution.probed_env,
+                substitution_container_env,
                 resolved_config
                     .as_ref()
                     .map(|c| c.workspace_folder.as_path()),

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -206,6 +206,7 @@ fn resolve_workspace_configuration(
     workspace_folder: &Path,
     config_path: Option<&Path>,
     mount_workspace_git_root: bool,
+    config: &DevContainerConfig,
 ) -> Result<WorkspaceConfig> {
     // Determine the root folder path based on mount_workspace_git_root flag
     let root_folder_path = if mount_workspace_git_root {
@@ -237,21 +238,32 @@ fn resolve_workspace_configuration(
         }
     };
 
-    // Compute workspace folder (container path - typically /workspaces/<basename>)
-    let workspace_basename = root_folder_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("workspace");
-    let container_workspace_folder = format!("/workspaces/{}", workspace_basename);
-
-    // Compute workspace mount specification
-    // Format: type=bind,source=<host-path>,target=<container-path>
-    // Always provided to indicate the default workspace mounting behavior
-    let workspace_mount = Some(format!(
-        "type=bind,source={},target={}",
-        root_folder_path.display(),
-        container_workspace_folder
-    ));
+    // Compute workspace folder and mount. For compose flows, preserve authored
+    // workspaceFolder and do not inject single-container default mounts.
+    let (container_workspace_folder, workspace_mount) = if config.uses_compose() {
+        let folder = config
+            .workspace_folder
+            .clone()
+            .unwrap_or_else(|| "/".to_string());
+        (folder, config.workspace_mount.clone())
+    } else {
+        let workspace_basename = root_folder_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace");
+        let folder = config
+            .workspace_folder
+            .clone()
+            .unwrap_or_else(|| format!("/workspaces/{}", workspace_basename));
+        let mount = config.workspace_mount.clone().or_else(|| {
+            Some(format!(
+                "type=bind,source={},target={}",
+                root_folder_path.display(),
+                folder
+            ))
+        });
+        (folder, mount)
+    };
 
     Ok(WorkspaceConfig {
         workspace_folder: container_workspace_folder,
@@ -1340,8 +1352,11 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
     } else {
         resolve_workspace_configuration(
             workspace_folder,
-            args.config_path.as_deref(),
+            resolved_config_path
+                .as_deref()
+                .or(args.config_path.as_deref()),
             args.mount_workspace_git_root,
+            &config,
         )
         .ok()
     };
@@ -3291,6 +3306,43 @@ API_KEY=another-secret
 
         let result = execute_read_configuration(args).await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_resolve_workspace_configuration_compose_preserves_workspace_folder() {
+        use serde_json::json;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DevContainerConfig {
+            docker_compose_file: Some(json!("docker-compose.yml")),
+            service: Some("app".to_string()),
+            workspace_folder: Some("/workspaces/compose-basic".to_string()),
+            ..Default::default()
+        };
+
+        let workspace =
+            resolve_workspace_configuration(temp_dir.path(), None, true, &config).unwrap();
+
+        assert_eq!(workspace.workspace_folder, "/workspaces/compose-basic");
+        assert!(workspace.workspace_mount.is_none());
+    }
+
+    #[test]
+    fn test_resolve_workspace_configuration_compose_defaults_root_without_mount() {
+        use serde_json::json;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = DevContainerConfig {
+            docker_compose_file: Some(json!("docker-compose.yml")),
+            service: Some("app".to_string()),
+            ..Default::default()
+        };
+
+        let workspace =
+            resolve_workspace_configuration(temp_dir.path(), None, true, &config).unwrap();
+
+        assert_eq!(workspace.workspace_folder, "/");
+        assert!(workspace.workspace_mount.is_none());
     }
 
     #[tokio::test]

--- a/crates/deacon/src/commands/shared/env_user.rs
+++ b/crates/deacon/src/commands/shared/env_user.rs
@@ -10,9 +10,11 @@ pub struct EnvUserResolution {
     pub effective_env: HashMap<String, String>,
     pub effective_user: Option<String>,
     /// Raw probed container environment (before merging with config remoteEnv / CLI overrides).
-    /// Callers use this as the `container_env` source for pass-3 (`containerSubstitute`)
-    /// substitution of `${containerEnv:VAR}` tokens left behind by pass 1.
+    /// Callers may use this for runtime behavior that depends on user shell startup.
     pub probed_env: HashMap<String, String>,
+    /// Raw container environment from container inspect (`Config.Env`), before userEnvProbe.
+    /// This is the canonical source for `${containerEnv:VAR}` substitutions.
+    pub container_env: HashMap<String, String>,
 }
 
 /// Resolve the effective environment and user by probing the container (when enabled) and
@@ -34,6 +36,26 @@ pub async fn resolve_env_and_user<D: Docker>(
     let effective_user = cli_user.or(config_remote_user);
 
     let mut probed_env = HashMap::new();
+    let mut container_env = HashMap::new();
+
+    match docker_client.inspect_container(container_id).await {
+        Ok(Some(info)) => {
+            container_env = info.env;
+        }
+        Ok(None) => {
+            warn!(
+                "Container '{}' not found during env resolution",
+                container_id
+            );
+        }
+        Err(error) => {
+            warn!(
+                "Container inspect failed while reading base container env: {}",
+                error
+            );
+        }
+    }
+
     if probe_mode != ContainerProbeMode::None {
         let prober = ContainerEnvironmentProber::new();
         match prober
@@ -56,11 +78,18 @@ pub async fn resolve_env_and_user<D: Docker>(
     }
 
     let prober = ContainerEnvironmentProber::new();
-    let effective_env = prober.build_effective_env(&probed_env, config_remote_env, cli_env);
+    let substitution_source = if container_env.is_empty() {
+        &probed_env
+    } else {
+        &container_env
+    };
+    let effective_env =
+        prober.build_effective_env(&probed_env, substitution_source, config_remote_env, cli_env);
 
     EnvUserResolution {
         effective_env,
         effective_user,
         probed_env,
+        container_env,
     }
 }

--- a/crates/deacon/src/commands/up/args.rs
+++ b/crates/deacon/src/commands/up/args.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, PartialEq)]
 pub struct NormalizedMount {
     pub mount_type: MountType,
+    /// Source path/volume for bind/volume mounts. Empty for tmpfs mounts.
     pub source: String,
     pub target: String,
     /// Whether the volume is externally managed (not created by deacon). Per
@@ -42,12 +43,16 @@ pub struct NormalizedMount {
 pub enum MountType {
     Bind,
     Volume,
+    Tmpfs,
 }
 
 impl NormalizedMount {
     /// Parse and validate a mount string from CLI.
     ///
-    /// Expected format: `type=(bind|volume),source=<path>,target=<path>[,external=(true|false)][,readonly|readonly=(true|false)|ro][,consistency=(cached|consistent|delegated)]`
+    /// Expected format:
+    /// `type=(bind|volume|tmpfs),target=<path>[,source=<path>][,external=(true|false)][,readonly|readonly=(true|false)|ro][,consistency=(cached|consistent|delegated)]`
+    ///
+    /// `source` is required for `bind` and `volume`, optional for `tmpfs`.
     ///
     /// Per #119, `readonly` (bare or `=true/false`) and `ro` (bare) are
     /// Docker-aligned aliases for the read-only flag — distinct from
@@ -118,14 +123,35 @@ impl NormalizedMount {
             })
         })?;
 
-        let source = source.ok_or_else(|| {
-            DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-                message: format!(
-                    "Invalid mount format: '{}'. Missing required field: source",
-                    mount_str
-                ),
-            })
-        })?;
+        // Validate and convert mount type
+        let mount_type = match mount_type_str {
+            "bind" => MountType::Bind,
+            "volume" => MountType::Volume,
+            "tmpfs" => MountType::Tmpfs,
+            _ => {
+                return Err(
+                    DeaconError::Config(deacon_core::errors::ConfigError::Validation {
+                        message: format!(
+                            "Invalid mount format: '{}'. type must be 'bind', 'volume', or 'tmpfs'",
+                            mount_str
+                        ),
+                    })
+                    .into(),
+                );
+            }
+        };
+
+        let source = match mount_type {
+            MountType::Bind | MountType::Volume => source.ok_or_else(|| {
+                DeaconError::Config(deacon_core::errors::ConfigError::Validation {
+                    message: format!(
+                        "Invalid mount format: '{}'. Missing required field: source",
+                        mount_str
+                    ),
+                })
+            })?,
+            MountType::Tmpfs => source.unwrap_or(""),
+        };
 
         let target = target.ok_or_else(|| {
             DeaconError::Config(deacon_core::errors::ConfigError::Validation {
@@ -135,23 +161,6 @@ impl NormalizedMount {
                 ),
             })
         })?;
-
-        // Validate and convert mount type
-        let mount_type = match mount_type_str {
-            "bind" => MountType::Bind,
-            "volume" => MountType::Volume,
-            _ => {
-                return Err(
-                    DeaconError::Config(deacon_core::errors::ConfigError::Validation {
-                        message: format!(
-                            "Invalid mount format: '{}'. type must be 'bind' or 'volume'",
-                            mount_str
-                        ),
-                    })
-                    .into(),
-                );
-            }
-        };
 
         // Validate external value if provided
         let external_flag = match external {
@@ -221,11 +230,15 @@ impl NormalizedMount {
                 match self.mount_type {
                     MountType::Bind => "bind",
                     MountType::Volume => "volume",
+                    MountType::Tmpfs => "tmpfs",
                 }
             ),
-            format!("source={}", self.source),
             format!("target={}", self.target),
         ];
+
+        if matches!(self.mount_type, MountType::Bind | MountType::Volume) {
+            parts.insert(1, format!("source={}", self.source));
+        }
 
         // Per #119, `external` is a deacon-internal marker (externally-
         // managed volume) — not a valid `docker --mount` option. It lives

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -997,6 +997,7 @@ fn normalized_mount_to_compose_mount(
         mount_type: match mount.mount_type {
             MountType::Bind => "bind".to_string(),
             MountType::Volume => "volume".to_string(),
+            MountType::Tmpfs => "tmpfs".to_string(),
         },
         source: mount.source.clone(),
         target: mount.target.clone(),
@@ -1152,6 +1153,25 @@ mod tests {
         assert_eq!(b.mount_type, "volume");
         assert_eq!(b.source, "/host/b");
         assert!(!b.read_only);
+    }
+
+    #[test]
+    fn config_mounts_tmpfs_string_form_normalizes_without_source() {
+        let merged = deacon_core::mount::merge_mounts(
+            &[serde_json::json!("type=tmpfs,target=/mnt/config-tmp")],
+            &[],
+            None,
+        )
+        .expect("merge_mounts should accept tmpfs mount string");
+
+        assert_eq!(merged.mounts.len(), 1);
+        let parsed =
+            NormalizedMount::parse(&merged.mounts[0]).expect("normalized mount string reparses");
+        let compose_mount = normalized_mount_to_compose_mount(&parsed);
+
+        assert_eq!(compose_mount.mount_type, "tmpfs");
+        assert!(compose_mount.source.is_empty());
+        assert_eq!(compose_mount.target, "/mnt/config-tmp");
     }
 
     /// #266: when config and CLI mounts target the same path, the later

--- a/crates/deacon/src/commands/up/merged_config.rs
+++ b/crates/deacon/src/commands/up/merged_config.rs
@@ -227,8 +227,8 @@ pub(crate) async fn merge_image_metadata_into_config(
 ///
 /// Per the upstream spec (`docs/specs/devcontainer-reference.md` § Image
 /// Metadata): when an image is used, the CLI MUST read the
-/// `devcontainer.metadata` LABEL — a JSON array of partial `devcontainer.json`
-/// entries — and merge each entry into the resolved configuration with
+/// `devcontainer.metadata` LABEL — either a single partial `devcontainer.json`
+/// object or an array of partial entries — and merge each entry into the resolved configuration with
 /// **lower precedence than the user's devcontainer.json**.
 ///
 /// This call site runs *after* the image is locally available (i.e. after
@@ -242,7 +242,7 @@ pub(crate) async fn merge_image_metadata_into_config(
 ///   image. The container itself still runs with the image's own ENV/USER
 ///   instructions, which Docker applies at run time.
 /// - If the LABEL is absent, return the config unchanged.
-/// - If the LABEL is present but malformed (not a JSON array, or entries
+/// - If the LABEL is present but malformed (not valid JSON, or entries
 ///   that don't deserialize as `DevContainerConfig`), surface a warn with
 ///   the parse error and return the config unchanged. We do not fail the
 ///   `up` flow on a bad image label — the spec says image metadata is the
@@ -408,14 +408,56 @@ fn apply_image_metadata_label(
         return user_config;
     };
 
-    let entries: Vec<DevContainerConfig> = match serde_json::from_str(label_json) {
+    let label_value: serde_json::Value = match serde_json::from_str(label_json) {
         Ok(v) => v,
         Err(e) => {
             tracing::warn!(
-                "Image '{}' has a devcontainer.metadata label that is not a valid \
-                 JSON array of devcontainer entries; proceeding without merge: {}",
+                "Image '{}' has a devcontainer.metadata label that is not valid \
+                 JSON; proceeding without merge: {}",
                 image_ref,
                 e
+            );
+            return user_config;
+        }
+    };
+    let entries: Vec<DevContainerConfig> = match label_value {
+        serde_json::Value::Array(values) => {
+            let parsed: Result<Vec<DevContainerConfig>, _> = values
+                .into_iter()
+                .map(serde_json::from_value::<DevContainerConfig>)
+                .collect();
+            match parsed {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        "Image '{}' has a devcontainer.metadata label with array entries \
+                         that are not valid devcontainer configs; proceeding without merge: {}",
+                        image_ref,
+                        e
+                    );
+                    return user_config;
+                }
+            }
+        }
+        serde_json::Value::Object(map) => {
+            match serde_json::from_value::<DevContainerConfig>(serde_json::Value::Object(map)) {
+                Ok(v) => vec![v],
+                Err(e) => {
+                    tracing::warn!(
+                        "Image '{}' has a devcontainer.metadata label object that is not a \
+                         valid devcontainer config; proceeding without merge: {}",
+                        image_ref,
+                        e
+                    );
+                    return user_config;
+                }
+            }
+        }
+        _ => {
+            tracing::warn!(
+                "Image '{}' has a devcontainer.metadata label that is neither an object nor array; \
+                 proceeding without merge",
+                image_ref
             );
             return user_config;
         }
@@ -798,6 +840,35 @@ mod image_metadata_merge_tests {
     }
 
     #[test]
+    fn object_form_image_metadata_label_is_applied() {
+        let label = r#"{
+            "containerEnv": {
+                "R4_PREBUILT": "object"
+            },
+            "remoteEnv": {
+                "R4_PREBUILT_REMOTE": "remote"
+            },
+            "init": true
+        }"#
+        .to_string();
+        let user = DevContainerConfig::default();
+        let merged = apply_image_metadata_label("alpine:3.18", Some(&label), user);
+
+        assert_eq!(
+            merged.container_env.get("R4_PREBUILT"),
+            Some(&"object".to_string())
+        );
+        assert_eq!(
+            merged
+                .remote_env
+                .get("R4_PREBUILT_REMOTE")
+                .and_then(|v| v.as_deref()),
+            Some("remote")
+        );
+        assert_eq!(merged.init, Some(true));
+    }
+
+    #[test]
     fn missing_label_is_a_noop() {
         let user = user_config_with_env(&[("X", "1")]);
         let user_clone = user.clone();
@@ -816,10 +887,10 @@ mod image_metadata_merge_tests {
         let merged = apply_image_metadata_label("alpine:3.18", Some(&label), user);
         assert_eq!(merged.container_env, user_clone.container_env);
 
-        // Also handle "valid JSON but not an array of devcontainer entries".
+        // Also handle "valid JSON but not a devcontainer config object/array".
         let user = user_config_with_env(&[("X", "1")]);
         let user_clone = user.clone();
-        let label = r#"{"oops": "not-an-array"}"#.to_string();
+        let label = r#"true"#.to_string();
         let merged = apply_image_metadata_label("alpine:3.18", Some(&label), user);
         assert_eq!(merged.container_env, user_clone.container_env);
     }

--- a/crates/deacon/src/commands/up/mod.rs
+++ b/crates/deacon/src/commands/up/mod.rs
@@ -538,7 +538,8 @@ pub(crate) async fn execute_up_with_runtime(
     let identity = match &host_ca_set {
         Some(set) => identity.with_host_ca(HOST_CA_BUNDLE_PATH, &set.subjects),
         None => identity,
-    };
+    }
+    .with_additional_labels(&discovered_labels);
     let workspace_hash = identity.workspace_hash.clone();
 
     // Initialize state manager

--- a/crates/deacon/src/commands/up/tests.rs
+++ b/crates/deacon/src/commands/up/tests.rs
@@ -230,6 +230,28 @@ fn test_normalized_mount_parse_volume_with_external() {
 }
 
 #[test]
+fn test_normalized_mount_parse_tmpfs_without_source() {
+    let mount = NormalizedMount::parse("type=tmpfs,target=/tmp-work").unwrap();
+    assert!(matches!(mount.mount_type, MountType::Tmpfs));
+    assert_eq!(mount.source, "");
+    assert_eq!(mount.target, "/tmp-work");
+    assert!(!mount.read_only);
+}
+
+#[test]
+fn test_normalized_mount_to_spec_string_tmpfs_omits_source() {
+    let mount = NormalizedMount {
+        mount_type: MountType::Tmpfs,
+        source: String::new(),
+        target: "/tmp-work".to_string(),
+        external: false,
+        read_only: false,
+        consistency: None,
+    };
+    assert_eq!(mount.to_spec_string(), "type=tmpfs,target=/tmp-work");
+}
+
+#[test]
 fn test_normalized_mount_parse_with_consistency_cached() {
     let mount = NormalizedMount::parse(
         "type=bind,source=/host/path,target=/container/path,consistency=cached",


### PR DESCRIPTION
## Summary
- fix compose `up -> exec` container lookup drift by adding a label-based fallback when compose project resolution misses
- align compose read-configuration workspace handling to preserve authored `workspaceFolder` and default to `/` (without injecting single-container default mounts)
- align override-command + feature entrypoint behavior with reference process shape by using `/bin/sh` wrapper semantics and composing feature entrypoints into the wrapper path
- include the related parity fixes completed in this batch for tmpfs mounts, id-label persistence, post-start running validation, compose project name usage, image metadata object form, and containerEnv PATH substitution source

## Validation
- cargo fmt --all --quiet
- cargo fmt --all --quiet -- --check
- cargo build --quiet
- cargo clippy --all-targets -- -D warnings
- make test-nextest-fast

## References
- #290
- #291
- #292
- #293
- #294
- #295
- #296
- #298
- #300
- #301