### PR TITLE
fix(read-config): discover the running container before cold base-image resolution

### DIFF
--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -1697,87 +1697,44 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         //      where `config.image` is None — at read-config time we
         //      don't know the built image tag, but we can find it via
         //      the container that `up` created.
-        let image_metadata_entries: Vec<deacon_core::config::DevContainerConfig> = if container_info
-            .is_none()
-        {
-            use deacon_core::docker::Docker;
-            let docker = deacon_core::docker::CliDocker::with_path(args.docker_path.clone());
+        let image_metadata_entries: Vec<deacon_core::config::DevContainerConfig> =
+            if container_info.is_none() {
+                use deacon_core::docker::Docker;
+                let docker = deacon_core::docker::CliDocker::with_path(args.docker_path.clone());
 
-            // The config file backing this read (CLI `--config` or the
-            // auto-discovered path); its parent anchors compose files and the
-            // Dockerfile, mirroring the feature-anchor logic above.
-            let config_path_for_build = args
-                .config_path
-                .as_deref()
-                .or(resolved_config_path.as_deref());
-            let config_dir = config_path_for_build
-                .and_then(|p| p.parent())
-                .unwrap_or(workspace_folder);
+                // The config file backing this read (CLI `--config` or the
+                // auto-discovered path); its parent anchors compose files and the
+                // Dockerfile, mirroring the feature-anchor logic above.
+                let config_path_for_build = args
+                    .config_path
+                    .as_deref()
+                    .or(resolved_config_path.as_deref());
+                let config_dir = config_path_for_build
+                    .and_then(|p| p.parent())
+                    .unwrap_or(workspace_folder);
 
-            // Resolve the base image whose `devcontainer.metadata` label seeds
-            // the merged config, matching the reference CLI's precedence:
-            //   1. literal `config.image`
-            //   2. compose primary service's resolved `image:`
-            //   3. Dockerfile `FROM` base (following multi-stage + ARG)
-            //   4. fall back to the workspace's running container's image
-            // The reference reads the base image's baked-in feature metadata
-            // (e.g. `mcr…/devcontainers/base`'s `git` customizations) even for
-            // compose / Dockerfile configs before any container exists, so a
-            // cold `read-configuration` must too (#307 follow-up).
-            let mut image_ref: Option<String> = if let Some(image) = config.image.as_deref() {
-                Some(image.to_string())
-            } else if config.uses_compose() {
-                use deacon_core::compose::{ComposeManager, ServiceShape};
-                let manager = ComposeManager::with_docker_path(args.docker_path.clone());
-                // Resolve to absolute paths so the compose files (anchored to
-                // `config_dir`) are opened correctly regardless of the child
-                // process CWD — a relative `config_dir` otherwise gets joined
-                // twice and the `-f` file is not found.
-                let abs_workspace = workspace_folder
-                    .canonicalize()
-                    .unwrap_or_else(|_| workspace_folder.to_path_buf());
-                let abs_config_dir = config_dir
-                    .canonicalize()
-                    .unwrap_or_else(|_| config_dir.to_path_buf());
-                match manager.create_project(&config, &abs_workspace, &abs_config_dir) {
-                    Ok(project) => {
-                        match manager
-                            .get_command(&project)
-                            .extract_service_shape(&project.service)
-                            .await
-                        {
-                            Ok(ServiceShape::Image(img)) => Some(img),
-                            // Build-shaped or unresolvable services contribute
-                            // no base-image metadata (best-effort, like #91).
-                            _ => None,
-                        }
-                    }
-                    Err(_) => None,
-                }
-            } else if let Some(cfg_path) = config_path_for_build {
-                // Dockerfile-based (`build.dockerfile` / legacy `dockerFile`).
-                match resolve_devcontainer_build_config(&config, cfg_path) {
-                    Ok(Some(rb)) => match std::fs::read_to_string(&rb.dockerfile_path) {
-                        Ok(content) => resolve_dockerfile_base_image(
-                            &content,
-                            &rb.options,
-                            rb.target.as_deref(),
-                        ),
-                        Err(_) => None,
-                    },
-                    _ => None,
-                }
-            } else {
-                None
-            };
+                // Resolve the base image whose `devcontainer.metadata` label seeds
+                // the merged config, matching the reference CLI's precedence:
+                //   1. WARM — a running container for this workspace. Its image is the
+                //      actual built/pulled one, carrying the true baked metadata (e.g.
+                //      a Dockerfile build's own `devcontainer.metadata` LABEL), which
+                //      cold static resolution cannot see. The reference reads the
+                //      running container's image metadata when one exists, so we must
+                //      too — otherwise a warm `--include-merged-configuration` drops
+                //      the image-layer metadata (regression from #339).
+                //   2. COLD (no container) — resolve the base image statically from the
+                //      config shape: literal `config.image`, else the compose primary
+                //      service's resolved `image:`, else the Dockerfile `FROM` base
+                //      (multi-stage + ARG). This keeps a cold read reflecting the base
+                //      image's baked-in feature metadata (#307/#339); corpus fixtures
+                //      have no running container, so they fall through to here.
+                let mut image_ref: Option<String> = None;
 
-            // Fallback: no static base resolved above. Find the workspace's
-            // container via the spec-mandated `devcontainer.local_folder`
-            // label (#80) — the workspaceHash/configHash pair drifts whenever
-            // `up` mutates the config mid-flight (workspace_mount injection,
-            // image-metadata merge, etc.), so read-config can never
-            // reconstruct an identical hash. The path label is stable.
-            if image_ref.is_none() {
+                // (1) Warm: find the workspace's container via the spec-mandated
+                // `devcontainer.local_folder` label (#80) — the workspaceHash/configHash
+                // pair drifts whenever `up` mutates the config mid-flight (workspace_mount
+                // injection, image-metadata merge, etc.), so read-config can never
+                // reconstruct an identical hash. The path label is stable.
                 if let Ok(canonical_workspace) = workspace_folder.canonicalize() {
                     let label_selector = format!(
                         "devcontainer.source=deacon,devcontainer.local_folder={}",
@@ -1791,15 +1748,64 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
                         }
                     }
                 }
-            }
-            if let Some(image_ref) = image_ref {
-                parse_image_metadata_entries(&docker, &image_ref).await
+
+                // (2) Cold: no running container — resolve the base image statically.
+                if image_ref.is_none() {
+                    image_ref = if let Some(image) = config.image.as_deref() {
+                        Some(image.to_string())
+                    } else if config.uses_compose() {
+                        use deacon_core::compose::{ComposeManager, ServiceShape};
+                        let manager = ComposeManager::with_docker_path(args.docker_path.clone());
+                        // Resolve to absolute paths so the compose files (anchored to
+                        // `config_dir`) are opened correctly regardless of the child
+                        // process CWD — a relative `config_dir` otherwise gets joined
+                        // twice and the `-f` file is not found.
+                        let abs_workspace = workspace_folder
+                            .canonicalize()
+                            .unwrap_or_else(|_| workspace_folder.to_path_buf());
+                        let abs_config_dir = config_dir
+                            .canonicalize()
+                            .unwrap_or_else(|_| config_dir.to_path_buf());
+                        match manager.create_project(&config, &abs_workspace, &abs_config_dir) {
+                            Ok(project) => {
+                                match manager
+                                    .get_command(&project)
+                                    .extract_service_shape(&project.service)
+                                    .await
+                                {
+                                    Ok(ServiceShape::Image(img)) => Some(img),
+                                    // Build-shaped or unresolvable services contribute
+                                    // no base-image metadata (best-effort, like #91).
+                                    _ => None,
+                                }
+                            }
+                            Err(_) => None,
+                        }
+                    } else if let Some(cfg_path) = config_path_for_build {
+                        // Dockerfile-based (`build.dockerfile` / legacy `dockerFile`).
+                        match resolve_devcontainer_build_config(&config, cfg_path) {
+                            Ok(Some(rb)) => match std::fs::read_to_string(&rb.dockerfile_path) {
+                                Ok(content) => resolve_dockerfile_base_image(
+                                    &content,
+                                    &rb.options,
+                                    rb.target.as_deref(),
+                                ),
+                                Err(_) => None,
+                            },
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
+                }
+                if let Some(image_ref) = image_ref {
+                    parse_image_metadata_entries(&docker, &image_ref).await
+                } else {
+                    Vec::new()
+                }
             } else {
                 Vec::new()
-            }
-        } else {
-            Vec::new()
-        };
+            };
 
         let mut merged = compute_merged_configuration(
             &config,


### PR DESCRIPTION
## Summary

Fixes a regression from #339 caught by the canary sweep. `read-configuration --include-merged-configuration` resolved by `--workspace-folder` alone (no `--container-id`) stopped surfacing a running container's image `devcontainer.metadata` label.

#339 made the **cold** static base-image resolution (compose service `image:` / Dockerfile `FROM` base) run **before** the running-container fallback. For a Dockerfile config, the statically-resolved FROM base — which lacks the *built* image's baked label — won, so the image-layer metadata was dropped on the warm path.

## Fix

Swap the precedence to match the reference CLI:
1. **WARM** — a running container for this workspace. Its image is the actual built/pulled one, carrying the true baked metadata.
2. **COLD** — only when no container exists, resolve the base image statically (`config.image` / compose service image / Dockerfile `FROM` base).

## Verification

- **Warm path restored**: `up/image-metadata-merge` canary now passes all 4 scenarios; scenario 4's merged `containerEnv` = `{IMAGE_LAYER, CONFIG_LAYER, MERGED_LAYER}` (was `{CONFIG_LAYER}` while broken).
- **Cold parity preserved**: all cold merged-config corpus cases (compose-array, compose-postgres, dockerfile-build, universal-jsonc, node-ts, object-form-metadata) still reach normalized parity with the pinned oracle — fixtures have no running container, so they fall through to the cold path unchanged.
- `cargo fmt --check` + `clippy --all-targets --all-features` clean; 61 `read_configuration` unit tests green.

Touches parity paths indirectly via behavior; the `parity / live-certification` lane will run its full corpus. (This is a `src`-only change, so the lane triggers only on the merged-`main` nightly / dispatch — I verified the corpus locally against the real oracle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT