### PR TITLE
chore(tests): isolate deacon's shared state cache per test process

### DIFF
--- a/crates/deacon/tests/integration_compose_config_mounts.rs
+++ b/crates/deacon/tests/integration_compose_config_mounts.rs
@@ -7,7 +7,8 @@
 //! primary service container with the token resolved, the original compose
 //! service volume is untouched, and a CLI `--mount` is applied alongside it.
 
-use assert_cmd::Command;
+mod support;
+
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -25,8 +26,7 @@ fn is_docker_available() -> bool {
 
 /// Best-effort cleanup; ignore failures since the project may already be torn down.
 fn deacon_down(workspace: &Path) {
-    let _ = Command::cargo_bin("deacon")
-        .unwrap()
+    let _ = support::deacon_command()
         .current_dir(workspace)
         .arg("down")
         .arg("--workspace-folder")
@@ -137,8 +137,7 @@ volumes:
     let cli_mount_source = workspace.join("cli-data");
     fs::create_dir_all(&cli_mount_source).unwrap();
 
-    let up_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let up_output = support::deacon_command()
         .current_dir(workspace)
         .arg("up")
         .arg("--workspace-folder")

--- a/crates/deacon/tests/integration_compose_features_build.rs
+++ b/crates/deacon/tests/integration_compose_features_build.rs
@@ -14,7 +14,8 @@
 //! because each test uses its own temp dir, compose project name, and image
 //! tag.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::TempDir;
@@ -146,8 +147,7 @@ fn compose_features_image_shape_installs_feature() {
     // Best-effort cleanup before the test in case a previous run left state.
     compose_cleanup(workspace);
 
-    let up = Command::cargo_bin("deacon")
-        .expect("deacon binary")
+    let up = support::deacon_command()
         .current_dir(workspace)
         .args([
             "up",
@@ -270,8 +270,7 @@ fn compose_features_build_shape_installs_feature() {
     // subdirectory.
     compose_cleanup(workspace);
 
-    let up = Command::cargo_bin("deacon")
-        .expect("deacon binary")
+    let up = support::deacon_command()
         .current_dir(workspace)
         .args([
             "up",
@@ -399,8 +398,7 @@ fn build_compose_with_features_tags_final_image() {
     .expect("write devcontainer.json");
 
     let image_tag = "deacon-test/compose-features:latest";
-    let out = Command::cargo_bin("deacon")
-        .expect("deacon binary")
+    let out = support::deacon_command()
         .current_dir(workspace)
         .args([
             "build",

--- a/crates/deacon/tests/integration_down.rs
+++ b/crates/deacon/tests/integration_down.rs
@@ -1,13 +1,14 @@
 //! Integration tests for the down command
 
-use assert_cmd::Command;
+mod support;
+
 use predicates::prelude::*;
 use tempfile::TempDir;
 
 /// Test that down command works with basic arguments
 #[test]
 fn test_down_command_basic() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     // Create a temp directory for testing
     let temp_dir = TempDir::new().unwrap();
@@ -38,7 +39,7 @@ fn test_down_command_basic() {
 /// Test that down command accepts remove flag
 #[test]
 fn test_down_command_with_remove() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     // Create a temp directory for testing
     let temp_dir = TempDir::new().unwrap();
@@ -68,7 +69,7 @@ fn test_down_command_with_remove() {
 /// Test that down command shows help when run with --help
 #[test]
 fn test_down_command_help() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     cmd.arg("down")
         .arg("--help")
@@ -82,7 +83,7 @@ fn test_down_command_help() {
 /// Test that up command accepts shutdown flag
 #[test]
 fn test_up_command_with_shutdown() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     // Create a temp directory without devcontainer.json (will fail but should accept the flag)
     let temp_dir = TempDir::new().unwrap();
@@ -101,7 +102,7 @@ fn test_up_command_with_shutdown() {
 /// Test that down command accepts --all flag
 #[test]
 fn test_down_command_with_all() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     let temp_dir = TempDir::new().unwrap();
 
@@ -130,7 +131,7 @@ fn test_down_command_with_all() {
 /// Test that down command accepts --volumes flag
 #[test]
 fn test_down_command_with_volumes() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     let temp_dir = TempDir::new().unwrap();
 
@@ -159,7 +160,7 @@ fn test_down_command_with_volumes() {
 /// Test that down command accepts --force flag
 #[test]
 fn test_down_command_with_force() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     let temp_dir = TempDir::new().unwrap();
 
@@ -188,7 +189,7 @@ fn test_down_command_with_force() {
 /// Test that down command accepts --timeout flag
 #[test]
 fn test_down_command_with_timeout() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     let temp_dir = TempDir::new().unwrap();
 
@@ -218,7 +219,7 @@ fn test_down_command_with_timeout() {
 /// Test that down command accepts combined flags
 #[test]
 fn test_down_command_with_combined_flags() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
 
     let temp_dir = TempDir::new().unwrap();
 

--- a/crates/deacon/tests/smoke_compose_edges.rs
+++ b/crates/deacon/tests/smoke_compose_edges.rs
@@ -9,7 +9,8 @@
 //! NOTE: These tests assume Docker is available and running. They will fail
 //! if Docker/Compose is not present or cannot start containers.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -66,7 +67,7 @@ fn test_compose_path_detection_without_docker() {
     .unwrap();
 
     // Test up command with compose configuration
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -81,7 +82,7 @@ fn test_compose_path_detection_without_docker() {
     );
 
     // Cleanup only if we actually brought the project up successfully
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -133,7 +134,7 @@ fn test_compose_subfolder_config() {
     .unwrap();
 
     // Test up command with --config pointing to subfolder config
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -151,7 +152,7 @@ fn test_compose_subfolder_config() {
     );
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -185,7 +186,7 @@ fn test_compose_missing_file_edge_case() {
     .unwrap();
 
     // Test up command with missing compose file
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -246,7 +247,7 @@ services:
     .unwrap();
 
     // Test up command with invalid compose file
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -330,7 +331,7 @@ fn test_compose_multiple_files() {
     .unwrap();
 
     // Test up command with multiple compose files
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -400,7 +401,7 @@ RUN echo "app service" > /tmp/app.txt
     // The default log level is `warn`; the "Building Docker Compose service:
     // <name>" status is emitted at INFO, so opt into it via the global `-v`
     // flag to assert on the compose-service build indicators below.
-    let mut build_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut build_cmd = support::deacon_command();
     let build_output = build_cmd
         .current_dir(&temp_dir)
         .arg("-v")
@@ -499,16 +500,11 @@ fn test_compose_down_stops_but_keeps_containers() {
 
     cleanup();
 
-    // deacon's workspace-state cache lives under `std::env::temp_dir()` (shared
-    // across processes). Isolate this test's state via a per-test TMPDIR so a
-    // concurrent docker test can't clobber the shared state index and make our
-    // `down` lose the saved compose project. `up` and `down` must share it.
-    let state_home = temp_dir.path().join("state-home");
-    fs::create_dir_all(&state_home).unwrap();
-
-    let up = Command::cargo_bin("deacon")
-        .unwrap()
-        .env("TMPDIR", &state_home)
+    // `support::deacon_command()` isolates deacon's shared workspace-state cache
+    // per test process, so a concurrent docker test can't clobber the state
+    // index and make our `down` lose the saved compose project. `up` and `down`
+    // share the same isolated home automatically (same process).
+    let up = support::deacon_command()
         .arg("up")
         .arg("--workspace-folder")
         .arg(temp_dir.path())
@@ -522,9 +518,7 @@ fn test_compose_down_stops_but_keeps_containers() {
     );
     assert_eq!(count("running"), 1, "service should be running after up");
 
-    let down = Command::cargo_bin("deacon")
-        .unwrap()
-        .env("TMPDIR", &state_home)
+    let down = support::deacon_command()
         .arg("down")
         .arg("--workspace-folder")
         .arg(temp_dir.path())

--- a/crates/deacon/tests/smoke_compose_override_command.rs
+++ b/crates/deacon/tests/smoke_compose_override_command.rs
@@ -7,7 +7,8 @@
 //!
 //! These hit a real Docker daemon and are docker-gated via a graceful skip.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -24,8 +25,7 @@ fn is_docker_available() -> bool {
 
 /// Best-effort cleanup; ignore failures since the project may already be torn down.
 fn deacon_down(workspace: &Path) {
-    let _ = Command::cargo_bin("deacon")
-        .unwrap()
+    let _ = support::deacon_command()
         .current_dir(workspace)
         .arg("down")
         .arg("--workspace-folder")
@@ -108,8 +108,7 @@ fn test_compose_override_command_default_keeps_service_alive() {
     )
     .unwrap();
 
-    let up_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let up_output = support::deacon_command()
         .current_dir(workspace)
         .arg("up")
         .arg("--workspace-folder")
@@ -170,8 +169,7 @@ fn test_compose_override_command_explicit_false_runs_natural_command() {
     )
     .unwrap();
 
-    let up_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let up_output = support::deacon_command()
         .current_dir(workspace)
         .arg("up")
         .arg("--workspace-folder")
@@ -236,8 +234,7 @@ fn test_compose_override_command_lifecycle_runs() {
     )
     .unwrap();
 
-    let up_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let up_output = support::deacon_command()
         .current_dir(workspace)
         .arg("up")
         .arg("--workspace-folder")

--- a/crates/deacon/tests/smoke_down.rs
+++ b/crates/deacon/tests/smoke_down.rs
@@ -8,7 +8,8 @@
 //! NOTE: These tests assume Docker is available and running. They will fail
 //! if Docker is not present or cannot start containers.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -49,7 +50,7 @@ fn test_down_before_up() {
     .unwrap();
 
     // Test down command before any up
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -96,7 +97,7 @@ fn test_down_after_up_idempotent() {
     .unwrap();
 
     // First: up command
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -114,7 +115,7 @@ fn test_down_after_up_idempotent() {
     );
 
     // Second: down command (should succeed)
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -134,7 +135,7 @@ fn test_down_after_up_idempotent() {
     println!("Down after up succeeded");
 
     // Third: down command again (should be idempotent, not error)
-    let mut down_cmd2 = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd2 = support::deacon_command();
     let down_output2 = down_cmd2
         .current_dir(&temp_dir)
         .arg("down")
@@ -184,8 +185,7 @@ fn test_down_all_sweeps_stale_by_local_folder() {
     .unwrap();
 
     // Bring up the deacon-managed container.
-    let up_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let up_output = support::deacon_command()
         .arg("up")
         .arg("--skip-post-create")
         .arg("--skip-non-blocking-commands")
@@ -246,8 +246,7 @@ fn test_down_all_sweeps_stale_by_local_folder() {
     );
 
     // Sweep everything with --all --remove.
-    let down_output = Command::cargo_bin("deacon")
-        .unwrap()
+    let down_output = support::deacon_command()
         .arg("down")
         .arg("--workspace-folder")
         .arg(&workspace)

--- a/crates/deacon/tests/smoke_exec.rs
+++ b/crates/deacon/tests/smoke_exec.rs
@@ -9,7 +9,8 @@
 //! NOTE: These tests assume Docker is available and running. They will fail
 //! if Docker is not present or cannot start containers.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -48,7 +49,7 @@ fn test_exec_stdout_without_tty() {
     .unwrap();
 
     // Ensure container is up
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -65,7 +66,7 @@ fn test_exec_stdout_without_tty() {
     );
 
     // Test exec command without TTY
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -88,7 +89,7 @@ fn test_exec_stdout_without_tty() {
     );
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -122,7 +123,7 @@ fn test_exec_exit_code_propagation() {
     .unwrap();
 
     // Ensure container is up for exit code test
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -139,7 +140,7 @@ fn test_exec_exit_code_propagation() {
     );
 
     // Test exec command that exits with specific code
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -161,7 +162,7 @@ fn test_exec_exit_code_propagation() {
     );
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -195,7 +196,7 @@ fn test_exec_working_directory() {
     .unwrap();
 
     // Ensure container is up
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -212,7 +213,7 @@ fn test_exec_working_directory() {
     );
 
     // Test exec with working directory
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -236,7 +237,7 @@ fn test_exec_working_directory() {
     );
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -270,7 +271,7 @@ fn test_exec_env_merges() {
     .unwrap();
 
     // Ensure container is up
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -287,7 +288,7 @@ fn test_exec_env_merges() {
     );
 
     // Test exec with --env
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -321,7 +322,7 @@ fn test_exec_env_merges() {
     );
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -360,7 +361,7 @@ fn test_up_remote_env_in_config() {
     .unwrap();
 
     // Test up command with remoteEnv in config
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -378,7 +379,7 @@ fn test_up_remote_env_in_config() {
     );
 
     // Test that we can exec and see the environment
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -430,7 +431,7 @@ fn test_exec_subfolder_config() {
     .unwrap();
 
     // Test up with config in subfolder
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -450,7 +451,7 @@ fn test_exec_subfolder_config() {
     );
 
     // Test exec with --config in subfolder
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -495,7 +496,7 @@ fn test_exec_tty_detection() {
     .unwrap();
 
     // Ensure container is up
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -512,7 +513,7 @@ fn test_exec_tty_detection() {
     );
 
     // Test exec command that checks if running in TTY
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -531,7 +532,7 @@ fn test_exec_tty_detection() {
     );
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")

--- a/crates/deacon/tests/smoke_exec_stdin.rs
+++ b/crates/deacon/tests/smoke_exec_stdin.rs
@@ -7,7 +7,8 @@
 //! NOTE: These tests assume Docker is available and running. They will fail
 //! if Docker is not present or cannot start containers.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -46,7 +47,7 @@ fn test_exec_stdin_basic() {
     .unwrap();
 
     // Ensure container is up
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_out = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -63,7 +64,7 @@ fn test_exec_stdin_basic() {
     );
 
     // Exec with stdin
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -86,7 +87,7 @@ fn test_exec_stdin_basic() {
     assert!(exec_stdout.contains("hello stdin test"));
 
     // Cleanup
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _ = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -121,7 +122,7 @@ fn test_exec_stdin_streaming() {
     .unwrap();
 
     // First: up command to create container
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -140,7 +141,7 @@ fn test_exec_stdin_streaming() {
 
     // Second: exec command with stdin data
     let test_input = "hello stdin streaming test\nline 2\nline 3";
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -175,7 +176,7 @@ fn test_exec_stdin_streaming() {
     );
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -211,7 +212,7 @@ fn test_exec_stdin_shell_commands() {
     .unwrap();
 
     // First: up command to create container
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -230,7 +231,7 @@ fn test_exec_stdin_shell_commands() {
 
     // Test exec with tr command to transform stdin
     let test_input = "hello world";
-    let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut exec_cmd = support::deacon_command();
     let exec_output = exec_cmd
         .current_dir(&temp_dir)
         .arg("exec")
@@ -260,7 +261,7 @@ fn test_exec_stdin_shell_commands() {
     );
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")

--- a/crates/deacon/tests/smoke_spinner.rs
+++ b/crates/deacon/tests/smoke_spinner.rs
@@ -3,7 +3,8 @@
 //! Verifies that spinner output does not appear when stderr is not a TTY (as in CI/assert_cmd capture)
 //! and that outputs remain free of spinner artifacts.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -35,7 +36,7 @@ fn spinner_not_rendered_when_not_tty_up_down() {
     .unwrap();
 
     // Run `deacon up` with captured IO (non-TTY). Spinner should NOT render.
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -71,7 +72,7 @@ fn spinner_not_rendered_when_not_tty_up_down() {
     }
 
     // Run `deacon down` and again ensure no spinner frames leak
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")

--- a/crates/deacon/tests/smoke_up_idempotent.rs
+++ b/crates/deacon/tests/smoke_up_idempotent.rs
@@ -7,7 +7,8 @@
 //! NOTE: These tests assume Docker is available and running. They will fail
 //! if Docker is not present or cannot start containers.
 
-use assert_cmd::Command;
+mod support;
+
 use std::fs;
 use tempfile::TempDir;
 
@@ -50,7 +51,7 @@ fn test_up_idempotency() {
     .unwrap();
 
     // First up command
-    let mut up_cmd1 = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd1 = support::deacon_command();
     let up_output1 = up_cmd1
         .current_dir(&temp_dir)
         .arg("up")
@@ -66,7 +67,7 @@ fn test_up_idempotency() {
     );
 
     // Second up command (should be idempotent)
-    let mut up_cmd2 = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd2 = support::deacon_command();
     let up_output2 = up_cmd2
         .current_dir(&temp_dir)
         .arg("up")
@@ -89,7 +90,7 @@ fn test_up_idempotency() {
     }
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -129,7 +130,7 @@ fn test_skip_non_blocking_commands() {
     .unwrap();
 
     // Test up command with --skip-non-blocking-commands flag
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -153,7 +154,7 @@ fn test_skip_non_blocking_commands() {
     }
 
     // Test a regular up command after the skip version for comparison
-    let mut up_cmd_normal = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd_normal = support::deacon_command();
     let up_output_normal = up_cmd_normal
         .current_dir(&temp_dir)
         .arg("up")
@@ -171,7 +172,7 @@ fn test_skip_non_blocking_commands() {
     );
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")
@@ -208,7 +209,7 @@ fn test_skip_flag_combinations() {
     .unwrap();
 
     // Test up with --skip-post-create flag
-    let mut up_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd = support::deacon_command();
     let up_output = up_cmd
         .current_dir(&temp_dir)
         .arg("up")
@@ -227,7 +228,7 @@ fn test_skip_flag_combinations() {
     );
 
     // Test up with both skip flags
-    let mut up_cmd_both = Command::cargo_bin("deacon").unwrap();
+    let mut up_cmd_both = support::deacon_command();
     let up_output_both = up_cmd_both
         .current_dir(&temp_dir)
         .arg("up")
@@ -247,7 +248,7 @@ fn test_skip_flag_combinations() {
     );
 
     // Clean up: down command
-    let mut down_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut down_cmd = support::deacon_command();
     let _down_output = down_cmd
         .current_dir(&temp_dir)
         .arg("down")

--- a/crates/deacon/tests/support/mod.rs
+++ b/crates/deacon/tests/support/mod.rs
@@ -2,6 +2,44 @@
 
 #![allow(dead_code)]
 
+use assert_cmd::Command;
+use std::sync::OnceLock;
+use tempfile::TempDir;
+
+/// Process-global isolated temp home, created once per test process.
+///
+/// deacon's workspace-state cache lives at `std::env::temp_dir()/deacon-state/`
+/// — a path shared across every process. Its on-disk `index.json` is a single
+/// read-modify-write file, so two concurrent `deacon` invocations (e.g. two
+/// parallel `up`/`down` tests) can clobber each other's index entry
+/// (last-writer-wins), making a later `down` "lose" the state its `up` saved.
+/// See `crates/core/src/state.rs::default_cache_dir`.
+static ISOLATED_TMP: OnceLock<TempDir> = OnceLock::new();
+
+fn isolated_tmp_home() -> &'static std::path::Path {
+    ISOLATED_TMP
+        .get_or_init(|| TempDir::new().expect("failed to create isolated temp home for tests"))
+        .path()
+}
+
+/// Build a `deacon` CLI command with an isolated temp home, so its
+/// workspace-state cache can't collide with other test processes.
+///
+/// Prefer this over `Command::cargo_bin("deacon")` in any test that runs
+/// `up`/`down`/`exec` (or otherwise touches workspace state). Under nextest each
+/// test runs in its own process, so the [`OnceLock`] home is unique per test;
+/// an `up` and its later `down` within the same test share it (as they must).
+/// The redirect is via `TMPDIR` (Unix) plus `TMP`/`TEMP` (Windows), which is
+/// what `std::env::temp_dir()` honors on each platform.
+pub fn deacon_command() -> Command {
+    let home = isolated_tmp_home();
+    let mut cmd = Command::cargo_bin("deacon").expect("deacon binary should build");
+    cmd.env("TMPDIR", home);
+    cmd.env("TMP", home);
+    cmd.env("TEMP", home);
+    cmd
+}
+
 /// Helper to skip tests that require network access.
 ///
 /// Tests that make network requests should use this as a guard at the beginning:

--- a/crates/deacon/tests/up_prebuild.rs
+++ b/crates/deacon/tests/up_prebuild.rs
@@ -10,7 +10,8 @@
 //! Note: These tests require Docker and are only compiled on Unix systems.
 #![cfg(unix)]
 
-use assert_cmd::Command;
+mod support;
+
 use predicates::prelude::*;
 use std::path::PathBuf;
 
@@ -83,7 +84,7 @@ fn test_prebuild_stops_after_update_content() {
 
     let config_path = fixture_path.join("devcontainer.json");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -118,7 +119,7 @@ fn test_prebuild_rerun_executes_update_content_again() {
     let config_path = fixture_path.join("devcontainer.json");
 
     // First prebuild run
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -130,7 +131,7 @@ fn test_prebuild_rerun_executes_update_content_again() {
         .success();
 
     // Second prebuild run (rerun scenario)
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -159,7 +160,7 @@ fn test_prebuild_does_not_run_post_create() {
     let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -192,7 +193,7 @@ fn test_prebuild_skip_post_attach_honored() {
     let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -221,7 +222,7 @@ fn test_prebuild_with_features_metadata_merge() {
     let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -253,7 +254,7 @@ fn test_prebuild_without_update_content_command() {
     let fixture_path = _fixture.path().to_path_buf();
     let config_path = fixture_path.join("devcontainer.json");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = support::deacon_command();
     cmd.arg("up")
         .arg("--workspace-folder")
         .arg(&fixture_path)
@@ -319,7 +320,7 @@ fn test_prebuild_to_normal_transition_reruns_oncreate_updatecontent() {
 
     // Helper function to read counter from container
     let read_counter = |phase: &str, temp_dir: &tempfile::TempDir| -> Option<u32> {
-        let mut exec_cmd = Command::cargo_bin("deacon").unwrap();
+        let mut exec_cmd = support::deacon_command();
         let exec_output = exec_cmd
             .current_dir(temp_dir.path())
             .arg("exec")
@@ -347,7 +348,7 @@ fn test_prebuild_to_normal_transition_reruns_oncreate_updatecontent() {
     // - Skip postCreate, postStart, postAttach (these are post* hooks)
     // - Store markers in .devcontainer-state/prebuild/ (isolated from normal markers)
 
-    let mut prebuild_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut prebuild_cmd = support::deacon_command();
     let prebuild_output = prebuild_cmd
         .current_dir(temp_dir.path())
         .arg("up")
@@ -423,7 +424,7 @@ fn test_prebuild_to_normal_transition_reruns_oncreate_updatecontent() {
     // up should see no markers and treat this as a fresh environment, running all
     // lifecycle phases including onCreate and updateContent again.
 
-    let mut normal_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut normal_cmd = support::deacon_command();
     let normal_output = normal_cmd
         .current_dir(temp_dir.path())
         .arg("up")
@@ -558,7 +559,7 @@ fn test_prebuild_marker_directory_isolation() {
     // Phase 1: Run prebuild and verify markers are in prebuild subdirectory
     // ========================================================================
 
-    let mut prebuild_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut prebuild_cmd = support::deacon_command();
     let prebuild_output = prebuild_cmd
         .current_dir(temp_dir.path())
         .arg("--user-data-folder")
@@ -618,7 +619,7 @@ fn test_prebuild_marker_directory_isolation() {
     // Phase 2: Run normal up and verify markers are in base directory
     // ========================================================================
 
-    let mut normal_cmd = Command::cargo_bin("deacon").unwrap();
+    let mut normal_cmd = support::deacon_command();
     let normal_output = normal_cmd
         .current_dir(temp_dir.path())
         .arg("--user-data-folder")


### PR DESCRIPTION
## Summary

Kills a shared-path flaky-test class found in a sweep (finding #1). deacon's workspace-state cache lives at `std::env::temp_dir()/deacon-state/` — a path shared by **every** process.

## The race

`DiskCache` loads `index.json` into memory once at open and **rewrites the whole index on every `set`** (`crates/core/src/state.rs` → `crates/core/src/cache/disk.rs`). So two concurrent `deacon` invocations (e.g. parallel `up`/`down` docker tests) each hold a stale in-memory index and clobber the other's entry — last-writer-wins. A later `down` in a fresh process reloads an index missing its own entry and **"loses" the state its `up` saved**. Atomic writes prevent corruption but not this lost update.

`smoke_compose_edges.rs` already worked around it by hand with a per-test `TMPDIR`; every other up/down test stayed exposed, and new ones would forget.

## Fix (test-side, correctly scoped)

Add `support::deacon_command()` — a factory that builds the `deacon` CLI command with `TMPDIR`/`TMP`/`TEMP` redirected to a process-global `OnceLock<TempDir>`. Under nextest each test is its own process, so the home is unique per test, and a test's `up`/`down`/`exec` share it (as they must). Retrofit the **11** up/down/exec test files that spawn the binary to use it, and drop the hand-rolled workaround.

A product-side fix would mean reworking the shared `DiskCache`'s concurrency model (broad — it also backs the features cache — and risky: a naive index merge would break `down`'s removals), so isolation is the proportionate fix.

## Verification

- **Empirical isolation check**: with the helper, `deacon up` wrote **0** files to shared `/tmp/deacon-state` (stayed at 213) and put its state in the isolated dir instead.
- `make test-nextest-fast` — 3123 passed ✓
- `cargo clippy --all-targets --all-features -- -D warnings` + `cargo fmt --all -- --check` ✓
- Docker spot-checks: `integration_down` (9/9), `smoke_up_idempotent` (3/3, real up/down cycles) pass.

## Sweep notes (for the curious)

The same sweep cleared the other axes: **ports** (all binds use ephemeral `:0`), **env races** (fully hardened via `temp_env`), and **docker names** (already unique via `unique_name()`/tempdir labels — a couple of latent-but-unreachable fixed image tags noted for optional defense-in-depth). The perf-ceiling flake is addressed separately in #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)