### PR TITLE
fix(read-configuration): read image devcontainer.metadata even when not pulled (#307)

### DIFF
--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -818,11 +818,19 @@ async fn parse_image_metadata_entries(
 ) -> Vec<deacon_core::config::DevContainerConfig> {
     use deacon_core::docker::Docker;
 
-    let info = match docker.inspect_image(image_ref).await {
+    // Resolve the image's `devcontainer.metadata` label. The reference CLI reads
+    // it even when the image isn't cached locally (it pulls on demand), so
+    // `--include-merged-configuration` reflects image-baked entrypoints/init/
+    // mounts/customizations regardless of local cache (issue #307). Use
+    // `ensure_image_available` (inspect, then `docker pull` on miss) instead of a
+    // local-only `inspect_image`, matching upstream `inspectDockerImage(…,
+    // pullImageOnError=true)`. Best-effort: a pull failure falls through to the
+    // empty-metadata path below, so the command still succeeds offline.
+    let info = match docker.ensure_image_available(image_ref).await {
         Ok(Some(info)) => info,
         Ok(None) => {
             debug!(
-                "Image '{}' not locally available; mergedConfiguration will not include image metadata",
+                "Image '{}' not available (inspect+pull); mergedConfiguration will not include image metadata",
                 image_ref
             );
             return Vec::new();


### PR DESCRIPTION
## Summary
Fixes #307. `read-configuration --include-merged-configuration` only read an image's `devcontainer.metadata` LABEL when the image was **already cached locally** (`inspect_image` returns `None` on a miss), so it dropped image-baked `entrypoints`/`init`/`mounts`/`customizations` that the reference CLI includes. Swap to `ensure_image_available` (inspect, then `docker pull` on miss), matching upstream `inspectDockerImage(…, pullImageOnError=true)`.

## Verification
Per the investigation, **warm** (image present) deacon output is already byte-identical to `@devcontainers/cli@0.87.0` for every #307 field (`entrypoints` all three, `init:true`, both `mounts`, `capAdd`, `securityOpt`). This change makes the **cold** path pull like the reference. Closes the `parity_corpus_merged` image-metadata divergence and #221 (same root cause). Best-effort: a pull failure falls through to the empty-metadata path, so the command still succeeds offline. 17 read-config integration tests + fmt green.

## ⚠️ Behavior note (please confirm)
This makes `read-configuration --include-merged-configuration` perform a **`docker pull` of the base image when it isn't cached** — for a large base (e.g. `mcr.microsoft.com/devcontainers/universal:2-linux`) that's a multi-GB pull on a nominally read-only command. **This is exactly what the reference CLI does**, and the registry asserts conformance here (`bhv-readconfig-merged-configuration`), so it's correct for parity — but it is a surprising side effect worth a conscious sign-off. A lighter manifest-only label fetch (pull just the config blob) is possible but adds real surface (arbitrary-image manifest resolution + registry auth); recommend shipping the parity fix now and treating manifest-only as a later optimization. Trivially reversible (one-line) if you'd rather not pull on read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)