### PR TITLE
feat(cli): migrate --runtime/--no-redact/--log-level to clap-native env=

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,16 @@ current code before "implementing" a deferral.
   that delegates to an existing method (e.g. `Docker::exec_with_line_prefix` defaults to
   `exec`). Mocks and delegating runtimes then need no change; only override where the new
   behavior matters (and in the enum/wrapper runtimes that must forward it).
+- **Flag-backed env vars use clap's native `env=`, never a hand-rolled `std::env::var`
+  read.** A CLI flag that is also settable via the environment MUST declare it on the
+  `#[arg(...)]` (`env = "DEACON_<SCREAMING_FLAG>"`), so clap owns the precedence
+  (flag > env > default) and `--help` advertises `[env: …]` for free. Do NOT read the same
+  var by hand below the CLI layer — resolve at the `Cli` struct and thread the value down
+  (see `--runtime`/`DEACON_CONTAINER_RUNTIME`, `--log-level`, `--no-redact`,
+  `--override-config`; #180). `doctor`'s env snapshot in `core::doctor` is a *diagnostic*
+  read (it reports which vars are set) and is the one legitimate exception — keep its list
+  in sync with the canonical names actually consumed. Env-only knobs with **no** backing
+  flag (`DEACON_NO_PROMPT`, `DEACON_CACHE_DIR`, `DEACON_LOG`/`RUST_LOG`, …) stay manual.
 
 **Logging:**
 - Use `tracing` spans for workflows: `config.resolve`, `feature.install`, `lifecycle.run`

--- a/crates/core/src/doctor.rs
+++ b/crates/core/src/doctor.rs
@@ -453,6 +453,8 @@ fn collect_environment_info() -> EnvironmentInfo {
         "TERM",
         "DEACON_LOG_LEVEL",
         "DEACON_LOG_FORMAT",
+        "DEACON_CONTAINER_RUNTIME",
+        "DEACON_NO_REDACT",
         "DOCKER_HOST",
         "DOCKER_CONFIG",
         "DOCKER_CERT_PATH",

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -62,20 +62,14 @@ impl std::fmt::Display for RuntimeKind {
 pub struct RuntimeFactory;
 
 impl RuntimeFactory {
-    /// Detect runtime from CLI flag, environment variable, or default
+    /// Resolve the runtime from the (already env-resolved) CLI flag, or default.
     ///
-    /// Precedence: CLI flag > `DEACON_CONTAINER_RUNTIME` env var > default (docker).
+    /// Precedence: CLI flag > default (docker). The `DEACON_CONTAINER_RUNTIME`
+    /// environment variable is resolved at the CLI layer by clap's `env=`
+    /// attribute on `--runtime`, so by the time a value reaches here it already
+    /// reflects flag-over-env-over-default. See `deacon::cli::Cli::runtime`.
     pub fn detect_runtime(cli_runtime: Option<RuntimeKind>) -> RuntimeKind {
-        if let Some(runtime) = cli_runtime {
-            runtime
-        } else if let Some(env_runtime) = std::env::var("DEACON_CONTAINER_RUNTIME")
-            .ok()
-            .and_then(|v| v.parse().ok())
-        {
-            env_runtime
-        } else {
-            RuntimeKind::Docker
-        }
+        cli_runtime.unwrap_or(RuntimeKind::Docker)
     }
 
     /// Create runtime instance based on RuntimeKind
@@ -725,35 +719,24 @@ mod tests {
 
     #[test]
     fn test_detect_runtime_default() {
-        temp_env::with_var_unset("DEACON_CONTAINER_RUNTIME", || {
-            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
-        });
+        // `None` (no CLI flag / env resolved) falls back to Docker. The
+        // `DEACON_CONTAINER_RUNTIME` env var is now resolved at the CLI layer by
+        // clap's `env=` on `--runtime`, so `detect_runtime` no longer reads the
+        // environment itself — the flag-vs-env precedence is covered by the clap
+        // parse tests in `deacon::cli`.
+        assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
     }
 
     #[test]
     fn test_detect_runtime_cli_precedence() {
-        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("podman"), || {
-            assert_eq!(
-                RuntimeFactory::detect_runtime(Some(RuntimeKind::Docker)),
-                RuntimeKind::Docker
-            );
-        });
-    }
-
-    #[test]
-    fn test_detect_runtime_env_var() {
-        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("podman"), || {
-            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Podman);
-        });
-
-        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("docker"), || {
-            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
-        });
-
-        // Invalid env var should fall back to default
-        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("invalid"), || {
-            assert_eq!(RuntimeFactory::detect_runtime(None), RuntimeKind::Docker);
-        });
+        assert_eq!(
+            RuntimeFactory::detect_runtime(Some(RuntimeKind::Docker)),
+            RuntimeKind::Docker
+        );
+        assert_eq!(
+            RuntimeFactory::detect_runtime(Some(RuntimeKind::Podman)),
+            RuntimeKind::Podman
+        );
     }
 
     #[test]

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -129,7 +129,7 @@ pub enum LogFormat {
 }
 
 /// Log level options
-#[derive(Debug, Clone, ValueEnum)]
+#[derive(Debug, Clone, ValueEnum, PartialEq, Eq)]
 pub enum LogLevel {
     /// Error messages only
     Error,
@@ -883,7 +883,14 @@ pub struct Cli {
     pub log_format: Option<LogFormat>,
 
     /// Log level (baseline verbosity). Shifted by repeated `-v`/`-q`.
-    #[arg(long, global = true, value_enum, default_value = "warn")]
+    /// Also settable via the `DEACON_LOG_LEVEL` environment variable.
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value = "warn",
+        env = "DEACON_LOG_LEVEL"
+    )]
     pub log_level: LogLevel,
 
     /// Increase log verbosity, repeatable: `-v`=info, `-vv`=debug, `-vvv`=trace.
@@ -958,8 +965,9 @@ pub struct Cli {
     #[arg(long, global = true, value_name = "PATH")]
     pub secrets_file: Vec<PathBuf>,
 
-    /// Disable secret redaction in output (debugging only - WARNING: may expose secrets)
-    #[arg(long, global = true)]
+    /// Disable secret redaction in output (debugging only - WARNING: may expose secrets).
+    /// Also settable via the `DEACON_NO_REDACT` environment variable.
+    #[arg(long, global = true, env = "DEACON_NO_REDACT")]
     pub no_redact: bool,
 
     /// Progress format (json|none|auto). Auto is silent unless --progress-file is set.
@@ -976,7 +984,7 @@ pub struct Cli {
     pub plugin: Vec<String>,
 
     /// Container runtime to use (docker or podman; can be set via DEACON_CONTAINER_RUNTIME env var)
-    #[arg(long, global = true, value_enum)]
+    #[arg(long, global = true, value_enum, env = "DEACON_CONTAINER_RUNTIME")]
     pub runtime: Option<RuntimeOption>,
 
     /// Path to docker executable
@@ -2365,6 +2373,90 @@ mod tests {
                 cli.override_config,
                 Some(PathBuf::from("/tmp/from-flag.json"))
             );
+        });
+    }
+
+    // --- #180 Category B: clap-native env= migrations ---
+
+    #[test]
+    fn test_runtime_flag_parses() {
+        let cli = Cli::parse_from(["deacon", "--runtime", "podman"]);
+        assert_eq!(cli.runtime, Some(RuntimeOption::Podman));
+    }
+
+    #[test]
+    fn test_runtime_defaults_none() {
+        temp_env::with_var_unset("DEACON_CONTAINER_RUNTIME", || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert_eq!(cli.runtime, None);
+        });
+    }
+
+    #[test]
+    fn test_runtime_reads_env_var() {
+        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("podman"), || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert_eq!(cli.runtime, Some(RuntimeOption::Podman));
+        });
+    }
+
+    #[test]
+    fn test_runtime_flag_beats_env_var() {
+        temp_env::with_var("DEACON_CONTAINER_RUNTIME", Some("podman"), || {
+            let cli = Cli::parse_from(["deacon", "--runtime", "docker"]);
+            assert_eq!(cli.runtime, Some(RuntimeOption::Docker));
+        });
+    }
+
+    #[test]
+    fn test_no_redact_flag_parses() {
+        let cli = Cli::parse_from(["deacon", "--no-redact"]);
+        assert!(cli.no_redact);
+    }
+
+    #[test]
+    fn test_no_redact_defaults_false() {
+        temp_env::with_var_unset("DEACON_NO_REDACT", || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert!(!cli.no_redact);
+        });
+    }
+
+    #[test]
+    fn test_no_redact_reads_env_var() {
+        temp_env::with_var("DEACON_NO_REDACT", Some("true"), || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert!(cli.no_redact);
+        });
+    }
+
+    #[test]
+    fn test_log_level_flag_parses() {
+        let cli = Cli::parse_from(["deacon", "--log-level", "debug"]);
+        assert_eq!(cli.log_level, LogLevel::Debug);
+    }
+
+    #[test]
+    fn test_log_level_defaults_warn() {
+        temp_env::with_var_unset("DEACON_LOG_LEVEL", || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert_eq!(cli.log_level, LogLevel::Warn);
+        });
+    }
+
+    #[test]
+    fn test_log_level_reads_env_var() {
+        temp_env::with_var("DEACON_LOG_LEVEL", Some("trace"), || {
+            let cli = Cli::parse_from(["deacon"]);
+            assert_eq!(cli.log_level, LogLevel::Trace);
+        });
+    }
+
+    #[test]
+    fn test_log_level_flag_beats_env_var() {
+        temp_env::with_var("DEACON_LOG_LEVEL", Some("trace"), || {
+            let cli = Cli::parse_from(["deacon", "--log-level", "error"]);
+            assert_eq!(cli.log_level, LogLevel::Error);
         });
     }
 


### PR DESCRIPTION
## Summary

Category B of #180 (part 1 of 2). Three flag-backed env vars were read by hand below the CLI layer; this moves them onto clap's `env=` attribute so clap owns precedence (**flag > env > default**) and `--help` advertises `[env: …]` for free.

| Flag | Env var | Change |
|---|---|---|
| `--runtime` | `DEACON_CONTAINER_RUNTIME` | `env=` added; `RuntimeFactory::detect_runtime` drops its manual env branch (now flag-or-default; env resolved at CLI tier, threaded via `self.runtime`) |
| `--no-redact` | `DEACON_NO_REDACT` | `env=` added (clap boolish parse) |
| `--log-level` | `DEACON_LOG_LEVEL` | `env=` added — previously this var was **only** a doctor diagnostic and never actually backed the flag; now it does (DEACON_LOG/RUST_LOG still win for the effective directive) |

## Stale-issue notes

- The issue's premise that `detect_runtime` reads `DEACON_RUNTIME` is **stale** — it already read `DEACON_CONTAINER_RUNTIME`, matching what `doctor` reports, so the "reconcile names" item was already satisfied.
- The acceptance item "preserve the experimental-Podman warning after the `detect_runtime` refactor" is **moot**: no such warning exists in `detect_runtime`.

## Details

- `doctor`'s env snapshot now lists `DEACON_CONTAINER_RUNTIME` and `DEACON_NO_REDACT` for discoverability; its reads stay diagnostic (the one legitimate exception to the no-hand-rolled-read rule).
- temp-env parse tests (flag / env / flag-beats-env) per var, mirroring the `DEACON_OVERRIDE_CONFIG` template. The `runtime.rs` env-precedence tests move to the CLI layer where the env is now resolved.
- The clap-`env=` convention is documented in `CLAUDE.md` for future flag additions.

## Follow-ups

- **Part 2** (`--log-format`, `--force-tty-if-json`): meatier because their env reads live deep in the `up` flow — will thread the resolved json-mode into `UpArgs` (fixing a latent bug where `--log-format json` as a *flag* doesn't trigger PTY gating that only reads the env var).
- **Category A** (net-new env vars) tracked separately.

## Testing

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `make test-nextest-fast` — 3095 passed, 31 skipped ✓
- `--help` verified to advertise `[env: …]` for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)