### PR TITLE
docs(readme): reference 0.2.0-rc.15 in the install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The install script supports a `--prerelease` flag and these environment variable
 
 ```bash
 # Install a specific version
-curl -fsSL https://get2knowio.github.io/deacon/install.sh | DEACON_VERSION=0.2.0-rc.2 bash
+curl -fsSL https://get2knowio.github.io/deacon/install.sh | DEACON_VERSION=0.2.0-rc.15 bash
 
 # Install the latest pre-release
 curl -fsSL https://get2knowio.github.io/deacon/install.sh | bash -s -- --prerelease


### PR DESCRIPTION
## Summary

Updates the version-pinned install-script example in `README.md` from the stale `0.2.0-rc.2` to the current **`0.2.0-rc.15`**.

```bash
curl -fsSL https://get2knowio.github.io/deacon/install.sh | DEACON_VERSION=0.2.0-rc.15 bash
```

## Note (not changed here — flagging for a decision)

The **Manual Download** table links use `releases/latest/download/deacon-v0.2.0-<target>`. Two pre-existing issues, unrelated to this bump:
- `releases/latest` resolves to the latest **non-prerelease**; since every release so far is an `-rc` pre-release, it currently 404s.
- The asset filenames are `deacon-v0.2.0-rc.15-<target>`, not `deacon-v0.2.0-<target>`.

Left as-is because fixing them is a scheme choice (pin each release's URLs vs. keep pointing at the eventual stable `v0.2.0`). Happy to update the table to working rc.15 URLs if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT