### PR TITLE
chore(examples): fix two fixture-drift canaries and record the 2026-07-22 sweep

### DIFF
--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -22,7 +22,31 @@ pass, so they don't have to be re-evaluated from scratch every session.
 - `🚫 deferred` — exercises a deacon capability that isn't implemented yet.
 - `❓ unverified` — not evaluated this cycle.
 
-Last broad sweep: **2026-07-20** against `main` @ `de5b045` (post-#318/#319) —
+Last broad sweep: **2026-07-22** against `main` @ `3db4306` (post-#338/#339/#340/#341,
+the merged-config base-image + lifecycle-`containerEnv` parity work) — all 91 canaries
+run with the release binary. **87 pass, 3 fixture, 1 deacon-bug** on first pass; after the
+fixes below, **all 91 pass**:
+
+- `up/image-metadata-merge` — was **✗ deacon-bug**: a regression from #339. Warm
+  `read-configuration --include-merged-configuration` (container already up, resolved by
+  `--workspace-folder`) dropped the running container's image `devcontainer.metadata`
+  label because #339's cold static FROM-base resolution ran *before* container discovery.
+  Fixed in **PR #342** (container-first precedence); scenario 4 passes again. ✅
+- `build/duplicate-tags` — was **⚠️ fixture** (stale after #330, `447b2ab`): deacon now
+  emits `imageName` as an array to match the reference CLI, but the exec.sh asserted a bare
+  string. Updated the assertion to the de-duplicated single-element array. ✅
+- `up/up-exec-down` — was **⚠️ fixture**: the exec.sh passed `--mount-workspace-git-root
+  false` to `up`/`exec` only. Since #273/#309 that flag governs the in-container workspace
+  folder, but `run-user-commands`/`down` don't accept it, so they derived a different cwd →
+  `chdir` rc 127. Dropped the flag so all four subcommands git-root-anchor consistently. ✅
+  (Latent deacon inconsistency to follow up: `run-user-commands` lacks the
+  `--mount-workspace-git-root` flag that `up`/`exec` have; the robust fix is to read the
+  resolved container's `remoteWorkspaceFolder` instead of re-deriving cwd host-side.)
+- `up/compose-profiles` — still **⚠️ fixture** (missing `nginx.conf`, unchanged baseline).
+- `compose/multiple-compose-files`, `compose/multiservice-down` — transient environment
+  (Docker address-pool exhaustion from leftover networks); pass cleanly after cleanup.
+
+Prior sweep: **2026-07-20** against `main` @ `de5b045` (post-#318/#319) —
 all 91 canaries run with the release binary. **90 pass, 1 fixture**. One was a real deacon bug
 (`features/oci-digest-pin`), fixed in PR #321 and re-verified ✅ at `8179744`;
 two were unclassified and have since been decided (both fixture-side):
@@ -77,7 +101,7 @@ and aren't listed.
 | build/compose-unsupported-flags | ✅ pass | 2026-07-20 `de5b045` | asserts errors (`--push`/`--output`) |
 | build/compose-with-features | ✅ pass | 2026-07-20 `de5b045` | compose+features build (#139) |
 | build/dockerfile-with-features | ✅ pass | 2026-07-20 `de5b045` | feature layering (#129) |
-| build/duplicate-tags | ✅ pass | 2026-07-20 `de5b045` | tag de-dup (#129) |
+| build/duplicate-tags | ✅ pass | 2026-07-22 `3db4306` | tag de-dup (#129); exec.sh updated to assert `imageName` array form (#330) |
 | build/image-reference | ✅ pass | 2026-07-20 `de5b045` |  |
 | build/image-reference-with-features | ✅ pass | 2026-07-20 `de5b045` | image-ref+features (#134) |
 | build/invalid-config-name | ✅ pass | 2026-07-20 `de5b045` | asserts error |
@@ -144,7 +168,7 @@ and aren't listed.
 | up/gpu-modes | ✅ pass | 2026-07-20 `de5b045` | GPU `all` failure expected on non-GPU hosts (tolerated) |
 | up/host-ca | ✅ pass | 2026-07-20 `de5b045` | `--inject-host-ca` explicit bundle; debian-slim → env-var-only fallback (no `ca-certificates`), canonical bundle + CA env vars present (016) |
 | up/id-labels-reconnect | ✅ pass | 2026-07-20 `de5b045` | full-ID on reconnect (#143) |
-| up/image-metadata-merge | ✅ pass | 2026-07-20 `de5b045` |  |
+| up/image-metadata-merge | ✅ pass | 2026-07-22 `3db4306` | scenario 4 (warm read-config) regressed by #339, fixed in PR #342 (container-first metadata resolution) |
 | up/initialize-command | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/lifecycle-hooks | ✅ pass | 2026-07-20 `de5b045` | non-existent `devuser`→root (apt needs root); array hooks→argv `["bash","-c",…]` (#151) |
 | up/override-command | ✅ pass | 2026-07-20 `de5b045` |  |
@@ -154,7 +178,7 @@ and aren't listed.
 | up/remove-existing | ✅ pass | 2026-07-20 `de5b045` | full-ID reuse (#143) |
 | up/security-options | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/skip-lifecycle | ✅ pass | 2026-07-20 `de5b045` |  |
-| up/up-exec-down | ✅ pass | 2026-07-20 `de5b045` | compound-flow up→exec→run-user-commands→down by --workspace-folder (#187 configHash fix) |
+| up/up-exec-down | ✅ pass | 2026-07-22 `3db4306` | compound-flow up→exec→run-user-commands→down by --workspace-folder (#187 configHash fix); exec.sh drops `--mount-workspace-git-root false` so all four subcommands anchor consistently (run-user-commands/down lack the flag) |
 | up/update-remote-user-uid | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/user-env-probe-modes | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/wait-for | ✅ pass | 2026-07-20 `de5b045` |  |

--- a/examples/build/duplicate-tags/exec.sh
+++ b/examples/build/duplicate-tags/exec.sh
@@ -27,13 +27,14 @@ OUTPUT="$(run "$DEACON_BIN" build --workspace-folder "$SCRIPT_DIR" \
 
 echo "build output: ${OUTPUT}" >&2
 
-# The duplicate tag must collapse to a single string in `imageName`, not a
-# duplicated array. Parse with python to assert the exact shape.
+# The duplicate tag must collapse to a single entry. `imageName` is always a JSON
+# array (matching the reference CLI; see #330), so two identical `--image-name`
+# flags yield a one-element array, not a two-element one. Assert the exact shape.
 python3 -c '
 import json, sys
 data = json.loads(sys.argv[1])
 assert data["outcome"] == "success", data
 name = data["imageName"]
-assert name == "myorg/dups:latest", "expected single string imageName, got: %r" % (name,)
-print("OK: imageName de-duplicated to a single string")
+assert name == ["myorg/dups:latest"], "expected de-duplicated single-element array, got: %r" % (name,)
+print("OK: imageName de-duplicated to a single-element array")
 ' "$OUTPUT"

--- a/examples/up/up-exec-down/exec.sh
+++ b/examples/up/up-exec-down/exec.sh
@@ -20,12 +20,19 @@ MARKER="up-exec-down-ok"
 # Identity resolution is anchored to --workspace-folder for every subcommand,
 # which is exactly what this canary verifies — so this is all exec /
 # run-user-commands / down need to find up's container.
+#
+# Every subcommand must ALSO derive the same in-container workspace folder as
+# `up` mounted, because `exec`/`run-user-commands` chdir into it before running.
+# Since #273/#309 that derivation is governed by `--mount-workspace-git-root`,
+# but `run-user-commands` (and `down`) don't accept that flag while `up`/`exec`
+# do — so passing `--mount-workspace-git-root false` only to some subcommands
+# makes them disagree on the path and `chdir` fails (rc 127). The one choice that
+# is consistent across ALL four here is the default (git-root anchoring): inside
+# this monorepo `up` mounts the git root and every subcommand derives the same
+# `/workspaces/<repo>/examples/up/up-exec-down` cwd. (The identity marker lives at
+# `/tmp`, so the mount location doesn't affect what this canary asserts.)
 WS_ARGS=(--workspace-folder "$SCRIPT_DIR")
-
-# `up` additionally bind-mounts the workspace. Mount only THIS example folder
-# (not the enclosing monorepo git root) so the canary is self-contained when
-# run from within this repo. The mount source does not affect identity.
-UP_ARGS=("${WS_ARGS[@]}" --mount-workspace-git-root false)
+UP_ARGS=("${WS_ARGS[@]}")
 
 run() {
 	echo "+ $*" >&2


### PR DESCRIPTION
## Summary

The **2026-07-22 canary sweep** (against `main` @ `3db4306`, post-#338/#339/#340/#341) ran all 91 canaries: **87 pass, 3 fixture, 1 deacon-bug**. This PR lands the two example-side fixes and records the sweep in `CANARY_STATUS.md`. The deacon-bug is fixed separately in **#342**.

### Fixes
- **`build/duplicate-tags`** — assert `imageName` as a de-duplicated **single-element array**, not a bare string. deacon emits `imageName` as an array to match the reference CLI since #330 (`447b2ab`); the exec.sh had drifted. Example drift, not a deacon bug.
- **`up/up-exec-down`** — drop `--mount-workspace-git-root false`. Since #273/#309 that flag governs the in-container workspace-folder derivation, but only `up`/`exec` accept it while `run-user-commands`/`down` don't — so passing it to some subcommands made them `chdir` into a path the others never mounted (rc 127). Without the flag, all four git-root-anchor consistently inside the monorepo (the identity marker lives at `/tmp`, so the mount location doesn't affect what the canary asserts).

Both verified passing with the fixed binary.

### Noted follow-up (not fixed here)
`run-user-commands` lacks the `--mount-workspace-git-root` flag that `up`/`exec` have. The robust fix is for `exec`/`run-user-commands` to read the resolved container's `remoteWorkspaceFolder` rather than re-deriving the cwd host-side from git-root logic. Captured in `CANARY_STATUS.md`.

### CANARY_STATUS.md
New 2026-07-22 sweep header + updated the `build/duplicate-tags`, `up/image-metadata-merge`, and `up/up-exec-down` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT