### PR TITLE
fix(read-config): resolve base-image metadata for compose & dockerfile merged config

### DIFF
--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -6,6 +6,9 @@
 //! Spec: the containers.dev spec / reference CLI
 //! Implementation: specs/001-read-config-parity/spec.md
 
+use crate::commands::shared::build_resolution::{
+    resolve_devcontainer_build_config, resolve_dockerfile_base_image,
+};
 use crate::commands::shared::{ConfigLoadArgs, TerminalDimensions, load_config};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
@@ -588,6 +591,14 @@ fn apply_upstream_merge_shape(
     let Some(obj) = base.as_object_mut() else {
         return base;
     };
+
+    // `id` is a per-metadata-entry marker on each `devcontainer.metadata` label
+    // entry (e.g. `ghcr.io/devcontainers/features/git:1`), not a merged-config
+    // field. It rides through `DevContainerConfig::extra` on the merge chain and
+    // the last entry's value survives, but upstream's `mergeConfiguration`
+    // (`pickConfigProperties`) never emits `id` in `MergedDevContainerConfig` —
+    // strip it so the merged output matches the reference.
+    obj.remove("id");
 
     for (singular, _) in COLLECTED_PROPERTIES {
         obj.remove(*singular);
@@ -1686,44 +1697,109 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         //      where `config.image` is None — at read-config time we
         //      don't know the built image tag, but we can find it via
         //      the container that `up` created.
-        let image_metadata_entries: Vec<deacon_core::config::DevContainerConfig> =
-            if container_info.is_none() {
-                use deacon_core::docker::Docker;
-                let docker = deacon_core::docker::CliDocker::with_path(args.docker_path.clone());
-                let image_ref: Option<String> = if let Some(image) = config.image.as_deref() {
-                    Some(image.to_string())
-                } else if let Ok(canonical_workspace) = workspace_folder.canonicalize() {
-                    // For `build.dockerfile` configs `config.image` is None at
-                    // read-config time. Find the workspace's container via the
-                    // spec-mandated `devcontainer.local_folder` label (#80) —
-                    // the workspaceHash/configHash pair drifts whenever `up`
-                    // mutates the config mid-flight (workspace_mount injection,
-                    // image-metadata merge, etc.), so read-config can never
-                    // reconstruct an identical hash. The path label is stable.
+        let image_metadata_entries: Vec<deacon_core::config::DevContainerConfig> = if container_info
+            .is_none()
+        {
+            use deacon_core::docker::Docker;
+            let docker = deacon_core::docker::CliDocker::with_path(args.docker_path.clone());
+
+            // The config file backing this read (CLI `--config` or the
+            // auto-discovered path); its parent anchors compose files and the
+            // Dockerfile, mirroring the feature-anchor logic above.
+            let config_path_for_build = args
+                .config_path
+                .as_deref()
+                .or(resolved_config_path.as_deref());
+            let config_dir = config_path_for_build
+                .and_then(|p| p.parent())
+                .unwrap_or(workspace_folder);
+
+            // Resolve the base image whose `devcontainer.metadata` label seeds
+            // the merged config, matching the reference CLI's precedence:
+            //   1. literal `config.image`
+            //   2. compose primary service's resolved `image:`
+            //   3. Dockerfile `FROM` base (following multi-stage + ARG)
+            //   4. fall back to the workspace's running container's image
+            // The reference reads the base image's baked-in feature metadata
+            // (e.g. `mcr…/devcontainers/base`'s `git` customizations) even for
+            // compose / Dockerfile configs before any container exists, so a
+            // cold `read-configuration` must too (#307 follow-up).
+            let mut image_ref: Option<String> = if let Some(image) = config.image.as_deref() {
+                Some(image.to_string())
+            } else if config.uses_compose() {
+                use deacon_core::compose::{ComposeManager, ServiceShape};
+                let manager = ComposeManager::with_docker_path(args.docker_path.clone());
+                // Resolve to absolute paths so the compose files (anchored to
+                // `config_dir`) are opened correctly regardless of the child
+                // process CWD — a relative `config_dir` otherwise gets joined
+                // twice and the `-f` file is not found.
+                let abs_workspace = workspace_folder
+                    .canonicalize()
+                    .unwrap_or_else(|_| workspace_folder.to_path_buf());
+                let abs_config_dir = config_dir
+                    .canonicalize()
+                    .unwrap_or_else(|_| config_dir.to_path_buf());
+                match manager.create_project(&config, &abs_workspace, &abs_config_dir) {
+                    Ok(project) => {
+                        match manager
+                            .get_command(&project)
+                            .extract_service_shape(&project.service)
+                            .await
+                        {
+                            Ok(ServiceShape::Image(img)) => Some(img),
+                            // Build-shaped or unresolvable services contribute
+                            // no base-image metadata (best-effort, like #91).
+                            _ => None,
+                        }
+                    }
+                    Err(_) => None,
+                }
+            } else if let Some(cfg_path) = config_path_for_build {
+                // Dockerfile-based (`build.dockerfile` / legacy `dockerFile`).
+                match resolve_devcontainer_build_config(&config, cfg_path) {
+                    Ok(Some(rb)) => match std::fs::read_to_string(&rb.dockerfile_path) {
+                        Ok(content) => resolve_dockerfile_base_image(
+                            &content,
+                            &rb.options,
+                            rb.target.as_deref(),
+                        ),
+                        Err(_) => None,
+                    },
+                    _ => None,
+                }
+            } else {
+                None
+            };
+
+            // Fallback: no static base resolved above. Find the workspace's
+            // container via the spec-mandated `devcontainer.local_folder`
+            // label (#80) — the workspaceHash/configHash pair drifts whenever
+            // `up` mutates the config mid-flight (workspace_mount injection,
+            // image-metadata merge, etc.), so read-config can never
+            // reconstruct an identical hash. The path label is stable.
+            if image_ref.is_none() {
+                if let Ok(canonical_workspace) = workspace_folder.canonicalize() {
                     let label_selector = format!(
                         "devcontainer.source=deacon,devcontainer.local_folder={}",
                         canonical_workspace.display()
                     );
-                    match docker.list_containers(Some(&label_selector)).await {
-                        Ok(containers) if !containers.is_empty() => {
-                            match docker.inspect_container(&containers[0].id).await {
-                                Ok(Some(info)) => Some(info.image),
-                                _ => None,
+                    if let Ok(containers) = docker.list_containers(Some(&label_selector)).await {
+                        if let Some(first) = containers.first() {
+                            if let Ok(Some(info)) = docker.inspect_container(&first.id).await {
+                                image_ref = Some(info.image);
                             }
                         }
-                        _ => None,
                     }
-                } else {
-                    None
-                };
-                if let Some(image_ref) = image_ref {
-                    parse_image_metadata_entries(&docker, &image_ref).await
-                } else {
-                    Vec::new()
                 }
+            }
+            if let Some(image_ref) = image_ref {
+                parse_image_metadata_entries(&docker, &image_ref).await
             } else {
                 Vec::new()
-            };
+            }
+        } else {
+            Vec::new()
+        };
 
         let mut merged = compute_merged_configuration(
             &config,
@@ -1848,6 +1924,22 @@ mod tests {
             .map(|e| e["vscode"]["id"].as_str().unwrap())
             .collect();
         assert_eq!(ids, vec!["img0", "img1", "feat0", "base0"]);
+    }
+
+    #[test]
+    fn test_merge_shape_strips_per_entry_id() {
+        // `id` is a per-metadata-entry marker (e.g. a feature ref on an image
+        // label entry) that rides through the merge chain via `extra`. Upstream's
+        // `MergedDevContainerConfig` never emits it — the merged shape must drop it.
+        let base = json!({
+            "name": "x",
+            "id": "./local-features/setup-user",
+            "remoteUser": "codespace"
+        });
+        let shaped = apply_upstream_merge_shape(base, &[]);
+        assert!(shaped.get("id").is_none(), "id must be stripped: {shaped}");
+        assert_eq!(shaped["remoteUser"], "codespace");
+        assert_eq!(shaped["name"], "x");
     }
 
     #[test]

--- a/crates/deacon/src/commands/shared/build_resolution.rs
+++ b/crates/deacon/src/commands/shared/build_resolution.rs
@@ -95,6 +95,167 @@ pub(crate) fn resolve_devcontainer_build_config(
     }
 }
 
+/// Resolve the external base image a Dockerfile's target stage ultimately
+/// derives from, following multi-stage `FROM … AS <name>` chains and applying
+/// global `ARG` defaults (`build.args` override them). Returns `None` when the
+/// base cannot be statically determined (`FROM scratch`, an unresolved `ARG`,
+/// or no `FROM` at all).
+///
+/// Used by `read-configuration --include-merged-configuration` to locate the
+/// image whose `devcontainer.metadata` label seeds `mergedConfiguration` for
+/// Dockerfile-based configs — matching the reference CLI, which reads the base
+/// image's baked-in metadata (e.g. `mcr.microsoft.com/devcontainers/base`'s
+/// `git` customizations) even before the image is built.
+pub(crate) fn resolve_dockerfile_base_image(
+    content: &str,
+    build_args: &HashMap<String, String>,
+    target: Option<&str>,
+) -> Option<String> {
+    // Global ARGs (declared before the first FROM) are the only ones usable in
+    // FROM lines. Seed defaults from the Dockerfile; `build.args` override them.
+    let mut global_args: HashMap<String, String> = HashMap::new();
+    // (lowercased stage name, raw FROM reference) in declaration order.
+    let mut stages: Vec<(Option<String>, String)> = Vec::new();
+    let mut seen_from = false;
+
+    for logical in join_continuations(content) {
+        let line = logical.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut it = line.split_whitespace();
+        let Some(instr) = it.next() else { continue };
+        match instr.to_ascii_uppercase().as_str() {
+            "ARG" if !seen_from => {
+                if let Some(decl) = it.next() {
+                    if let Some((name, default)) = decl.split_once('=') {
+                        global_args.insert(name.to_string(), default.to_string());
+                    }
+                }
+            }
+            "FROM" => {
+                seen_from = true;
+                let Some(from_ref) = it.next() else { continue };
+                // Optional `AS <name>` (case-insensitive keyword).
+                let mut name = None;
+                if let Some(kw) = it.next() {
+                    if kw.eq_ignore_ascii_case("AS") {
+                        name = it.next().map(|n| n.to_ascii_lowercase());
+                    }
+                }
+                stages.push((name, from_ref.to_string()));
+            }
+            _ => {}
+        }
+    }
+
+    if stages.is_empty() {
+        return None;
+    }
+
+    // Pick the target stage (by name, case-insensitive) or the last stage.
+    let start = match target {
+        Some(t) => {
+            let t = t.to_ascii_lowercase();
+            stages
+                .iter()
+                .position(|(n, _)| n.as_deref() == Some(t.as_str()))
+                .unwrap_or(stages.len() - 1)
+        }
+        None => stages.len() - 1,
+    };
+
+    // Follow the FROM chain until it points at an external image rather than an
+    // earlier stage name. Bounded by the stage count to avoid cycles.
+    let mut idx = start;
+    for _ in 0..stages.len() {
+        let resolved = substitute_dockerfile_args(&stages[idx].1, &global_args, build_args);
+        if let Some(prev) = stages
+            .iter()
+            .position(|(n, _)| n.as_deref() == Some(resolved.to_ascii_lowercase().as_str()))
+        {
+            idx = prev;
+            continue;
+        }
+        if resolved.eq_ignore_ascii_case("scratch") {
+            return None;
+        }
+        return Some(resolved);
+    }
+    None
+}
+
+/// Join Dockerfile line continuations (`\` at end of line) into logical lines.
+fn join_continuations(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut acc = String::new();
+    for line in content.lines() {
+        let trimmed_end = line.trim_end();
+        if let Some(prefix) = trimmed_end.strip_suffix('\\') {
+            acc.push_str(prefix);
+            acc.push(' ');
+        } else {
+            acc.push_str(line);
+            out.push(std::mem::take(&mut acc));
+        }
+    }
+    if !acc.is_empty() {
+        out.push(acc);
+    }
+    out
+}
+
+/// Substitute `${VAR}` / `$VAR` in a Dockerfile FROM reference using build args
+/// (highest precedence) then global ARG defaults. Unresolved refs are left as-is.
+fn substitute_dockerfile_args(
+    input: &str,
+    global_args: &HashMap<String, String>,
+    build_args: &HashMap<String, String>,
+) -> String {
+    let lookup = |name: &str| -> Option<String> {
+        build_args
+            .get(name)
+            .or_else(|| global_args.get(name))
+            .cloned()
+    };
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() {
+            if bytes[i + 1] == b'{' {
+                // ${VAR} (tolerate ${VAR:-default} / ${VAR:+x} by taking the name up to ':' or '}')
+                if let Some(end) = input[i + 2..].find('}') {
+                    let raw = &input[i + 2..i + 2 + end];
+                    let name = raw.split_once(':').map(|(n, _)| n).unwrap_or(raw);
+                    if let Some(v) = lookup(name) {
+                        out.push_str(&v);
+                    }
+                    i += 2 + end + 1;
+                    continue;
+                }
+            } else {
+                // $VAR — name is [A-Za-z0-9_]+
+                let start = i + 1;
+                let mut j = start;
+                while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+                    j += 1;
+                }
+                if j > start {
+                    if let Some(v) = lookup(&input[start..j]) {
+                        out.push_str(&v);
+                    }
+                    i = j;
+                    continue;
+                }
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
 fn insert_stringified_values(
     options: &mut HashMap<String, String>,
     values: &serde_json::Map<String, serde_json::Value>,
@@ -163,6 +324,57 @@ mod tests {
         assert_eq!(
             resolved.options.get("BUILDKIT_INLINE_CACHE"),
             Some(&"1".to_string())
+        );
+    }
+
+    #[test]
+    fn base_image_follows_multistage_and_arg_default() {
+        // Mirrors fixtures/parity-corpus/dockerfile-build/.devcontainer/Dockerfile:
+        // target `dev` FROMs `base`, which FROMs an ARG-parameterized external image.
+        let content = "\
+ARG VARIANT=bookworm
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT} AS base
+ARG NODE_VERSION=20
+RUN echo hi
+FROM base AS dev
+RUN echo dev
+";
+        let base = resolve_dockerfile_base_image(content, &HashMap::new(), Some("dev"));
+        assert_eq!(
+            base.as_deref(),
+            Some("mcr.microsoft.com/devcontainers/base:bookworm")
+        );
+    }
+
+    #[test]
+    fn base_image_build_arg_overrides_default() {
+        let content = "ARG VARIANT=bookworm\nFROM debian:${VARIANT}\n";
+        let mut args = HashMap::new();
+        args.insert("VARIANT".to_string(), "bullseye".to_string());
+        assert_eq!(
+            resolve_dockerfile_base_image(content, &args, None).as_deref(),
+            Some("debian:bullseye")
+        );
+    }
+
+    #[test]
+    fn base_image_defaults_to_last_stage_without_target() {
+        let content = "FROM alpine:3.19 AS build\nFROM ubuntu:22.04 AS run\n";
+        assert_eq!(
+            resolve_dockerfile_base_image(content, &HashMap::new(), None).as_deref(),
+            Some("ubuntu:22.04")
+        );
+    }
+
+    #[test]
+    fn base_image_scratch_and_empty_are_none() {
+        assert_eq!(
+            resolve_dockerfile_base_image("FROM scratch\n", &HashMap::new(), None),
+            None
+        );
+        assert_eq!(
+            resolve_dockerfile_base_image("RUN echo hi\n", &HashMap::new(), None),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

`read-configuration --include-merged-configuration` now matches the pinned reference CLI (`@devcontainers/cli@0.87.0`) for **compose** and **Dockerfile** configs run cold (no prior `up`). Previously deacon only resolved the base image via a literal `config.image` or a *running* container, so cold reads of compose/dockerfile configs silently dropped the base image's baked-in `devcontainer.metadata` customizations (e.g. `mcr.microsoft.com/devcontainers/base`'s `git` copilot instructions).

## What changed

**1. Base-image resolution precedence** now mirrors the reference:
1. literal `config.image`
2. compose primary service's resolved `image:` (via `docker compose config --format json`)
3. Dockerfile `FROM` base — new `resolve_dockerfile_base_image`, following multi-stage `AS`/ARG chains and applying `build.args` overrides
4. fall back to the workspace's running container image (prior behavior, now last)

**2. Strip the per-entry `id` marker** from the merged shape. `id` (a per-metadata-entry marker like a feature ref on an image label entry) rides through `DevContainerConfig::extra` on the merge chain and the last one survives, but upstream's `MergedDevContainerConfig` (`pickConfigProperties`) never emits it.

## Verification

All **22 valid parity-corpus cases** now reach byte-parity with the oracle on the normalized `mergedConfiguration` block — verified **locally against the real reference CLI** (Docker + pinned oracle 0.87.0). Cases directly fixed: `universal-jsonc` (id leak), `compose-array`, `compose-postgres`, `dockerfile-build`.

New hermetic unit tests:
- `resolve_dockerfile_base_image`: multi-stage + ARG default, build-arg override, last-stage default, `scratch`/empty → `None`
- `apply_upstream_merge_shape` strips `id`

`make test-nextest-fast` green (3056 passed); fmt + clippy `--all-targets --all-features` clean; conformance `validate` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT