### PR TITLE
fix(up): default workspace mount target to /workspaces/<basename>

### DIFF
--- a/crates/core/src/docker.rs
+++ b/crates/core/src/docker.rs
@@ -441,6 +441,25 @@ pub fn derive_container_workspace_folder(mounts: &[Mount]) -> Option<String> {
     longest_bind_mount.map(|mount| mount.destination.clone())
 }
 
+/// The default container path where the workspace bind-mount is placed when the
+/// config declares no explicit `workspaceMount`.
+///
+/// The reference CLI ALWAYS mounts the workspace at `/workspaces/<basename>`,
+/// where `<basename>` is the final component of the mount source (the git root
+/// when git-root mounting is active, otherwise the workspace folder) — it never
+/// uses `workspaceFolder` as the mount target. `workspaceFolder` is the working
+/// directory / `${containerWorkspaceFolder}`, resolved separately. Aligning here
+/// closes issue #273.
+fn default_workspace_mount_target(workspace_path: &Path) -> String {
+    format!(
+        "/workspaces/{}",
+        workspace_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace")
+    )
+}
+
 /// Convert a single `appPort` specification into a docker `-p` value, matching
 /// the reference CLI exactly:
 ///
@@ -2238,18 +2257,13 @@ impl ContainerOps for CliRuntime {
                 .map_err(|e| DockerError::CLIError(format!("Invalid workspaceMount: {}", e)))?;
             args.extend(mount.to_docker_args());
         } else {
-            // Use default workspace mount - respect workspaceFolder from config if specified
-            let target_path = if let Some(ref workspace_folder) = config.workspace_folder {
-                workspace_folder.clone()
-            } else {
-                format!(
-                    "/workspaces/{}",
-                    workspace_path
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or("workspace")
-                )
-            };
+            // Default workspace mount target. The reference CLI ALWAYS mounts the
+            // workspace at `/workspaces/<basename>`, independent of `workspaceFolder`
+            // (which is the working directory / containerWorkspaceFolder, not the
+            // mount target). Earlier deacon mounted at `workspaceFolder` when set,
+            // which diverged (issue #273). Align to the reference; the working dir
+            // is set separately from `container_workspace_folder`.
+            let target_path = default_workspace_mount_target(workspace_path);
             let workspace_mount = {
                 // Use platform-aware path conversion for Docker Desktop compatibility
                 let platform = crate::platform::Platform::detect();
@@ -4095,6 +4109,27 @@ mod tests {
 
         let result = derive_container_workspace_folder(&mounts);
         assert_eq!(result, Some("/workspace".to_string()));
+    }
+
+    #[test]
+    fn test_default_workspace_mount_target_uses_basename() {
+        // The default mount target is always /workspaces/<basename> of the mount
+        // source, matching the reference CLI — never `workspaceFolder` (issue #273).
+        assert_eq!(
+            default_workspace_mount_target(Path::new("/home/user/deacon")),
+            "/workspaces/deacon"
+        );
+        // Git-root mounting: the source is the git root, so its basename wins even
+        // when the actual workspace lives in a subdir.
+        assert_eq!(
+            default_workspace_mount_target(Path::new("/home/runner/work/deacon/deacon")),
+            "/workspaces/deacon"
+        );
+        // Trailing-slash / degenerate paths fall back safely.
+        assert_eq!(
+            default_workspace_mount_target(Path::new("/")),
+            "/workspaces/workspace"
+        );
     }
 
     #[test]

--- a/crates/deacon/tests/integration_feature_lifecycle.rs
+++ b/crates/deacon/tests/integration_feature_lifecycle.rs
@@ -213,6 +213,7 @@ fn test_feature_lifecycle_commands_execute_before_config() {
         "name": "Lifecycle Ordering Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./feature-a": {},
             "./feature-b": {}
@@ -302,6 +303,7 @@ fn test_feature_lifecycle_commands_in_installation_order() {
         "name": "Installation Order Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./first-feature": {},
             "./second-feature": {},
@@ -359,6 +361,7 @@ fn test_multiple_lifecycle_phases_ordering() {
         "name": "Multi-Phase Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./multi-phase-feature": {}
         },
@@ -469,6 +472,7 @@ fn test_empty_feature_lifecycle_commands_filtered() {
         "name": "Empty Commands Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./null-feature": {},
             "./empty-feature": {},
@@ -525,6 +529,7 @@ fn test_array_format_feature_lifecycle_commands() {
         "name": "Array Command Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./array-cmd-feature": {}
         }
@@ -582,6 +587,7 @@ fn test_object_format_feature_lifecycle_commands() {
         "name": "Object Command Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./object-cmd-feature": {}
         }
@@ -642,6 +648,7 @@ fn test_feature_oncreate_command_fails_immediately() {
         "name": "Feature Lifecycle Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./failing-feature": {}
         },
@@ -730,6 +737,7 @@ fn test_feature_postcreate_command_fails_before_config_command() {
         "name": "Feature PostCreate Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
         "features": {{
             "./failing-postcreate": {{}}
         }},
@@ -811,6 +819,7 @@ fn test_feature_updatecontent_command_fails_immediately() {
         "name": "Feature UpdateContent Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./failing-update": {}
         },
@@ -894,6 +903,7 @@ fn test_multiple_features_second_feature_fails() {
         "name": "Multiple Features Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./succeeding-feature": {},
             "./failing-feature": {}
@@ -970,6 +980,7 @@ fn test_error_attribution_identifies_failing_feature() {
         "name": "Error Attribution Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./my-custom-feature": {}
         }
@@ -1035,6 +1046,7 @@ fn test_feature_poststart_command_failure_does_not_fail_up() {
         "name": "PostStart Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./failing-poststart": {}
         },
@@ -1091,6 +1103,7 @@ fn test_feature_postattach_command_failure_does_not_fail_up() {
         "name": "PostAttach Fail Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./failing-postattach": {}
         },
@@ -1149,6 +1162,7 @@ fn test_feature_command_timeout_behavior() {
         "name": "Timeout Test",
         "image": "alpine:3.19",
         "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
         "features": {
             "./hanging-feature": {}
         }

--- a/crates/deacon/tests/lifecycle_parallel_output.rs
+++ b/crates/deacon/tests/lifecycle_parallel_output.rs
@@ -74,6 +74,7 @@ fn test_parallel_lifecycle_output_is_key_prefixed() {
   "image": "debian:bookworm-slim",
   "remoteUser": "root",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
   "postCreateCommand": {{
     "alpha": "echo hello-from-alpha",
     "beta": "echo hello-from-beta"

--- a/crates/deacon/tests/parity_state_diff.rs
+++ b/crates/deacon/tests/parity_state_diff.rs
@@ -747,8 +747,8 @@ async fn state_diff_intra_deacon_single_vs_compose() {
 // ===========================================================================
 
 #[tokio::test]
-async fn state_diff_default_workspace_mount_target_divergence() {
-    const CASE: &str = "default-workspace-mount-target-divergence";
+async fn state_diff_default_workspace_mount_target_parity() {
+    const CASE: &str = "default-workspace-mount-target-parity";
     let oracle = ff(Oracle::acquire().await);
     ff(require_docker().await);
     let deacon_bin = Path::new(env!("CARGO_BIN_EXE_deacon"));
@@ -782,26 +782,33 @@ async fn state_diff_default_workspace_mount_target_divergence() {
             .is_some_and(|m| m.mount_type == "bind")
     };
 
-    // deacon: workspace mounted AT workspaceFolder.
+    // After aligning the default mount target (issue #273), deacon and the
+    // reference must AGREE: both mount the workspace at the spec default
+    // /workspaces/<basename>, and NEITHER mounts it at `workspaceFolder`
+    // (/workspace), which is the working directory, not the mount target.
+    let mounts_under_workspaces = |snap: &StateSnapshot| {
+        snap.mounts
+            .keys()
+            .any(|d| d.starts_with("/workspaces/") && is_workspace_bind(snap, d))
+    };
     assert!(
-        is_workspace_bind(&d_snap, "/workspace"),
-        "deacon should mount the workspace at workspaceFolder (/workspace): {:?}",
+        !d_snap.mounts.contains_key("/workspace"),
+        "deacon still mounts the workspace at workspaceFolder (/workspace) instead \
+         of /workspaces/<basename>; #273 alignment regressed: {:?}",
         d_snap.mounts
     );
-    // upstream: workspace mounted at the spec default /workspaces/<basename>,
-    // NOT at workspaceFolder.
+    assert!(
+        mounts_under_workspaces(&d_snap),
+        "deacon should mount the workspace under /workspaces/<basename> after #273: {:?}",
+        d_snap.mounts
+    );
     assert!(
         !up_snap.mounts.contains_key("/workspace"),
-        "reference CLI unexpectedly mounted the workspace at /workspace; the \
-         default-mount-target divergence may be gone — reconcile deacon's \
-         default (docker.rs) and update this test: {:?}",
+        "reference CLI unexpectedly mounted the workspace at /workspace: {:?}",
         up_snap.mounts
     );
     assert!(
-        up_snap
-            .mounts
-            .keys()
-            .any(|d| d.starts_with("/workspaces/") && is_workspace_bind(&up_snap, d)),
+        mounts_under_workspaces(&up_snap),
         "reference CLI should mount the workspace under /workspaces/<basename>: {:?}",
         up_snap.mounts
     );

--- a/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
+++ b/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
@@ -109,6 +109,7 @@ fn test_run_user_commands_runs_feature_lifecycle_commands() {
   "image": "debian:bookworm-slim",
   "remoteUser": "root",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
   "features": {{ "./features/lc": {{}} }},
   "postCreateCommand": "echo cfg > /tmp/cfg-postcreate.flag"
 }}"#

--- a/crates/deacon/tests/run_user_commands_prebuild.rs
+++ b/crates/deacon/tests/run_user_commands_prebuild.rs
@@ -93,6 +93,7 @@ fn test_run_user_commands_prebuild_stops_after_update_content() {
     "image": "alpine:3.18",
     "remoteUser": "root",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind",
     "onCreateCommand": "echo onCreate > /tmp/onCreate.flag",
     "updateContentCommand": "echo updateContent > /tmp/updateContent.flag",
     "postCreateCommand": "echo postCreate > /tmp/postCreate.flag",

--- a/crates/deacon/tests/smoke_basic.rs
+++ b/crates/deacon/tests/smoke_basic.rs
@@ -126,7 +126,8 @@ fn smoke_up_then_exec_traditional() {
     let config = r#"{
         "name": "SmokeUpExec",
         "image": "nginx:alpine",
-        "workspaceFolder": "/workspace"
+        "workspaceFolder": "/workspace",
+        "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
     }"#;
     fs::create_dir(tmp.path().join(".devcontainer")).unwrap();
     fs::write(tmp.path().join(".devcontainer/devcontainer.json"), config).unwrap();
@@ -240,7 +241,8 @@ fn test_exec_environment_and_working_directory() {
     let devcontainer_config = r#"{
     "name": "Exec Test Container",
     "image": "alpine:3.19",
-    "workspaceFolder": "/custom/workspace"
+    "workspaceFolder": "/custom/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/custom/workspace,type=bind"
 }
 "#;
 
@@ -394,6 +396,7 @@ fn test_up_exec_happy_path() {
     "name": "Happy Path Test Container",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postCreateCommand": "echo 'Container ready'"
 }
 "#;

--- a/crates/deacon/tests/smoke_exec.rs
+++ b/crates/deacon/tests/smoke_exec.rs
@@ -36,7 +36,8 @@ fn test_exec_stdout_without_tty() {
     let devcontainer_config = r#"{
     "name": "Exec Test Container",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -109,7 +110,8 @@ fn test_exec_exit_code_propagation() {
     let devcontainer_config = r#"{
     "name": "Exec Exit Code Test",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -181,7 +183,8 @@ fn test_exec_working_directory() {
     let devcontainer_config = r#"{
     "name": "Exec Working Dir Test",
     "image": "alpine:3.19", 
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -255,7 +258,8 @@ fn test_exec_env_merges() {
     let devcontainer_config = r#"{
     "name": "Exec Env Test",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -340,6 +344,7 @@ fn test_up_remote_env_in_config() {
     "name": "Remote Env Config Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "remoteEnv": {
         "CONFIG_VAR": "config_value",
         "EMPTY_VAR": ""
@@ -413,6 +418,7 @@ fn test_exec_subfolder_config() {
     "name": "Subfolder Config Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postCreateCommand": "echo 'subfolder-postCreate' > /tmp/marker_subfolder"
 }"#;
 
@@ -477,7 +483,8 @@ fn test_exec_tty_detection() {
     let devcontainer_config = r#"{
     "name": "TTY Detection Test",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();

--- a/crates/deacon/tests/smoke_exec_stdin.rs
+++ b/crates/deacon/tests/smoke_exec_stdin.rs
@@ -34,7 +34,8 @@ fn test_exec_stdin_basic() {
     let devcontainer_config = r#"{
     "name": "Exec Stdin Test Container",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -108,7 +109,8 @@ fn test_exec_stdin_streaming() {
     let devcontainer_config = r#"{
     "name": "Exec Stdin Streaming Test Container",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();
@@ -197,7 +199,8 @@ fn test_exec_stdin_shell_commands() {
     let devcontainer_config = r#"{
     "name": "Exec Stdin Shell Commands Test Container",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace"
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }"#;
 
     fs::create_dir(temp_dir.path().join(".devcontainer")).unwrap();

--- a/crates/deacon/tests/smoke_lifecycle.rs
+++ b/crates/deacon/tests/smoke_lifecycle.rs
@@ -36,6 +36,7 @@ fn test_lifecycle_hooks_stable_order() {
     "name": "Lifecycle Order Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "echo 'onCreate-1' > /tmp/marker_onCreate",
     "updateContentCommand": "echo 'updateContent-2' > /tmp/marker_updateContent", 
     "postCreateCommand": "echo 'postCreate-3' > /tmp/marker_postCreate",
@@ -97,6 +98,7 @@ fn test_lifecycle_resume_sc002_only_runtime_hooks_rerun() {
     "name": "Lifecycle Resume SC002 Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "count=$(cat /tmp/counter_onCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_onCreate",
     "updateContentCommand": "count=$(cat /tmp/counter_updateContent 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_updateContent",
     "postCreateCommand": "count=$(cat /tmp/counter_postCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postCreate",
@@ -270,6 +272,7 @@ echo $count > /tmp/counter_dotfiles
     "name": "Lifecycle Resume Dotfiles SC002 Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "count=$(cat /tmp/counter_onCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_onCreate",
     "postCreateCommand": "count=$(cat /tmp/counter_postCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postCreate",
     "postStartCommand": "count=$(cat /tmp/counter_postStart 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postStart",
@@ -420,6 +423,7 @@ fn test_lifecycle_resume_sc002_multiple_resumes() {
     "name": "Lifecycle Multiple Resumes Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "count=$(cat /tmp/counter_onCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_onCreate",
     "postCreateCommand": "count=$(cat /tmp/counter_postCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postCreate",
     "postStartCommand": "count=$(cat /tmp/counter_postStart 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postStart",
@@ -546,7 +550,8 @@ fn test_lifecycle_skip_non_blocking_commands() {
     let devcontainer_config = r#"{
     "name": "Skip Non-blocking Test",
     "image": "alpine:3.19",
-    "workspaceFolder": "/workspace", 
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postStartCommand": "echo 'postStart-ran' > /tmp/marker_postStart",
     "postAttachCommand": "echo 'postAttach-ran' > /tmp/marker_postAttach"
 }"#;
@@ -593,6 +598,7 @@ fn test_secret_masking_in_lifecycle_logs() {
     "name": "Secret Masking Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "remoteEnv": {
         "SECRET_VALUE": "my-secret-password",
         "PUBLIC_VALUE": "public-info"
@@ -689,6 +695,7 @@ fn test_lifecycle_phase_order_sc001() {
     "name": "Lifecycle Order SC001 Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "seq=1; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_onCreate; sleep 0.1",
     "updateContentCommand": "seq=2; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_updateContent; sleep 0.1",
     "postCreateCommand": "seq=3; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_postCreate; sleep 0.1",
@@ -881,6 +888,7 @@ echo "$seq,$ts" > /tmp/lifecycle_order_dotfiles
     "name": "Lifecycle Dotfiles Order Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "seq=1; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_onCreate; sleep 0.1",
     "updateContentCommand": "seq=2; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_updateContent; sleep 0.1",
     "postCreateCommand": "seq=3; ts=$(date +%s%N); echo \"$seq,$ts\" > /tmp/lifecycle_order_postCreate; sleep 0.1",
@@ -1069,6 +1077,7 @@ fn test_features_accessible_in_container() {
     "name": "Feature Access Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postCreateCommand": "echo 'Container ready for feature test'"
 }"#;
 

--- a/crates/deacon/tests/smoke_up_idempotent.rs
+++ b/crates/deacon/tests/smoke_up_idempotent.rs
@@ -37,6 +37,7 @@ fn test_up_idempotency() {
     "name": "Up Idempotency Test Container",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postCreateCommand": "echo 'postCreate executed' > /tmp/marker_postCreate",
     "postStartCommand": "echo 'postStart executed' > /tmp/marker_postStart"
 }"#;
@@ -113,6 +114,7 @@ fn test_skip_non_blocking_commands() {
     "name": "Skip Non-Blocking Commands Test Container",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "echo 'onCreate executed' > /tmp/marker_onCreate",
     "postCreateCommand": "echo 'postCreate executed' > /tmp/marker_postCreate",
     "postStartCommand": "echo 'postStart executed' > /tmp/marker_postStart",
@@ -194,6 +196,7 @@ fn test_skip_flag_combinations() {
     "name": "Skip Flag Combinations Test Container",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "postCreateCommand": "echo 'postCreate executed'"
 }"#;
 

--- a/crates/deacon/tests/up_prebuild.rs
+++ b/crates/deacon/tests/up_prebuild.rs
@@ -302,6 +302,7 @@ fn test_prebuild_to_normal_transition_reruns_oncreate_updatecontent() {
     "name": "Prebuild Transition SC004/FR008 Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "count=$(cat /tmp/counter_onCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_onCreate",
     "updateContentCommand": "count=$(cat /tmp/counter_updateContent 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_updateContent",
     "postCreateCommand": "count=$(cat /tmp/counter_postCreate 2>/dev/null || echo 0); count=$((count + 1)); echo $count > /tmp/counter_postCreate",
@@ -529,6 +530,7 @@ fn test_prebuild_marker_directory_isolation() {
     "name": "Marker Isolation Test",
     "image": "alpine:3.19",
     "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
     "onCreateCommand": "echo 'onCreate ran'",
     "updateContentCommand": "echo 'updateContent ran'"
 }"#;

--- a/fixtures/devcontainer-up/feature-and-dotfiles/devcontainer.json
+++ b/fixtures/devcontainer-up/feature-and-dotfiles/devcontainer.json
@@ -3,6 +3,7 @@
   "image": "ubuntu:22.04",
   "remoteUser": "root",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "remoteEnv": {
     "FIXTURE_TYPE": "feature-and-dotfiles"
   },

--- a/fixtures/devcontainer-up/single-container/devcontainer.json
+++ b/fixtures/devcontainer-up/single-container/devcontainer.json
@@ -3,6 +3,7 @@
   "image": "ubuntu:22.04",
   "remoteUser": "root",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "remoteEnv": {
     "TEST_ENV": "single-container"
   },


### PR DESCRIPTION
## Summary

Fixes #273 — aligns deacon's single-container default workspace mount to `/workspaces/<basename>`, matching the reference CLI (`@devcontainers/cli@0.87.0`). Previously deacon mounted at `workspaceFolder` when set; the reference always mounts at `/workspaces/<basename>` and uses `workspaceFolder` only as the working directory.

## Oracle-verified
Verified locally against the pinned oracle (Docker + `@devcontainers/cli@0.87.0` both run in this environment): for `workspaceFolder: /workspace` with no `workspaceMount`, the reference mounts at `/workspaces/<basename>` and its `exec` **fails `chdir /workspace`** — deacon post-fix matches exactly. deacon's old behavior "worked" only because of the #273 bug.

## Code change (narrow)
- `crates/core/src/docker.rs`: `default_workspace_mount_target()` = `/workspaces/<basename>`, used unconditionally for the default mount (was: `workspaceFolder` when set). Only the default-mount + explicit-`workspaceFolder` case changes; the working dir is set separately from `container_workspace_folder`, so it's unaffected.

## Test-fixture migration
deacon's test fixtures pervasively set `workspaceFolder: /workspace` (relying on the old bug). Migrated the affected **single-container** fixtures to add an explicit `workspaceMount` targeting `/workspace` (both CLIs respect an explicit mount → parity; keeps `/workspace` valid for command/assertion references). Compose fixtures are untouched (separate code path, unaffected). Covers `smoke_exec`, `smoke_exec_stdin`, `smoke_up_idempotent`, `smoke_basic`, `smoke_lifecycle`, `integration_feature_lifecycle`, `lifecycle_parallel_output`, `run_user_commands_feature_lifecycle`, `run_user_commands_prebuild`, `up_prebuild`, and the on-disk `fixtures/devcontainer-up/{feature-and-dotfiles,single-container}` fixtures.

## Verification
- Hermetic unit test for the mount-target helper; `parity_state_diff` divergence test rewritten to assert **parity**.
- All affected single-container integration tests pass against **real Docker locally** (verified across the `docker` and `full` nextest profiles). Remaining local failures are pre-existing/environmental (compose-env, registry-network) — red on `main` too.

## Follow-up (separate PR)
The ~50 `examples/` (canary) `devcontainer.json` files share the same `workspaceFolder: /workspace` convention and will get the same treatment in a dedicated PR — they are not run by nextest CI, so they're logically separable from this change.

## Conformance
Within `bhv-state-diff-parity`'s scope; no new behavior, no waiver went stale. Restores that behavior's recorded `reference: aligned` state on the live parity lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)