### PR TITLE
docs(parity): characterize the container process-shape deviation (#290)

### DIFF
--- a/crates/parity-harness/src/normalize.rs
+++ b/crates/parity-harness/src/normalize.rs
@@ -329,9 +329,16 @@ pub struct StateSnapshot {
     pub exposed_ports: BTreeSet<String>,
     /// `HostConfig.PortBindings` keys actually PUBLISHED to the host.
     pub published_ports: BTreeSet<String>,
-    /// Captured for debugging; NOT diffed (keep-alive strategy differs by CLI).
+    /// Captured for debugging; NOT diffed. The container process shape is a
+    /// deacon-internal keep-alive/entrypoint-wrapper detail with no observable
+    /// behavioral difference — both CLIs keep the container running so `exec`,
+    /// lifecycle hooks, and feature entrypoints work identically. deacon uses a
+    /// PATH-robust `sh -c '… sleep infinity || tail -f /dev/null'`; the reference
+    /// an `exec "$@"` keep-alive loop. Intentional, characterized divergence (#290);
+    /// the behaviorally-significant cases (overrideCommand exit #291, feature
+    /// entrypoint composition #292) ARE observable and covered elsewhere.
     pub entrypoint: Vec<String>,
-    /// Captured for debugging; NOT diffed.
+    /// Captured for debugging; NOT diffed — see `entrypoint` (#290).
     pub cmd: Vec<String>,
     /// Captured (compose-project-prefix-normalized) for debugging; NOT diffed.
     pub networks: BTreeSet<String>,


### PR DESCRIPTION
## Summary

Closes out **#290** (container entrypoint/command wrapper parity). Since that issue was filed (deacon rc.13), deacon's `Config.Entrypoint` now **matches** the reference (`["/bin/sh"]`), and the two behaviorally-significant cases in this cluster are fixed: **#291** (`overrideCommand=false` now fails with rc 1 when the container exits) and **#292** (feature-contributed entrypoints are composed with the keep-alive wrapper, so the container stays running and `exec` works).

The only remaining difference is the **keep-alive Cmd wrapper shape**, which the observable-state parity harness *already* captures-but-never-diffs. This PR makes that intentional exclusion explicit and traceable to #290:

- deacon: `sh -c '… sleep infinity || tail -f /dev/null'` (PATH-robust, with a fallback)
- reference: `sh -c 'echo Container started; trap "exit 0" 15; exec "$@"; while sleep 1 & wait $!; do :; done'`

Both keep the container running so `exec`, lifecycle hooks, and feature entrypoints behave identically — a deacon-internal implementation detail with no observable behavioral effect. Doc-only change to `StateSnapshot`.

Verified against oracle 0.87.0:
- #290 image case: `Entrypoint=["/bin/sh"]` on both.
- #291: `overrideCommand=false` → deacon rc 1 (was rc 0), reference rc 1.
- #292: feature entrypoint → container `running`, `exec` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT