### PR TITLE
docs(config): characterize extends as an intentional ahead-of-spec divergence

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -30,8 +30,12 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use tracing::{debug, instrument, warn};
 
-/// Maximum allowed depth of the extends chain. Matches the reference
-/// devcontainer CLI; deeper chains almost certainly indicate a config bug.
+/// Maximum allowed depth of the extends chain; deeper chains almost certainly
+/// indicate a config bug (a cycle or an unbounded include graph). Note that
+/// `extends` is a deacon capability *ahead of* the reference CLI — the
+/// reference does not implement it (see the field docs on
+/// [`DevContainerConfig::extends`]) — so this bound is deacon's own, not a
+/// mirror of upstream behavior.
 const MAX_EXTENDS_DEPTH: usize = 32;
 
 /// Default function to return an empty JSON object for serde defaults.
@@ -516,7 +520,21 @@ fn parse_resource_string(s: &str) -> Result<u64> {
 pub struct DevContainerConfig {
     /// Paths to extend from. Can be a single path or array of paths.
     ///
-    /// Reference: [Configuration - extends](https://containers.dev/implementors/json_reference/#extends)
+    /// **Ahead-of-spec, intentional divergence from the reference CLI.**
+    /// `extends` is *not* part of the finalized containers.dev configuration
+    /// reference (there is no `#extends` anchor there); it is the in-flight
+    /// spec proposal [devcontainers/spec#22]. deacon implements it eagerly —
+    /// the full chain is resolved and merged (base-first, child-wins) for
+    /// `up`, `build`, `read-configuration --include-merged-configuration`,
+    /// `outdated`, `set-up`, and `upgrade`. The reference CLI does **not**
+    /// resolve `extends` at all: `read-configuration` echoes the field
+    /// literally, and `up`/`build` fail to find an image because they never
+    /// follow it. This is therefore a deliberate deacon capability, **not** a
+    /// parity guarantee — see `fixtures/parity-corpus/errors/README.md`
+    /// (characterized divergence) and `docs/DIFFERENTIATORS.md`. Tracked by
+    /// issue #297.
+    ///
+    /// [devcontainers/spec#22]: https://github.com/devcontainers/spec/issues/22
     #[serde(
         default,
         deserialize_with = "deserialize_extends",

--- a/docs/DIFFERENTIATORS.md
+++ b/docs/DIFFERENTIATORS.md
@@ -52,6 +52,13 @@ kind of thing worth calling out in a blog post or on the project page.
   merged `containerEnv`, merged `forwardPorts`, etc. — so multi-file config
   composition just works.
 
+  This is an **ahead-of-spec capability**, tracking the in-flight proposal
+  [devcontainers/spec#22](https://github.com/devcontainers/spec/issues/22), and
+  is therefore an *intentional divergence* — deacon deliberately does more than
+  the reference here, so `extends` behavior is **not** covered by our
+  reference-parity claims. The divergence is characterized in
+  `fixtures/parity-corpus/errors/README.md`. (Issue #297.)
+
 ## Robustness
 
 - **Valid compose project names where the reference fails.** Both derive the compose

--- a/fixtures/parity-corpus/errors/README.md
+++ b/fixtures/parity-corpus/errors/README.md
@@ -53,9 +53,30 @@ mistake; preserve silently where deacon simply does not model the field.**
 
 The reference does **not resolve `extends` even at `build` time** — it errors
 with "No image information specified" rather than on the missing/cyclic target,
-i.e. it never followed the `extends` field at all. That is a deeper divergence
-worth its own investigation (is deacon's `extends` an extension beyond what the
-reference implements?) and is tracked separately, not by this tier.
+i.e. it never followed the `extends` field at all.
+
+**Resolved (issue #297):** yes — deacon's `extends` is a deliberate capability
+*ahead of* the reference, not accidental drift. `extends` is the in-flight spec
+proposal [devcontainers/spec#22], which the reference CLI (v0.87.0) does not
+implement: `read-configuration` echoes the field literally, and `up`/`build`
+fail to find an image because they never follow it. deacon resolves the full
+chain eagerly across `up`, `build`, `read-configuration`, `outdated`, `set-up`,
+and `upgrade` (see the field docs on `DevContainerConfig::extends` and
+`docs/DIFFERENTIATORS.md`). The consequences are therefore **intentional,
+characterized divergences**, not parity bugs:
+
+- `extends` → missing / cyclic target: `deacon-stricter` (deacon resolves
+  eagerly and rejects; reference never resolves). Encoded in `extends-missing`
+  and `extends-cycle`.
+- `extends` → valid target (conformance case 44): both succeed, but deacon
+  merges the base config (e.g. the base `containerEnv` appears in the resolved
+  config / created container) while the reference drops it. This is a
+  deacon-only superset, expected by design.
+
+deacon does **not** claim reference parity for configs that use `extends`; it
+claims to do strictly *more*.
+
+[devcontainers/spec#22]: https://github.com/devcontainers/spec/issues/22
 
 ## Why these are encoded as PASS, not bugs
 


### PR DESCRIPTION
Closes #297.

## Decision

`extends` is **kept** and documented as an intentional, ahead-of-spec capability — not removed. Investigation established:

- **deacon resolves `extends` at `up`/`build`, not just `read-configuration`** (`config.rs` → `resolve_extends_chain_with_paths`), matching #297's own observation and 11 passing `integration_extends` tests. It is a working, fully-plumbed feature.
- **It is a marketed differentiator**: the reference CLI v0.87.0 *errors* on `extends` configs; deacon composes them (`docs/DIFFERENTIATORS.md`).
- **It tracks the in-flight spec proposal [devcontainers/spec#22]** — `extends` is not yet in the finalized containers.dev json_reference (the old `#extends` citation was a dead anchor).

So the right resolution for #297 ("if intentionally deacon-specific, document it and separate it from parity claims") is documentation, not a behavioral change.

## Changes (docs only, no logic)

- **`config.rs`**: replace the dead `#extends` json_reference citation with an ahead-of-spec note linking devcontainers/spec#22; fix the `MAX_EXTENDS_DEPTH` comment that wrongly claimed it "matches the reference."
- **`fixtures/parity-corpus/errors/README.md`**: answer the open question this corpus already flagged ("is `extends` an extension beyond the reference?") — yes — and enumerate the characterized divergences (missing/cyclic → `deacon-stricter`; valid target → deacon-only superset, conformance case 44).
- **`docs/DIFFERENTIATORS.md`**: label the capability ahead-of-spec and explicitly exclude it from reference-parity claims.

## Testing
- `cargo fmt --all -- --check` ✅
- `integration_extends` — 11/11 pass (unchanged behavior) ✅
- No code paths modified.

[devcontainers/spec#22]: https://github.com/devcontainers/spec/issues/22

🤖 Generated with [Claude Code](https://claude.com/claude-code)