### PR TITLE
chore(conformance): trip on unmodeled keywords at re-vendoring

### DIFF
--- a/crates/conformance/tests/inventory_baseline.rs
+++ b/crates/conformance/tests/inventory_baseline.rs
@@ -52,6 +52,52 @@ fn exact_unit_counts_per_document() {
     assert_eq!(inv.revision, "rev-schema-113500f4");
 }
 
+/// The pinned schemas must yield NO `unmodeled-keyword` units — a re-vendoring tripwire.
+///
+/// The extractor recurses into a fixed set of sub-schema positions; any keyword outside
+/// that set is captured verbatim as a single `unmodeled-keyword` unit and is NOT
+/// recursed into. That is deliberate (nothing is ever silently dropped) but coarse: a
+/// keyword whose value CONTAINS sub-schemas collapses a whole subtree into one opaque
+/// unit, which a human then classifies with one disposition instead of classifying the
+/// constraints inside it.
+///
+/// The base document is draft 2019-09, so `dependentSchemas`, `dependentRequired`, and
+/// `unevaluatedItems` are all live possibilities at the next pin bump (`dependencies`
+/// likewise for the draft-07 feature document). None appear today, so this holds at
+/// zero.
+///
+/// If a re-vendoring trips this, do NOT just bump the expectation: decide how the new
+/// keyword should be modelled (its own `ConstraintKind`, folded into an existing one, or
+/// legitimately opaque) and teach `schema::extract` to recurse into it if it carries
+/// sub-schemas. Substance participates in the unit ID hash, so choosing the model late
+/// is far cheaper than choosing it wrong and re-hashing every affected classification.
+#[test]
+fn pinned_schemas_yield_no_unmodeled_keywords() {
+    let inv = committed();
+    let unmodeled: Vec<(&str, String)> = inv
+        .units
+        .iter()
+        .filter(|u| u.kind == ConstraintKind::UnmodeledKeyword)
+        .map(|u| {
+            let keyword = u
+                .substance
+                .get("keyword")
+                .and_then(|k| k.as_str())
+                .unwrap_or("<none>")
+                .to_string();
+            (u.pointer.as_str(), keyword)
+        })
+        .collect();
+
+    assert!(
+        unmodeled.is_empty(),
+        "the pinned schemas introduced {} unmodeled keyword(s): {unmodeled:?}\n\
+         Decide how to model each one (see this test's doc comment) — do not simply \
+         update the expectation.",
+        unmodeled.len()
+    );
+}
+
 #[test]
 fn forward_ports_array_type_unit_exists() {
     let inv = committed();


### PR DESCRIPTION
Follow-up to #318, closing the one review finding left open there.

## The gap

`schema::extract::recurse()` handles a fixed set of sub-schema positions. Any keyword outside it falls to the `unmodeled-keyword` catch-all, which captures the value verbatim but does **not** recurse into it. Nothing is silently dropped — and V12 still forces exactly one classification — but a keyword whose value *contains* sub-schemas collapses a whole subtree into one opaque unit, so a human classifies one blob instead of the constraints inside it.

This matters at the next pin bump: `devContainer.base.schema.json` is **draft 2019-09**, which defines `dependentSchemas`, `dependentRequired`, and `unevaluatedItems` (`unevaluatedProperties` is already handled). `dependencies` is likewise live for the draft-07 feature document. None appear at pin `113500f4`, so the current count is zero.

## Why a tripwire rather than implementing the recursion

Speculatively modelling these now would mean guessing at real decisions with no upstream instance to check against — `dependencies` has two distinct shapes in draft-07; `dependentRequired` is arguably `required`-kind rather than its own; whether a `dependentSchemas` sub-schema should carry a context is a judgement call. **Substance participates in the unit ID hash**, so a model chosen wrong is expensive to unwind once classifications reference those IDs, whereas a model chosen *late* costs nothing.

So this pins the zero and fails loudly at the moment the decision actually needs making, with the guidance inline in the test's doc comment ("do not simply update the expectation").

## Change

One test in `inventory_baseline.rs` — the file that already exists as a deliberate re-vendoring tripwire alongside the exact per-document unit counts. No production code touched, no change to the committed inventory.

## Verification

- `cargo fmt --all -- --check` clean; `clippy --all-targets --all-features -D warnings` clean
- 187/187 `deacon-conformance` tests pass
- The emit path is already proven by the existing `unmodeled_keyword_captured_verbatim` fixture test; traced that `dependentSchemas` falls through every keyword table to the catch-all, so the tripwire does fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT