### PR TITLE
chore(parity): cover object-form image-metadata label in merged-config corpus

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -82,6 +82,25 @@ jobs:
       - name: Build deacon
         run: cargo build -p deacon
 
+      - name: Build corpus fixture images
+        # Some corpus cases pin a LOCALLY-built image (tag ends `:local`) that no
+        # public registry provides — e.g. the object-form `devcontainer.metadata`
+        # label (#300/#332), which every published image dropped in favor of the
+        # array form. Build each `fixtures/parity-corpus/*/image/Dockerfile` to the
+        # tag its sibling devcontainer.json references, so both CLIs resolve the
+        # label by local `docker inspect` (no registry involved). Runs BEFORE the
+        # pre-pull so those tags already exist locally.
+        run: |
+          set -euo pipefail
+          for df in fixtures/parity-corpus/*/image/Dockerfile; do
+            [ -e "$df" ] || continue
+            dir="$(dirname "$df")"
+            tag="$(jq -r '.image' "$(dirname "$dir")/.devcontainer/devcontainer.json")"
+            echo "::group::docker build -t ${tag} ${dir}"
+            docker build -t "${tag}" "${dir}"
+            echo "::endgroup::"
+          done
+
       - name: Pre-pull corpus base images
         # `read-configuration --include-merged-configuration` reads an image's
         # `devcontainer.metadata` LABEL, pulling on a cache miss to match the
@@ -89,12 +108,14 @@ jobs:
         # `universal` image) would blow the harness's 120s per-invocation bound.
         # Warm the cache once, up front, so both CLIs resolve labels by local
         # inspect — the bound then guards real hangs, not first-pull latency.
+        # `:local` tags are built above (no registry), so skip them here.
         run: |
           set -euo pipefail
           grep -rhoE '"image"[[:space:]]*:[[:space:]]*"[^"]+"' \
             fixtures/parity-corpus/*/.devcontainer/devcontainer.json \
             | sed -E 's/.*"image"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' \
             | sort -u \
+            | grep -v ':local$' \
             | while read -r img; do
                 echo "::group::docker pull ${img}"
                 docker pull "${img}" || echo "warn: failed to pre-pull ${img} (continuing)"

--- a/fixtures/parity-corpus/object-form-metadata/.devcontainer/devcontainer.json
+++ b/fixtures/parity-corpus/object-form-metadata/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Object-form image metadata",
+  "image": "deacon-parity-object-metadata:local"
+}

--- a/fixtures/parity-corpus/object-form-metadata/image/Dockerfile
+++ b/fixtures/parity-corpus/object-form-metadata/image/Dockerfile
@@ -1,0 +1,12 @@
+# Fixture image for the `object-form-metadata` parity corpus case (#300/#332).
+#
+# Its `devcontainer.metadata` label is a single JSON OBJECT (the legacy form),
+# not the JSON array the modern reference CLI bakes. `parity_corpus_merged`
+# reads this label to prove deacon and the pinned oracle parse the object form
+# identically — coverage that no public image provides (they are all array-form).
+#
+# Built locally (never published) by the parity CI lane's "Build corpus fixture
+# images" step to the tag the fixture's devcontainer.json references. Both CLIs
+# resolve the label by local `docker inspect`, so no registry is involved.
+FROM alpine:3.19
+LABEL devcontainer.metadata='{"customizations":{"vscode":{"extensions":["deacon.object-form"]}},"remoteUser":"objuser","containerEnv":{"OBJ_FORM":"yes"}}'


### PR DESCRIPTION
## Summary

Closes the **object-form image-metadata** gap from #332. Adds a tier1 parity-corpus case, `object-form-metadata`, whose image carries a `devcontainer.metadata` label that is a single JSON **object** (the legacy form) rather than the JSON **array** every public image now bakes. `parity_corpus_merged` reads that label and proves deacon and the pinned oracle (`@devcontainers/cli@0.87.0`) parse the object form **identically** — coverage that previously lived only in the unit test `test_parse_image_metadata_label_object_and_array_forms`.

## How the image exists in CI

No published image carries an object-form label anymore, so the fixture pins a locally-built tag (`deacon-parity-object-metadata:local`). The parity lane now:
- **Builds** every `fixtures/parity-corpus/*/image/Dockerfile` to the tag its sibling `devcontainer.json` references, before the comparison (a new "Build corpus fixture images" step).
- **Skips** `:local` tags in the pre-pull step (they have no registry).

Both CLIs resolve the label by local `docker inspect` — no registry involved.

## Verification

Built the image locally and ran both CLIs against the fixture: **full normalized parity** on the `mergedConfiguration` block (customizations object→array, `remoteUser`, `containerEnv` all match). `parity_registry_check` (incl. `corpora_meet_registered_minimums`) green; `cargo fmt` clean.

This PR touches parity paths, so the `parity / live-certification` lane runs on it.

The second half of #332 (lifecycle-command `${containerEnv:*}` divergence) is a behavior change handled in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT