### PR TITLE
fix(config): substitute variables inside customizations (#312)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,17 @@ Document this checklist in plan.md or PR description to prevent spec drift.
 3. If fixed identifier: leave it out, and add a comment explaining why (see `wait_for`
    for the pattern).
 
+**Object-shaped raw-JSON fields carrying user templates must ALSO be substituted.**
+The checklist above is worded for `String`/`Option<String>` fields, but a
+`serde_json::Value` field that holds user template strings (`build`, `mounts`,
+`customizations`) must be recursively substituted via
+`VariableSubstitution::substitute_json_value{,_with_options}` in BOTH passes — the
+reference CLI resolves `${localWorkspaceFolder}` / `${localEnv:*}` /
+`${containerWorkspaceFolder}` inside them (e.g. `customizations.vscode.settings`).
+`customizations` was missed this way (#312). This is distinct from the
+`#[serde(flatten)] extra` UNMODELED passthrough, which stays **verbatim** — modeled
+object fields carrying templates are substituted; unknown top-level keys are not.
+
 **Config validation philosophy (constitution IV — "strict on mistakes, faithful on the
 unmodeled"):** two-sided, applied consistently.
 - **Modeled fields fail fast on the developer's mistakes.** Typed fields already do this

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -925,6 +925,18 @@ impl DevContainerConfig {
             ));
         }
 
+        // Substitute customizations: template strings inside customizations (e.g.
+        // `terminal.integrated.cwd = "${localWorkspaceFolder}/src"`) are resolved by
+        // the reference CLI; deacon emitted them literally (#312). Recursively
+        // substitute string leaves. (Unmodeled `extra` passthrough stays verbatim.)
+        if !config.customizations.is_null() {
+            config.customizations = VariableSubstitution::substitute_json_value(
+                &config.customizations,
+                context,
+                &mut report,
+            );
+        }
+
         // Substitute workspace_folder
         if let Some(ref workspace_folder) = config.workspace_folder {
             config.workspace_folder = Some(VariableSubstitution::substitute_string(
@@ -1158,6 +1170,16 @@ impl DevContainerConfig {
             config.build = Some(VariableSubstitution::substitute_json_value_with_options(
                 build, context, options, report,
             )?);
+        }
+
+        // Substitute customizations — see apply_variable_substitution (#312).
+        if !config.customizations.is_null() {
+            config.customizations = VariableSubstitution::substitute_json_value_with_options(
+                &config.customizations,
+                context,
+                options,
+                report,
+            )?;
         }
 
         // Substitute mounts (JSON values that may contain strings)
@@ -4058,6 +4080,56 @@ mod tests {
         assert_eq!(args.get("LITERAL").and_then(|v| v.as_str()), Some("plain"));
         // No unresolved templates remain anywhere in the build object.
         assert!(!substituted.build.unwrap().to_string().contains("${"));
+    }
+
+    #[test]
+    fn test_substitution_covers_customizations() {
+        // #312: the reference CLI substitutes template strings inside
+        // `customizations`; deacon must too (not leave them literal).
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let mut context = SubstitutionContext::new(workspace).unwrap();
+        context
+            .local_env
+            .insert("USER".to_string(), "alice".to_string());
+        context.container_workspace_folder = Some("/workspaces/proj".to_string());
+
+        let config = DevContainerConfig {
+            customizations: serde_json::json!({
+                "vscode": {
+                    "settings": {
+                        "terminal.integrated.cwd": "${localWorkspaceFolder}/src",
+                        "some.user": "${localEnv:USER}",
+                        "some.container": "${containerWorkspaceFolder}/x",
+                        "literal": "plain"
+                    }
+                }
+            }),
+            ..Default::default()
+        };
+
+        // Basic pass.
+        let (substituted, _) = config.clone().apply_variable_substitution(&context);
+        let s = &substituted.customizations["vscode"]["settings"];
+        assert_eq!(s["some.user"].as_str(), Some("alice"));
+        assert_eq!(s["some.container"].as_str(), Some("/workspaces/proj/x"));
+        assert_eq!(s["literal"].as_str(), Some("plain"));
+        assert!(
+            !s["terminal.integrated.cwd"]
+                .as_str()
+                .unwrap()
+                .contains("${localWorkspaceFolder}")
+        );
+        assert!(!substituted.customizations.to_string().contains("${"));
+
+        // Advanced pass mirrors it.
+        use crate::variable::{SubstitutionOptions, SubstitutionReport};
+        let options = SubstitutionOptions::default();
+        let mut report = SubstitutionReport::new();
+        let advanced = config
+            .apply_variable_substitution_advanced(&context, &options, &mut report)
+            .unwrap();
+        assert!(!advanced.customizations.to_string().contains("${"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #312 (substitution half). The reference CLI (`@devcontainers/cli@0.87.0`) resolves template strings — `${localWorkspaceFolder}`, `${localEnv:*}`, `${containerWorkspaceFolder}` — inside `customizations` (e.g. `customizations.vscode.settings.terminal.integrated.cwd`). deacon emitted them **literally** because neither substitution pass visited the field.

## Change
Recursively substitute `config.customizations` (string leaves only) in **both** `apply_variable_substitution` and `apply_variable_substitution_advanced`, mirroring how `build`/`mounts` are handled. Distinct from the `#[serde(flatten)] extra` unmodeled passthrough, which stays verbatim.

## Verification
- Oracle-verified: deacon and the oracle now produce **identical** `customizations` output for a fixture whose settings contain `${localWorkspaceFolder}/src` + `${localEnv:*}`.
- New unit test `test_substitution_covers_customizations` (both passes); all 119 config tests + clippy + fmt green.
- Resolves the `parity_read_configuration` `customizations...cwd` divergence.

## Note
The `customizations.vscode` array **merge** divergence (image-metadata-contributed blocks) is a separate concern tracked under #307 (image-baked metadata) — it resolves once image entries populate the array, and is out of scope here.

CLAUDE.md updated: object-shaped raw-JSON fields carrying user templates must be recursively substituted (the checklist previously only prompted for `String` fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)