### PR TITLE
chore(examples): mount workspace explicitly in single-container canary fixtures (#273)

### DIFF
--- a/examples/cli/custom-container-name/.devcontainer/devcontainer.json
+++ b/examples/cli/custom-container-name/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
   "name": "Custom Container Name Example",
   "image": "ubuntu:22.04",
   "remoteUser": "root",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/cli/port-forwarding/devcontainer.json
+++ b/examples/cli/port-forwarding/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "CLI Port Forwarding Example",
   "image": "nginx:alpine",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "portsAttributes": {
     "80": {
       "label": "Nginx Web Server",

--- a/examples/configuration/secrets-declarative/devcontainer.json
+++ b/examples/configuration/secrets-declarative/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"secrets": {
 		"GITHUB_TOKEN": {
 			"description": "Personal access token for GitHub API calls and clones from private repos",

--- a/examples/configuration/workspace-trust/.devcontainer.json
+++ b/examples/configuration/workspace-trust/.devcontainer.json
@@ -2,5 +2,6 @@
 	"name": "Workspace trust gate",
 	"image": "alpine:3.18",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"initializeCommand": "touch ./initialize-ran.marker"
 }

--- a/examples/container-lifecycle/execution-order/devcontainer.json
+++ b/examples/container-lifecycle/execution-order/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Lifecycle Execution Order Demo",
   "image": "alpine:3.18",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "containerEnv": {
     "DEMO_START_TIME": "$(date +%s)"
   },

--- a/examples/container-lifecycle/non-blocking-and-skip/devcontainer.json
+++ b/examples/container-lifecycle/non-blocking-and-skip/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Non-Blocking and Skip Flags Demo",
   "image": "alpine:3.19",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "containerEnv": {
     "DEMO_PHASE": "lifecycle-skip-example"
   },

--- a/examples/container-lifecycle/progress-events/devcontainer.json
+++ b/examples/container-lifecycle/progress-events/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Progress Events Demo",
   "image": "alpine:3.19",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "containerEnv": {
     "DEMO_PHASE": "progress-tracking"
   },

--- a/examples/container-lifecycle/redaction/devcontainer.json
+++ b/examples/container-lifecycle/redaction/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Redaction Demo",
   "image": "alpine:3.19",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "containerEnv": {
     "PUBLIC_VALUE": "this-is-public-info",
     "API_KEY": "secret-api-key-12345",

--- a/examples/doctor/host-requirements-failure/.devcontainer/devcontainer.json
+++ b/examples/doctor/host-requirements-failure/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"hostRequirements": {
 		"cpus": 1024,
 		"memory": "9999gb",

--- a/examples/doctor/host-requirements/devcontainer.json
+++ b/examples/doctor/host-requirements/devcontainer.json
@@ -6,5 +6,6 @@
     "memory": "4GB",
     "storage": "10GB"
   },
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/down/basic/.devcontainer/devcontainer.json
+++ b/examples/down/basic/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"shutdownAction": "stopContainer",
 	"mounts": [
 		"type=volume,source=deacon-down-demo,target=/data"

--- a/examples/exec/container-id-targeting/.devcontainer.json
+++ b/examples/exec/container-id-targeting/.devcontainer.json
@@ -5,5 +5,6 @@
   "remoteEnv": {
     "CONTAINER_ENV_VAR": "set-by-config"
   },
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/exit-code-handling/.devcontainer.json
+++ b/examples/exec/exit-code-handling/.devcontainer.json
@@ -2,5 +2,6 @@
   "name": "Exec Exit Code Example",
   "image": "mcr.microsoft.com/devcontainers/base:debian",
   "remoteUser": "vscode",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/id-label-targeting/.devcontainer.json
+++ b/examples/exec/id-label-targeting/.devcontainer.json
@@ -10,5 +10,6 @@
   "remoteEnv": {
     "APP_NAME": "exec-label-demo"
   },
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/interactive-pty/.devcontainer.json
+++ b/examples/exec/interactive-pty/.devcontainer.json
@@ -7,5 +7,6 @@
     }
   },
   "remoteUser": "vscode",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/non-interactive-streaming/.devcontainer.json
+++ b/examples/exec/non-interactive-streaming/.devcontainer.json
@@ -2,5 +2,6 @@
   "name": "Exec Non-Interactive Example",
   "image": "mcr.microsoft.com/devcontainers/base:debian",
   "remoteUser": "vscode",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/remote-env-variables/.devcontainer.json
+++ b/examples/exec/remote-env-variables/.devcontainer.json
@@ -8,5 +8,6 @@
     "LOG_LEVEL": "info",
     "CONFIG_SOURCE": "devcontainer.json"
   },
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/remote-user-execution/.devcontainer.json
+++ b/examples/exec/remote-user-execution/.devcontainer.json
@@ -3,6 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
   "remoteUser": "node",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "remoteEnv": {
     "USER_TYPE": "non-root"
   }

--- a/examples/exec/user-env-probe-modes/.devcontainer.json
+++ b/examples/exec/user-env-probe-modes/.devcontainer.json
@@ -3,5 +3,6 @@
   "image": "mcr.microsoft.com/devcontainers/base:debian",
   "remoteUser": "vscode",
   "userEnvProbe": "loginInteractiveShell",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/exec/workspace-folder-discovery/.devcontainer/devcontainer.json
+++ b/examples/exec/workspace-folder-discovery/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "WORKSPACE_NAME": "exec-workspace-example"
   },
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "customizations": {
     "vscode": {
       "extensions": ["dbaeumer.vscode-eslint"]

--- a/examples/features/contributed-options/devcontainer.json
+++ b/examples/features/contributed-options/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./probe-feature": {}
 	}

--- a/examples/features/dependency-ordering/devcontainer.json
+++ b/examples/features/dependency-ordering/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./feature-app": {},
 		"./feature-base": {},

--- a/examples/features/feature-contributed-lifecycle/devcontainer.json
+++ b/examples/features/feature-contributed-lifecycle/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./monitor": {},
 		"./tooling": {}

--- a/examples/features/feature-env-injection/devcontainer.json
+++ b/examples/features/feature-env-injection/devcontainer.json
@@ -4,6 +4,7 @@
 	"remoteUser": "vscode",
 	"containerUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./capture-env": {}
 	}

--- a/examples/features/local-feature/devcontainer.json
+++ b/examples/features/local-feature/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./hello-feature": {
 			"greeting": "bonjour"

--- a/examples/features/oci-digest-pin/devcontainer.json
+++ b/examples/features/oci-digest-pin/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Feature ref pinned by @sha256 digest",
 	"image": "mcr.microsoft.com/devcontainers/base:alpine",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"remoteUser": "root",
 	"features": {
 		"ghcr.io/devcontainers/features/git:1@sha256:REPLACE_WITH_REAL_DIGEST": {}

--- a/examples/features/option-sanitization/devcontainer.json
+++ b/examples/features/option-sanitization/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"features": {
 		"./report": {
 			"my-string-option": "Hello, World!",

--- a/examples/observability/json-logs/devcontainer.json
+++ b/examples/observability/json-logs/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Observability JSON Logs Example",
   "image": "ubuntu:22.04",
   "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "username": "devcontainer"

--- a/examples/read-configuration/named-config-search/.devcontainer/devcontainer.json
+++ b/examples/read-configuration/named-config-search/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"containerEnv": {
 		"VARIANT": "default"
 	}

--- a/examples/read-configuration/named-config-search/.devcontainer/python/devcontainer.json
+++ b/examples/read-configuration/named-config-search/.devcontainer/python/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/python:3.12",
 	"remoteUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"containerEnv": {
 		"VARIANT": "python"
 	}

--- a/examples/read-configuration/named-config-search/.devcontainer/rust/devcontainer.json
+++ b/examples/read-configuration/named-config-search/.devcontainer/rust/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/rust:1",
 	"remoteUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"containerEnv": {
 		"VARIANT": "rust"
 	}

--- a/examples/run-user-commands/basic/.devcontainer/devcontainer.json
+++ b/examples/run-user-commands/basic/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"onCreateCommand": "echo onCreate > /tmp/onCreate.flag",
 	"updateContentCommand": "echo updateContent > /tmp/updateContent.flag",
 	"postCreateCommand": "echo postCreate > /tmp/postCreate.flag",

--- a/examples/template-management/optional-paths/.devcontainer/devcontainer.json
+++ b/examples/template-management/optional-paths/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
 	"name": "${templateOption:projectName}",
 	"image": "alpine:3.18",
 	"remoteUser": "root",
-	"workspaceFolder": "/workspace"
+	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
 }

--- a/examples/up/additional-mounts/.devcontainer/devcontainer.json
+++ b/examples/up/additional-mounts/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "ubuntu:22.04",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"mounts": [
 		"source=${localWorkspaceFolder}/config,target=/etc/myapp,type=bind",
 		"source=myapp-cache,target=/var/cache/myapp,type=volume"

--- a/examples/up/basic-image/.devcontainer/devcontainer.json
+++ b/examples/up/basic-image/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"postCreateCommand": "echo 'Container setup complete!'"
 }

--- a/examples/up/configuration-output/.devcontainer/devcontainer.json
+++ b/examples/up/configuration-output/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "debian:bookworm-slim",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"remoteEnv": {
 		"ENV_FROM_CONFIG": "true",
 		"CONFIG_VERSION": "1.0"

--- a/examples/up/container-user-vs-remote-user/.devcontainer/devcontainer.json
+++ b/examples/up/container-user-vs-remote-user/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "containerUser vs remoteUser",
 	"image": "mcr.microsoft.com/devcontainers/base:debian",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"containerUser": "root",
 	"remoteUser": "vscode",
 	"postCreateCommand": "id -un > /tmp/postcreate.user"

--- a/examples/up/dockerfile-build/.devcontainer/devcontainer.json
+++ b/examples/up/dockerfile-build/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		"context": ".."
 	},
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"remoteUser": "devuser",
 	"postCreateCommand": "node --version && npm --version"
 }

--- a/examples/up/dotfiles-integration/.devcontainer/devcontainer.json
+++ b/examples/up/dotfiles-integration/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "ubuntu:22.04",
 	"remoteUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {

--- a/examples/up/gpu-modes/.devcontainer/devcontainer.json
+++ b/examples/up/gpu-modes/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"postCreateCommand": "echo 'GPU mode demonstration container ready'"
 }

--- a/examples/up/host-ca/.devcontainer/devcontainer.json
+++ b/examples/up/host-ca/.devcontainer/devcontainer.json
@@ -4,5 +4,6 @@
 	"remoteUser": "root",
 	"overrideCommand": true,
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"postCreateCommand": "test -f /usr/local/share/deacon/host-ca.crt && echo 'postCreate sees the injected corporate CA bundle'"
 }

--- a/examples/up/id-labels-reconnect/.devcontainer/devcontainer.json
+++ b/examples/up/id-labels-reconnect/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"postCreateCommand": "echo 'Container ready for reconnection'"
 }

--- a/examples/up/image-metadata-merge/.devcontainer/devcontainer.json
+++ b/examples/up/image-metadata-merge/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 	},
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"containerEnv": {
 		"CONFIG_LAYER": "from-devcontainer-json"
 	},

--- a/examples/up/initialize-command/.devcontainer/devcontainer.json
+++ b/examples/up/initialize-command/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"initializeCommand": "echo \"host-side init at $(date -u +%FT%TZ)\" > .initialize-marker",
 	"postCreateCommand": "echo container-side >> /tmp/lifecycle.log"
 }

--- a/examples/up/lifecycle-hooks/.devcontainer/devcontainer.json
+++ b/examples/up/lifecycle-hooks/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "ubuntu:22.04",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	
 	"onCreateCommand": {
 		"install-deps": "apt-get update && apt-get install -y curl git",

--- a/examples/up/override-command/.devcontainer/devcontainer.json
+++ b/examples/up/override-command/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 	},
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"overrideCommand": false,
 	"shutdownAction": "none"
 }

--- a/examples/up/ports-config/.devcontainer/devcontainer.json
+++ b/examples/up/ports-config/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Ports: forwardPorts, portsAttributes, otherPortsAttributes, appPort",
 	"image": "nginx:1.25-alpine",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"appPort": 8080,
 	"forwardPorts": [
 		80,

--- a/examples/up/prebuild-mode/.devcontainer/devcontainer.json
+++ b/examples/up/prebuild-mode/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 	},
 	"remoteUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	
 	"onCreateCommand": "echo 'Installing base dependencies...' && sudo apt-get update && sudo apt-get install -y build-essential",
 	"updateContentCommand": "echo 'Updating content at:' && date && npm cache clean --force 2>/dev/null || true",

--- a/examples/up/remote-env-secrets/.devcontainer/devcontainer.json
+++ b/examples/up/remote-env-secrets/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "ubuntu:22.04",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"remoteEnv": {
 		"APP_ENV": "development",
 		"LOG_LEVEL": "debug",

--- a/examples/up/remove-existing/.devcontainer/devcontainer.json
+++ b/examples/up/remove-existing/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"onCreateCommand": "echo 'Container created at:' > /tmp/created.txt && date >> /tmp/created.txt",
 	"postCreateCommand": "cat /tmp/created.txt"
 }

--- a/examples/up/security-options/.devcontainer/devcontainer.json
+++ b/examples/up/security-options/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"init": true,
 	"privileged": false,
 	"capAdd": [

--- a/examples/up/skip-lifecycle/.devcontainer/devcontainer.json
+++ b/examples/up/skip-lifecycle/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "ubuntu:22.04",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"onCreateCommand": "echo 'onCreate executed' && apt-get update",
 	"updateContentCommand": "echo 'updateContent executed' && date > /tmp/update.txt",
 	"postCreateCommand": "echo 'postCreate executed' && mkdir -p /workspace/setup",

--- a/examples/up/update-remote-user-uid/.devcontainer/devcontainer.json
+++ b/examples/up/update-remote-user-uid/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 	"remoteUser": "devuser",
 	"containerUser": "devuser",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"updateRemoteUserUID": true,
 	"postCreateCommand": "id -u > /tmp/uid && id -g > /tmp/gid && stat -c '%u' /workspace > /tmp/workspace.uid"
 }

--- a/examples/up/user-env-probe-modes/.devcontainer/devcontainer.json
+++ b/examples/up/user-env-probe-modes/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:debian",
 	"remoteUser": "vscode",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"userEnvProbe": "loginInteractiveShell",
 	"postCreateCommand": "echo $PATH > /tmp/probe.path && (echo \"PROBE_VAR=${PROBE_VAR:-<unset>}\") > /tmp/probe.var"
 }

--- a/examples/up/wait-for/.devcontainer/devcontainer.json
+++ b/examples/up/wait-for/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "alpine:3.18",
 	"remoteUser": "root",
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"onCreateCommand": "sleep 1 && echo onCreate >> /tmp/lifecycle.log",
 	"updateContentCommand": "sleep 1 && echo updateContent >> /tmp/lifecycle.log",
 	"postCreateCommand": "sleep 1 && echo postCreate >> /tmp/lifecycle.log",

--- a/examples/up/with-features/.devcontainer/devcontainer.json
+++ b/examples/up/with-features/.devcontainer/devcontainer.json
@@ -19,5 +19,6 @@
 		"infinity"
 	],
 	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
 	"postCreateCommand": "node --version && zsh --version"
 }


### PR DESCRIPTION
## Summary

Follow-up to #331 (the #273 mount-target alignment). The `examples/` canary `devcontainer.json` files share the repo-wide `workspaceFolder: /workspace` convention that relied on deacon's *old* mount-at-`workspaceFolder` behavior. With #273 aligning the default single-container mount to `/workspaces/<basename>`, these examples would `cd` into a nonexistent `/workspace` on `deacon up` (the reference CLI fails identically).

## Change
Add `"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"` to the **56 affected single-container** (non-compose, no existing mount) example fixtures. This keeps `/workspace` valid (both CLIs respect an explicit `workspaceMount` → parity) and preserves the `/workspace` references in each example's `exec.sh`/README. Compose examples are untouched (unaffected by #273). Applied via a script with per-file JSON validation.

## Verification
- `deacon up` + lifecycle on `examples/up/lifecycle-hooks` succeeds (previously would fail `chdir /workspace`).
- The pinned oracle (`@devcontainers/cli@0.87.0`) mounts identically (`target=/workspace`, `outcome: success`, same `remoteWorkspaceFolder`) — **full parity**.

## Note
These fixtures are canaries (`examples/*/exec.sh`), not run by nextest CI — hence a separate PR from #331. A full canary sweep against the new `main` is a reasonable follow-up; a representative lifecycle example was verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)