### PR TITLE
chore(tests): loosen workspace-mounts perf ceiling to catastrophe-only

### DIFF
--- a/crates/deacon/tests/workspace_mounts.rs
+++ b/crates/deacon/tests/workspace_mounts.rs
@@ -1472,8 +1472,18 @@ mod performance_tests {
     use std::time::{Duration, Instant};
     use tempfile::TempDir;
 
-    /// Maximum allowed time for workspace discovery + mount rendering path
-    const MAX_DURATION_MS: u64 = 200;
+    /// Catastrophe ceiling for the workspace-discovery + mount-rendering hot path.
+    ///
+    /// These tests exercise the hot path functionally (the per-iteration
+    /// assertions below verify each operation succeeds) and measure its average
+    /// duration. The measured value is a *soft* signal: a precise wall-clock
+    /// budget (this was 200ms) flaky-fails under parallel CI load — nextest runs
+    /// many test processes at once, and filesystem canonicalization/git-root
+    /// detection can spike under IO contention (worst on Windows' locking FS).
+    /// The bound below is deliberately generous so it can only trip on a genuine
+    /// hang or an order-of-magnitude regression, never on ordinary CI jitter,
+    /// while the functional assertions still guard correctness on every run.
+    const MAX_DURATION_MS: u64 = 5000;
 
     /// Test that workspace discovery completes within time budget
     ///


### PR DESCRIPTION
## Summary

Hardens the flaky wall-clock assertions in `workspace_mounts.rs`'s `performance_tests` (finding #2 from a flaky-test sweep).

These tests asserted a **200ms average** wall-clock ceiling over the workspace-discovery + mount-rendering hot path. Two of them (`test_workspace_discovery_performance`, `test_combined_workspace_and_mount_performance`) do real filesystem canonicalization / git-root detection, which can spike under nextest's parallel load — worst on Windows' locking filesystem — making a precise wall-clock bound a flaky-fail risk on the **fast** lane.

## Change

- Keep the functional per-iteration assertions (`.is_ok()`/`.is_some()`) — they still guard correctness on every run.
- Raise the shared ceiling from 200ms → **5s**: a deliberately generous "catastrophe/hang" gate that can only trip on a genuine hang or an order-of-magnitude regression, never on ordinary CI jitter.
- Documented the rationale on the constant.

## Testing

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- All 4 perf tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)