### PR TITLE
feat(exec): recover remoteUser/remoteEnv from container label with --container-id (#322 part 3)

### DIFF
--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -666,6 +666,30 @@ where
 
             config_remote_user = resolved.remote_user.clone();
             config_remote_env = Some(resolved.remote_env.clone());
+        } else {
+            // #322: `exec --container-id` (no --workspace-folder/--config) has no
+            // workspace config, so recover `remoteUser`/`remoteEnv` from the
+            // container's own `devcontainer.metadata` label — which `up` now stamps.
+            // This makes exec consistent with `set-up` and `read-configuration`,
+            // which already read the label, and matches the reference CLI (#322).
+            if let Ok(Some(container_info)) = docker_client.inspect_container(&container_id).await {
+                if resolved_container_mounts.is_empty() {
+                    resolved_container_mounts = container_info.mounts.clone();
+                }
+                match crate::commands::shared::container_metadata::config_from_metadata_label(
+                    &container_info,
+                ) {
+                    Ok(Some(meta)) => {
+                        config_remote_user = meta.remote_user.clone();
+                        config_remote_env = Some(meta.remote_env.clone());
+                    }
+                    Ok(None) => {}
+                    Err(e) => tracing::warn!(
+                        "Failed to recover config from devcontainer.metadata label: {}",
+                        e
+                    ),
+                }
+            }
         }
 
         // Host-CA reconnect (016, T032): if `up` injected a corporate CA, the

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -279,53 +279,11 @@ async fn load_optional_config(path: Option<&std::path::Path>) -> Result<DevConta
 }
 
 /// Extract a `DevContainerConfig` from the container's `devcontainer.metadata`
-/// label. This label is a JSON array of metadata fragments that
-/// `ConfigMerger` already knows how to fold together.
-///
-/// Per spec §4 the label's contents are the authoritative image-metadata
-/// source. Missing label is NOT an error: many containers are not built by
-/// `deacon up` and still benefit from set-up running lifecycle hooks against
-/// the user's `--config`.
+/// label. Thin wrapper over the shared
+/// [`container_metadata::config_from_metadata_label`] so set-up, exec, and
+/// read-configuration all fold the label identically (#322).
 fn extract_image_metadata_config(container: &ContainerInfo) -> Result<Option<DevContainerConfig>> {
-    let Some(label) = container.labels.get("devcontainer.metadata") else {
-        debug!(
-            container_id = %container.id,
-            "Container has no devcontainer.metadata label; proceeding without image metadata"
-        );
-        return Ok(None);
-    };
-
-    let value: serde_json::Value = serde_json::from_str(label).with_context(|| {
-        format!(
-            "Failed to parse devcontainer.metadata label as JSON for container '{}'",
-            container.id
-        )
-    })?;
-
-    // PR-2 (#27) emits the label as a JSON array; tolerate both array and
-    // single-object forms for older images built before that bump.
-    let fragments: Vec<serde_json::Value> = match value {
-        serde_json::Value::Array(arr) => arr,
-        other => vec![other],
-    };
-
-    if fragments.is_empty() {
-        return Ok(None);
-    }
-
-    let mut configs = Vec::with_capacity(fragments.len());
-    for (idx, fragment) in fragments.into_iter().enumerate() {
-        let cfg: DevContainerConfig = serde_json::from_value(fragment).with_context(|| {
-            format!(
-                "Failed to deserialize devcontainer.metadata fragment {} for container '{}'",
-                idx, container.id
-            )
-        })?;
-        configs.push(cfg);
-    }
-
-    let merged = deacon_core::config::ConfigMerger::merge_configs(&configs);
-    Ok(Some(merged))
+    crate::commands::shared::container_metadata::config_from_metadata_label(container)
 }
 
 /// Merge `--config` (if any) on top of image metadata config (if any).

--- a/crates/deacon/src/commands/shared/container_metadata.rs
+++ b/crates/deacon/src/commands/shared/container_metadata.rs
@@ -1,0 +1,53 @@
+//! Shared recovery of a container's `devcontainer.metadata` label into config.
+//!
+//! deacon stamps the merged `devcontainer.metadata` array on containers it
+//! creates (#322), and reads it back — without the workspace — from
+//! `set-up`, `read-configuration --container-id`, and `exec --container-id`.
+//! This is the single parser those callers share (CLAUDE.md principle 6),
+//! rather than each re-implementing the fold.
+
+use anyhow::{Context, Result};
+
+use deacon_core::config::{ConfigMerger, DevContainerConfig};
+use deacon_core::docker::ContainerInfo;
+
+/// Extract a merged [`DevContainerConfig`] from a container's
+/// `devcontainer.metadata` label.
+///
+/// The label is a JSON array of metadata fragments (tolerating the legacy
+/// single-object form) that [`ConfigMerger`] folds together. A missing label is
+/// NOT an error — many containers aren't built by `deacon up` — so this returns
+/// `Ok(None)` and the caller falls back to whatever config it already has.
+pub fn config_from_metadata_label(container: &ContainerInfo) -> Result<Option<DevContainerConfig>> {
+    let Some(label) = container.labels.get("devcontainer.metadata") else {
+        return Ok(None);
+    };
+
+    let value: serde_json::Value = serde_json::from_str(label).with_context(|| {
+        format!(
+            "Failed to parse devcontainer.metadata label as JSON for container '{}'",
+            container.id
+        )
+    })?;
+
+    let fragments: Vec<serde_json::Value> = match value {
+        serde_json::Value::Array(arr) => arr,
+        other => vec![other],
+    };
+    if fragments.is_empty() {
+        return Ok(None);
+    }
+
+    let mut configs = Vec::with_capacity(fragments.len());
+    for (idx, fragment) in fragments.into_iter().enumerate() {
+        let cfg: DevContainerConfig = serde_json::from_value(fragment).with_context(|| {
+            format!(
+                "Failed to deserialize devcontainer.metadata fragment {} for container '{}'",
+                idx, container.id
+            )
+        })?;
+        configs.push(cfg);
+    }
+
+    Ok(Some(ConfigMerger::merge_configs(&configs)))
+}

--- a/crates/deacon/src/commands/shared/mod.rs
+++ b/crates/deacon/src/commands/shared/mod.rs
@@ -27,6 +27,7 @@ pub(crate) fn resolve_runtime(
 
 pub(crate) mod build_resolution;
 pub mod config_loader;
+pub mod container_metadata;
 pub mod env_user;
 pub mod feature_resolver;
 pub mod host_ca;

--- a/crates/deacon/src/commands/up/container.rs
+++ b/crates/deacon/src/commands/up/container.rs
@@ -91,6 +91,12 @@ pub(crate) async fn execute_container_up(
     // Merge CLI forward_ports into config
     let mut config = config.clone();
 
+    // #322: capture the pure USER config BEFORE any image-metadata merge, so the
+    // `devcontainer.metadata` config entry we stamp carries only devcontainer.json's
+    // own picked properties (remoteEnv/remoteUser/…) and does NOT duplicate the base
+    // image's metadata (which is already present as separate label entries).
+    let user_config_for_metadata = config.clone();
+
     // Host-CA injection (016, T028): synthesize the six CA env vars into the
     // container environment at create time, insert-if-absent so user
     // containerEnv values win (FR-024). The canonical bundle is written by the
@@ -568,6 +574,31 @@ pub(crate) async fn execute_container_up(
         &config
     };
 
+    // #322: stamp the merged `devcontainer.metadata` on the container so config
+    // that lives only in devcontainer.json (esp. `remoteEnv`) survives on the
+    // container and is recoverable by exec/read-configuration/set-up without the
+    // workspace — matching the reference CLI. Informational label; never feeds
+    // `devcontainerId` (see `ContainerIdentity::id_hash_labels`).
+    let create_identity_owned;
+    let create_identity: &ContainerIdentity = match config.image.as_deref() {
+        Some(image_ref) => {
+            match super::merged_config::build_container_metadata_label(
+                docker,
+                image_ref,
+                &user_config_for_metadata,
+            )
+            .await
+            {
+                Some(json) => {
+                    create_identity_owned = identity.clone().with_metadata_label(json);
+                    &create_identity_owned
+                }
+                None => identity,
+            }
+        }
+        None => identity,
+    };
+
     // Create container using DockerLifecycle trait.
     //
     // We pass `workspace_mount_source` (#67), not the raw workspace folder,
@@ -578,7 +609,7 @@ pub(crate) async fn execute_container_up(
     // affects the bind mount and not workspace+config hashing.
     let container_result = docker
         .up(
-            identity,
+            create_identity,
             config_for_create,
             &workspace_mount_source,
             args.remove_existing_container,

--- a/crates/deacon/src/commands/up/merged_config.rs
+++ b/crates/deacon/src/commands/up/merged_config.rs
@@ -443,6 +443,99 @@ fn apply_image_metadata_label(
     ConfigMerger::merge_configs(&chain)
 }
 
+/// Serialize the config's metadata-relevant ("picked") properties into a single
+/// `devcontainer.metadata` entry (#322). This is the entry deacon appends after
+/// the image's own metadata entries, so config living only in devcontainer.json —
+/// notably `remoteEnv` — is recoverable from the container by
+/// exec/read-configuration/set-up. Mirrors upstream `pickConfigProperties`.
+/// Null/empty values are dropped so the entry stays minimal.
+pub(crate) fn config_metadata_entry(config: &DevContainerConfig) -> serde_json::Value {
+    const PICK: &[&str] = &[
+        "init",
+        "privileged",
+        "capAdd",
+        "securityOpt",
+        "entrypoint",
+        "mounts",
+        "onCreateCommand",
+        "updateContentCommand",
+        "postCreateCommand",
+        "postStartCommand",
+        "postAttachCommand",
+        "waitFor",
+        "remoteUser",
+        "containerUser",
+        "updateRemoteUserUID",
+        "userEnvProbe",
+        "remoteEnv",
+        "containerEnv",
+        "customizations",
+        "overrideCommand",
+        "portsAttributes",
+        "otherPortsAttributes",
+        "shutdownAction",
+        "hostRequirements",
+    ];
+    let mut entry = serde_json::Map::new();
+    if let Ok(serde_json::Value::Object(full)) = serde_json::to_value(config) {
+        for k in PICK {
+            if let Some(v) = full.get(*k) {
+                let empty = match v {
+                    serde_json::Value::Null => true,
+                    serde_json::Value::Array(a) => a.is_empty(),
+                    serde_json::Value::Object(o) => o.is_empty(),
+                    serde_json::Value::String(s) => s.is_empty(),
+                    _ => false,
+                };
+                if !empty {
+                    entry.insert((*k).to_string(), v.clone());
+                }
+            }
+        }
+    }
+    serde_json::Value::Object(entry)
+}
+
+/// Build the `devcontainer.metadata` JSON to stamp on the created container
+/// (#322): the image's own metadata entries (from its `devcontainer.metadata`
+/// LABEL, which the feature-extended image inherits from the base) followed by
+/// the config entry from [`config_metadata_entry`].
+///
+/// Returns `None` when there's nothing config-only to preserve (no image label
+/// and an empty config entry) — the container then just keeps the base image's
+/// inherited label, which is already correct.
+pub(crate) async fn build_container_metadata_label(
+    docker: &impl Docker,
+    image_ref: &str,
+    config: &DevContainerConfig,
+) -> Option<String> {
+    let mut entries: Vec<serde_json::Value> = match docker.inspect_image(image_ref).await {
+        Ok(Some(info)) => match info.labels.get("devcontainer.metadata") {
+            Some(label) => match serde_json::from_str::<serde_json::Value>(label) {
+                Ok(serde_json::Value::Array(a)) => a,
+                Ok(other) => vec![other], // single-object legacy form
+                Err(_) => Vec::new(),
+            },
+            None => Vec::new(),
+        },
+        _ => Vec::new(),
+    };
+
+    let cfg_entry = config_metadata_entry(config);
+    let cfg_nonempty = cfg_entry
+        .as_object()
+        .map(|o| !o.is_empty())
+        .unwrap_or(false);
+    // Nothing config-only to add and no image entries → leave the inherited label.
+    if !cfg_nonempty && entries.is_empty() {
+        return None;
+    }
+    if cfg_nonempty {
+        entries.push(cfg_entry);
+    }
+    serde_json::to_string(&serde_json::Value::Array(entries)).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -450,6 +543,51 @@ mod tests {
     use deacon_core::features::{FeatureMetadata, OptionValue, ResolvedFeature};
 
     use super::*;
+
+    #[test]
+    fn config_metadata_entry_picks_only_config_properties() {
+        // remoteEnv/remoteUser/capAdd/customizations are picked; image/build/name/
+        // features/forwardPorts and null/empty values are dropped (#322).
+        let config: DevContainerConfig = serde_json::from_str(
+            r#"{
+                "name": "demo",
+                "image": "alpine:3.19",
+                "forwardPorts": [3000],
+                "features": { "ghcr.io/x/y:1": {} },
+                "remoteUser": "root",
+                "remoteEnv": { "R": "1" },
+                "capAdd": ["NET_ADMIN"],
+                "securityOpt": [],
+                "customizations": { "vscode": { "extensions": ["x"] } }
+            }"#,
+        )
+        .unwrap();
+        let entry = config_metadata_entry(&config);
+        let obj = entry.as_object().unwrap();
+        // picked:
+        assert_eq!(obj.get("remoteUser").and_then(|v| v.as_str()), Some("root"));
+        assert!(obj.contains_key("remoteEnv"));
+        assert!(obj.contains_key("capAdd"));
+        assert!(obj.contains_key("customizations"));
+        // NOT picked / dropped:
+        assert!(!obj.contains_key("image"));
+        assert!(!obj.contains_key("name"));
+        assert!(!obj.contains_key("features"));
+        assert!(!obj.contains_key("forwardPorts"));
+        assert!(!obj.contains_key("securityOpt"), "empty arrays are dropped");
+    }
+
+    #[test]
+    fn config_metadata_entry_empty_for_bare_config() {
+        let config: DevContainerConfig =
+            serde_json::from_str(r#"{ "name": "x", "image": "alpine:3.19" }"#).unwrap();
+        assert!(
+            config_metadata_entry(&config)
+                .as_object()
+                .unwrap()
+                .is_empty()
+        );
+    }
 
     // ============================================================================
     // T016: Tests for feature order preservation in metadata extraction


### PR DESCRIPTION
## Summary

Part 3 of **#322** — completes the core loop. `exec --container-id` (no `--workspace-folder`/`--config`) loaded no config, so the metadata-label recovery (which sits behind `if let Some(config_ctx)`) was skipped and `remoteEnv`/`remoteUser` were dropped. It now reads the container's own `devcontainer.metadata` label (stamped by `up` in part 2) and applies them — making `exec` consistent with `set-up`/`read-configuration` (CLAUDE.md principle 6) and matching the reference.

## Changes
- New shared `commands::shared::container_metadata::config_from_metadata_label` — the single label→config fold. `set-up`'s private copy now delegates to it (no third implementation, per the issue).
- exec's config-resolution block gains an `else` (workspace-config absent) that inspects the container, folds the label, and sets `config_remote_user`/`config_remote_env`.

## Verification (vs oracle 0.87.0)
`up` a config with `remoteEnv: {REMOTE_ONLY}` + `remoteUser: root`, then:
```
deacon exec --container-id <cid> -- sh -c 'echo $REMOTE_ONLY; whoami'
→ from-devcontainer-json / root   (was: empty / root)
```
Byte-identical to `devcontainer exec --container-id`.

## Stacking
Depends on **#350** (part 2, which writes the label). Independent code-wise (graceful when no label present) but should merge **after** #350 for the end-to-end behavior. No file overlap with #350.

`fmt`/`clippy --all-targets --all-features` clean; set-up + shared unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT