### PR TITLE
feat(up): write devcontainer.metadata on compose service containers (#322 part 2b)

### DIFF
--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -408,6 +408,41 @@ pub(crate) async fn execute_compose_up(
         handle_lockfile_post_build(args, config_path, &fb.lockfile).await?;
     }
 
+    // #322: stamp the merged `devcontainer.metadata` on the compose service
+    // container too (via `deacon_labels`, applied by the injection override), so
+    // config living only in devcontainer.json — esp. `remoteEnv` — survives and
+    // is recoverable by exec/read-configuration/set-up `--container-id`, exactly
+    // like the single-container path. The effective image is the feature-extended
+    // one when features were built, else the service's own `image:`.
+    {
+        use deacon_core::compose::ServiceShape;
+        let effective_image = match &project.service_image_override {
+            Some(img) => Some(img.clone()),
+            None => match compose_manager
+                .get_command(&project)
+                .extract_service_shape(&project.service)
+                .await
+            {
+                Ok(ServiceShape::Image(img)) => Some(img),
+                _ => None,
+            },
+        };
+        if let Some(img) = effective_image {
+            if let Some(json) = super::merged_config::build_container_metadata_label(
+                &runtime.cli_docker(),
+                &img,
+                config,
+            )
+            .await
+            {
+                project.deacon_labels.insert(
+                    deacon_core::container::LABEL_DEVCONTAINER_METADATA.to_string(),
+                    json,
+                );
+            }
+        }
+    }
+
     // Apply `devcontainer.json` `mounts` (#266) and feature-contributed
     // `mounts` (#272) to the compose project. Run through `merge_mounts` in a
     // single call — same as the single-container path (up/container.rs) —


### PR DESCRIPTION
## Summary

Extends the container-metadata label (#322 parts 2/3) to the **Compose** create path, so config-only values (esp. `remoteEnv`) survive on compose service containers and are recoverable via `exec`/`read-configuration`/`set-up --container-id` — same as single-container/Dockerfile.

## Change
After feature resolution (so the effective image is known — the feature-extended image when features were built, else the service's own `image:`) and before the project starts, deacon builds the merged `devcontainer.metadata` array (image entries + config entry via the shared `build_container_metadata_label`) and stamps it via `project.deacon_labels`, which the injection override applies to the service container.

## Verification (vs oracle 0.87.0)
Compose config with `remoteEnv: {REMOTE_ONLY}` + `remoteUser: root`:
```
deacon exec --container-id <cid> -- sh -c 'echo $REMOTE_ONLY'
→ from-devcontainer-json   (matches the reference)
```
Stamped config entry is `{remoteUser, remoteEnv}` — no image-metadata double-count.

`fmt`/`clippy --all-targets --all-features` clean.

This completes the label **writing** across all container-create paths. Remaining #322 stage: the registry `bhv-` record (part 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT