### PR TITLE
fix(exec,run-user-commands): use / cwd for Compose configs without a workspaceFolder

### DIFF
--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -421,24 +421,6 @@ async fn resolve_compose_target_container(
     }
 }
 
-/// Determine the working directory inside the container
-#[instrument(skip(config))]
-pub fn determine_container_working_dir(
-    config: &DevContainerConfig,
-    workspace_folder: &Path,
-    mount_workspace_git_root: bool,
-) -> String {
-    // Matches read-configuration / the mount / the reference (issue #309): explicit
-    // workspaceFolder verbatim, else /workspaces/<basename(root)>[/<subpath>].
-    let dir = deacon_core::workspace::container_workspace_folder(
-        workspace_folder,
-        config.workspace_folder.as_deref(),
-        mount_workspace_git_root,
-    );
-    debug!("Container working directory: {}", dir);
-    dir
-}
-
 /// Apply pass-3 (`containerSubstitute`) to working_dir and effective_env values.
 ///
 /// Tokens like `${containerEnv:HOME}` are deliberately preserved by pass 1 (config
@@ -735,21 +717,16 @@ where
                 Some(config_ctx) => {
                     // Prefer the running container's ACTUAL workspace bind-mount
                     // (flag-independent, matches where `up` mounted) over host-side
-                    // re-derivation from `--mount-workspace-git-root`, which breaks
-                    // when this invocation's flag differs from `up`'s. Fall back to
-                    // the host-side derivation when no mount is available.
-                    crate::commands::shared::container_workspace_folder_from_mounts(
+                    // re-derivation; for a Compose config without an explicit
+                    // workspaceFolder this resolves to `/` (the reference default,
+                    // a valid chdir target) instead of the single-container
+                    // `/workspaces/<basename>` the Compose service never mounts.
+                    crate::commands::shared::resolve_container_cwd(
                         &config_ctx.config,
                         config_ctx.workspace_folder.as_path(),
                         &resolved_container_mounts,
+                        args.mount_workspace_git_root,
                     )
-                    .unwrap_or_else(|| {
-                        determine_container_working_dir(
-                            &config_ctx.config,
-                            config_ctx.workspace_folder.as_path(),
-                            args.mount_workspace_git_root,
-                        )
-                    })
                 }
                 None => {
                     debug!("No config context; resolving home folder as cwd");
@@ -822,47 +799,6 @@ mod tests {
     use super::*;
     use deacon_core::config::DevContainerConfig;
     use tempfile::TempDir;
-
-    #[test]
-    fn test_determine_container_working_dir_with_config() {
-        let config = DevContainerConfig {
-            workspace_folder: Some("/custom/workspace".to_string()),
-            ..Default::default()
-        };
-
-        let temp_dir = TempDir::new().unwrap();
-        let workspace_path = temp_dir.path();
-
-        let working_dir = determine_container_working_dir(&config, workspace_path, true);
-        assert_eq!(working_dir, "/custom/workspace");
-    }
-
-    #[test]
-    fn test_determine_container_working_dir_default() {
-        let config = DevContainerConfig {
-            workspace_folder: None,
-            ..Default::default()
-        };
-
-        let temp_dir = TempDir::new().unwrap();
-        let workspace_path = temp_dir.path();
-        let workspace_name = workspace_path.file_name().unwrap().to_str().unwrap();
-
-        let working_dir = determine_container_working_dir(&config, workspace_path, false);
-        assert_eq!(working_dir, format!("/workspaces/{}", workspace_name));
-    }
-
-    #[test]
-    fn test_determine_container_working_dir_fallback() {
-        let config = DevContainerConfig {
-            workspace_folder: None,
-            ..Default::default()
-        };
-
-        // Use a path that might not have a proper file name
-        let working_dir = determine_container_working_dir(&config, Path::new("/"), false);
-        assert_eq!(working_dir, "/workspaces/workspace");
-    }
 
     #[test]
     fn test_compose_config_detection() {

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -198,30 +198,21 @@ async fn execute_lifecycle_commands(
     let substitution_context = SubstitutionContext::new(workspace_folder)?;
 
     // Determine the container workspace folder = the lifecycle cwd. Prefer the
-    // RUNNING container's ACTUAL workspace bind-mount over host-side re-derivation:
-    // `run-user-commands` doesn't expose `--mount-workspace-git-root`, so a
-    // host-side guess (previously hardcoded to the git-root default) disagrees with
-    // an `up --mount-workspace-git-root false` and the lifecycle `chdir` fails.
-    // Reading the mount reflects exactly where `up` mounted, regardless of flags.
-    // Fall back to host-side derivation when the mount can't be read.
-    let container_workspace_folder = {
+    // RUNNING container's ACTUAL workspace bind-mount over host-side re-derivation
+    // (`run-user-commands` doesn't expose `--mount-workspace-git-root`, so a
+    // host-side guess disagrees with an `up --mount-workspace-git-root false`); a
+    // Compose config without an explicit workspaceFolder resolves to `/` (the
+    // reference default), not the single-container `/workspaces/<basename>` the
+    // service never mounts (#294/#295).
+    let mounts = {
         use deacon_core::docker::Docker;
-        let from_mount = match cli.inspect_container(container_id).await {
-            Ok(Some(info)) => crate::commands::shared::container_workspace_folder_from_mounts(
-                config,
-                workspace_folder,
-                &info.mounts,
-            ),
-            _ => None,
-        };
-        from_mount.unwrap_or_else(|| {
-            crate::commands::shared::derive_container_workspace_folder(
-                config,
-                workspace_folder,
-                true,
-            )
-        })
+        match cli.inspect_container(container_id).await {
+            Ok(Some(info)) => info.mounts,
+            _ => Vec::new(),
+        }
     };
+    let container_workspace_folder =
+        crate::commands::shared::resolve_container_cwd(config, workspace_folder, &mounts, true);
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -42,4 +42,4 @@ pub use env_user::resolve_env_and_user;
 pub use identity::canonical_reconnect_identity;
 pub use remote_env::NormalizedRemoteEnv;
 pub use terminal::TerminalDimensions;
-pub use workspace::{container_workspace_folder_from_mounts, derive_container_workspace_folder};
+pub use workspace::{derive_container_workspace_folder, resolve_container_cwd};

--- a/crates/deacon/src/commands/shared/workspace.rs
+++ b/crates/deacon/src/commands/shared/workspace.rs
@@ -72,6 +72,34 @@ pub fn container_workspace_folder_from_mounts(
     }
 }
 
+/// Resolve the container working directory for `exec` / `run-user-commands` /
+/// lifecycle, applying the full reference-matching precedence:
+///   1. explicit `config.workspaceFolder`, or the running container's actual
+///      workspace bind-mount (both via [`container_workspace_folder_from_mounts`]);
+///   2. for a **Compose** config with no explicit `workspaceFolder`, `/` — the
+///      reference's effective Compose workspace, and always a valid `chdir`
+///      target (deacon previously used the single-container default
+///      `/workspaces/<basename>`, which the Compose service doesn't mount, so
+///      `exec`/lifecycle `chdir` failed with rc 127 — issues #294/#295);
+///   3. otherwise the single-container host-side derivation
+///      (`/workspaces/<basename(root)>[/<subpath>]`).
+pub fn resolve_container_cwd(
+    config: &DevContainerConfig,
+    host_workspace_folder: &Path,
+    mounts: &[Mount],
+    mount_workspace_git_root: bool,
+) -> String {
+    if let Some(folder) =
+        container_workspace_folder_from_mounts(config, host_workspace_folder, mounts)
+    {
+        return folder;
+    }
+    if config.uses_compose() {
+        return "/".to_string();
+    }
+    derive_container_workspace_folder(config, host_workspace_folder, mount_workspace_git_root)
+}
+
 /// Derive the container workspace folder (the lifecycle & exec working directory)
 /// from configuration and the host workspace path.
 ///
@@ -203,6 +231,49 @@ mod tests {
         let got =
             container_workspace_folder_from_mounts(&config, Path::new("/host/repo/pkg"), &mounts);
         assert_eq!(got.as_deref(), Some("/pkg"));
+    }
+
+    fn compose_config() -> DevContainerConfig {
+        let mut c = minimal_config();
+        c.docker_compose_file = Some(serde_json::json!("docker-compose.yml"));
+        c.service = Some("app".to_string());
+        c
+    }
+
+    #[test]
+    fn cwd_compose_without_workspace_folder_is_root() {
+        // Reference default for a Compose config without an explicit workspaceFolder
+        // is `/` (a valid chdir target), NOT `/workspaces/<basename>` (#294/#295).
+        let config = compose_config();
+        assert!(config.uses_compose());
+        let got = resolve_container_cwd(&config, Path::new("/host/my-project"), &[], false);
+        assert_eq!(got, "/");
+    }
+
+    #[test]
+    fn cwd_compose_honors_explicit_workspace_folder() {
+        let mut config = compose_config();
+        config.workspace_folder = Some("/workspaces/compose-basic".to_string());
+        let got = resolve_container_cwd(&config, Path::new("/host/my-project"), &[], false);
+        assert_eq!(got, "/workspaces/compose-basic");
+    }
+
+    #[test]
+    fn cwd_single_container_uses_workspaces_basename() {
+        // Non-compose without an explicit folder keeps the single-container default.
+        let config = minimal_config();
+        let got = resolve_container_cwd(&config, Path::new("/host/my-project"), &[], false);
+        assert_eq!(got, "/workspaces/my-project");
+    }
+
+    #[test]
+    fn cwd_prefers_workspace_mount_over_compose_root() {
+        // A Compose service that DOES mount the workspace resolves from the mount,
+        // not the `/` fallback.
+        let config = compose_config();
+        let mounts = vec![bind("/host/my-project", "/workspaces/my-project")];
+        let got = resolve_container_cwd(&config, Path::new("/host/my-project"), &mounts, false);
+        assert_eq!(got, "/workspaces/my-project");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the compose-path exec/lifecycle working-directory bug behind **#294** and **#295**. For a Compose config with no explicit `workspaceFolder`, deacon derived the single-container default `/workspaces/<basename>` as the cwd — but the Compose service never mounts that path, so `exec`/`run-user-commands` failed with `chdir … no such file or directory` (rc 127). The reference CLI uses `/` (its effective Compose workspace) and succeeds.

## Fix

New `resolve_container_cwd` — the single cwd precedence shared by `exec` and `run-user-commands`:
1. explicit `workspaceFolder` / the running container's actual workspace bind-mount (existing `container_workspace_folder_from_mounts`, from #344);
2. **Compose + no explicit folder → `/`** (the reference default, always a valid chdir target);
3. otherwise the single-container `/workspaces/<basename>` derivation.

This unifies and replaces `exec`'s `determine_container_working_dir`.

## Verification (vs oracle 0.87.0)

- **#295**: `up` + `exec` on a Compose config with `containerEnv`/`remoteEnv` and no `workspaceFolder` → `pwd=/ CONFIG_ENV=config REMOTE_ENV=remote`, **identical to the reference** (was rc-127 `chdir` failure).
- **#294**: `run-user-commands` lifecycle `chdir` now succeeds on the same shape; read-config `workspaceFolder` parity was already fixed.
- **No regressions**: single-container + explicit-`workspaceFolder` paths unchanged — `exec/workspace-folder-discovery`, `run-user-commands/basic`, `up/up-exec-down`, `up/compose-basic` canaries green.
- New unit tests: compose→`/`, compose honors explicit folder, single-container `/workspaces/<basename>`, and workspace-mount-preferred-over-`/`.

Two sibling issues in this cluster were **already fixed** on `main` (verified separately) and closed: #293 (tmpfs mounts accepted + applied) and #301 (honors the Compose top-level `name`).

Closes #294. Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT