### PR TITLE
fix(build): always emit imageName as an array in JSON output

### DIFF
--- a/crates/deacon/src/commands/build/mod.rs
+++ b/crates/deacon/src/commands/build/mod.rs
@@ -2255,10 +2255,12 @@ fn output_result(
                 result.tags.clone()
             };
 
+            // The reference CLI always emits `imageName` as an array, regardless of
+            // tag count (issue #310). Emit a (possibly one-element) array for any
+            // non-empty tag list rather than collapsing the single-tag case to a
+            // bare string.
             let mut success_result = if display_tags.is_empty() {
                 result::BuildSuccess::default()
-            } else if display_tags.len() == 1 {
-                result::BuildSuccess::new_single(display_tags[0].clone())
             } else {
                 result::BuildSuccess::new_multiple(display_tags)
             };

--- a/crates/deacon/src/commands/build/result.rs
+++ b/crates/deacon/src/commands/build/result.rs
@@ -15,11 +15,16 @@ use serde::{Deserialize, Serialize};
 /// ```json
 /// {
 ///   "outcome": "success",
-///   "imageName": "myimage:latest" | ["myimage:latest", "myimage:v1.0"],
+///   "imageName": ["myimage:latest", "myimage:v1.0"],  // always an array on output (issue #310)
 ///   "exportPath": "/path/to/export.tar",  // optional
 ///   "pushed": true  // optional
 /// }
 /// ```
+///
+/// On output `imageName` is always a JSON array, matching the reference CLI, even
+/// for a single tag. The [`ImageNameOutput::Single`] variant remains only so a
+/// bare-string value still *deserializes* (input tolerance); it is never produced
+/// on the success path.
 #[allow(dead_code)] // Used in Phase 3 implementation
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -27,8 +32,8 @@ pub struct BuildSuccess {
     /// Always "success" for successful builds
     outcome: String,
 
-    /// Deterministic fallback tag or list of tags when multiple provided.
-    /// Can be either a single string or an array of strings.
+    /// The tag(s) the build produced. Always serialized as an array on output
+    /// (issue #310); the `Single` variant exists only for deserialization tolerance.
     #[serde(skip_serializing_if = "Option::is_none")]
     image_name: Option<ImageNameOutput>,
 
@@ -221,6 +226,24 @@ mod tests {
 
         assert!(json.contains(r#""outcome":"success"#));
         assert!(json.contains(r#""imageName":["myimage:latest","myimage:v1.0"]"#));
+    }
+
+    #[test]
+    fn test_build_success_single_tag_serializes_as_array() {
+        // The success path builds imageName via new_multiple even for one tag, so a
+        // single custom tag must render as a one-element ARRAY, not a bare string,
+        // matching the reference CLI (issue #310).
+        let result = BuildSuccess::new_multiple(vec!["myimage:latest".to_string()]);
+        let json = serde_json::to_string(&result).unwrap();
+
+        assert!(json.contains(r#""imageName":["myimage:latest"]"#));
+        // Guard against the regression: never a bare-string imageName on output.
+        assert!(!json.contains(r#""imageName":"myimage:latest"#));
+
+        // And it round-trips back to the array variant.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["imageName"].is_array());
+        assert_eq!(parsed["imageName"][0], "myimage:latest");
     }
 
     #[test]

--- a/specs-completed/006-build-subcommand/contracts/build-cli-contract.yaml
+++ b/specs-completed/006-build-subcommand/contracts/build-cli-contract.yaml
@@ -117,12 +117,13 @@ components:
           type: string
           const: success
         imageName:
-          oneOf:
-            - type: string
-            - type: array
-              items:
-                type: string
-          description: Deterministic fallback tag or list of tags when multiple provided.
+          type: array
+          items:
+            type: string
+          description: >-
+            The tag(s) the build produced, always as an array (even for a single
+            tag), matching the reference CLI (issue #310). A bare string is still
+            accepted on input for tolerance but is never emitted.
         exportPath:
           type: string
           nullable: true


### PR DESCRIPTION
## Summary

Fixes #310 — a `build` parity divergence. `deacon build --output-format json` collapsed the single-tag case to a bare **string** `imageName`; the reference CLI (`@devcontainers/cli@0.87.0`) always emits an **array**, regardless of tag count. This is the common case (zero or one `--image-name`).

## Change
- `commands/build/mod.rs`: emit a (possibly one-element) array for any non-empty tag list — drop the `len() == 1` → `new_single` branch.
- `commands/build/result.rs`: `ImageNameOutput::Single` is retained for **input**-deserialization tolerance but is never produced on the success path; doc comments updated to state the array-only output invariant.
- `build-cli-contract.yaml`: tighten `imageName` from `oneOf: string | array` to array-only (which is why the string branch went unnoticed — the contract permitted it).

## Tests
- New `test_build_success_single_tag_serializes_as_array`: one tag → `["myimage:latest"]`, guards against the bare-string regression, and round-trips to the array variant.
- Existing `json_output_purity` / `integration_build` tests already tolerated either shape; all build_success tests (13, incl. a real-build integration test) green. fmt + clippy (workspace, all-features) clean.

## Conformance
No new registry behavior — sub-cause of the existing `bhv-build-image-parity` (backed by `case-build-parity` → `parity_build`, the live test whose `imageName should be an array` assertion found this). The fix restores that behavior's recorded `reference: aligned` state on the live lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)