### PR TITLE
feat(conformance): characterize exec --container-id metadata recovery (#322 part 4)

### DIFF
--- a/conformance/registry/behaviors/exec.json
+++ b/conformance/registry/behaviors/exec.json
@@ -10,6 +10,16 @@
       "reference": "aligned",
       "decision": "follow-spec",
       "notes": "Backed by case-exec-parity (parity_exec)."
+    },
+    {
+      "id": "bhv-exec-container-id-metadata",
+      "area": "exec",
+      "statement": "exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv from the container's devcontainer.metadata label — which up stamps at create time — and applies them, matching the reference. remoteEnv, which lives only in devcontainer.json, is thereby recoverable without the workspace.",
+      "applicability": [],
+      "spec": "conformant",
+      "reference": "aligned",
+      "decision": "follow-spec",
+      "notes": "#322: up writes the merged devcontainer.metadata label (single-container, Dockerfile, and compose paths); exec/read-configuration/set-up read it back via the shared container_metadata::config_from_metadata_label helper. Backed by case-exec-container-id-metadata (parity_up_exec)."
     }
   ]
 }

--- a/conformance/registry/cases.json
+++ b/conformance/registry/cases.json
@@ -220,6 +220,15 @@
       ]
     },
     {
+      "id": "case-exec-container-id-metadata",
+      "behaviors": ["bhv-exec-container-id-metadata"],
+      "context": [],
+      "executable": { "binary": "parity_up_exec" },
+      "outcomes": [
+        { "channel": "chan-stdout", "expectation": "exec --container-id recovers the config-only remoteEnv from the container's devcontainer.metadata label, byte-identical to the reference" }
+      ]
+    },
+    {
       "id": "case-user-profiles",
       "behaviors": ["bhv-user-profiles"],
       "context": [],

--- a/conformance/registry/sources/spec.json
+++ b/conformance/registry/sources/spec.json
@@ -26,6 +26,14 @@
       "behaviors": ["bhv-exec-command-parity"]
     },
     {
+      "id": "src-spec-container-metadata-recovery",
+      "inventory": "spec",
+      "revision": "rev-spec-113500f4",
+      "locator": "Container metadata label recovery",
+      "summary": "The merged configuration is written to the container's devcontainer.metadata label at create time, so config that lives only in devcontainer.json (e.g. remoteEnv) is recoverable from the running container by exec/read-configuration/set-up without the workspace.",
+      "behaviors": ["bhv-exec-container-id-metadata"]
+    },
+    {
       "id": "src-spec-lifecycle-up",
       "inventory": "spec",
       "revision": "rev-spec-113500f4",

--- a/crates/deacon/src/commands/up/compose.rs
+++ b/crates/deacon/src/commands/up/compose.rs
@@ -408,6 +408,41 @@ pub(crate) async fn execute_compose_up(
         handle_lockfile_post_build(args, config_path, &fb.lockfile).await?;
     }
 
+    // #322: stamp the merged `devcontainer.metadata` on the compose service
+    // container too (via `deacon_labels`, applied by the injection override), so
+    // config living only in devcontainer.json — esp. `remoteEnv` — survives and
+    // is recoverable by exec/read-configuration/set-up `--container-id`, exactly
+    // like the single-container path. The effective image is the feature-extended
+    // one when features were built, else the service's own `image:`.
+    {
+        use deacon_core::compose::ServiceShape;
+        let effective_image = match &project.service_image_override {
+            Some(img) => Some(img.clone()),
+            None => match compose_manager
+                .get_command(&project)
+                .extract_service_shape(&project.service)
+                .await
+            {
+                Ok(ServiceShape::Image(img)) => Some(img),
+                _ => None,
+            },
+        };
+        if let Some(img) = effective_image {
+            if let Some(json) = super::merged_config::build_container_metadata_label(
+                &runtime.cli_docker(),
+                &img,
+                config,
+            )
+            .await
+            {
+                project.deacon_labels.insert(
+                    deacon_core::container::LABEL_DEVCONTAINER_METADATA.to_string(),
+                    json,
+                );
+            }
+        }
+    }
+
     // Apply `devcontainer.json` `mounts` (#266) and feature-contributed
     // `mounts` (#272) to the compose project. Run through `merge_mounts` in a
     // single call — same as the single-container path (up/container.rs) —

--- a/crates/deacon/tests/parity_up_exec.rs
+++ b/crates/deacon/tests/parity_up_exec.rs
@@ -71,6 +71,7 @@ async fn parity_up_and_exec_traditional() {
   "image": "alpine:3.19",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "containerEnv": { "PARITY_TOKEN": "tkn-42" },
+  "remoteEnv": { "REMOTE_ONLY": "from-devcontainer-json" },
   "postCreateCommand": "sh -lc 'echo ready > /tmp/parity_marker; printf \"env=[%s]\\n\" \"${containerEnv:PARITY_TOKEN}\" > /tmp/parity_env_marker'"
 }
 "#,
@@ -228,6 +229,57 @@ async fn parity_up_and_exec_traditional() {
     };
     let deacon_labels_json =
         docker_out(&["inspect", "-f", "{{ json .Config.Labels }}", &deacon_id]);
+
+    // #322: `exec --container-id` (no --workspace-folder/--config) must recover the
+    // config-only `remoteEnv` from the container's `devcontainer.metadata` label —
+    // which `up` now stamps — identically to the reference. Runs while the
+    // containers are still alive, before teardown below.
+    let deacon_cid_inv = ff(exec_deacon(
+        BINARY,
+        "container-id",
+        ExecKind::Lifecycle,
+        deacon_bin,
+        &[
+            "exec",
+            "--container-id",
+            deacon_id.as_str(),
+            "--",
+            "sh",
+            "-lc",
+            "printf 'remote=[%s]' \"$REMOTE_ONLY\"",
+        ],
+        ws,
+    )
+    .await);
+    ff(deacon_cid_inv.require_success());
+    let oracle_cid_inv = ff(exec_oracle(
+        BINARY,
+        "container-id",
+        ExecKind::Lifecycle,
+        &oracle.path,
+        &[
+            "exec",
+            "--container-id",
+            upstream_id.as_str(),
+            "sh",
+            "-lc",
+            "printf 'remote=[%s]' \"$REMOTE_ONLY\"",
+        ],
+        ws,
+    )
+    .await);
+    ff(oracle_cid_inv.require_success());
+    let deacon_cid_env = deacon_cid_inv.stdout_string();
+    let oracle_cid_env = oracle_cid_inv.stdout_string();
+    assert!(
+        deacon_cid_env.contains("remote=[from-devcontainer-json]"),
+        "deacon exec --container-id did not recover remoteEnv from the metadata label: {deacon_cid_env:?}"
+    );
+    assert_eq!(
+        deacon_cid_env.trim(),
+        oracle_cid_env.trim(),
+        "exec --container-id remoteEnv recovery diverged (deacon vs oracle)"
+    );
 
     // Best-effort teardown BEFORE the label assertions so a failed assertion never
     // leaks containers. Errors are intentionally ignored.


### PR DESCRIPTION
## Summary

Final stage of **#322**. Records the now-implemented, oracle-verified behavior in the conformance registry and covers it with a **live parity case** — recorded as `reference: aligned` / `follow-spec` (a covered behavior, never a blocking gap).

## Changes
- **`bhv-exec-container-id-metadata`** (exec.json): `exec --container-id` recovers `remoteUser`/`remoteEnv` from the container's `devcontainer.metadata` label — which `up` now stamps — matching the reference.
- **`src-spec-container-metadata-recovery`** (sources/spec.json): source unit for the "config survives on the container via the metadata label" mechanism.
- **`case-exec-container-id-metadata`** (cases.json): backed by `parity_up_exec`.
- **`parity_up_exec` extended**: the fixture gains `remoteEnv`; after `up`, the test execs `--container-id` on **both** CLIs and asserts deacon recovers `remote=[from-devcontainer-json]` **byte-identically** to the reference.

## Gates
- `deacon-conformance validate` ok
- `certify` clean (0 blocking, 10 waived) — the behavior is covered, not a gap
- `parity_registry_check` green
- extended `parity_up_exec` passes against oracle 0.87.0 (ran locally)

## #322 complete
| Part | PR |
|---|---|
| 1 plumbing | #349 ✅ |
| 2 write label (single/Dockerfile) | #350 ✅ |
| 3 exec reads label | #351 ✅ |
| 2b compose | #352 🔄 |
| 4 registry (this) | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT