### PR TITLE
feat(up): write the merged devcontainer.metadata label on created containers (#322 part 2)

### DIFF
--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -91,6 +91,12 @@ pub(crate) async fn execute_container_up(
     // Merge CLI forward_ports into config
     let mut config = config.clone();
 
+    // #322: capture the pure USER config BEFORE any image-metadata merge, so the
+    // `devcontainer.metadata` config entry we stamp carries only devcontainer.json's
+    // own picked properties (remoteEnv/remoteUser/…) and does NOT duplicate the base
+    // image's metadata (which is already present as separate label entries).
+    let user_config_for_metadata = config.clone();
+
     // Host-CA injection (016, T028): synthesize the six CA env vars into the
     // container environment at create time, insert-if-absent so user
     // containerEnv values win (FR-024). The canonical bundle is written by the
@@ -568,6 +574,31 @@ pub(crate) async fn execute_container_up(
         &config
     };
 
+    // #322: stamp the merged `devcontainer.metadata` on the container so config
+    // that lives only in devcontainer.json (esp. `remoteEnv`) survives on the
+    // container and is recoverable by exec/read-configuration/set-up without the
+    // workspace — matching the reference CLI. Informational label; never feeds
+    // `devcontainerId` (see `ContainerIdentity::id_hash_labels`).
+    let create_identity_owned;
+    let create_identity: &ContainerIdentity = match config.image.as_deref() {
+        Some(image_ref) => {
+            match super::merged_config::build_container_metadata_label(
+                docker,
+                image_ref,
+                &user_config_for_metadata,
+            )
+            .await
+            {
+                Some(json) => {
+                    create_identity_owned = identity.clone().with_metadata_label(json);
+                    &create_identity_owned
+                }
+                None => identity,
+            }
+        }
+        None => identity,
+    };
+
     // Create container using DockerLifecycle trait.
     //
     // We pass `workspace_mount_source` (#67), not the raw workspace folder,
@@ -578,7 +609,7 @@ pub(crate) async fn execute_container_up(
     // affects the bind mount and not workspace+config hashing.
     let container_result = docker
         .up(
-            identity,
+            create_identity,
             config_for_create,
             &workspace_mount_source,
             args.remove_existing_container,

--- a/crates/deacon/src/commands/up/merged_config.rs
+++ b/crates/deacon/src/commands/up/merged_config.rs
@@ -443,6 +443,99 @@ fn apply_image_metadata_label(
     ConfigMerger::merge_configs(&chain)
 }
 
+/// Serialize the config's metadata-relevant ("picked") properties into a single
+/// `devcontainer.metadata` entry (#322). This is the entry deacon appends after
+/// the image's own metadata entries, so config living only in devcontainer.json —
+/// notably `remoteEnv` — is recoverable from the container by
+/// exec/read-configuration/set-up. Mirrors upstream `pickConfigProperties`.
+/// Null/empty values are dropped so the entry stays minimal.
+pub(crate) fn config_metadata_entry(config: &DevContainerConfig) -> serde_json::Value {
+    const PICK: &[&str] = &[
+        "init",
+        "privileged",
+        "capAdd",
+        "securityOpt",
+        "entrypoint",
+        "mounts",
+        "onCreateCommand",
+        "updateContentCommand",
+        "postCreateCommand",
+        "postStartCommand",
+        "postAttachCommand",
+        "waitFor",
+        "remoteUser",
+        "containerUser",
+        "updateRemoteUserUID",
+        "userEnvProbe",
+        "remoteEnv",
+        "containerEnv",
+        "customizations",
+        "overrideCommand",
+        "portsAttributes",
+        "otherPortsAttributes",
+        "shutdownAction",
+        "hostRequirements",
+    ];
+    let mut entry = serde_json::Map::new();
+    if let Ok(serde_json::Value::Object(full)) = serde_json::to_value(config) {
+        for k in PICK {
+            if let Some(v) = full.get(*k) {
+                let empty = match v {
+                    serde_json::Value::Null => true,
+                    serde_json::Value::Array(a) => a.is_empty(),
+                    serde_json::Value::Object(o) => o.is_empty(),
+                    serde_json::Value::String(s) => s.is_empty(),
+                    _ => false,
+                };
+                if !empty {
+                    entry.insert((*k).to_string(), v.clone());
+                }
+            }
+        }
+    }
+    serde_json::Value::Object(entry)
+}
+
+/// Build the `devcontainer.metadata` JSON to stamp on the created container
+/// (#322): the image's own metadata entries (from its `devcontainer.metadata`
+/// LABEL, which the feature-extended image inherits from the base) followed by
+/// the config entry from [`config_metadata_entry`].
+///
+/// Returns `None` when there's nothing config-only to preserve (no image label
+/// and an empty config entry) — the container then just keeps the base image's
+/// inherited label, which is already correct.
+pub(crate) async fn build_container_metadata_label(
+    docker: &impl Docker,
+    image_ref: &str,
+    config: &DevContainerConfig,
+) -> Option<String> {
+    let mut entries: Vec<serde_json::Value> = match docker.inspect_image(image_ref).await {
+        Ok(Some(info)) => match info.labels.get("devcontainer.metadata") {
+            Some(label) => match serde_json::from_str::<serde_json::Value>(label) {
+                Ok(serde_json::Value::Array(a)) => a,
+                Ok(other) => vec![other], // single-object legacy form
+                Err(_) => Vec::new(),
+            },
+            None => Vec::new(),
+        },
+        _ => Vec::new(),
+    };
+
+    let cfg_entry = config_metadata_entry(config);
+    let cfg_nonempty = cfg_entry
+        .as_object()
+        .map(|o| !o.is_empty())
+        .unwrap_or(false);
+    // Nothing config-only to add and no image entries → leave the inherited label.
+    if !cfg_nonempty && entries.is_empty() {
+        return None;
+    }
+    if cfg_nonempty {
+        entries.push(cfg_entry);
+    }
+    serde_json::to_string(&serde_json::Value::Array(entries)).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -450,6 +543,51 @@ mod tests {
     use deacon_core::features::{FeatureMetadata, OptionValue, ResolvedFeature};
 
     use super::*;
+
+    #[test]
+    fn config_metadata_entry_picks_only_config_properties() {
+        // remoteEnv/remoteUser/capAdd/customizations are picked; image/build/name/
+        // features/forwardPorts and null/empty values are dropped (#322).
+        let config: DevContainerConfig = serde_json::from_str(
+            r#"{
+                "name": "demo",
+                "image": "alpine:3.19",
+                "forwardPorts": [3000],
+                "features": { "ghcr.io/x/y:1": {} },
+                "remoteUser": "root",
+                "remoteEnv": { "R": "1" },
+                "capAdd": ["NET_ADMIN"],
+                "securityOpt": [],
+                "customizations": { "vscode": { "extensions": ["x"] } }
+            }"#,
+        )
+        .unwrap();
+        let entry = config_metadata_entry(&config);
+        let obj = entry.as_object().unwrap();
+        // picked:
+        assert_eq!(obj.get("remoteUser").and_then(|v| v.as_str()), Some("root"));
+        assert!(obj.contains_key("remoteEnv"));
+        assert!(obj.contains_key("capAdd"));
+        assert!(obj.contains_key("customizations"));
+        // NOT picked / dropped:
+        assert!(!obj.contains_key("image"));
+        assert!(!obj.contains_key("name"));
+        assert!(!obj.contains_key("features"));
+        assert!(!obj.contains_key("forwardPorts"));
+        assert!(!obj.contains_key("securityOpt"), "empty arrays are dropped");
+    }
+
+    #[test]
+    fn config_metadata_entry_empty_for_bare_config() {
+        let config: DevContainerConfig =
+            serde_json::from_str(r#"{ "name": "x", "image": "alpine:3.19" }"#).unwrap();
+        assert!(
+            config_metadata_entry(&config)
+                .as_object()
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     // ============================================================================
     // T016: Tests for feature order preservation in metadata extraction


### PR DESCRIPTION
## Summary

Part 2 of **#322**. deacon now stamps `devcontainer.metadata` on the container it creates — the image's own metadata entries (inherited from the base by the feature-extended image) plus a config entry carrying devcontainer.json's picked properties (`remoteEnv`/`remoteUser`/`customizations`/…). This lets config that lives only in devcontainer.json (`remoteEnv` being the clear case) survive on the container and be recovered by `read-configuration`/`set-up` via `--container-id`, matching the reference. (`exec` reading it is part 3.)

## Changes
- `config_metadata_entry` — serialize the config's `pickConfigProperties` subset (dropping null/empty).
- `build_container_metadata_label` — image label entries + the config entry, as a JSON array.
- Wired into the single-container / Dockerfile-build create path via `identity.with_metadata_label(...)`. Crucially, the entry is built from the **pure user config captured before** the image-metadata merge, so it carries only devcontainer.json's own properties and never duplicates the base image's entries (fixed a double-count I caught during verification).

## Safety
- Informational label — stripped from the parity **state-diff** (`devcontainer.` prefix), so no observable-state divergence; never feeds `devcontainerId` (part 1).
- deacon's `up`/`read-config --workspace-folder` read the **image** label, not the container's, so writing the container label introduces no double-merge.

## Verification (vs oracle 0.87.0)
- `image` + `remoteEnv`/`remoteUser` config → `read-configuration --container-id` recovers `remoteEnv`/`remoteUser`/`customizations` **byte-identically** to the reference.
- The stamped config entry matches the reference's shape (`{remoteUser, remoteEnv}`) — no image-metadata double-count.
- New hermetic unit tests for `config_metadata_entry` (picks config props, drops image/name/features/empty).

## Remaining #322 stages
- **Part 2b**: compose containers (separate create path).
- **Part 3**: `exec --container-id` reads/applies the label.
- **Part 4**: registry `bhv-` record.

`fmt`/`clippy --all-targets --all-features` clean; unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT