### PR TITLE
fix(tests): give git-worktree fixtures unique sibling paths

### DIFF
--- a/crates/core/tests/integration_worktree.rs
+++ b/crates/core/tests/integration_worktree.rs
@@ -59,8 +59,17 @@ fn setup_git_worktree_fixture() -> Result<(TempDir, PathBuf, PathBuf), Box<dyn s
         .args(["commit", "-m", "Initial commit"])
         .output()?;
 
-    // Create a worktree
-    let worktree_path = main_path.join("../worktree-feature");
+    // Create a worktree as a sibling of the main repo. The sibling name is
+    // derived from the main repo's unique TempDir basename so concurrent test
+    // processes (nextest runs each test in its own process) never collide on a
+    // shared `<system-temp>/worktree-feature` path — that shared-path race made
+    // this suite intermittently fail, most visibly on Windows' slower/locking
+    // filesystem (the walk-up would find no `.git` and return the subdir).
+    let unique = main_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo");
+    let worktree_path = main_path.join(format!("../{unique}-worktree-feature"));
     Command::new("git")
         .current_dir(&main_path)
         .args([
@@ -281,8 +290,14 @@ fn test_multiple_worktrees_isolation() {
         return;
     }
 
-    // Create two worktrees
-    let worktree1_path = main_path.join("../worktree1");
+    // Create two worktrees as siblings, with names derived from the main repo's
+    // unique TempDir basename so concurrent test processes don't collide on
+    // shared `<system-temp>/worktree{1,2}` paths (see setup_git_worktree_fixture).
+    let unique = main_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo");
+    let worktree1_path = main_path.join(format!("../{unique}-worktree1"));
     if Command::new("git")
         .current_dir(&main_path)
         .args([
@@ -299,7 +314,7 @@ fn test_multiple_worktrees_isolation() {
         return;
     }
 
-    let worktree2_path = main_path.join("../worktree2");
+    let worktree2_path = main_path.join(format!("../{unique}-worktree2"));
     if Command::new("git")
         .current_dir(&main_path)
         .args([


### PR DESCRIPTION
## Summary

Fixes an intermittent Windows CI failure in `test_resolve_workspace_root_detects_worktree` (from-subdir assertion) — surfaced while validating #180's PR2 (unrelated code; the Windows re-run went green, confirming a flake).

## Root cause

Four tests in `crates/core/tests/integration_worktree.rs` created their worktree at a **fixed shared path**: `main_path.join("../worktree-feature")` resolves to `<system-temp>/worktree-feature` (and `../worktree1`/`../worktree2`) regardless of the unique per-test TempDir. nextest runs each test in its own process, so concurrent worktree tests **collided on that one path** — one process's `git worktree add`/cleanup clobbered another's worktree directory, so during the walk-up the worktree's `.git` file was missing. `resolve_workspace_root` then found no git root and returned the subdirectory unchanged:

```
left:  ...\worktree-feature\src      # returned subdir, unchanged
right: ...\worktree-feature          # expected worktree root
```

Windows' slower, file-locking filesystem widens the race window, which is why it flaked there and not on Linux/macOS.

## Fix

Derive each worktree's sibling name from the main repo's **unique TempDir basename** (`main_path.file_name()`), so parallel test processes never share a worktree path. Behavior is otherwise unchanged (still a sibling of the main repo, still canonicalized before use).

## Testing

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo nextest run -E 'binary(=integration_worktree)'` — 5/5 pass, repeated 3× with no flake ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)