### PR TITLE
fix(parity): object-form image metadata in read-config + containerEnv substitution source

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1320,6 +1320,29 @@ impl DevContainerConfig {
     }
 }
 
+/// Parse a `devcontainer.metadata` image LABEL value into partial config entries.
+///
+/// Per the containers.dev image-metadata specification, the LABEL may hold either
+/// a single partial `devcontainer.json` **object** or an **array** of such
+/// partial entries. Both forms MUST be accepted and yield the same merge
+/// behavior (see the reference CLI's `imageMetadata` handling). Returns the
+/// parsed entries, or a serde error if the JSON is malformed or an entry does
+/// not deserialize as a `DevContainerConfig`.
+pub fn parse_image_metadata_label(
+    label_json: &str,
+) -> std::result::Result<Vec<DevContainerConfig>, serde_json::Error> {
+    let value: serde_json::Value = serde_json::from_str(label_json)?;
+    match value {
+        serde_json::Value::Array(values) => values
+            .into_iter()
+            .map(serde_json::from_value::<DevContainerConfig>)
+            .collect(),
+        // A single object (or any other scalar, which will fail deserialization
+        // below with a precise serde error) is treated as one entry.
+        other => Ok(vec![serde_json::from_value::<DevContainerConfig>(other)?]),
+    }
+}
+
 impl Default for DevContainerConfig {
     fn default() -> Self {
         Self {
@@ -3924,6 +3947,40 @@ mod tests {
             .unwrap();
         assert!(compose_file.ends_with("/compose.yml"));
         assert!(!compose_file.contains("${"));
+    }
+
+    #[test]
+    fn test_parse_image_metadata_label_object_and_array_forms() {
+        // Per #300 — the `devcontainer.metadata` image LABEL may be a single
+        // object OR an array of partial entries; both must parse equivalently.
+        let object_form = r#"{ "containerEnv": {"R4_PREBUILT":"object"}, "remoteEnv": {"R4_PREBUILT_REMOTE":"remote"}, "init": true }"#;
+        let array_form = r#"[{ "containerEnv": {"R4_PREBUILT":"object"}, "remoteEnv": {"R4_PREBUILT_REMOTE":"remote"}, "init": true }]"#;
+
+        let from_object = parse_image_metadata_label(object_form).expect("object form parses");
+        let from_array = parse_image_metadata_label(array_form).expect("array form parses");
+
+        assert_eq!(from_object.len(), 1);
+        assert_eq!(from_array.len(), 1);
+        for entries in [&from_object, &from_array] {
+            let entry = &entries[0];
+            assert_eq!(
+                entry.container_env.get("R4_PREBUILT"),
+                Some(&"object".to_string())
+            );
+            assert_eq!(
+                entry.remote_env.get("R4_PREBUILT_REMOTE"),
+                Some(&Some("remote".to_string()))
+            );
+            assert_eq!(entry.init, Some(true));
+        }
+    }
+
+    #[test]
+    fn test_parse_image_metadata_label_rejects_malformed() {
+        // A scalar (neither object nor array) is not a valid metadata payload.
+        assert!(parse_image_metadata_label("\"just-a-string\"").is_err());
+        // Broken JSON surfaces as an error, not a silent empty result.
+        assert!(parse_image_metadata_label("{ not json").is_err());
     }
 
     #[test]

--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -763,7 +763,10 @@ where
             None
         };
 
-    // Merge probed environment with container_env (probed env is lowest priority)
+    // Merge probed environment with container_env (probed env is lowest priority).
+    // This is the environment *injected into* lifecycle command processes — the
+    // userEnvProbe login/interactive additions (e.g. extra PATH entries) belong
+    // here so commands run with the same environment a shell would see.
     let merged_env = if let Some(probed) = probed_env.as_ref() {
         let prober = crate::container_env_probe::ContainerEnvironmentProber::new();
         prober.merge_environments(probed, Some(&config.container_env), None)
@@ -771,13 +774,48 @@ where
         config.container_env.clone()
     };
 
-    // Create substitution context with container information and merged env
+    // The source for `${containerEnv:VAR}` substitution is the container's BASE
+    // environment (the image's `ENV` plus create-time `containerEnv`), NOT the
+    // userEnvProbe additions (#298). Absorbing probe-only PATH entries into
+    // `${containerEnv:PATH}` diverges from the reference CLI, which resolves
+    // container variables from the container environment alone. Read the base
+    // env from the container's `Config.Env` via inspect, then overlay the
+    // config's `containerEnv` so it wins on conflicts — mirroring
+    // `resolve_env_and_user`'s canonical container-env source.
+    let container_env_for_substitution = {
+        let mut base = match docker.inspect_container(&config.container_id).await {
+            Ok(Some(info)) => info.env,
+            Ok(None) => {
+                warn!(
+                    "Container '{}' not found while reading base env for containerEnv \
+                     substitution; using config containerEnv only",
+                    config.container_id
+                );
+                HashMap::new()
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to inspect container '{}' for base containerEnv substitution; \
+                     using config containerEnv only: {}",
+                    config.container_id, e
+                );
+                HashMap::new()
+            }
+        };
+        for (key, value) in &config.container_env {
+            base.insert(key.clone(), value.clone());
+        }
+        base
+    };
+
+    // Create substitution context with container information and the BASE env.
     let container_context = substitution_context
         .clone()
         .with_container_workspace_folder(config.container_workspace_folder.clone())
-        .with_container_env(merged_env.clone());
+        .with_container_env(container_env_for_substitution);
 
-    // Create an updated config with merged environment
+    // Create an updated config with the merged environment (probe additions
+    // included) so lifecycle command *processes* inherit the probed shell env.
     let updated_config = ContainerLifecycleConfig {
         container_env: merged_env,
         ..config.clone()

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -845,11 +845,13 @@ async fn parse_image_metadata_entries(
         return Vec::new();
     };
 
-    match serde_json::from_str::<Vec<deacon_core::config::DevContainerConfig>>(label_json) {
+    // The label may be a single object or an array of partial config entries;
+    // both forms are accepted per the image-metadata spec (#300).
+    match deacon_core::config::parse_image_metadata_label(label_json) {
         Ok(entries) => entries,
         Err(e) => {
             tracing::warn!(
-                "Image '{}' has a devcontainer.metadata label that is not a valid JSON array of devcontainer entries; proceeding without it: {}",
+                "Image '{}' has a devcontainer.metadata label that is not a valid devcontainer metadata object/array; proceeding without it: {}",
                 image_ref,
                 e
             );

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -1174,6 +1174,29 @@ mod tests {
         assert_eq!(compose_mount.target, "/mnt/config-tmp");
     }
 
+    #[test]
+    fn config_mounts_tmpfs_destination_key_normalizes_without_source() {
+        // #293: the reference CLI accepts `type=tmpfs,destination=…` (Docker's
+        // `destination`/`dst` alias for `target`) with no `source`. The config
+        // string is normalized by `merge_mounts` before it reaches the compose
+        // `NormalizedMount::parse`, so the alias must survive the round trip.
+        let merged = deacon_core::mount::merge_mounts(
+            &[serde_json::json!("type=tmpfs,destination=/mnt/config-tmp")],
+            &[],
+            None,
+        )
+        .expect("merge_mounts should accept tmpfs mount with destination key");
+
+        assert_eq!(merged.mounts.len(), 1);
+        let parsed =
+            NormalizedMount::parse(&merged.mounts[0]).expect("normalized mount string reparses");
+        let compose_mount = normalized_mount_to_compose_mount(&parsed);
+
+        assert_eq!(compose_mount.mount_type, "tmpfs");
+        assert!(compose_mount.source.is_empty());
+        assert_eq!(compose_mount.target, "/mnt/config-tmp");
+    }
+
     /// #266: when config and CLI mounts target the same path, the later
     /// source (CLI, appended after config) must win — matching
     /// `merge_mounts`' "config overrides features" precedence extended one

--- a/crates/deacon/src/commands/up/merged_config.rs
+++ b/crates/deacon/src/commands/up/merged_config.rs
@@ -408,60 +408,21 @@ fn apply_image_metadata_label(
         return user_config;
     };
 
-    let label_value: serde_json::Value = match serde_json::from_str(label_json) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                "Image '{}' has a devcontainer.metadata label that is not valid \
-                 JSON; proceeding without merge: {}",
-                image_ref,
-                e
-            );
-            return user_config;
-        }
-    };
-    let entries: Vec<DevContainerConfig> = match label_value {
-        serde_json::Value::Array(values) => {
-            let parsed: Result<Vec<DevContainerConfig>, _> = values
-                .into_iter()
-                .map(serde_json::from_value::<DevContainerConfig>)
-                .collect();
-            match parsed {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        "Image '{}' has a devcontainer.metadata label with array entries \
-                         that are not valid devcontainer configs; proceeding without merge: {}",
-                        image_ref,
-                        e
-                    );
-                    return user_config;
-                }
+    // The label may be a single object or an array of partial config entries;
+    // both forms are accepted per the image-metadata spec (#70, #300).
+    let entries: Vec<DevContainerConfig> =
+        match deacon_core::config::parse_image_metadata_label(label_json) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "Image '{}' has a devcontainer.metadata label that is not a valid \
+                     devcontainer metadata object/array; proceeding without merge: {}",
+                    image_ref,
+                    e
+                );
+                return user_config;
             }
-        }
-        serde_json::Value::Object(map) => {
-            match serde_json::from_value::<DevContainerConfig>(serde_json::Value::Object(map)) {
-                Ok(v) => vec![v],
-                Err(e) => {
-                    tracing::warn!(
-                        "Image '{}' has a devcontainer.metadata label object that is not a \
-                         valid devcontainer config; proceeding without merge: {}",
-                        image_ref,
-                        e
-                    );
-                    return user_config;
-                }
-            }
-        }
-        _ => {
-            tracing::warn!(
-                "Image '{}' has a devcontainer.metadata label that is neither an object nor array; \
-                 proceeding without merge",
-                image_ref
-            );
-            return user_config;
-        }
-    };
+        };
 
     if entries.is_empty() {
         return user_config;


### PR DESCRIPTION
## Summary

Addresses spec-parity gaps surfaced by recent conformance testing that were **not** covered by #303 (which resolved most of the same batch of issues yesterday). Each item below was verified against current `main` empirically.

### Fixes #300 — object-form `devcontainer.metadata` image labels
`read-configuration` only parsed the **array** form of the `devcontainer.metadata` LABEL, silently dropping valid **object-form** metadata (the `up` path already accepted both after #303). Introduces a shared core helper `deacon_core::config::parse_image_metadata_label` that accepts both the single-object and array forms, and wires **both** `read-configuration` and `up`'s `apply_image_metadata_label` to it — de-duplicating ~50 lines of array/object branching in `merged_config.rs`.

### Fixes #298 — `${containerEnv:PATH}` absorbing userEnvProbe additions
The primary repro (up → exec / `remoteEnv`) was already fixed + tested by #303 via `env_user.rs`. This closes the **remaining secondary path**: `container_lifecycle.rs` substituted lifecycle *command strings* using the probe-augmented `merged_env`, so probe-only PATH entries leaked into `${containerEnv:...}`. Now those references resolve from the container's **base** environment (`Config.Env` via inspect, overlaid with config `containerEnv`), while the probe-augmented env still feeds command *process* injection — matching the reference CLI.

### #293 — tmpfs mounts (regression test)
Confirmed already fixed by #303. Adds a regression test for the exact `type=tmpfs,destination=/…` (no `source`) config-mount form the issue reports; it is normalized by core `merge_mounts` before reaching the compose parser.

## Testing
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `make test-nextest-fast` — 2823 tests passed ✅
- New unit tests: object/array metadata equivalence, malformed-metadata rejection, tmpfs `destination` normalization.

## Notes
Related issues #291, #296, #301, #290, #292, #294, #295 were verified to be resolved by #303 and are candidates for closure (verification comments posted separately). #273 and #297 are align-vs-characterize decisions, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)