### PR TITLE
fix(lifecycle): stop substituting ${containerEnv:*} in lifecycle command strings

### DIFF
--- a/crates/core/src/container_lifecycle.rs
+++ b/crates/core/src/container_lifecycle.rs
@@ -774,45 +774,25 @@ where
         config.container_env.clone()
     };
 
-    // The source for `${containerEnv:VAR}` substitution is the container's BASE
-    // environment (the image's `ENV` plus create-time `containerEnv`), NOT the
-    // userEnvProbe additions (#298). Absorbing probe-only PATH entries into
-    // `${containerEnv:PATH}` diverges from the reference CLI, which resolves
-    // container variables from the container environment alone. Read the base
-    // env from the container's `Config.Env` via inspect, then overlay the
-    // config's `containerEnv` so it wins on conflicts — mirroring
-    // `resolve_env_and_user`'s canonical container-env source.
-    let container_env_for_substitution = {
-        let mut base = match docker.inspect_container(&config.container_id).await {
-            Ok(Some(info)) => info.env,
-            Ok(None) => {
-                warn!(
-                    "Container '{}' not found while reading base env for containerEnv \
-                     substitution; using config containerEnv only",
-                    config.container_id
-                );
-                HashMap::new()
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to inspect container '{}' for base containerEnv substitution; \
-                     using config containerEnv only: {}",
-                    config.container_id, e
-                );
-                HashMap::new()
-            }
-        };
-        for (key, value) in &config.container_env {
-            base.insert(key.clone(), value.clone());
-        }
-        base
-    };
-
-    // Create substitution context with container information and the BASE env.
+    // The reference CLI does NOT resolve `${containerEnv:VAR}` inside lifecycle
+    // COMMAND STRINGS — it leaves the token literal, so the container shell that
+    // runs the command produces an empty expansion (verified against the pinned
+    // oracle: a `postCreateCommand` referencing `${containerEnv:PATH}` yields the
+    // same empty result as `sh -c` on the raw token). `${containerEnv:*}` is
+    // resolved only in `remoteEnv` — a separate, post-start pass deacon handles
+    // elsewhere — never in lifecycle command strings.
+    //
+    // So the lifecycle substitution context deliberately leaves `container_env`
+    // UNSET: the substitution engine then leaves `${containerEnv:*}` tokens
+    // literal (variable.rs three-pass model), matching the reference. Resolving
+    // them here would both diverge from the reference AND inject a containerEnv
+    // value into the command string host-side — a command-injection / word-split
+    // hazard the reference structurally avoids (a value like `x; rm -rf /` would
+    // execute). The command PROCESS still receives the full container env via
+    // `updated_config.container_env` below; only textual substitution is dropped.
     let container_context = substitution_context
         .clone()
-        .with_container_workspace_folder(config.container_workspace_folder.clone())
-        .with_container_env(container_env_for_substitution);
+        .with_container_workspace_folder(config.container_workspace_folder.clone());
 
     // Create an updated config with the merged environment (probe additions
     // included) so lifecycle command *processes* inherit the probed shell env.
@@ -4812,6 +4792,40 @@ mod tests {
                 assert_ne!(args[1], "${localWorkspaceFolder}");
             }
             _ => panic!("Expected Exec variant after substitution"),
+        }
+    }
+
+    #[test]
+    fn test_lifecycle_leaves_container_env_token_literal() {
+        // Alignment with the reference CLI (#332): `${containerEnv:VAR}` in a
+        // lifecycle COMMAND string is NOT resolved — it stays literal so the
+        // container shell expands it (to empty), exactly as the oracle does.
+        // Other container-context variables (`${containerWorkspaceFolder}`) DO
+        // resolve. `run_lifecycle` guarantees this by building the substitution
+        // context WITHOUT `container_env` (the default here), so this test pins
+        // the invariant the fix relies on.
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let context = SubstitutionContext::new(temp_dir.path())
+            .unwrap()
+            .with_container_workspace_folder("/workspaces/proj".to_string());
+        // No `.with_container_env(...)` — mirrors the lifecycle path.
+        assert!(context.container_env.is_none());
+
+        let cmd = LifecycleCommandValue::Shell(
+            "echo ${containerEnv:PATH} at ${containerWorkspaceFolder}".to_string(),
+        );
+        match cmd.substitute_variables(&context) {
+            LifecycleCommandValue::Shell(s) => {
+                assert!(
+                    s.contains("${containerEnv:PATH}"),
+                    "containerEnv token must stay literal for the shell to expand: {s}"
+                );
+                assert!(
+                    s.contains("/workspaces/proj"),
+                    "containerWorkspaceFolder must still resolve: {s}"
+                );
+            }
+            _ => panic!("expected Shell variant"),
         }
     }
 

--- a/crates/deacon/tests/parity_up_exec.rs
+++ b/crates/deacon/tests/parity_up_exec.rs
@@ -58,13 +58,20 @@ async fn parity_up_and_exec_traditional() {
     let ws_str = ws.to_string_lossy().into_owned();
 
     fs::create_dir(ws.join(".devcontainer")).unwrap();
+    // `containerEnv` + a lifecycle command that references `${containerEnv:*}`
+    // exercises the #332 parity: the reference CLI does NOT substitute
+    // `${containerEnv:VAR}` inside lifecycle command strings — it leaves the token
+    // literal for the container shell (which expands it to empty). deacon aligns
+    // (it used to inject the value, a command-injection hazard). Both CLIs must
+    // produce the SAME empty marker (verified below).
     fs::write(
         ws.join(".devcontainer/devcontainer.json"),
         r#"{
   "name": "ParityUpExec",
   "image": "alpine:3.19",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "sh -lc 'echo ready > /tmp/parity_marker'"
+  "containerEnv": { "PARITY_TOKEN": "tkn-42" },
+  "postCreateCommand": "sh -lc 'echo ready > /tmp/parity_marker; printf \"env=[%s]\\n\" \"${containerEnv:PARITY_TOKEN}\" > /tmp/parity_env_marker'"
 }
 "#,
     )
@@ -91,7 +98,7 @@ async fn parity_up_and_exec_traditional() {
         ws_str.as_str(),
         "sh",
         "-lc",
-        "cat /tmp/parity_marker && pwd",
+        "cat /tmp/parity_marker && cat /tmp/parity_env_marker",
     ];
     let oracle_exec_inv = ff(exec_oracle(
         BINARY,
@@ -125,7 +132,7 @@ async fn parity_up_and_exec_traditional() {
         "--",
         "sh",
         "-lc",
-        "cat /tmp/parity_marker && pwd",
+        "cat /tmp/parity_marker && cat /tmp/parity_env_marker",
     ];
     let deacon_exec_inv = ff(exec_deacon(
         BINARY,
@@ -139,6 +146,27 @@ async fn parity_up_and_exec_traditional() {
     ff(deacon_exec_inv.require_success());
     let out2 = deacon_exec_inv.stdout_string();
     assert!(out2.contains("ready"), "deacon marker missing: {}", out2);
+
+    // #332: `${containerEnv:PARITY_TOKEN}` in the postCreateCommand must resolve
+    // IDENTICALLY for both CLIs. The reference leaves it literal → the shell
+    // expands it to empty → `env=[]`. deacon aligns, so both markers match. A
+    // regression that made deacon inject the value would surface here as
+    // `env=[tkn-42]` vs `env=[]`.
+    fn env_marker_line(out: &str) -> &str {
+        out.lines()
+            .find(|l| l.starts_with("env="))
+            .unwrap_or_else(|| panic!("env marker line missing in exec output: {out:?}"))
+    }
+    let oracle_env = env_marker_line(&out1);
+    let deacon_env = env_marker_line(&out2);
+    assert_eq!(
+        deacon_env, oracle_env,
+        "lifecycle `${{containerEnv:*}}` substitution diverged (deacon vs oracle)"
+    );
+    assert_eq!(
+        deacon_env, "env=[]",
+        "reference leaves `${{containerEnv:*}}` literal (shell → empty); deacon must match"
+    );
 
     // --- Label parity checks (plain local docker inspection of the containers) ---
     fn docker_out(args: &[&str]) -> String {


### PR DESCRIPTION
## Summary

Aligns deacon with the reference CLI on `${containerEnv:VAR}` handling inside lifecycle **command strings**, and removes a command-injection hazard. Closes the lifecycle-`containerEnv` half of #332.

## The divergence (found while adding #332 coverage)

#332 assumed this behavior was `reference: aligned`. It isn't. Verified against the pinned oracle (`@devcontainers/cli@0.87.0`):

- The reference resolves `${containerEnv:*}` **only in `remoteEnv`** (a separate post-start pass). In lifecycle command strings it leaves the token **literal**, so the container shell expands it — to empty.
- deacon (via #298/#304) instead **injected** the container's env value into the command string host-side.

This wasn't just a parity gap — it was a **command-injection / word-split hazard** the reference structurally avoids:

```
containerEnv.MSG = "x; echo INJECTED > /tmp/inj"
postCreateCommand: sh -lc 'echo ${containerEnv:MSG} > /tmp/out'
  before (deacon): /tmp/out=INJECTED, the injected command ran
  after  (deacon): /tmp/out=[],       no injection   ← matches the reference
```

## Fix

Build the lifecycle substitution context **without** `container_env`, so the substitution engine leaves `${containerEnv:*}` literal (variable.rs three-pass model) — exactly what the reference does. `${containerWorkspaceFolder}` and other container variables still resolve. The command **process** still receives the full (probe-augmented) container env via `updated_config.container_env`; only textual substitution into the command string is dropped.

This reverts the substitution premise of #298/#304 (decision made with the maintainer after showing the injection hazard); #304's other change (object-form image metadata) is unaffected.

## Verification

- Manual, against the real oracle: post-fix deacon produces byte-identical lifecycle output (`plain=[] def=[]`) and no longer executes the injection.
- Extends `parity_up_exec` to assert both CLIs resolve a lifecycle `${containerEnv:*}` identically (empty) — touches parity paths, so the `parity / live-certification` lane runs on this PR.
- New unit test pins the "leave `${containerEnv:*}` literal, still resolve `${containerWorkspaceFolder}`" invariant.
- `cargo fmt --check` + `clippy --all-targets --all-features` clean; 73 `container_lifecycle` unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT