### PR TITLE
chore(release): v0.2.0-rc.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.14" }
+deacon-core = { path = "crates/core", version = "0.2.0-rc.15" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.14"
+version = "0.2.0-rc.15"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Version bump **0.2.0-rc.14 → 0.2.0-rc.15** across all four sync points:
- `crates/deacon/Cargo.toml`
- `crates/core/Cargo.toml`
- root `Cargo.toml` (`deacon-core` path-dep `version`)
- `Cargo.lock` (both `deacon` and `deacon-core`)

## What's in this release candidate (since rc.14)

- **Parity / merged config**: resolve base-image `devcontainer.metadata` for compose & Dockerfile configs (#339), object-form image-metadata corpus coverage (#340), and the pre-pull timeout fix (#338).
- **Lifecycle `${containerEnv:*}` alignment** (#341): match the reference (leave it literal in lifecycle command strings) — also closes a command-injection hazard. **#332 closed.**
- **Warm read-config regression fix** (#342): container-first metadata resolution.
- **exec/run-user-commands cwd fix** (#344): derive the working dir from the container's actual workspace bind-mount (robust to `--mount-workspace-git-root` asymmetry).
- Canary fixture fixes + 2026-07-22 sweep record (#343).

## Release steps

Once this merges green, an annotated `v0.2.0-rc.15` tag on the merged commit triggers `release.yml` (verify → build/publish the 8 target binaries + checksums/SBOMs/provenance, deploy the install script). The `-rc` tag is flagged pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT