### PR TITLE
fix(exec,run-user-commands): derive cwd from the container's actual workspace mount

### DIFF
--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -556,6 +556,12 @@ where
             );
         }
 
+        // The resolved container's actual mounts, captured during resolution so the
+        // working directory can be recovered from the real workspace bind-mount
+        // (robust to `--mount-workspace-git-root` asymmetry) rather than re-derived
+        // host-side. Left empty when resolution doesn't inspect (falls back below).
+        let mut resolved_container_mounts: Vec<deacon_core::docker::Mount> = Vec::new();
+
         // Resolve target container using ContainerSelector priority:
         // 1. Direct container ID (--container-id)
         // 2. Label-based lookup (--id-label)
@@ -597,6 +603,7 @@ where
                     if info.state != "running" {
                         return Err(anyhow::anyhow!("Dev container is not running."));
                     }
+                    resolved_container_mounts = info.mounts.clone();
                     info.id
                 }
                 None => {
@@ -638,6 +645,9 @@ where
         if let Some(config_ctx) = resolved_config.as_ref() {
             let resolved = match docker_client.inspect_container(&container_id).await {
                 Ok(Some(container_info)) => {
+                    if resolved_container_mounts.is_empty() {
+                        resolved_container_mounts = container_info.mounts.clone();
+                    }
                     // #223: `up` resolves `remoteUser` (and other fields) from the
                     // image's `devcontainer.metadata` LABEL as a lower-precedence
                     // layer. `exec` only loads the raw devcontainer.json, so a
@@ -722,11 +732,25 @@ where
             cli_workdir.clone()
         } else {
             match resolved_config.as_ref() {
-                Some(config_ctx) => determine_container_working_dir(
-                    &config_ctx.config,
-                    config_ctx.workspace_folder.as_path(),
-                    args.mount_workspace_git_root,
-                ),
+                Some(config_ctx) => {
+                    // Prefer the running container's ACTUAL workspace bind-mount
+                    // (flag-independent, matches where `up` mounted) over host-side
+                    // re-derivation from `--mount-workspace-git-root`, which breaks
+                    // when this invocation's flag differs from `up`'s. Fall back to
+                    // the host-side derivation when no mount is available.
+                    crate::commands::shared::container_workspace_folder_from_mounts(
+                        &config_ctx.config,
+                        config_ctx.workspace_folder.as_path(),
+                        &resolved_container_mounts,
+                    )
+                    .unwrap_or_else(|| {
+                        determine_container_working_dir(
+                            &config_ctx.config,
+                            config_ctx.workspace_folder.as_path(),
+                            args.mount_workspace_git_root,
+                        )
+                    })
+                }
                 None => {
                     debug!("No config context; resolving home folder as cwd");
                     deacon_core::container_env_probe::resolve_home_folder(

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -197,11 +197,31 @@ async fn execute_lifecycle_commands(
     // Create substitution context
     let substitution_context = SubstitutionContext::new(workspace_folder)?;
 
-    // Determine container workspace folder. `run-user-commands` does not expose
-    // `--mount-workspace-git-root`, so it uses the git-root default (true) — which
-    // matches how `up` (also defaulting to true) created the container and mount.
-    let container_workspace_folder =
-        crate::commands::shared::derive_container_workspace_folder(config, workspace_folder, true);
+    // Determine the container workspace folder = the lifecycle cwd. Prefer the
+    // RUNNING container's ACTUAL workspace bind-mount over host-side re-derivation:
+    // `run-user-commands` doesn't expose `--mount-workspace-git-root`, so a
+    // host-side guess (previously hardcoded to the git-root default) disagrees with
+    // an `up --mount-workspace-git-root false` and the lifecycle `chdir` fails.
+    // Reading the mount reflects exactly where `up` mounted, regardless of flags.
+    // Fall back to host-side derivation when the mount can't be read.
+    let container_workspace_folder = {
+        use deacon_core::docker::Docker;
+        let from_mount = match cli.inspect_container(container_id).await {
+            Ok(Some(info)) => crate::commands::shared::container_workspace_folder_from_mounts(
+                config,
+                workspace_folder,
+                &info.mounts,
+            ),
+            _ => None,
+        };
+        from_mount.unwrap_or_else(|| {
+            crate::commands::shared::derive_container_workspace_folder(
+                config,
+                workspace_folder,
+                true,
+            )
+        })
+    };
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -42,4 +42,4 @@ pub use env_user::resolve_env_and_user;
 pub use identity::canonical_reconnect_identity;
 pub use remote_env::NormalizedRemoteEnv;
 pub use terminal::TerminalDimensions;
-pub use workspace::derive_container_workspace_folder;
+pub use workspace::{container_workspace_folder_from_mounts, derive_container_workspace_folder};

--- a/crates/deacon/src/commands/shared/workspace.rs
+++ b/crates/deacon/src/commands/shared/workspace.rs
@@ -1,6 +1,76 @@
 //! Workspace folder derivation helpers.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use deacon_core::config::DevContainerConfig;
+use deacon_core::docker::Mount;
+
+/// Recover the container workspace folder from a RUNNING container's actual
+/// workspace bind-mount, instead of re-deriving it host-side from the
+/// `--mount-workspace-git-root` flag.
+///
+/// Re-deriving host-side is fragile: subcommands disagree when their flags differ
+/// (e.g. `up --mount-workspace-git-root false` then `exec`/`run-user-commands`
+/// with the default), so the derived cwd doesn't match where `up` mounted and a
+/// `chdir` into it fails. Reading the container's real mount is flag-independent —
+/// it reflects exactly what `up` did, which is what the reference CLI's
+/// `remoteWorkspaceFolder` encodes.
+///
+/// Precedence:
+///   1. An explicit `config.workspaceFolder` — used verbatim (the reference does
+///      the same; it's the authored value, independent of any mount).
+///   2. The workspace bind mount: the bind mount whose host `source` is an
+///      ancestor-or-equal of `host_workspace_folder` (the most specific one when
+///      several match), joined with the source→workspace subpath onto its
+///      container `destination`.
+///
+/// Returns `None` when neither applies (no explicit folder and no matching bind
+/// mount — e.g. a volume-workspace or an unreadable container), so the caller can
+/// fall back to [`derive_container_workspace_folder`].
+pub fn container_workspace_folder_from_mounts(
+    config: &DevContainerConfig,
+    host_workspace_folder: &Path,
+    mounts: &[Mount],
+) -> Option<String> {
+    if let Some(explicit) = config.workspace_folder.as_deref() {
+        return Some(explicit.to_string());
+    }
+
+    let host = host_workspace_folder
+        .canonicalize()
+        .unwrap_or_else(|_| host_workspace_folder.to_path_buf());
+
+    // Pick the bind mount with the LONGEST (most specific) source that contains
+    // the host workspace, so nested mounts resolve to the innermost one.
+    let mut best: Option<(&Mount, String)> = None;
+    let mut best_len = 0usize;
+    for m in mounts {
+        if m.mount_type != "bind" {
+            continue;
+        }
+        let Some(src) = m.source.as_deref() else {
+            continue;
+        };
+        let src_canon = Path::new(src)
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from(src));
+        if let Ok(sub) = host.strip_prefix(&src_canon) {
+            let len = src_canon.as_os_str().len();
+            if best.is_none() || len > best_len {
+                best_len = len;
+                // Container paths are POSIX; a Windows host subpath uses `\`.
+                best = Some((m, sub.to_string_lossy().replace('\\', "/")));
+            }
+        }
+    }
+
+    let (m, sub) = best?;
+    if sub.is_empty() {
+        Some(m.destination.clone())
+    } else {
+        Some(format!("{}/{}", m.destination.trim_end_matches('/'), sub))
+    }
+}
 
 /// Derive the container workspace folder (the lifecycle & exec working directory)
 /// from configuration and the host workspace path.
@@ -59,5 +129,90 @@ mod tests {
 
         let result = derive_container_workspace_folder(&config, &host_path, false);
         assert_eq!(result, "/workspaces/workspace");
+    }
+
+    // --- container_workspace_folder_from_mounts (mount-based recovery) ---
+    // Synthetic (non-existent) paths canonicalize to themselves, so strip_prefix
+    // works on the literal paths.
+
+    fn bind(source: &str, dest: &str) -> Mount {
+        Mount {
+            mount_type: "bind".to_string(),
+            source: Some(source.to_string()),
+            destination: dest.to_string(),
+            mode: None,
+            rw: None,
+            propagation: None,
+            name: None,
+            driver: None,
+        }
+    }
+
+    #[test]
+    fn from_mounts_explicit_workspace_folder_wins() {
+        let mut config = minimal_config();
+        config.workspace_folder = Some("/custom/wsf".to_string());
+        // Even with a contradicting mount, the explicit folder is used verbatim.
+        let mounts = vec![bind("/host/proj", "/workspaces/proj")];
+        let got = container_workspace_folder_from_mounts(&config, Path::new("/host/proj"), &mounts);
+        assert_eq!(got.as_deref(), Some("/custom/wsf"));
+    }
+
+    #[test]
+    fn from_mounts_source_equals_workspace_returns_destination() {
+        // Mirrors `up --mount-workspace-git-root false`: the workspace folder
+        // itself is mounted, so the container cwd is the mount destination.
+        let config = minimal_config();
+        let mounts = vec![bind(
+            "/host/examples/up-exec-down",
+            "/workspaces/up-exec-down",
+        )];
+        let got = container_workspace_folder_from_mounts(
+            &config,
+            Path::new("/host/examples/up-exec-down"),
+            &mounts,
+        );
+        assert_eq!(got.as_deref(), Some("/workspaces/up-exec-down"));
+    }
+
+    #[test]
+    fn from_mounts_git_root_mount_appends_subpath() {
+        // Mirrors the default (git-root) mount: the git root is mounted and the
+        // workspace is a subdir, so the cwd is destination + subpath.
+        let config = minimal_config();
+        let mounts = vec![bind("/host/repo", "/workspaces/repo")];
+        let got = container_workspace_folder_from_mounts(
+            &config,
+            Path::new("/host/repo/examples/up-exec-down"),
+            &mounts,
+        );
+        assert_eq!(
+            got.as_deref(),
+            Some("/workspaces/repo/examples/up-exec-down")
+        );
+    }
+
+    #[test]
+    fn from_mounts_prefers_most_specific_source() {
+        // A nested bind mount (deeper source) wins over the enclosing one.
+        let config = minimal_config();
+        let mounts = vec![
+            bind("/host/repo", "/workspaces/repo"),
+            bind("/host/repo/pkg", "/pkg"),
+        ];
+        let got =
+            container_workspace_folder_from_mounts(&config, Path::new("/host/repo/pkg"), &mounts);
+        assert_eq!(got.as_deref(), Some("/pkg"));
+    }
+
+    #[test]
+    fn from_mounts_none_when_no_matching_bind() {
+        let config = minimal_config();
+        // A volume mount (not bind) and an unrelated bind mount → no match.
+        let mut vol = bind("some-volume", "/data");
+        vol.mount_type = "volume".to_string();
+        let mounts = vec![vol, bind("/other/place", "/elsewhere")];
+        let got = container_workspace_folder_from_mounts(&config, Path::new("/host/proj"), &mounts);
+        assert_eq!(got, None);
     }
 }


### PR DESCRIPTION
## Summary

Retires the flag-asymmetry fragility flagged in the 2026-07-22 canary sweep (and noted in `CANARY_STATUS.md`). `exec` and `run-user-commands` re-derived the in-container working directory **host-side** from `--mount-workspace-git-root` — and `run-user-commands` didn't even expose the flag (it hardcoded the git-root default). When a later subcommand's flag differed from the `up` that created the container (e.g. `up --mount-workspace-git-root false` then `exec`/`run-user-commands` with the default), they disagreed on the path and the `chdir` failed with **rc 127**.

## Fix

Recover the working directory from the **running container's actual workspace bind-mount** — which reflects exactly where `up` mounted, regardless of flags. This is the robust equivalent of the reference CLI's `remoteWorkspaceFolder`.

New shared helper `container_workspace_folder_from_mounts`:
1. explicit `config.workspaceFolder` wins verbatim, else
2. the most-specific bind mount whose host `source` contains the workspace, joined with the source→workspace subpath onto its container `destination`.

Both callers **fall back** to the previous host-side derivation when no mount is readable (volume-workspace / unreadable container), so nothing regresses.

**Self-contained**: no changes to `up`, container identity, `devcontainerId`, or `create_container` — the callers already inspect the container. (I deliberately avoided routing the workspace folder through identity labels, which would have perturbed `devcontainerId`.)

## Verification

- **Flag asymmetry fixed**: `up --mount-workspace-git-root false` then flagless `exec`/`run-user-commands`/`down` all succeed (`run-user-commands` previously rc 127).
- **No regressions**: default (git-root), explicit-`workspaceFolder` (`/workspace`), and `--container-id` paths unchanged — `exec/*` and `run-user-commands/*` canaries green.
- New unit tests cover both mount shapes (source==workspace, git-root+subpath), most-specific-source selection, explicit-folder precedence, and the no-match fallback.
- `cargo fmt --check` + `clippy --all-targets --all-features` clean; 33 exec + 8 workspace unit tests pass.

Follow-up to the note left in #343 / `CANARY_STATUS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT