### PR TITLE
fix(up,exec): container workspace folder uses git-root subpath (#309 follow-up)

### DIFF
--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -426,27 +426,17 @@ async fn resolve_compose_target_container(
 pub fn determine_container_working_dir(
     config: &DevContainerConfig,
     workspace_folder: &Path,
+    mount_workspace_git_root: bool,
 ) -> String {
-    // Use containerWorkspaceFolder if specified in config
-    if let Some(ref container_workspace_folder) = config.workspace_folder {
-        debug!(
-            "Using containerWorkspaceFolder from config: {}",
-            container_workspace_folder
-        );
-        container_workspace_folder.clone()
-    } else {
-        // Default to /workspaces/{workspace_name}
-        let workspace_name = workspace_folder
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("workspace");
-        let default_path = format!("/workspaces/{}", workspace_name);
-        debug!(
-            "Using default container working directory: {}",
-            default_path
-        );
-        default_path
-    }
+    // Matches read-configuration / the mount / the reference (issue #309): explicit
+    // workspaceFolder verbatim, else /workspaces/<basename(root)>[/<subpath>].
+    let dir = deacon_core::workspace::container_workspace_folder(
+        workspace_folder,
+        config.workspace_folder.as_deref(),
+        mount_workspace_git_root,
+    );
+    debug!("Container working directory: {}", dir);
+    dir
 }
 
 /// Apply pass-3 (`containerSubstitute`) to working_dir and effective_env values.
@@ -735,6 +725,7 @@ where
                 Some(config_ctx) => determine_container_working_dir(
                     &config_ctx.config,
                     config_ctx.workspace_folder.as_path(),
+                    args.mount_workspace_git_root,
                 ),
                 None => {
                     debug!("No config context; resolving home folder as cwd");
@@ -818,7 +809,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let workspace_path = temp_dir.path();
 
-        let working_dir = determine_container_working_dir(&config, workspace_path);
+        let working_dir = determine_container_working_dir(&config, workspace_path, true);
         assert_eq!(working_dir, "/custom/workspace");
     }
 
@@ -833,7 +824,7 @@ mod tests {
         let workspace_path = temp_dir.path();
         let workspace_name = workspace_path.file_name().unwrap().to_str().unwrap();
 
-        let working_dir = determine_container_working_dir(&config, workspace_path);
+        let working_dir = determine_container_working_dir(&config, workspace_path, false);
         assert_eq!(working_dir, format!("/workspaces/{}", workspace_name));
     }
 
@@ -845,7 +836,7 @@ mod tests {
         };
 
         // Use a path that might not have a proper file name
-        let working_dir = determine_container_working_dir(&config, Path::new("/"));
+        let working_dir = determine_container_working_dir(&config, Path::new("/"), false);
         assert_eq!(working_dir, "/workspaces/workspace");
     }
 

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -197,9 +197,11 @@ async fn execute_lifecycle_commands(
     // Create substitution context
     let substitution_context = SubstitutionContext::new(workspace_folder)?;
 
-    // Determine container workspace folder
+    // Determine container workspace folder. `run-user-commands` does not expose
+    // `--mount-workspace-git-root`, so it uses the git-root default (true) — which
+    // matches how `up` (also defaulting to true) created the container and mount.
     let container_workspace_folder =
-        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder);
+        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder, true);
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {

--- a/crates/deacon/src/commands/shared/workspace.rs
+++ b/crates/deacon/src/commands/shared/workspace.rs
@@ -2,34 +2,26 @@
 
 use std::path::Path;
 
-/// Derive the container workspace folder from configuration or the host workspace path.
+/// Derive the container workspace folder (the lifecycle & exec working directory)
+/// from configuration and the host workspace path.
 ///
-/// If `config.workspace_folder` is set, returns that value directly.
-/// Otherwise, derives it as `/workspaces/{dir_name}` where `dir_name` is the
-/// last component of the host `workspace_folder` path (falling back to `"workspace"`
-/// if the path has no final component).
-///
-/// NOTE (issue #309): `read-configuration` already routes through
-/// [`deacon_core::workspace::container_workspace_folder`], which additionally
-/// walks to the git root and appends the workspace subpath to match the reference
-/// CLI. This container-aware `up`/`exec`/`run-user-commands` path does NOT yet do
-/// so — it lacks the `mount_workspace_git_root` flag in scope. Converging it (so
-/// the *used* lifecycle/exec working dir matches the mount for git-subdir
-/// workspaces) is a tracked follow-up; the common and non-git-temp cases already
-/// agree.
+/// Delegates to [`deacon_core::workspace::container_workspace_folder`] so the used
+/// working dir matches `read-configuration` and the reference CLI (issue #309): an
+/// explicit `workspaceFolder` wins verbatim, otherwise `/workspaces/<basename(root)>
+/// [/<subpath>]` where `root` is the git root when `mount_workspace_git_root` is
+/// set (else the workspace folder), with the root→workspace subpath appended. This
+/// keeps the working dir on the actual mounted path for git-subdir workspaces
+/// instead of a `/workspaces/<userFolderBasename>` that does not exist.
 pub fn derive_container_workspace_folder(
     config: &deacon_core::config::DevContainerConfig,
     workspace_folder: &Path,
+    mount_workspace_git_root: bool,
 ) -> String {
-    if let Some(ref folder) = config.workspace_folder {
-        folder.clone()
-    } else {
-        let dir_name = workspace_folder
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("workspace");
-        format!("/workspaces/{}", dir_name)
-    }
+    deacon_core::workspace::container_workspace_folder(
+        workspace_folder,
+        config.workspace_folder.as_deref(),
+        mount_workspace_git_root,
+    )
 }
 
 #[cfg(test)]
@@ -47,7 +39,7 @@ mod tests {
         config.workspace_folder = Some("/custom/path".to_string());
         let host_path = PathBuf::from("/home/user/my-project");
 
-        let result = derive_container_workspace_folder(&config, &host_path);
+        let result = derive_container_workspace_folder(&config, &host_path, true);
         assert_eq!(result, "/custom/path");
     }
 
@@ -56,7 +48,7 @@ mod tests {
         let config = minimal_config();
         let host_path = PathBuf::from("/home/user/my-project");
 
-        let result = derive_container_workspace_folder(&config, &host_path);
+        let result = derive_container_workspace_folder(&config, &host_path, false);
         assert_eq!(result, "/workspaces/my-project");
     }
 
@@ -65,7 +57,7 @@ mod tests {
         let config = minimal_config();
         let host_path = PathBuf::from("/");
 
-        let result = derive_container_workspace_folder(&config, &host_path);
+        let result = derive_container_workspace_folder(&config, &host_path, false);
         assert_eq!(result, "/workspaces/workspace");
     }
 }

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -265,8 +265,9 @@ pub(crate) async fn execute_compose_up(
                 // Spec default is `/workspaces/${localWorkspaceFolderBasename}`,
                 // not a bare `/workspaces`.
                 let remote_workspace_folder = super::helpers::default_remote_workspace_folder(
-                    config.workspace_folder.as_deref(),
                     workspace_folder,
+                    config.workspace_folder.as_deref(),
+                    args.mount_workspace_git_root,
                 );
 
                 // Serialize configuration if requested
@@ -512,6 +513,7 @@ pub(crate) async fn execute_compose_up(
             workspace_folder,
             &args.docker_path,
             force_pty,
+            args.mount_workspace_git_root,
         )
         .await?;
     }
@@ -571,8 +573,9 @@ pub(crate) async fn execute_compose_up(
     // Spec default is `/workspaces/${localWorkspaceFolderBasename}`, not a bare
     // `/workspaces`.
     let remote_workspace_folder = super::helpers::default_remote_workspace_folder(
-        config.workspace_folder.as_deref(),
         workspace_folder,
+        config.workspace_folder.as_deref(),
+        args.mount_workspace_git_root,
     );
 
     // Serialize configuration if requested
@@ -677,6 +680,7 @@ pub(crate) async fn execute_compose_post_create(
     workspace_folder: &Path,
     docker_path: &str,
     force_pty: bool,
+    mount_workspace_git_root: bool,
 ) -> Result<()> {
     debug!("Executing post-create lifecycle for compose project");
 
@@ -693,8 +697,11 @@ pub(crate) async fn execute_compose_post_create(
     // inside the shell and fall through to the default dir if it is absent. This
     // matches the reference CLI (run lifecycle from workspaceFolder) when the
     // workspace is mounted, and stays graceful when it is not.
-    let container_workspace_folder =
-        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder);
+    let container_workspace_folder = crate::commands::shared::derive_container_workspace_folder(
+        config,
+        workspace_folder,
+        mount_workspace_git_root,
+    );
 
     // Get the primary container ID
     let compose_manager = ComposeManager::with_docker_path(docker_path.to_string());

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -815,8 +815,9 @@ pub(crate) async fn execute_container_up(
     // source under `--mount-workspace-git-root`), so the reported value always
     // matches what is really mounted inside the container.
     let remote_workspace_folder = super::helpers::default_remote_workspace_folder(
+        workspace_folder,
         config.workspace_folder.as_deref(),
-        &workspace_mount_source,
+        args.mount_workspace_git_root,
     );
 
     // Serialize configuration if requested

--- a/crates/deacon/src/commands/up/helpers.rs
+++ b/crates/deacon/src/commands/up/helpers.rs
@@ -25,25 +25,21 @@ const EROFS: i32 = 30;
 /// Resolve the container workspace folder reported to callers.
 ///
 /// When the config sets an explicit `workspaceFolder`, that value is used
-/// verbatim. Otherwise the spec default is
-/// `/workspaces/${localWorkspaceFolderBasename}` — the basename of
-/// `mount_source` (the actual bind-mount source, i.e. the git root under
-/// `--mount-workspace-git-root`). A bare `/workspaces` (no basename) diverged
-/// from the reference CLI, which always reports `/workspaces/<basename>`.
+/// verbatim. Otherwise the spec/reference default is
+/// `/workspaces/<basename(root)>[/<subpath>]` — the git root basename (under
+/// `--mount-workspace-git-root`) plus the root→workspace subpath (issue #309),
+/// so the reported value matches the mount and the used working dir. Delegates to
+/// the single source of truth, [`deacon_core::workspace::container_workspace_folder`].
 pub(crate) fn default_remote_workspace_folder(
+    workspace_folder: &Path,
     config_workspace_folder: Option<&str>,
-    mount_source: &Path,
+    mount_workspace_git_root: bool,
 ) -> String {
-    match config_workspace_folder {
-        Some(wf) => wf.to_string(),
-        None => format!(
-            "/workspaces/{}",
-            mount_source
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("workspace")
-        ),
-    }
+    deacon_core::workspace::container_workspace_folder(
+        workspace_folder,
+        config_workspace_folder,
+        mount_workspace_git_root,
+    )
 }
 
 /// Check if any features are disallowed and return an error if found.
@@ -490,20 +486,23 @@ mod remote_workspace_folder_tests {
     fn defaults_to_workspaces_basename_when_unset() {
         // Parity with the reference CLI: `/workspaces/<basename>`, never a bare
         // `/workspaces`.
-        let got = default_remote_workspace_folder(None, Path::new("/home/me/myproject"));
+        let got = default_remote_workspace_folder(Path::new("/home/me/myproject"), None, false);
         assert_eq!(got, "/workspaces/myproject");
     }
 
     #[test]
     fn honors_explicit_workspace_folder() {
-        let got =
-            default_remote_workspace_folder(Some("/custom/app"), Path::new("/home/me/myproject"));
+        let got = default_remote_workspace_folder(
+            Path::new("/home/me/myproject"),
+            Some("/custom/app"),
+            true,
+        );
         assert_eq!(got, "/custom/app");
     }
 
     #[test]
     fn falls_back_to_workspace_when_basename_missing() {
-        let got = default_remote_workspace_folder(None, Path::new("/"));
+        let got = default_remote_workspace_folder(Path::new("/"), None, false);
         assert_eq!(got, "/workspaces/workspace");
     }
 }

--- a/crates/deacon/src/commands/up/lifecycle.rs
+++ b/crates/deacon/src/commands/up/lifecycle.rs
@@ -199,9 +199,13 @@ pub(crate) async fn execute_lifecycle_commands(
     // Create substitution context
     let substitution_context = SubstitutionContext::new(workspace_folder)?;
 
-    // Determine container workspace folder
-    let container_workspace_folder =
-        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder);
+    // Determine container workspace folder (matches the mount / read-configuration
+    // for git-subdir workspaces, #309).
+    let container_workspace_folder = crate::commands::shared::derive_container_workspace_folder(
+        config,
+        workspace_folder,
+        args.mount_workspace_git_root,
+    );
 
     // Determine if JSON log mode is active by checking DEACON_LOG_FORMAT env var
     // Per FR-001, FR-002: PTY toggle only applies in JSON log mode


### PR DESCRIPTION
## Summary

Follow-up to #334 (the read-configuration `${containerWorkspaceFolder}` fix). The container-aware `up`/`exec`/`run-user-commands`/`compose` paths derived the working dir as `/workspaces/<workspaceFolderBasename>` — no git-root walk, no subpath. After #273 aligned the mount to `/workspaces/<gitRootBasename>`, this left a git-subdir workspace's lifecycle/exec `cd`-ing into a **nonexistent path** — a real #273 regression: `deacon up` on a git-subdir workspace (no explicit `workspaceFolder`) failed its lifecycle `chdir`, and `deacon exec` failed `chdir /workspaces/<leafBasename>`.

## Fix
Converge all three working-dir functions on the shared `deacon_core::workspace::container_workspace_folder` (introduced in #334):
- `commands/shared/workspace.rs::derive_container_workspace_folder` (up lifecycle, compose)
- `commands/exec.rs::determine_container_working_dir` (exec)
- `commands/up/helpers.rs::default_remote_workspace_folder` (the reported `remoteWorkspaceFolder`)

Each threads `mount_workspace_git_root` from its command's args (`up`, `exec`, and compose have the flag; `run-user-commands` uses the git-root default it doesn't expose, matching how `up` created the container).

## Oracle-verified
Against `@devcontainers/cli@0.87.0` (local Docker), on a git repo with the config in `sub/pkg`:
- oracle: mount `/workspaces/<root>`, `remoteWorkspaceFolder` + `exec pwd` = `/workspaces/<root>/sub/pkg`
- deacon (post-fix): **identical** — `up` lifecycle succeeds, `exec pwd` = `/workspaces/<root>/sub/pkg`

## Blast radius
Only git-subdir workspaces without an explicit `workspaceFolder` change. Temp-dir (non-git) test fixtures resolve to `/workspaces/<basename>` (unchanged), and explicit-`workspaceFolder` fixtures use the value verbatim (unchanged) — so the test suite is unaffected. All affected unit tests + smoke_exec working-dir tests pass; fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)