### PR TITLE
ci(parity): pre-pull corpus base images before live comparison

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -82,6 +82,25 @@ jobs:
       - name: Build deacon
         run: cargo build -p deacon
 
+      - name: Pre-pull corpus base images
+        # `read-configuration --include-merged-configuration` reads an image's
+        # `devcontainer.metadata` LABEL, pulling on a cache miss to match the
+        # reference CLI (#307). On a cold runner a multi-GB base (e.g. the
+        # `universal` image) would blow the harness's 120s per-invocation bound.
+        # Warm the cache once, up front, so both CLIs resolve labels by local
+        # inspect — the bound then guards real hangs, not first-pull latency.
+        run: |
+          set -euo pipefail
+          grep -rhoE '"image"[[:space:]]*:[[:space:]]*"[^"]+"' \
+            fixtures/parity-corpus/*/.devcontainer/devcontainer.json \
+            | sed -E 's/.*"image"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
+            | sort -u \
+            | while read -r img; do
+                echo "::group::docker pull ${img}"
+                docker pull "${img}" || echo "warn: failed to pre-pull ${img} (continuing)"
+                echo "::endgroup::"
+              done
+
       - name: Run live parity comparison
         run: cargo nextest run --profile parity
 


### PR DESCRIPTION
## Summary
After #307 (`read-configuration` reads image `devcontainer.metadata`, pulling on a cache miss), the `parity / live-certification` lane failed `parity_corpus_merged` on a **120s timeout** — not a divergence. On a cold runner, deacon's read-config pulls the multi-GB `universal` image, exceeding the harness's per-invocation bound.

## Fix
Add a **Pre-pull corpus base images** step before the live comparison that pulls every `image` referenced in `fixtures/parity-corpus/*/.devcontainer/devcontainer.json`. Both CLIs then resolve the metadata labels via a fast local `inspect`, so the 120s bound guards real hangs instead of first-pull latency. Failures to pull are non-fatal (`|| warn`), preserving the harness's fail-open behavior.

## Context
This was the **last** red in the parity lane. With #308/#310/#273/#309/#312/#307 merged, the run showed **zero field divergences** and `parity_state_diff` (the #273 alignment) passing — only the universal-jsonc invocation timed out on its cold pull. This makes the lane green without weakening the bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)