### PR TITLE
feat(conformance): add normative clause inventory (021)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,6 +40,15 @@ parity = { max-threads = 2 }
 # CLI-only parity tests
 parity-cli = { max-threads = 8 }
 
+# Dev-only `deacon-conformance` hermetic test binaries — `registry_valid`,
+# `classification_join`, `inventory_*`, `gap_certification`, `traceability`, and the
+# 021-normative-clause-inventory binaries `clause_extraction` / `clause_determinism` /
+# `clause_baseline` / `clause_diff` / `clause_classification_join` — carry NO override:
+# they are fast, non-docker, non-network, no-model tests that run in EVERY profile
+# (default / dev-fast / full / ci) by default (they are neither in any `default-filter`
+# exclusion nor a docker/smoke group). This is the standing convention for conformance
+# tests; the five clause binaries follow it (T003).
+
 # Default profile: Balanced parallelization for local development
 [profile.default]
 retries = 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ Document this checklist in your plan.md or PR description to prevent spec drift.
 - None (filesystem state/markers only) (008-up-lifecycle-hooks)
 
 ## Recent Changes
+- 021-normative-clause-inventory: prose companion to 020's schema inventory in the dev-only `deacon-conformance` crate. Vendored `docs/specs/` Markdown under `conformance/spec/<pin>/` (18 docs, `manifest.json` with fingerprints + `consumer`/`authoring` scope); machine-owned `conformance/inventory/clauses.json` (`clu-` units, substance-anchored ids) produced by `clause generate` (canonicalization, NOT extraction — no LLM/network in CI); hand-authored `clc-` records under `conformance/registry/clause-classifications/` (per-clause for consumer docs, document-scope `not-applicable` default for authoring docs). `validate`/`certify` enforce V11–V15 (V11–V14 generalized to inventory units, V15 = clause↔source integrity). `clause check`/`diff`/`scaffold` mirror the `inventory` subcommands; `diff` makes moves first-class. See `conformance/RULES.md` "Inventory join (V11–V15)".
 - 001-up-gap-spec: Added Rust stable (2021 edition) + clap, serde/serde_json, anyhow/thiserror, tracing, tokio (as already in repo)
 - 2025-11-19: Added pre-implementation checklist and common anti-patterns based on outdated subcommand implementation review
 - 2025-11-20: Standardized on `make test-nextest-*` targets exclusively; added mandatory nextest configuration requirements; documented test parallelization strategy for optimal resource utilization

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,10 +431,39 @@ surface, machine-extracted and classified under the consumer-only scope:
   (`behavior-mapped` / `non-testable` / `not-applicable`). `inventory generate` NEVER
   touches these.
 
+**Normative clause inventory** (021-normative-clause-inventory) — the prose companion to
+020: the pinned `docs/specs/` Markdown surface, canonicalized from human-authored
+(optionally LLM-proposed) clause records and classified under the consumer-only scope. No
+LLM/network in any CI-facing command:
+- `conformance/spec/<pin>/` — the byte-exact vendored upstream `docs/specs/` Markdown (18
+  ratified docs at `113500f4`: 14 `consumer`, 4 `authoring`) + `manifest.json` (SHA-256
+  fingerprints + per-document `scope`); re-vendored only at a new pin, never edited in place.
+- `conformance/inventory/clauses.json` — **machine-owned** canonical clause inventory
+  (`clu-` units, substance-anchored ids: `hash8` over `document ‖ normalize_substance`,
+  location EXCLUDED so a pure move keeps its id/disposition); the sole output of `clause
+  generate` (canonicalization + excerpt/strength verification, NOT extraction), hand edits
+  caught as V14/V15.
+- `conformance/registry/clause-classifications/<doc>.json` + `authoring.json` —
+  **hand-authored** `clc-` records: a per-clause record for every consumer clause, a
+  document-scope `not-applicable` default (`clc-doc-<key>`) for the four authoring docs plus
+  per-clause `behavior-mapped` overrides for the consumer install/apply clauses inside
+  `features`/`templates`. Resolution: per-clause wins; else the authoring doc-scope default
+  (never for `consumer` docs, never for `ambiguous` clauses — both V13/V12); else unclassified
+  (V12). `clause generate` NEVER touches these.
+
 **Commands** (dev-only, `cargo run -p deacon-conformance -- <cmd>`; NOT part of the
 `deacon` consumer CLI):
-- `validate` — structural integrity (violation classes V1–V14 + SCHEMA); reports all
+- `validate` — structural integrity (violation classes V1–V15 + SCHEMA; V11–V14 generalized
+  to inventory units = constraints AND clauses, V15 = clause↔source integrity); reports all
   violations in one run. Gates every PR via the hermetic `registry_valid` test.
+- `clause generate` — canonicalize the committed clause records against the vendored pinned
+  prose (recompute ids/fingerprints, verify each excerpt is present at its heading, cross-check
+  strength ↔ keywords); byte-stable atomic write; fail-loud on any integrity error.
+- `clause check` — regenerate in memory and byte-compare against `clauses.json`.
+- `clause diff <old> <new> [--format json|md]` — deterministic drift diff (match key: the
+  substance-anchored id; **moves are first-class**: new/removed/moved/changed/non-material).
+- `clause scaffold` — emit skeleton `clc-` records (sentinel `"UNREVIEWED"`, loader-rejected):
+  per-clause for consumer/ambiguous clauses, one per-document for uncovered authoring docs.
 - `report` — deterministic `report.json` + `report.md` into `target/conformance/`
   (byte-stable, no timestamps/absolute-paths). Knobs: `--registry <dir>` (fixtures),
   `--today <YYYY-MM-DD>` (waiver-expiry evaluation), `report --out-dir`. Includes an
@@ -890,6 +919,8 @@ RUST_LOG=debug cargo run -- up --container-data-folder /tmp/cache
 - strict-JSON files under `conformance/registry/` (version-controlled, hand-edited, (019-conformance-registry)
 - Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide) + existing workspace deps only — `serde`/`serde_json` (schema (020-schema-constraint-inventory)
 - strict-JSON files — vendored schemas under `conformance/schemas/<rev>/` (020-schema-constraint-inventory)
+- Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide) + existing crate deps only — `serde`/`serde_json` (record (021-normative-clause-inventory)
+- strict-JSON + vendored Markdown — vendored prose under (021-normative-clause-inventory)
 
 ## Recent Changes
 - 018-harden-parity-harness: Added the dev-only `crates/parity-harness/` crate (oracle resolution + exact-version verify, bounded exec with raw capture, the single `normalize` module, waiver/registry loaders, report fragments + `parity-report` aggregator bin); moved live parity onto the dedicated `[profile.parity]` nextest profile; retired the `DEACON_PARITY=1` gate and the three Python corpus runners; added the `parity / live-certification` CI lane. See the "Parity Test Harness" section.

--- a/conformance/RULES.md
+++ b/conformance/RULES.md
@@ -122,27 +122,48 @@ distort the coverage denominator). If a purported differentiator has no external
 observable effect on stdout, stderr, exit code, container state, or the filesystem, it is
 out of scope for the registry.
 
-## Constraint inventory (V11 – V14)
+## Inventory join (V11 – V15) — constraints AND clauses
 
-This section is the human-readable companion to the schema-constraint-inventory join
-enforced in `crates/conformance/src/validate.rs::check_inventory`
-(020-schema-constraint-inventory). It stands in the same validate.rs/RULES.md lockstep
-as R1 – R8 / V1 – V10: the classes below are updated in the SAME change that alters the
-enforcement.
+This section is the human-readable companion to the two inventory joins enforced in
+`crates/conformance/src/validate.rs`: `check_inventory` (the schema-constraint inventory,
+020-schema-constraint-inventory) and `check_clause_inventory` (the normative-clause
+inventory, 021-normative-clause-inventory). It stands in the same validate.rs/RULES.md
+lockstep as R1 – R8 / V1 – V10: the classes below are updated in the SAME change that
+alters the enforcement.
 
-The **inventory** is the machine-extracted set of every constraint in the two vendored,
-pinned upstream schemas. Each unit carries exactly one hand-authored **classification**
-recording its disposition under deacon's consumer-only scope. Validation joins the two
-(and the vendored schemas) and reports these four classes alongside V1 – V10 in one run;
-all four also **block `certify`** (the release gate) — an unclassified, stale, malformed,
-or provenance-broken inventory can no more be certified around than a `gap-` record can.
+An **inventory unit** is either a machine-extracted schema **constraint** (`cst-`, from the
+vendored pinned JSON schemas) or a canonicalized prose **clause** (`clu-`, from the vendored
+pinned `docs/specs/` Markdown). Each unit carries an **effective disposition** recorded by a
+hand-authored **classification** (`cls-` for constraints, `clc-` for clauses) under deacon's
+consumer-only scope. Validation joins each inventory against its classifications (and the
+vendored sources) and reports these classes alongside V1 – V10 in one run; **all block
+`certify`** (the release gate) — an unclassified, stale, malformed, provenance-broken, or
+source-inconsistent inventory can no more be certified around than a `gap-` record can.
 
-| Class | Statement | Remedy |
+V11 – V14 are the **generalized** inventory-unit classes (they run for constraints AND
+clauses). **V15 is new and prose-only** (schema constraints, whose substance IS the parsed
+JSON, have no separate source-text-integrity dimension).
+
+| Class | Statement (inventory unit = schema constraint OR prose clause) | Remedy |
 |-------|-----------|--------|
-| **V11** | a classification's `constraint` names a `cst-` unit absent from the committed inventory (**stale**) | Delete or re-point the record in the same change that moved the inventory. Waiver-style self-invalidation — a classification whose unit vanished never lingers. |
-| **V12** | a constraint unit has **zero** classifications (**unclassified** — this IS the drift item; there is no separate drift record type) or **more than one** (**duplicated**) | Author exactly one classification for it (or remove the duplicate). Every unit of every kind requires one — including `annotation` and `unmodeled-keyword` units. |
-| **V13** | a classification's shape/linkage is broken: the `id`-tail mirror, the `behaviors` arity/existence rule vs its `disposition`, or a missing `rationale` on a `non-testable`/`not-applicable` record | Fix the record to satisfy the arity table below. |
-| **V14** | **provenance** breakage: the schemas manifest fingerprint mismatches a vendored file, the inventory's `revision` ≠ the registry's `schema`-kind revision pin, or the committed inventory no longer byte-matches a fresh regeneration | Re-vendor / re-`inventory generate`; never hand-edit the machine-owned inventory. |
+| **V11** | a classification (`cls-`/`clc-`) names a unit id (`cst-`/`clu-`) absent from its committed inventory (**stale**) | Delete or re-point the record in the same change that moved the inventory. Waiver-style self-invalidation — a classification whose unit vanished never lingers. |
+| **V12** | a unit has **no effective disposition** (**unclassified** — this IS the drift item; there is no separate drift record type) or **more than one** per-unit record (**duplicated**). For a clause: no per-clause `clc-` record AND no permitted document-scope default (see below); an unresolved `ambiguous` clause is V12 by construction. | Author exactly one classification (or the permitted document-scope default). Every unit of every kind requires one. |
+| **V13** | a classification's shape/linkage is broken: the `id`-tail mirror, the `behaviors` arity/existence rule vs its `disposition`, a missing `rationale` on a `non-testable`/`not-applicable` record, a clause record with BOTH or NEITHER of `clause`/`document`, or a document-scope default on a **consumer** document | Fix the record to satisfy the arity table below and the document-scope rule. |
+| **V14** | **provenance** breakage: a manifest fingerprint (schemas OR spec) mismatches a vendored file, the inventory's `revision` ≠ the registry's matching-kind revision pin (`schema`/`spec`), or the committed inventory no longer byte-matches a fresh regeneration (`inventory generate` / `clause generate`) | Re-vendor / re-generate; never hand-edit the machine-owned inventory. |
+| **V15** (clauses only) | **clause↔source integrity**: a clause's `strength` label contradicts its excerpt's RFC-2119 keywords, a `descriptive` clause hides an unqualified mandatory keyword, or an excerpt is not present in the pinned document under its recorded heading/anchor | Fix the excerpt, anchor, or strength label; `clause generate` fails loud on the same conditions so the committed inventory can never carry them. |
+
+### Document-scope disposition default (clauses only, research Decision 7)
+
+A `clc-` classification MAY be **document-scoped** — one `clc-doc-<key>` record dispositioning
+every non-`ambiguous` clause of an **authoring**-scope document as `not-applicable` (consumer-only
+scope, constitution II). Resolution order for a clause: a per-clause record wins; else, if the
+clause's document is `authoring`-scope AND its `testability` ≠ `ambiguous`, the document-scope
+default applies; else the clause is unclassified (V12, blocking). Two guard rails, both V13:
+a document-scope default is permitted **only** for `authoring` documents (a `consumer` document
+is classified clause-by-clause), and an `ambiguous` clause is **never** covered by a blanket
+default — it needs an explicit per-clause decision. The mixed authoring documents
+(`features`/`templates`) carry the document-scope default for their authoring bulk PLUS per-clause
+`behavior-mapped` overrides for the consumer install/apply clauses inside them.
 
 ### Disposition arity (V13)
 

--- a/conformance/inventory/clauses.json
+++ b/conformance/inventory/clauses.json
@@ -1,0 +1,4034 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "units": [
+    {
+      "id": "clu-declarative-secrets-add-an-optional-secrets-property-to-the-devconta-io-9b453bae",
+      "document": "declarative-secrets",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "57f1fc68771f0b73215a4d0c6a4ff6998219b0a5087aa0b60ff3e74a6372d477",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "Add an optional `secrets` property to the `devContainer.base.schema.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-declarative-secrets-description-string-a-brief-description-of-the-se-io-8536a807",
+      "document": "declarative-secrets",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "dc27216cbc3c15dd18eec137f8c4190201fed3c89c3b1c786d69d5db177cf605",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "`description` | `string` | A brief description of the secret."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-declarative-secrets-documentationurl-string-a-url-pointing-to-where-io-58c0bc69",
+      "document": "declarative-secrets",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "acd864b20a65bea0fa5ec279cc57046fb91873794239f9c4de2298a7e18bef0e",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 5,
+          "excerpt": "`documentationUrl` | `string` | A URL pointing to where the user can obtain more information about the secret."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-declarative-secrets-implementations-may-inject-these-secrets-into-th-desc-d00b7761",
+      "document": "declarative-secrets",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "5424a1f2b6e93e5f12eac39c670c7a80db23d9fee7924f6620725c08bd2d983a",
+      "locations": [
+        {
+          "heading": "Example",
+          "anchor": "example",
+          "ordinal": 1,
+          "excerpt": "Implementations _may_ inject these secrets into the container as environment variables."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-declarative-secrets-the-keys-of-this-object-are-the-names-of-the-sec-desc-3b0681c7",
+      "document": "declarative-secrets",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "263aa9fcc3a3062fc9db8a741c2e692ece6a24eab8f4e133dfd39ecaa035135e",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "The keys of this object are the names of the secrets that are in use. Keys should be [valid Linux environment variable names](https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-declarative-secrets-these-secrets-are-recommended-to-the-user-but-ar-desc-922bbd63",
+      "document": "declarative-secrets",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "724ad6b9756306667c78be8e1a960bb6eceb7479e524f988a3b926fc413da409",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "These `secrets` are recommended to the user but are not _required_ for creation."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-ff771e6e",
+      "document": "devcontainer-id-variable",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "65f3bdd11295d9148ecec9f94fa7fbf2cbafb288cb6ab179fe2c78a288ea4716",
+      "locations": [
+        {
+          "heading": "Label-based Computation",
+          "anchor": "label-based-computation",
+          "ordinal": 2,
+          "excerpt": "Compute a SHA-256 hash from the UTF-8 encoded input string."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-45721081",
+      "document": "devcontainer-id-variable",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "5dac037e5366f859ea9e1269eb0109ab2f81e83b87777a878f37005a927fe5af",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the feature metadata are: `entrypoint`, `mounts`, `customizations`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-bd0ca7d0",
+      "document": "devcontainer-id-variable",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "eb71b941082ce5b4a31fe69c44f9c5aba7e078be1be3cac14f30ad925b42a30f",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the devcontainer.json are: `name`, `runArgs`, `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `workspaceFolder`, `workspaceMount`, `mounts`, `containerEnv`, `remoteEnv`, `containerUser`, `remoteUser`, `customizations`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-it-should-only-be-used-in-parts-of-the-configura-desc-556d8d7d",
+      "document": "devcontainer-id-variable",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "186858b37483e2549c61dbf1c0649fed8d7245e7e4e5c8f9ae9f5b7c12ada7e2",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "It should only be used in parts of the configuration and metadata that is not used for building the image because that would otherwise prevent pre-building the image at a time when the dev container's id is not known yet."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-the-identifier-must-only-contain-alphanumeric-ch-desc-13534537",
+      "document": "devcontainer-id-variable",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "a4f8c1bc88da93f19cbe60837e480c1edc66fcb992e2fa68b80da5060e910638",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 5,
+          "excerpt": "The identifier must only contain alphanumeric characters."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-they-must-ensure-that-it-is-unique-among-other-d-desc-f5994239",
+      "document": "devcontainer-id-variable",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "5ed612bacaa183ee2b5855a2a14139e5d516f990852777e0debeb11f0f3ce89a",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "They must ensure that it is unique among other dev containers on the same Docker host and that it is stable across rebuilds of dev containers."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-to-ensure-implementations-get-to-the-same-result-algo-001cb9f4",
+      "document": "devcontainer-id-variable",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "585cdbc708c4593928b4c760eff247536126efe3770e51c152f2da2af313b6ae",
+      "locations": [
+        {
+          "heading": "Label-based Computation",
+          "anchor": "label-based-computation",
+          "ordinal": 1,
+          "excerpt": "To ensure implementations get to the same result, the object keys must be sorted and any optional whitespace outside of the keys and values must be removed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-devcontainer-id-variable-use-a-base-32-encoded-representation-left-padded-algo-26efae91",
+      "document": "devcontainer-id-variable",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "ef90058a974829e249a2f86c4a602cbb6c8db274bad5b24e345d0922183e5ef8",
+      "locations": [
+        {
+          "heading": "Label-based Computation",
+          "anchor": "label-based-computation",
+          "ordinal": 3,
+          "excerpt": "Use a base-32 encoded representation left-padded with '0' to 52 characters as the result."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-a-new-property-dependson-can-be-optionally-added-desc-039bf6bd",
+      "document": "feature-dependencies",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "adfe9e90f555b501b8ee14d4cdb3f7d712f1e7ebc58ea00aa1698c57d924fc97",
+      "locations": [
+        {
+          "heading": "(A) Add `dependsOn` property",
+          "anchor": "a-add-dependson-property",
+          "ordinal": 1,
+          "excerpt": "A new property `dependsOn` can be optionally added to the `devcontainer-feature.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-adding-feature-s-to-this-property-tells-the-orch-algo-5150f266",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "e3124c52043fed7266f338891980c5b073c63b2bcde4b726c7d532266b691057",
+      "locations": [
+        {
+          "heading": "(A) Add `dependsOn` property",
+          "anchor": "a-add-dependson-property",
+          "ordinal": 2,
+          "excerpt": "Adding Feature(s) to this property tells the orchestrating tool to install the Feature(s) (with the associated options, if provided) before installing the Feature that declares the dependency."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-an-orchestrating-tool-should-remove-all-installs-algo-e4d47679",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "10a553dd42f84664ea1f938e2a202c162ae449e3218baca591d99f25176fed90",
+      "locations": [
+        {
+          "heading": "installsAfter",
+          "anchor": "installsafter",
+          "ordinal": 2,
+          "excerpt": "an orchestrating tool should remove all `installsAfter` directed edges that do not correspond with a Feature in the `worklist` that is set to be installed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-commit-to-installationorder-only-those-nodes-who-algo-bf65dc02",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "dd6242231bdf20bc27ffcf3113cd8cea4df733faf2d2393e47aea0f2e43ceb49",
+      "locations": [
+        {
+          "heading": "**(B3) Round-based sorting**",
+          "anchor": "b3-round-based-sorting",
+          "ordinal": 3,
+          "excerpt": "commit to `installationOrder` only those nodes who share the maximum `roundPriority`.  Return all nodes in `round` with a strictly lower `roundPriority` to the `worklist` to be reprocessed in subsequent iterations."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-compare-and-sort-each-feature-lexiographically-b-algo-ed9f808d",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "98bb5022cb6db48bd20d8cf88ca3468cd41bc3bfad35d485fd42f0612e65c20a",
+      "locations": [
+        {
+          "heading": "Definition: Round Stable Sort",
+          "anchor": "definition-round-stable-sort",
+          "ordinal": 1,
+          "excerpt": "Compare and sort each Feature lexiographically by their fully qualified resource name (For OCI-published Features, that means the ID without version or digest.)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-dependency-resolution-is-only-performed-on-initi-desc-603bcd42",
+      "document": "feature-dependencies",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "6fbdf08b066b86a709e5cbf96eedba7fc3818bcae6e72c184383a57df2424ad3",
+      "locations": [
+        {
+          "heading": "Image Metadata",
+          "anchor": "image-metadata",
+          "ordinal": 1,
+          "excerpt": "Dependency resolution is only performed on initial container creation by reading the `features` object of `devcontainer.json` and resolving the Features in that point in time."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-dependson-ghcr-io-second-1-flag-true-io-791d2b05",
+      "document": "feature-dependencies",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "336104359008f5381f222732d326a2f697cc60e06feb29004eae9c90fec6db0d",
+      "locations": [
+        {
+          "heading": "(A) Add `dependsOn` property",
+          "anchor": "a-add-dependson-property",
+          "ordinal": 3,
+          "excerpt": "    \"dependsOn\": {\n        \"ghcr.io/second:1\": {\n            \"flag\": true\n        },"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-feature-dependencies-each-node-in-the-graph-has-an-implicit-default-r-algo-72caf843",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "2f43bc54c79b04bf956741832006d27a4e42fa673a0ece2b3e8d190b8659a06b",
+      "locations": [
+        {
+          "heading": "**(B2) Assigning `roundPriority`**",
+          "anchor": "b2-assigning-roundpriority",
+          "ordinal": 1,
+          "excerpt": "Each node in the graph has an implicit, default `roundPriority` of 0."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-for-dependson-dependencies-the-dependency-will-b-algo-2ba70907",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "452824885b29d74e87df1e5176d14c7598f5a6ade4f8d5d2b7e59e9bccee631a",
+      "locations": [
+        {
+          "heading": "**(B1) Building dependency graph**",
+          "anchor": "b1-building-dependency-graph",
+          "ordinal": 2,
+          "excerpt": "For `dependsOn` dependencies, the dependency will be fed back into the worklist to be recursively resolved."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-from-the-user-defined-features-the-orchestrating-algo-038fa45f",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "7c7cf13a2540027ba7617f8f470cf16a85f63bd4ef4dae6f52e3385dfbd198cc",
+      "locations": [
+        {
+          "heading": "**(B1) Building dependency graph**",
+          "anchor": "b1-building-dependency-graph",
+          "ordinal": 1,
+          "excerpt": "From the user-defined Features, the orchestrating tool will build a dependency graph."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-if-there-is-ever-a-round-where-no-elements-are-a-algo-eaf1402b",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "48ea608cd6d2312d124accbf73d2cd82ed959cef7d133c7a1e5e45e3694859e1",
+      "locations": [
+        {
+          "heading": "**(B3) Round-based sorting**",
+          "anchor": "b3-round-based-sorting",
+          "ordinal": 4,
+          "excerpt": "If there is ever a round where no elements are added to `installationOrder`, the algorithm should terminate and return an error."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-installsafter-is-not-recursive-algo-6d8aa9e0",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "6584ebbcc054c7778d0cef8d42eb0dff7487103279ed14cf00efc01b4f7ce8cc",
+      "locations": [
+        {
+          "heading": "installsAfter",
+          "anchor": "installsafter",
+          "ordinal": 1,
+          "excerpt": "`installsAfter` is not recursive."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-mediatype-application-vnd-oci-image-manifest-v1-io-e17c68d7",
+      "document": "feature-dependencies",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "7cf3ebe906116eba03d9a31029238ffba75c3488715adb06537db03340cec9fa",
+      "locations": [
+        {
+          "heading": "Identifying Dependencies - OCI Registry",
+          "anchor": "identifying-dependencies---oci-registry",
+          "ordinal": 3,
+          "excerpt": "  \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\","
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-feature-dependencies-only-the-features-equal-to-the-max-roundpriority-algo-6e6948bb",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "13bb130402d6d2fe8a3914d1dd6dc20916b99bccf6952a3d361fce5c84562c0e",
+      "locations": [
+        {
+          "heading": "**(B2) Assigning `roundPriority`**",
+          "anchor": "b2-assigning-roundpriority",
+          "ordinal": 2,
+          "excerpt": "only the Features equal to the max `roundPriority` of that set will be committed (the remaining will be uncommitted and reevaulated in subsequent rounds)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-start-with-all-the-elements-from-b2-in-a-worklis-algo-e03a3c04",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "3296c07be05b2fe54781f6006219afef4a364d0770ecaadb294288184af4b43d",
+      "locations": [
+        {
+          "heading": "**(B3) Round-based sorting**",
+          "anchor": "b3-round-based-sorting",
+          "ordinal": 1,
+          "excerpt": "Start with all the elements from **(B2)** in a `worklist` and an empty list `installationOrder`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-the-orchestrating-tool-is-responsible-for-calcul-algo-10e3be9a",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "6668a0848ea7c87909fcea298a4a1c929a223c0891f581b75a6bdcaae1331f95",
+      "locations": [
+        {
+          "heading": "(B) `dependsOn` install order algorithm",
+          "anchor": "b-dependson-install-order-algorithm",
+          "ordinal": 1,
+          "excerpt": "The orchestrating tool is responsible for calculating a Feature installation order (or error, if no valid installation order can be resolved)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-the-orchestrating-tool-must-fallback-to-download-must-e98c49b3",
+      "document": "feature-dependencies",
+      "strength": "must",
+      "testability": "indirectly-testable",
+      "fingerprint": "f57d34fb2430193541038578bd91d84d32f25596c9db4b2e835234a17beeab27",
+      "locations": [
+        {
+          "heading": "Identifying Dependencies - OCI Registry",
+          "anchor": "identifying-dependencies---oci-registry",
+          "ordinal": 2,
+          "excerpt": "the orchestrating tool MUST fallback to downloading and extracting the Feature's contents to read the metadata properties."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-the-orchestrating-tool-should-assign-a-roundprio-algo-3ef2e621",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "e3a9da0a070d8a2cc1acfb47f7ba6479f9c007f60d4f056df1916641c0f74e23",
+      "locations": [
+        {
+          "heading": "overrideFeatureInstallOrder",
+          "anchor": "overridefeatureinstallorder",
+          "ordinal": 2,
+          "excerpt": "the orchestrating tool should assign a `roundPriority` of `n - idx` to each Feature, where `idx` is the zero-based index of the Feature in the array."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-the-overridefeatureinstallorder-property-of-devc-algo-116737c8",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "da7aec103404dc0799441d0d61d5b20abc5608b4102aa3db5000cfd33171c3e1",
+      "locations": [
+        {
+          "heading": "overrideFeatureInstallOrder",
+          "anchor": "overridefeatureinstallorder",
+          "ordinal": 1,
+          "excerpt": "The `overrideFeatureInstallOrder` property of `devcontainer.json` is an array of Feature IDs that are to be installed in descending priority order as soon as its dependencies outlined above are installed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-the-set-of-features-to-be-installed-is-the-union-algo-c707f67a",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "9c8d2f4b00bc868cfdc4a7d577cbf9ae444015bb6231668bb4e861b7a376743b",
+      "locations": [
+        {
+          "heading": "(B) `dependsOn` install order algorithm",
+          "anchor": "b-dependson-install-order-algorithm",
+          "ordinal": 2,
+          "excerpt": "The set of Features to be installed is the union of user-defined Features and their dependencies."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-this-specification-defines-two-features-as-equal-desc-c6fa6084",
+      "document": "feature-dependencies",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "cbdff8a82d660669fb35b31fd9250811be5f050d782b6044acff4e88b6a52f3b",
+      "locations": [
+        {
+          "heading": "Definition: Feature Equality",
+          "anchor": "definition-feature-equality",
+          "ordinal": 1,
+          "excerpt": "This specification defines two Features as equal if both Features point to the same exact contents and are executed with the same options."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-to-speed-up-dependency-resolution-all-features-p-desc-9ea95360",
+      "document": "feature-dependencies",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "d5dd5458512f9de1c2218fb753013e38e90b6aed38882e21bf0942fe22587029",
+      "locations": [
+        {
+          "heading": "Identifying Dependencies - OCI Registry",
+          "anchor": "identifying-dependencies---oci-registry",
+          "ordinal": 1,
+          "excerpt": "To speed up dependency resolution, all Features [published to an OCI registry](https://containers.dev/implementors/features-distribution/#oci-registry) will have their entire `devcontainer-feature.json` serialized and added as an [annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-two-feature-are-identical-if-their-manifest-dige-algo-ee493920",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "b02493dcfe31a7aa4c9b05730b0dd0638bca3d6ffc86ff8b4dd4fce0c29eee25",
+      "locations": [
+        {
+          "heading": "Definition: Feature Equality",
+          "anchor": "definition-feature-equality",
+          "ordinal": 2,
+          "excerpt": "two Feature are identical if their manifest digests are equal, and the options executed against the Feature are equal (compared value by value)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-feature-dependencies-while-the-worklist-is-not-empty-iterate-through-algo-9d7e0a05",
+      "document": "feature-dependencies",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "716070e1dd6d6ef49032562963c99037bd5c40d215eab05220b72d14414c5c2e",
+      "locations": [
+        {
+          "heading": "**(B3) Round-based sorting**",
+          "anchor": "b3-round-based-sorting",
+          "ordinal": 2,
+          "excerpt": "While the `worklist` is not empty, iterate through each element in the `worklist` and check if all its dependencies (if any) are already members of `installationOrder`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-a-feature-is-a-self-contained-entity-in-a-folder-desc-daed6e03",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "fbc2350f65f8abd60ee8a79cb699f7a66f797fe9c63990ef7fa1092236fcc2dc",
+      "locations": [
+        {
+          "heading": "Folder structure",
+          "anchor": "folder-structure",
+          "ordinal": 1,
+          "excerpt": "A Feature is a self contained entity in a folder with at least a `devcontainer-feature.json` and `install.sh` entrypoint script."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-a-feature-s-options-specified-as-the-value-of-a-desc-9028c1c5",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "39f8102c6749eb90b4af8f48cac4b7d26fef71699cfec45d00e8aae3d33c3104",
+      "locations": [
+        {
+          "heading": "Option Resolution",
+          "anchor": "option-resolution",
+          "ordinal": 1,
+          "excerpt": "A Feature's 'options' - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-all-commands-within-that-group-are-executed-in-p-algo-a78f4973",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "41c18bb9ba160b8ca9a06decdcc39f916dbd3d70dbfe11e06cbd70a9ba75aab3",
+      "locations": [
+        {
+          "heading": "Behavior",
+          "anchor": "behavior",
+          "ordinal": 3,
+          "excerpt": "all commands within that group are executed in parallel, but still blocking commands from subsequent Features and/or the `devcontainer.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-all-properties-are-optional-except-for-id-versio-desc-f714e36c",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "e6772b2c789b8bbb05b502fcc8027f86f168cc2b146c75f9ae36094efa9d81ec",
+      "locations": [
+        {
+          "heading": "devcontainer-feature.json properties",
+          "anchor": "devcontainer-featurejson-properties",
+          "ordinal": 1,
+          "excerpt": "All properties are optional **except for `id`, `version`, and `name`**."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-any-options-defined-by-a-feature-s-devcontainer-desc-94f2f9f6",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "d8b5bada7668979aafe80adf7ea8b405e0dc38f176f49b8978918ff69b8b26cb",
+      "locations": [
+        {
+          "heading": "Option Resolution",
+          "anchor": "option-resolution",
+          "ordinal": 4,
+          "excerpt": "Any options defined by a Feature's `devcontainer-feature.json` that are omitted in the user's `devcontainer.json` will be implicitly exported as its default value."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-applications-should-default-to-bin-sh-for-featur-desc-025df47e",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "c1f7aecc9fe8c1f51ed84b0fbcf71705f861d07d714efca97beb8ca55346d0d1",
+      "locations": [
+        {
+          "heading": "Authoring",
+          "anchor": "authoring",
+          "ordinal": 1,
+          "excerpt": "Applications should default to `/bin/sh` for Features that do not include this information."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-as-a-shorthand-the-value-of-a-feature-can-be-pro-desc-f3124266",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "f23348981e4a5f2aa1ba2ef316adbb8ce0cdafe3fdc4918a5721c0f2193b9a65",
+      "locations": [
+        {
+          "heading": "devcontainer.json properties",
+          "anchor": "devcontainerjson-properties",
+          "ordinal": 1,
+          "excerpt": "As a shorthand, the value of a `feature` can be provided as a single string. This string is mapped to an option called `version`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-by-default-features-are-installed-on-top-of-a-ba-desc-a302b55b",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "21280a83b815594a7ee8ff52dbc0c7a06a3253eb0b9eb9d8f980a303531abd1b",
+      "locations": [
+        {
+          "heading": "Installation order",
+          "anchor": "installation-order",
+          "ordinal": 1,
+          "excerpt": "By default, Features are installed on top of a base image in an order determined as optimal by the implementing tool."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-commands-provided-by-features-are-always-execute-desc-dd4498b0",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "ab4023ca20b5adafd4a7b0e781d6ffe06352c329b59a3395e1870273bf6b37a1",
+      "locations": [
+        {
+          "heading": "Behavior",
+          "anchor": "behavior",
+          "ordinal": 1,
+          "excerpt": "Commands provided by Features are always executed _before_ any user-provided lifecycle commands (i.e. in the `devcontainer.json`)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-220fd88c",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "65f3bdd11295d9148ecec9f94fa7fbf2cbafb288cb6ab179fe2c78a288ea4716",
+      "locations": [
+        {
+          "heading": "Label-based Computation",
+          "anchor": "label-based-computation",
+          "ordinal": 1,
+          "excerpt": "Compute a SHA-256 hash from the UTF-8 encoded input string."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-containerenv-is-added-before-the-feature-is-exec-desc-053522a1",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "633fb7949b881d8fda385a2fa6c2f2b74bb233488dc696b904e02bf24035b134",
+      "locations": [
+        {
+          "heading": "Implementation notes",
+          "anchor": "implementation-notes",
+          "ordinal": 3,
+          "excerpt": "`containerEnv` is added before the Feature is executed as `ENV` commands in the Dockerfile."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-a-local-feature-may-not-be-referenced-by-absolut-desc-e6c73d75",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "7afbf1d3814fd26ab51b9d57ded5822cbc120b7862201c49e5b4380956aca7e8",
+      "locations": [
+        {
+          "heading": "Locally referenced Features",
+          "anchor": "locally-referenced-features",
+          "ordinal": 3,
+          "excerpt": "A local Feature may **not** be referenced by absolute path."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-a-local-feature-s-source-code-must-be-contained-desc-95530a45",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "87ba1734c495f98752a735dcc95545f482008cdce8e2dba8e711722688cfd7af",
+      "locations": [
+        {
+          "heading": "Locally referenced Features",
+          "anchor": "locally-referenced-features",
+          "ordinal": 1,
+          "excerpt": "A local Feature's source code **must** be contained within a sub-folder of the `.devcontainer/ folder`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-an-annotation-named-dev-containers-metadata-shou-desc-b05655d2",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "af4d87a38e8a1a6adb7cf69d6ea4cff474475c5a93978244c2c35a3342efbbcb",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 3,
+          "excerpt": "an [annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) named `dev.containers.metadata` should be populated on the manifest when published by an implementing tool."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-each-features-s-devcontainer-feature-json-metada-desc-b76d2912",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "3dabc34024293edd4fc858dc5b4d4b55f59d19f03315fdc100fbf46867443127",
+      "locations": [
+        {
+          "heading": "devcontainer-collection.json",
+          "anchor": "devcontainer-collectionjson",
+          "ordinal": 1,
+          "excerpt": "Each Features's `devcontainer-feature.json` metadata file is appended into the `features` top-level array."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-each-packaged-feature-is-pushed-to-the-registry-desc-fd7d5c27",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "d31f27a47e7349f12a771dfea7b847296a5ef168ff04ee11de8e7f03f702f2cf",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 1,
+          "excerpt": "Each packaged feature is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the Feature, according to the semver specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-each-sub-directory-should-be-named-such-that-it-desc-28ecbc16",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "1120dcae375bb8179a2d5a557cc3e0e6fffe04d53116b541bcf5c0d99942aeec",
+      "locations": [
+        {
+          "heading": "Source code",
+          "anchor": "source-code",
+          "ordinal": 2,
+          "excerpt": "Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-features-are-distributed-as-tarballs-desc-bd68764b",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "7569738d29b6e360ac30d49762568b04f889678aee4adf0ec657d98332b07579",
+      "locations": [
+        {
+          "heading": "Packaging",
+          "anchor": "packaging",
+          "ordinal": 1,
+          "excerpt": "Features are distributed as tarballs."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-features-source-code-is-stored-in-a-git-reposito-desc-dfd5fa79",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "9285f34910cf394788269306ab3f69daf7b73c1bb6742e3cd5ce6d3cbf5e0f6e",
+      "locations": [
+        {
+          "heading": "Source code",
+          "anchor": "source-code",
+          "ordinal": 1,
+          "excerpt": "Features source code is stored in a git repository."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-mediatype-application-vnd-oci-image-manifest-v1-io-0a1ceea4",
+      "document": "features-distribution",
+      "strength": "io-contract",
+      "testability": "not-applicable",
+      "fingerprint": "7cf3ebe906116eba03d9a31029238ffba75c3488715adb06537db03340cec9fa",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 4,
+          "excerpt": "\"mediaType\": \"application/vnd.oci.image.manifest.v1+json\","
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-features-distribution-the-auto-generated-devcontainer-collection-json-desc-1182fae9",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "b1c1b8bed6b0f8444ccea730447d6ac3e7ce00105020e4c0e80a7aa36705c31f",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 2,
+          "excerpt": "The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `feature` name. The collection file is always tagged as `latest`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-the-relative-path-is-provided-using-unix-style-p-desc-95ef8af0",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "b32d830936433750e8fb4e1b56f95a0d7fe802c3083d64c49458fd2ce761eeb4",
+      "locations": [
+        {
+          "heading": "Locally referenced Features",
+          "anchor": "locally-referenced-features",
+          "ordinal": 4,
+          "excerpt": "The relative path is provided using unix-style path syntax (e.g. `./myFeature`) regardless of the host operating system."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-the-sub-folder-name-must-match-the-feature-s-id-desc-68ba92a6",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "b67eef65699a801c77a623d4ae2b2f2aca8870d0017bddc28dbab427341dddcc",
+      "locations": [
+        {
+          "heading": "Locally referenced Features",
+          "anchor": "locally-referenced-features",
+          "ordinal": 2,
+          "excerpt": "The sub-folder name **must** match the Feature's `id` field."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-the-tarball-is-named-devcontainer-feature-id-tgz-desc-d8398b64",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "946266beae42f74f58f89824268c04d6a070915d373ce4a21c6c3b37acbc609d",
+      "locations": [
+        {
+          "heading": "Packaging",
+          "anchor": "packaging",
+          "ordinal": 2,
+          "excerpt": "The tarball is named `devcontainer-feature-<id>.tgz`, where `<id>` is the Feature's `id` field."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-the-tgz-archive-file-must-be-named-devcontainer-desc-b32fee89",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "14609f05f1e26eee6046ecc9c59f580a6c251ff0f7421d2f6b2ded485c7a051b",
+      "locations": [
+        {
+          "heading": "Directly referencing a tarball",
+          "anchor": "directly-referencing-a-tarball",
+          "ordinal": 1,
+          "excerpt": "The `.tgz` archive file must be named `devcontainer-feature-<featureId>.tgz`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-distribution-tooling-that-handles-publishing-features-will-no-desc-4129df00",
+      "document": "features-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "cb7b1f7608454e925b90a6aaaa13908ce055efed320e24ec307f4abde48642bd",
+      "locations": [
+        {
+          "heading": "Versioning",
+          "anchor": "versioning",
+          "ordinal": 1,
+          "excerpt": "Tooling that handles publishing Features will not republish features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-each-command-contributed-by-a-feature-is-execute-desc-304ca215",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "3f506644900cd7346d861a3e9a41f5b41bfae11f52aad917d31eb7d13312319f",
+      "locations": [
+        {
+          "heading": "Behavior",
+          "anchor": "behavior",
+          "ordinal": 2,
+          "excerpt": "each command contributed by a Feature is executed in sequence (blocking the next command from executing)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-each-feature-script-executes-as-its-own-layer-to-desc-6a08d1b6",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "10cf453daaaf6a495e7c8027720551553b46e9e3a90c9fad7d67e8fb3a3f809c",
+      "locations": [
+        {
+          "heading": "Implementation notes",
+          "anchor": "implementation-notes",
+          "ordinal": 4,
+          "excerpt": "Each Feature script executes as its own layer to aid in caching and rebuilding."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-feature-identifiers-should-be-assumed-to-be-case-desc-68ef18bd",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "ec9c8f3dc8398887ff2df3c7bbe4ab794a24bfd000139382b5c0506e23deda4b",
+      "locations": [
+        {
+          "heading": "Referencing a feature",
+          "anchor": "referencing-a-feature",
+          "ordinal": 1,
+          "excerpt": "Feature identifiers should be assumed to be case-insensitive and should be normalized to lowercase."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-feature-scripts-run-as-the-root-user-and-sometim-desc-86913dfe",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "1c3723e1e6cf234d1ac1ac4a524362cb417ce57648c11a5ee8378b3701aec746",
+      "locations": [
+        {
+          "heading": "User environment variables",
+          "anchor": "user-environment-variables",
+          "ordinal": 1,
+          "excerpt": "Feature scripts run as the `root` user and sometimes need to know which user account the dev container will be used with."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-if-any-of-the-features-indicated-in-the-dependso-desc-b94a100f",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "92f64ad2e31292f62ec4e42c425ab57b23942c03ab9e538019bc764af604a522",
+      "locations": [
+        {
+          "heading": "The dependsOn property",
+          "anchor": "the-dependson-property",
+          "ordinal": 2,
+          "excerpt": "If any of the Features indicated in the `dependsOn` property cannot be installed (e.g. due to circular dependency, failure to resolve the Feature, etc) the entire dev container creation should fail."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-if-no-remoteuser-is-configured-remote-user-is-se-desc-fca91b8f",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "21c6a0e8bdc375f75887185955d32f3b5b6e11df4fa5d9a55355fd549608d62e",
+      "locations": [
+        {
+          "heading": "User environment variables",
+          "anchor": "user-environment-variables",
+          "ordinal": 3,
+          "excerpt": "If no `remoteUser` is configured, `_REMOTE_USER` is set to the same value as `_CONTAINER_USER`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-in-the-snippet-above-myfeature-must-be-installed-must-7630c7ee",
+      "document": "features",
+      "strength": "must",
+      "testability": "indirectly-testable",
+      "fingerprint": "3e24b542fec1ca3a352a36c7cb2a43c12d6c7e0a2f8c534dfcd7a934184dd051",
+      "locations": [
+        {
+          "heading": "The dependsOn property",
+          "anchor": "the-dependson-property",
+          "ordinal": 1,
+          "excerpt": "In the snippet above, `myfeature` MUST be installed after `foo`, `bar`, and `baz`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-installsafter-is-not-evaluated-recursively-algo-7d30c616",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "496ab77e551d613f5fa5045d59ae60e540cd1d1cd95a95d11f2203ebc153baeb",
+      "locations": [
+        {
+          "heading": "The installsAfter Property",
+          "anchor": "the-installsafter-property",
+          "ordinal": 1,
+          "excerpt": "`installsAfter` is **not** evaluated recursively."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-installsafter-only-influences-the-installation-o-algo-6fcd528e",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "9ca89830ad7f0b6cca8fb39eab656c6795153f7d55e40ba01480e56744889809",
+      "locations": [
+        {
+          "heading": "The installsAfter Property",
+          "anchor": "the-installsafter-property",
+          "ordinal": 2,
+          "excerpt": "`installsAfter` only influences the installation order of Features that are **already set to be installed**."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-it-will-be-emitted-to-a-file-named-devcontainer-io-1d1b4962",
+      "document": "features",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "c3754ca1d0c337408e597c390d2c072b070c6d45cd3a34d57f120ea685f4354a",
+      "locations": [
+        {
+          "heading": "Option Resolution",
+          "anchor": "option-resolution",
+          "ordinal": 2,
+          "excerpt": "it will be emitted to a file named `devcontainer-features.env` following the format `<OPTION_NAME>=<value>`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-defaults-to-array-of-old-ids-used-to-publish-thi-io-dc47b23f",
+      "document": "features-legacy-ids",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "ca9f421651e3b72f4de94d07a307418ded319676fc6163bf5bbec57511e3359a",
+      "locations": [
+        {
+          "heading": "1. legacyIds",
+          "anchor": "1-legacyids",
+          "ordinal": 1,
+          "excerpt": "Defaults to `[]`. Array of old IDs used to publish this Feature."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-defaults-to-false-indicates-that-the-feature-is-io-651a4b56",
+      "document": "features-legacy-ids",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "cde29c96bdde3b5ce4ab73f2f5595a9a078e2f6088682981df6d388db29ba802",
+      "locations": [
+        {
+          "heading": "2. deprecated",
+          "anchor": "2-deprecated",
+          "ordinal": 1,
+          "excerpt": "Defaults to `false`. Indicates that the Feature is deprecated, and will not receive any further updates/support."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-if-this-property-is-set-to-true-then-it-indicate-desc-cc1c45f4",
+      "document": "features-legacy-ids",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "f059953cd8b6db2fe3e23a5044238dab0500bccfbc3054a82c0dd252268d1f19",
+      "locations": [
+        {
+          "heading": "2. deprecated",
+          "anchor": "2-deprecated",
+          "ordinal": 2,
+          "excerpt": "If this property is set to `true`, then it indicates that the Feature is deprecated and won't be receiving any further updates/support. The OCI artifacts would exist, hence, the current dev configs will continue to work."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-the-cli-tooling-will-be-updated-to-also-look-at-algo-b10031b2",
+      "document": "features-legacy-ids",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "c6df5ab2f704f6ad69b4b3619ea23a52bde3381689b3a074a81b718280e26b40",
+      "locations": [
+        {
+          "heading": "Supporting backwards compatibility for installsAfter property",
+          "anchor": "supporting-backwards-compatibility-for-installsafter-property",
+          "ordinal": 1,
+          "excerpt": "the CLI tooling will be updated to also look at the `legacyIds` property along with the `id` for determining the installation order."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-the-property-is-useful-for-renaming-a-currently-desc-60127c26",
+      "document": "features-legacy-ids",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "8cbc40b2d2edb6a00a510b6e6845ab39cf78d4afebc3a0117c0b4c392e13da9f",
+      "locations": [
+        {
+          "heading": "1. legacyIds",
+          "anchor": "1-legacyids",
+          "ordinal": 2,
+          "excerpt": "The property is useful for renaming a currently published Feature within a single namespace."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-the-semantic-version-of-the-feature-defined-by-t-desc-d1b0f722",
+      "document": "features-legacy-ids",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "01c6e1fd2e2b25053ad2d560c7f7d109b5dbe11f87ffa7c2ff4cdc908afe8e6e",
+      "locations": [
+        {
+          "heading": "Example: Renaming a Feature",
+          "anchor": "example-renaming-a-feature",
+          "ordinal": 1,
+          "excerpt": "The semantic version of the Feature defined by the `version` property should be **continued** and should not be restarted at `1.0.0`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-legacy-ids-will-dual-publish-the-old-ids-defined-by-the-leg-desc-0d5a6b09",
+      "document": "features-legacy-ids",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "db9c6cb89d8a50544a8c4f88d4bfdad6e84c56762393422171c73b0b6a2e5283",
+      "locations": [
+        {
+          "heading": "Changes to the Features distribution specification",
+          "anchor": "changes-to-the-features-distribution-specification",
+          "ordinal": 1,
+          "excerpt": "will dual publish the old `id`s (defined by the `legacyIds` property), and the new `id`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-all-other-semantics-match-the-existing-lifecycle-desc-c02f9c97",
+      "document": "features-lifecycle-scripts",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "224df1ab876b976c5d21362b43e0d2f711164b812adb4202f6642adde7b79388",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "All other semantics match the existing [Lifecycle Scripts](https://containers.dev/implementors/json_reference/#lifecycle-scripts) and [lifecycle script parallel execution](https://containers.dev/implementors/spec/#parallel-exec) behavior exactly."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-as-with-all-lifecycle-hooks-commands-are-execute-desc-fb55e890",
+      "document": "features-lifecycle-scripts",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "4224f0fc12cf1462891d8b03da7bdbb668a1feb282325b32d4c98d63afb2edd8",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "As with all lifecycle hooks, commands are executed from the context (cwd) of the [project workspace folder](https://containers.dev/implementors/spec/#project-workspace-folder)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-3e112729",
+      "document": "features-lifecycle-scripts",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "a3b310e68a21162fc1d501734637778e58cd9a23b17821adf920960e468661ad",
+      "locations": [
+        {
+          "heading": "Installation",
+          "anchor": "installation",
+          "ordinal": 2,
+          "excerpt": "If one of the lifecycle scripts fails, any subsequent scripts will not be executed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-implementations-are-not-required-to-persist-feat-desc-e70d2cb7",
+      "document": "features-lifecycle-scripts",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "579b14ae03a22a694fb34e67fa711e4b6afb08b64b50ca06ec4b81228a3b210a",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "Implementations are not required to persist Feature install scripts beyond the initial build."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-no-subsequent-lifecycle-commands-shall-proceed-u-algo-0aca04ec",
+      "document": "features-lifecycle-scripts",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "aab1d4a5fe10d3b7a980128d1094fe2553d9fc232fd7879c31c4201dff584c5e",
+      "locations": [
+        {
+          "heading": "Installation",
+          "anchor": "installation",
+          "ordinal": 1,
+          "excerpt": "No subsequent lifecycle commands shall proceed until the current command completes."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-note-that-initializecommand-is-omitted-pending-f-desc-15212db2",
+      "document": "features-lifecycle-scripts",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "0078750de5af1351769decb8b42087dac37267ac83b6249c9a3d55ac2d86f940",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "Note that `initializeCommand` is omitted, pending further discussions around a secure design."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-lifecycle-scripts-when-a-dev-container-is-brought-up-for-each-life-algo-91b49557",
+      "document": "features-lifecycle-scripts",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "72ac478478772e96649995cebfbebcb50ec0d1f0e45a7234ae2ab6c56ed28902",
+      "locations": [
+        {
+          "heading": "Execution",
+          "anchor": "execution",
+          "ordinal": 1,
+          "excerpt": "When a dev container is brought up, for each lifecycle hook, each Feature that contributes a command to a lifecycle hook shall have the command executed in sequence, following the same execution order as outlined in [Feature installation order](https://containers.dev/implementors/features/#installation-order), and always before any user-provided lifecycle commands."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-parameters-like-capadd-securityop-are-concatenat-desc-1b18e10d",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "2a807196bb6011657b23c2c6e726317fe817de21909cdc9ce49ee9ffb498999f",
+      "locations": [
+        {
+          "heading": "Implementation notes",
+          "anchor": "implementation-notes",
+          "ordinal": 2,
+          "excerpt": "Parameters like `capAdd`, `securityOp`  are concatenated."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-parameters-like-privileged-init-are-included-if-desc-8051176c",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "92c48123cae158a9f9df3cdbace13dd1669c86ec7c5c644df87cf98eb37065ad",
+      "locations": [
+        {
+          "heading": "Implementation notes",
+          "anchor": "implementation-notes",
+          "ordinal": 1,
+          "excerpt": "Parameters like `privileged`, `init` are included if just 1 Feature requires them."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-proposals-value1-value2-io-691c42c1",
+      "document": "features",
+      "strength": "io-contract",
+      "testability": "not-applicable",
+      "fingerprint": "8ada6ab666cf96d8aab0306d839816f0d453ea582cc8f42af3c999e6478099b1",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 1,
+          "excerpt": "\"proposals\": [\"value1\", \"value2\"],"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-features-remote-user-and-container-user-environment-varia-desc-2c5cca76",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "e432e8d3a704519a1cf980131dc95c3456dc8dce917cc37bb9c546445de48861",
+      "locations": [
+        {
+          "heading": "User environment variables",
+          "anchor": "user-environment-variables",
+          "ordinal": 2,
+          "excerpt": "`_REMOTE_USER` and `_CONTAINER_USER` environment variables are passed to the Features scripts with `_CONTAINER_USER` being the container's user and `_REMOTE_USER` being the configured `remoteUser`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-replace-w-g-replace-d-g-touppercase-algo-37933881",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "126308dbe4a797db08bfdb2b7be4f2c447b0749afd07bccbea917dda4bf9500e",
+      "locations": [
+        {
+          "heading": "Option Resolution",
+          "anchor": "option-resolution",
+          "ordinal": 3,
+          "excerpt": ".replace(/[^\\w_]/g, '_')\n\t.replace(/^[\\d_]+/g, '_')\n\t.toUpperCase();"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-features-the-dependson-property-must-be-evaluated-recursi-desc-02808f73",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "30f1dbae9e022fb47c44adda509edde7b0eab37dca0db162ce046e3ccd0636ce",
+      "locations": [
+        {
+          "heading": "The dependsOn property",
+          "anchor": "the-dependson-property",
+          "ordinal": 3,
+          "excerpt": "The `dependsOn` property must be evaluated recursively."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-home-folders-of-the-two-users-are-passed-to-desc-e63de366",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "81b7f6d44a84e5c973ef24d757a6be2a31f9ab5f06a9f1e6b7f8f165262c1bc2",
+      "locations": [
+        {
+          "heading": "User environment variables",
+          "anchor": "user-environment-variables",
+          "ordinal": 4,
+          "excerpt": "the home folders of the two users are passed to the Feature scripts as `_REMOTE_USER_HOME` and `_CONTAINER_USER_HOME` environment variables."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-id-becomes-the-name-of-the-environment-varia-desc-31d4642c",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "7fc844c483144cd0e98e9e568bb956beb4c8f2592005f765c79db00b8a4a48cc",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 2,
+          "excerpt": "The ID becomes the name of the environment variable in all caps."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-install-sh-script-for-each-feature-should-be-desc-b7c920aa",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "cc41a00442664bf439b6bdb9debaa2bc723fe99c56958cf577bd0e62221d265b",
+      "locations": [
+        {
+          "heading": "Invoking install.sh",
+          "anchor": "invoking-installsh",
+          "ordinal": 1,
+          "excerpt": "The `install.sh` script for each Feature should be executed as `root` during a container image build."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-latest-version-annotation-is-added-implicitl-desc-60c7b3c7",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "02b74bcec1f3b92e0354dc27b81a7efcc94cc67366cde7d3caa572c00a47a36c",
+      "locations": [
+        {
+          "heading": "devcontainer.json properties",
+          "anchor": "devcontainerjson-properties",
+          "ordinal": 2,
+          "excerpt": "The `:latest` version annotation is added implicitly if omitted."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-orchestrating-tool-should-assign-a-roundprio-algo-0de9ab37",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "e3a9da0a070d8a2cc1acfb47f7ba6479f9c007f60d4f056df1916641c0f74e23",
+      "locations": [
+        {
+          "heading": "The 'overrideFeatureInstallOrder' property",
+          "anchor": "the-overridefeatureinstallorder-property",
+          "ordinal": 1,
+          "excerpt": "the orchestrating tool should assign a `roundPriority` of `n - idx` to each Feature, where `idx` is the zero-based index of the Feature in the array."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-the-properties-supporting-devcontainerid-in-the-desc-49ac4346",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "014fb65b0fd2a2b31101b69456efb33c7036780ac1949f42bd19a06acc5caa4d",
+      "locations": [
+        {
+          "heading": "Dev Container ID",
+          "anchor": "dev-container-id",
+          "ordinal": 1,
+          "excerpt": "the properties supporting `${devcontainerId}` in the Feature metadata are: `entrypoint`, `mounts`, `customizations`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-they-must-ensure-that-it-is-unique-among-other-d-desc-3180a890",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "5ed612bacaa183ee2b5855a2a14139e5d516f990852777e0debeb11f0f3ce89a",
+      "locations": [
+        {
+          "heading": "Dev Container ID",
+          "anchor": "dev-container-id",
+          "ordinal": 2,
+          "excerpt": "They must ensure that it is unique among other dev containers on the same Docker host and that it is stable across rebuilds of dev containers."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-to-ensure-that-the-appropriate-shell-is-used-the-desc-69c662f2",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "ea34cd67371b45729b6691eb61312bb1cec316853e0bcb6ff57402572164e8dc",
+      "locations": [
+        {
+          "heading": "Invoking install.sh",
+          "anchor": "invoking-installsh",
+          "ordinal": 2,
+          "excerpt": "To ensure that the appropriate shell is used, the execute bit should be set on `install.sh` and the file invoked directly (e.g. `chmod +x install.sh && ./install.sh`)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-tooling-that-handles-releasing-features-will-not-desc-e06497e8",
+      "document": "features",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "40c5a2301bc82348d0f49b6120d2ce328856caa5913787c1f33d00d6169e15fe",
+      "locations": [
+        {
+          "heading": "Versioning",
+          "anchor": "versioning",
+          "ordinal": 1,
+          "excerpt": "Tooling that handles releasing Features will not republish Features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-use-a-base-32-encoded-representation-left-padded-algo-cf1473ea",
+      "document": "features",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "ef90058a974829e249a2f86c4a602cbb6c8db274bad5b24e345d0922183e5ef8",
+      "locations": [
+        {
+          "heading": "Label-based Computation",
+          "anchor": "label-based-computation",
+          "ordinal": 2,
+          "excerpt": "Use a base-32 encoded representation left-padded with '0' to 52 characters as the result."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-user-env-additionally-the-home-folders-of-the-two-users-a-io-15684a98",
+      "document": "features-user-env",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "23d2597c36b68b34415dbd8215786bb11699ee6c5826e9d9420125a123dbf147",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "Additionally the home folders of the two users are passed to the feature scripts as `_REMOTE_USER_HOME` and `_CONTAINER_USER_HOME` environment variables."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-user-env-if-no-remoteuser-is-configured-remote-user-is-se-algo-d105730b",
+      "document": "features-user-env",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "21c6a0e8bdc375f75887185955d32f3b5b6e11df4fa5d9a55355fd549608d62e",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "If no `remoteUser` is configured, `_REMOTE_USER` is set to the same value as `_CONTAINER_USER`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-user-env-pass-remote-user-and-container-user-environment-io-3dda5725",
+      "document": "features-user-env",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "fa0c4edea876d5c186053fa625aa20d7989a2538d6c242e205891062877bbad7",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "Pass `_REMOTE_USER` and `_CONTAINER_USER` environment variables to the features scripts with `_CONTAINER_USER` being the container's user and `_REMOTE_USER` being the configured `remoteUser`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-features-user-env-the-container-user-can-be-set-with-containeruser-desc-b793399d",
+      "document": "features-user-env",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "cc920336d047c0bdcc1a361a9e7cff2a2e5e9d6704fe8be1d9b49d985572aa75",
+      "locations": [
+        {
+          "heading": "Notes",
+          "anchor": "notes",
+          "ordinal": 1,
+          "excerpt": "The container user can be set with `containerUser` in the devcontainer.json and image metadata, `user` in the docker-compose.yml, `USER` in the Dockerfile and can be passed down from the base image."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-gpu-host-requirement-a-string-indicating-minimum-memory-requirements-io-1b5d1079",
+      "document": "gpu-host-requirement",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "ab1e18aca5aab5732e3ea07ccae4ea88dcc50185ad16e50acf3b6abe53d68027",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-gpu-host-requirement-indicates-the-minimum-required-number-of-cores-io-529e3b33",
+      "document": "gpu-host-requirement",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "c43a40ea6701aa308d5bb12906025f04ab6cdfb2aa0733b5ba623434bdcf382b",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "Indicates the minimum required number of cores."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-gpu-host-requirement-indicates-whether-or-not-a-gpu-is-required-a-val-io-d8c6d13d",
+      "document": "gpu-host-requirement",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "a18a1608c34f16dd802eb32ba6475d102e96237125b7ae8e344cf6481f00b4a1",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "Indicates whether or not a GPU is required. A value 'optional' indicates that might be used if available."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-gpu-host-requirement-we-propose-to-add-a-new-gpu-property-to-the-host-io-6b095695",
+      "document": "gpu-host-requirement",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "d8e11d3b0122b938ab1c3f4b3347374ca0d90b400e649c3acb997be5934da429",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "We propose to add a new `gpu` property to the `hostRequirements` object in the devcontainer.json schema. The property can be a boolean value, the string `optional` or an object:"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-capadd-string-union-of-all-capadd-arrays-without-io-2f3f3193",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "d0cbd9b1433375c924d8f2adef40d622964043c16d2f41ccb6978b6a826853ad",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 3,
+          "excerpt": "| `capAdd` | `string[]` | Union of all `capAdd` arrays without duplicates. | x | x |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-forwardports-number-string-union-of-all-ports-wi-io-62ee1814",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "804d75346004c41d379b00050db026ba387635b02fb73377a5bef7e5e2962160",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 5,
+          "excerpt": "| `forwardPorts` | `(number \\| string)[]` | Union of all ports without duplicates. Last one wins (when mapping changes). | x |   |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-id-string-init-boolean-privileged-boolean-capadd-io-8cf55d2d",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "informative",
+      "fingerprint": "aae708226ad781f1dbdb459f10c014d913d0493e89661d80399d730ce6946430",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "[\n\t{\n\t\t\"id\"?: string,\n\t\t\"init\"?: boolean,\n\t\t\"privileged\"?: boolean,\n\t\t\"capAdd\"?: string[],\n\t\t\"securityOpt\"?: string[],\n\t\t\"entrypoint\"?: string,"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-image-metadata-init-boolean-true-if-at-least-one-is-true-false-io-68bfc594",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "4535692c77f91a14726a5a63f95fbbeca53eebc5090b003880a45c8287fc214c",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 2,
+          "excerpt": "| `init` | `boolean` | `true` if at least one is `true`, `false` otherwise. | x | x |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-mounts-string-type-src-dst-collected-list-of-all-io-a4d7d6d5",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "c9d2b3db41bce7fcf69df5ede7d7d44800db0f4ed61194e1b9a74fb21bed99bc",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 4,
+          "excerpt": "| `mounts` | `(string \\| { type, src, dst })[]` | Collected list of all mountpoints. Conflicts: Last source wins. | x | x |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-record-dev-container-config-and-feature-metadata-desc-dac9ade3",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "c395b7dd80036674919de94fca9e7f530e2a682234745220697c581b95d4f86e",
+      "locations": [
+        {
+          "heading": "Goal",
+          "anchor": "goal",
+          "ordinal": 1,
+          "excerpt": "Record dev container config and feature metadata in prebuilt images, such that, the image and the built-in features can be used with a devcontainer.json"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-the-metadata-is-added-to-the-image-as-a-devconta-io-721243cf",
+      "document": "image-metadata",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "add02a57c14257900762a3455f3c755a65accbe94e4b7ae17d884002eda3a87f",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "The metadata is added to the image as a `devcontainer.metadata` label with a JSON string value representing the above array or single object."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-to-apply-the-metadata-together-with-a-user-s-dev-desc-4d54126e",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "ff2ce432cdd3d3d8be2efd97bc4f582d45e62da56fdb3249854cf12ac90a7cf9",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 1,
+          "excerpt": "To apply the metadata together with a user's devcontainer.json at runtime the following merge logic by property is used."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-to-simplify-adding-this-metadata-for-other-tools-desc-8bade94f",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "2e384fd0d3b6c43a385b3d38efd948087e029edfce117aa765a0541d65734fd7",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "To simplify adding this metadata for other tools, we also support having a single top-level object with the same properties."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-variables-in-string-values-will-be-substituted-a-desc-31cd8289",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "2db43804d40be1dad427d6df92a856a6c76522f948a6b0636a5328daec0271c5",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 6,
+          "excerpt": "Variables in string values will be substituted at the time the value is applied. When the order matters, the devcontainer.json is considered last."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-we-are-adding-support-for-mounts-containerenv-co-desc-dbddd9df",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "9c83f1b3880a6121b63e7a8d6502445f4e98eff17b9d83914773f15b87064e95",
+      "locations": [
+        {
+          "heading": "Additional devcontainer.json Properties",
+          "anchor": "additional-devcontainerjson-properties",
+          "ordinal": 1,
+          "excerpt": "We are adding support for `mounts`, `containerEnv`, `containerUser`, `init`, `privileged`, `capAdd`, and `securityOpt` to the devcontainer.json"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-image-metadata-we-propose-to-add-metadata-to-the-image-with-the-desc-b54f56f3",
+      "document": "image-metadata",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "b1b3839a558b5fd5b67aed48d961d242983e30dc70bc544f75a0190f6e4b0005",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "We propose to add metadata to the image with the following structure using one entry per feature and devcontainer.json"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-command-string-or-list-of-command-arguments-to-desc-dff1da95",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "94ffeb7f8bebe95519f83482e90b70cd7fd2fd601f90e5b28edb4e9b0d5b0e79",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 2,
+          "excerpt": "A command string or list of command arguments to run on the **host machine** during initialization, including during container creation and on subsequent starts."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-command-to-run-each-time-a-tool-has-successful-desc-ac507e3c",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "99fdfeba53143d60470b445d373bb1f08d64cdf90d9fce477335d54b4d967382",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 7,
+          "excerpt": "A command to run each time a tool has successfully attached to the container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-command-to-run-each-time-the-container-is-succ-desc-56473251",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "f7c720d5902c45ddd5230646076dba2bb7bb2cee8e162270ae3cf914e362e39b",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 6,
+          "excerpt": "A command to run each time the container is successfully started."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-default-value-for-when-the-environment-variabl-io-e0533bcb",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "1d3998e37008ca596a616970ad4ed0acc4f48893cd6007514a221d8d3a052e70",
+      "locations": [
+        {
+          "heading": "Variables in devcontainer.json",
+          "anchor": "variables-in-devcontainerjson",
+          "ordinal": 2,
+          "excerpt": "A default value for when the environment variable is not set can be given with `${localEnv:VARIABLE_NAME:default_value}`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-dev-container-configuration-will-inherit-the-r-desc-8967e88c",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "a87b2335dad1778eb74fc0561ca955aae0ad8ccbfe23796d2ae4be3b07297bd2",
+      "locations": [
+        {
+          "heading": "remoteUser",
+          "anchor": "remoteuser",
+          "ordinal": 1,
+          "excerpt": "A dev container configuration will inherit the `remoteUser` property from the base image it uses."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-name-for-the-dev-container-displayed-in-the-ui-desc-94cd872c",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "a4a0c62de210dfbffd7f041dd2ba03fc6b943a1768ac2a397edac1c0696d8704",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 1,
+          "excerpt": "A name for the dev container displayed in the UI"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-482998a9",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "670401780221bec94352a1c3b3a9aea4ee7a384ee4f431d3d391f7a8d8bd3091",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 5,
+          "excerpt": "A set of name-value pairs that sets or overrides environment variables for the `devcontainer.json` supporting service / tool (or sub-processes like terminals) but not the container as a whole."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-f73a61bb",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "b26b92b32a6b28e0b864cf1bae78a62dfc4078312b6ac5138ebe4bd8c338c2d1",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 4,
+          "excerpt": "A set of name-value pairs that sets or overrides environment variables for the container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-a-string-indicating-minimum-memory-requirements-io-b29e3295",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "ab1e18aca5aab5732e3ea07ccae4ea88dcc50185ad16e50acf3b6abe53d68027",
+      "locations": [
+        {
+          "heading": "Minimum host requirements",
+          "anchor": "minimum-host-requirements",
+          "ordinal": 1,
+          "excerpt": "A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-an-array-of-docker-cli-arguments-that-should-be-io-2f81ef14",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "38c087f2c6b07e9d0f7432fd94c3054f77158ca9d1b0ff62ceaeb361e899501f",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 7,
+          "excerpt": "An array of [Docker CLI arguments](https://docs.docker.com/engine/reference/commandline/run/) that should be used when running the container. Defaults to `[]`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-an-array-of-port-numbers-or-host-port-values-io-5bb030ac",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "86ee5ac0bb1c8e5edf230bcc66015152f93a696dcb1eb125f2678961f5e4248b",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 2,
+          "excerpt": "An array of port numbers or `\"host:port\"` values"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-an-enum-that-specifies-the-command-any-tool-shou-io-805d039b",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "b2bdb7cf4e6f6269ecbf5df11c735847185880848e7269c796090d3e0f971110",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 8,
+          "excerpt": "An enum that specifies the command any tool should wait for before connecting. Defaults to `updateContentCommand`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-an-object-of-dev-container-feature-ids-and-relat-desc-9adb363c",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "963cd4ab5cb65ed443371dddbb282aaa2f9278c372965b1785fa2ca029beb064",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 13,
+          "excerpt": "An object of [Dev Container Feature IDs](https://containers.dev/features) and related options to be added into your primary container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-cross-orchestrator-way-to-add-additional-mounts-io-9f0f755a",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "8812c80630b8a471e242882a7fd942eb02d6a0dfae4469e6fbf5d501da5971a8",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 12,
+          "excerpt": "Cross-orchestrator way to add additional mounts to a container. Each value is a string that accepts the same values as the [Docker CLI `--mount` flag]"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-defaults-to-true-for-when-using-an-image-dockerf-io-76d19efa",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "aaceb8ffd8df6b2ac29275367670fe4475cc207f9aac41f854349633e969c3c5",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 10,
+          "excerpt": "Defaults to `true` for when using an image Dockerfile and `false` when referencing a Docker Compose file."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-dictates-when-port-forwarding-is-required-to-map-desc-535d595e",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "debcd1a7ddeef17e56d2da09ae9700ca4b6ee4f597df5aa4951df1b51b26ce04",
+      "locations": [
+        {
+          "heading": "Port attributes",
+          "anchor": "port-attributes",
+          "ordinal": 2,
+          "excerpt": "Dictates when port forwarding is required to map the port in the container to the same port locally or not."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-each-command-property-is-an-string-or-list-of-co-io-88240d31",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "a6900a2c7b313163dc65cc6e234c74391292ee70a7b60b60a12a13dfc666d0fe",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 1,
+          "excerpt": "Each command property is an string or list of command arguments that should execute from the `workspaceFolder`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-for-each-command-property-if-the-value-is-a-sing-algo-edd92849",
+      "document": "json-reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "c5f5c5f89406bc943a2982c0a56d296adb4e1459bf1401a978fc4961736e15c3",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 9,
+          "excerpt": "For each command property, if the value is a single string, it will be run in `/bin/sh`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-cb502f9a",
+      "document": "json-reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "a3b310e68a21162fc1d501734637778e58cd9a23b17821adf920960e468661ad",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 10,
+          "excerpt": "If one of the lifecycle scripts fails, any subsequent scripts will not be executed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-indicates-the-type-of-shell-to-use-to-probe-for-io-896c5f64",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "8f5a3342075bb671619ed016d8ad2ede5931f5f074285a0f149d4f1d3eb6492d",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 9,
+          "excerpt": "Indicates the type of shell to use to \"probe\" for user environment variables to include in `devcontainer.json` supporting services' / tools' processes: `none`, `interactiveShell`, `loginShell`, or `loginInteractiveShell` (default)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-it-and-subsequent-commands-execute-inside-the-co-desc-c68356ad",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "b71164c28d0805152deff5c556b2973b0e2868e038e2bb79a8f27faa9673ff44",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 3,
+          "excerpt": "It and subsequent commands execute **inside** the container immediately after it has started for the first time."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-it-executes-inside-the-container-after-oncreatec-desc-5d71a46e",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "307bba02fb4f45ea71de5345089dd8bfc2466e70b4569cc1915d9eb5d0e04489",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 4,
+          "excerpt": "It executes inside the container after `onCreateCommand` whenever new content is available in the source tree during the creation process."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-it-happens-after-updatecontentcommand-and-once-t-desc-9d62d901",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "5513c62662e79c2fb2743e2e38a8ab44cf6412c65b73d3e78afa6b346faeb3b9",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts",
+          "anchor": "lifecycle-scripts",
+          "ordinal": 5,
+          "excerpt": "It happens after `updateContentCommand` and once the dev container has been assigned to a user for the first time."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-notify-is-the-default-and-a-notification-will-ap-io-fbfdc269",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "indirectly-testable",
+      "fingerprint": "12d96cc2695a7a85f80fd2936b695dc451f8e4458f55a329791eb5192afafcd7",
+      "locations": [
+        {
+          "heading": "Port attributes",
+          "anchor": "port-attributes",
+          "ordinal": 1,
+          "excerpt": "`notify` is the default, and a notification will appear when the port is auto-forwarded."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-object-that-maps-a-port-number-host-port-value-r-desc-b51d0b4f",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "b0a18c88d7c5672913bef34b7ece3a88bfe2988c8c5f564553be05e07ededf42",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 3,
+          "excerpt": "Object that maps a port number, `\"host:port\"` value, range, or regular expression to a set of default options."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-on-linux-if-containeruser-or-remoteuser-is-speci-io-a22a9e99",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "cdca268b66ec07345fb372988f061ae9e6407a796a0a3a93729f16cf0e29d315",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 8,
+          "excerpt": "On Linux, if `containerUser` or `remoteUser` is specified, the user's UID/GID will be updated to match the local user's UID/GID to avoid permission problems with bind mounts. Defaults to `true`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-overrides-the-user-for-all-operations-run-as-ins-desc-de726edc",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "551faed09f7463b35aa9418f6d64b90e31132e3f2b22d2e1a6b40687c21cdcd5",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 7,
+          "excerpt": "Overrides the user for all operations run as inside the container. Defaults to either `root` or the last `USER` instruction in the related Dockerfile used to create the image."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-overrides-the-user-that-devcontainer-json-suppor-desc-61ec0c65",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "60f589d6ce63c107b9088a90ab950f551eee71a5d17fe45407320e0275ea4105",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 6,
+          "excerpt": "Overrides the user that `devcontainer.json` supporting services tools / runs as in the container (along with sub-processes like terminals, tasks, or debugging)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-path-that-the-docker-build-should-be-run-from-re-io-a9b5d4b9",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "330e62bbfe0e00d700a4a81a3e32a09a29dc6a5f8a5a3e7c5aa4badc2c977788",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 3,
+          "excerpt": "Path that the Docker build should be run from relative to `devcontainer.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-product-specific-properties-defined-in-supportin-desc-3094d978",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "28732f7af95fdae7bdba8252638ee901ea5a659a020165db1c32fcfce84499c4",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 15,
+          "excerpt": "Product specific properties, defined in [supporting tools](supporting-tools.md)"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-required-when-using-a-dockerfile-the-location-of-io-8a8518c6",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "9a3843ee2b223629277f9ccba3a7c64ded321f325947c3baecea5550c08f1c2d",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 2,
+          "excerpt": "**Required** when using a Dockerfile. The location of a [Dockerfile](https://docs.docker.com/engine/reference/builder/) that defines the contents of the container. The path is relative to the `devcontainer.json` file."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-required-when-using-an-image-the-name-of-an-imag-io-ceb577d8",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "b5430f8e07e342ab8b26acc513ff87ad9cd8b03c326e50440f1e2c93d797df3b",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 1,
+          "excerpt": "**Required** when using an image. The name of an image in a container registry"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-required-when-using-docker-compose-the-name-of-t-io-910c920c",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "4225ad3e74ffbeec255ce00fabec0708f56e54780979750fe891878ddf50e561",
+      "locations": [
+        {
+          "heading": "Docker Compose specific properties",
+          "anchor": "docker-compose-specific-properties",
+          "ordinal": 2,
+          "excerpt": "**Required** when [using Docker Compose](https://docs.docker.com/compose/). The name of the service `devcontainer.json` supporting services / tools should connect to once running."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-requires-workspacefolder-be-set-as-well-override-io-af28a4ff",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "52a0f8722ca25de6da757ce80a5adf94941edca78d50428ed61367f87e17565a",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 5,
+          "excerpt": "Requires `workspaceFolder` be set as well. Overrides the default local mount point for the workspace when the container is created."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-requires-workspacemount-be-set-sets-the-default-desc-76b98b58",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "c3861ab2c274f43af0a90548bba74009f2fad229eaeb32f023fdeac15e201888",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 6,
+          "excerpt": "Requires `workspaceMount` be set. Sets the default path that `devcontainer.json` supporting services / tools should open when connecting to the container. Defaults to the automatic source code mount location."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-sets-the-default-path-that-devcontainer-json-sup-desc-51f12465",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "9fde020f58aa5d552a63f675281fc113fa0c2e0765ddefdad07fca528cf314b1",
+      "locations": [
+        {
+          "heading": "Docker Compose specific properties",
+          "anchor": "docker-compose-specific-properties",
+          "ordinal": 3,
+          "excerpt": "Sets the default path that `devcontainer.json` supporting services / tools should open when connecting to the container (which is often the path to a volume mount where the source code can be found in the container). Defaults to `\"/\"`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-the-order-of-the-array-matters-since-the-content-io-bdf2bf4c",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "3e85baa965bcc41eb9e4722564962e937f25bb5f02854153e9cf2fb8e20f52aa",
+      "locations": [
+        {
+          "heading": "Docker Compose specific properties",
+          "anchor": "docker-compose-specific-properties",
+          "ordinal": 1,
+          "excerpt": "The order of the array matters since the contents of later files can override values set in previous ones."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-this-property-accepts-a-port-or-array-of-ports-t-desc-3f93bee1",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "9c3dcb3486043fae4bfddc4b71eef661bf6ba2fc6f226180d1764dbfb216464c",
+      "locations": [
+        {
+          "heading": "Image or Dockerfile specific properties",
+          "anchor": "image-or-dockerfile-specific-properties",
+          "ordinal": 4,
+          "excerpt": "This property accepts a port or array of ports that should be published locally when the container is running."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-this-property-allows-you-to-override-the-feature-desc-bebdddcd",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "c303a8005a298f180377117a90511c7650e9d4cecbfae01382ca492abe29cf25",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 14,
+          "excerpt": "This property allows you to override the Feature install order when needed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-values-are-none-stopcontainer-default-for-image-io-9ba26e5a",
+      "document": "json-reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "6c779461852ffda9b0b3fce9863220b38840952f60892234032a5e89194e239e",
+      "locations": [
+        {
+          "heading": "General devcontainer.json properties",
+          "anchor": "general-devcontainerjson-properties",
+          "ordinal": 11,
+          "excerpt": "Values are  `none`, `stopContainer` (default for image or Dockerfile), and `stopCompose` (default for Docker Compose)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-json-reference-variables-can-be-referenced-in-certain-string-va-desc-ca54b6fc",
+      "document": "json-reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "1baeb09505e33db9ed6ff591a1e96d3a1f26e62bf5cf2c2b060f89f4c36e87cd",
+      "locations": [
+        {
+          "heading": "Variables in devcontainer.json",
+          "anchor": "variables-in-devcontainerjson",
+          "ordinal": 1,
+          "excerpt": "Variables can be referenced in certain string values in `devcontainer.json` in the following format: **${variableName}**."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-dependson-an-array-of-feature-identifiers-equal-io-d7227bc0",
+      "document": "lockfile",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "766781c78ba87f7dcd10ddfb21ce43e7650a0332ab174725a7372d632a36ae3a",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 4,
+          "excerpt": "- `dependsOn`: An array of feature identifiers equal to the feature's `dependsOn` keys in its `devcontainer-feature.json` including any version or checksum suffix. If the array is empty, this property can be omitted. For every feature listed here, the lockfile will also have a feature record."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-integrity-sha256-followed-by-the-hex-encoded-sha-io-87cbdc86",
+      "document": "lockfile",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "e25588cef266d3d94bd9bc1f811319ecd08582f44bffb61023ffa4106300fa47",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 3,
+          "excerpt": "- `integrity`: `sha256:` followed by the hex encoded SHA-256 checksum of the download artifact."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-local-features-and-the-deprecated-github-release-desc-c92caf0c",
+      "document": "lockfile",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "4b665172ad8a4fede3463e7c00ff02f3eaef48977ce0e2c5d9ce9473df3d916c",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 6,
+          "excerpt": "Local features and the deprecated GitHub releases features are not recorded in the lockfile."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-resolved-oci-feature-a-qualified-feature-id-with-io-d5cc5400",
+      "document": "lockfile",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "7f9ac2c6024248ca213f9e485693c535c98d14cbad0807f60c44ce92978e5ca2",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "- `resolved`:\n    - OCI feature: A qualified feature id with the sha256 hash (not the version number).\n    - tarball feature: The `https:` URL used to download the feature."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-the-feature-identifiers-recorded-as-keys-and-in-desc-5c3b3fc9",
+      "document": "lockfile",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "df01a121dd5971bab6012a0702b33f2a7c2c2f3b17dbf25d35060da55301c76f",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 5,
+          "excerpt": "The feature identifiers recorded as keys and in the `dependsOn` arrays are converted to lowercase to simplify lookups and comparisons."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-the-lockfile-is-named-devcontainer-lock-json-is-io-0aa47a05",
+      "document": "lockfile",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "fe2e1771acaa1e01157a401069eca44cad5bde6aaeb18b59511df90faacafaa4",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 7,
+          "excerpt": "The lockfile is named `devcontainer-lock.json`, is located in the same folder as the `devcontainer.json` and contains a JSON object with a `\"features\"` property holding the above keys."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-lockfile-version-the-full-version-number-io-3dc63be7",
+      "document": "lockfile",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "2c1a532c2396a1954648af6630f1d5ed184414e09f2f8421be1b1750f8ddc01d",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 2,
+          "excerpt": "- `version`: The full version number."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-parallel-lifecycle-db-mysql-u-root-p-my-database-io-380cf840",
+      "document": "parallel-lifecycle",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "6b04c788eee93e8e43272cde40a5edca4aa48fc31b40fbfc2e02bccc853d475b",
+      "locations": [
+        {
+          "heading": "Example",
+          "anchor": "example",
+          "ordinal": 1,
+          "excerpt": "\"db\": [\"mysql\", \"-u\", \"root\", \"-p\", \"my database\"]"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-parallel-lifecycle-each-command-must-exit-successfully-for-the-stag-desc-3dfa4a54",
+      "document": "parallel-lifecycle",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "1ad8aecd6d0077c1e811a7b16a4838d8d34f8165bf1ac73128764865b5d55ff9",
+      "locations": [
+        {
+          "heading": "Spec changes",
+          "anchor": "spec-changes",
+          "ordinal": 2,
+          "excerpt": "Each command must exit successfully for the stage to be considered successful."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-parallel-lifecycle-each-entry-in-the-object-will-be-run-in-parallel-algo-9fe15a2e",
+      "document": "parallel-lifecycle",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "4806cc91bbc16e8cf9ff7affcfa0698da4e416c174591b9d8ccddc2514cbde96",
+      "locations": [
+        {
+          "heading": "Spec changes",
+          "anchor": "spec-changes",
+          "ordinal": 3,
+          "excerpt": "Each entry in the `object` will be run in parallel during that lifecycle step."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-parallel-lifecycle-the-key-of-the-object-will-be-a-unique-name-for-io-e2509dfa",
+      "document": "parallel-lifecycle",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "a95095a2c17e247c1727eac82389ddb94acdc5fbb148386113968d60f88f14dd",
+      "locations": [
+        {
+          "heading": "Spec changes",
+          "anchor": "spec-changes",
+          "ordinal": 1,
+          "excerpt": "The key of the `object` will be a unique name for the command and the value will be the `string` or `array` command."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-a-default-mount-should-be-included-so-that-the-s-desc-fc22f151",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "a27b9fe21d2e093cb969f22d559dae06569477e3d8157b98488bf2a2ec3bba90",
+      "locations": [
+        {
+          "heading": "Mounts",
+          "anchor": "mounts",
+          "ordinal": 1,
+          "excerpt": "A default mount should be included so that the source code is accessible from inside the container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-additionally-execute-the-poststartcommand-and-po-algo-1e29acde",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "e8e1a1782461558a2bc9797e291941bda08140cd5566eb79e2ffc7e643702567",
+      "locations": [
+        {
+          "heading": "Environment Resume",
+          "anchor": "environment-resume",
+          "ordinal": 1,
+          "excerpt": "Additionally, execute the `postStartCommand` and `postAttachCommand` in the container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-by-default-postcreatecommand-is-executed-in-the-algo-4585aa1e",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "bba043eb5d19858b79224a479a0f939c5d6fd7c2a928cbf9edd50fca1a1af43c",
+      "locations": [
+        {
+          "heading": "Post Container Creation",
+          "anchor": "post-container-creation",
+          "ordinal": 2,
+          "excerpt": "By default, `postCreateCommand` is executed in the background after reporting the successful creation of the development environment."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-capadd-string-io-19b2ff76",
+      "document": "reference",
+      "strength": "io-contract",
+      "testability": "informative",
+      "fingerprint": "51c0447344edc91c89e8e0055f6c43903dfe0b3ae69a1d48ba153ec05f2e0a4a",
+      "locations": [
+        {
+          "heading": "Image Metadata",
+          "anchor": "image-metadata",
+          "ordinal": 3,
+          "excerpt": "\"capAdd\"?: string[],"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-reference-collected-list-of-all-mountpoints-conflicts-last-algo-6e3a3659",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "62524122807f691f4a10f1dbf23b808f1a65761de62d712a50b62f809d235b72",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 3,
+          "excerpt": "Collected list of all mountpoints. Conflicts: Last source wins."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-collected-list-of-all-oncreatecommands-algo-c1f1604c",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "9f7700b05cf501ee898c87dda67972a81a61370f4b95bcfb7d34201f2b81965b",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 4,
+          "excerpt": "Collected list of all onCreateCommands."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-container-mounts-environment-variables-and-user-algo-fc512eb6",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "b2a00d969aabc5b1fbd34bb8ceaaa1e3fc2a929511ce738b4607c44fe9637d37",
+      "locations": [
+        {
+          "heading": "Container Creation",
+          "anchor": "container-creation",
+          "ordinal": 1,
+          "excerpt": "container [mounts](#mounts), [environment variables](#environment-variables), and [user](#users) configuration should be applied at this point."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-each-command-must-exit-successfully-for-the-stag-algo-bc7ea234",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "1ad8aecd6d0077c1e811a7b16a4838d8d34f8165bf1ac73128764865b5d55ff9",
+      "locations": [
+        {
+          "heading": "Parallel lifecycle script execution",
+          "anchor": "parallel-lifecycle-script-execution-a",
+          "ordinal": 2,
+          "excerpt": "Each command must exit successfully for the stage to be considered successful."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-each-entry-in-the-object-will-be-run-in-parallel-algo-6d33de69",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "4806cc91bbc16e8cf9ff7affcfa0698da4e416c174591b9d8ccddc2514cbde96",
+      "locations": [
+        {
+          "heading": "Parallel lifecycle script execution",
+          "anchor": "parallel-lifecycle-script-execution-a",
+          "ordinal": 1,
+          "excerpt": "Each entry in the `object` will be run in parallel during that lifecycle step."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-execution-of-initializecommand-algo-0e0c96b0",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "d91ddade317b95a212aa9aa5afb590e74242a02c78f3b4708dc5556e18b8d27a",
+      "locations": [
+        {
+          "heading": "Initialization",
+          "anchor": "initialization",
+          "ordinal": 1,
+          "excerpt": "Execution of `initializeCommand`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-however-remote-user-and-environment-variable-con-algo-a74a1d41",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "514f4a5e280839daa3be2290d1a01ece252c3adbd04598372c581621dd4af276",
+      "locations": [
+        {
+          "heading": "Container Creation",
+          "anchor": "container-creation",
+          "ordinal": 2,
+          "excerpt": "However, remote user and environment variable configuration should **not** be."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-if-the-waitfor-property-is-defined-then-executio-algo-0000032a",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "da81c72137f887cc18d17cd621b776ef164a316021d5d8ed60b9467b00aeab3e",
+      "locations": [
+        {
+          "heading": "Post Container Creation",
+          "anchor": "post-container-creation",
+          "ordinal": 3,
+          "excerpt": "If the `waitFor` property is defined, then execution should block until all commands in the sequence up to the specified property have executed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-per-variable-last-value-wins-algo-c8dcfd00",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "16101b6b481a2a1f543d1225d11eb8e8a26ccb6274fc7ccd448313280e3b8760",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 6,
+          "excerpt": "Per variable, last value wins."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-probed-environment-variables-should-be-merged-wi-algo-bc58ffe5",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "7cf10013173ff0e670ea16b23ff79f9dc2593d4f732b8c3bf29dd21481e933f0",
+      "locations": [
+        {
+          "heading": "Environment Variables",
+          "anchor": "environment-variables",
+          "ordinal": 2,
+          "excerpt": "\"probed\" environment variables should be merged with Remote environment variables for any processes the implementer injects after the container is created."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-products-using-it-should-expect-to-find-a-devcon-algo-2d2bc8c5",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "060efaedee60f176a8cba1861b47953df16a23fc57d60b84031387191b32c3de",
+      "locations": [
+        {
+          "heading": "devcontainer.json",
+          "anchor": "devcontainerjson",
+          "ordinal": 1,
+          "excerpt": "Products using it should expect to find a `devcontainer.json` file in one or more of the following locations (in order of precedence):"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-remote-environment-variables-and-user-configurat-algo-5e726990",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "29661fe192f8cacc5d9c38f43863bdf0f9c94121efaa5a9624dd7ca10385c233",
+      "locations": [
+        {
+          "heading": "Post Container Creation",
+          "anchor": "post-container-creation",
+          "ordinal": 4,
+          "excerpt": "Remote [environment variables](#environment-variables) and [user](#users) configuration should be applied to all created processes in the container (inclusive of `userEnvProbe`)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-server-npm-start-io-c402ff95",
+      "document": "reference",
+      "strength": "io-contract",
+      "testability": "informative",
+      "fingerprint": "15208922ebbb085a1010171b0240fe4ac9fc3034266748eeb56856d6914b3a22",
+      "locations": [
+        {
+          "heading": "Example",
+          "anchor": "example",
+          "ordinal": 1,
+          "excerpt": "\"server\": \"npm start\","
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-reference-service-declares-the-main-container-that-will-be-desc-63a9b6bf",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "840aae8aa19861868a331fbf34f6231e4f64386e0dd8cb2fdee25db825be3c13",
+      "locations": [
+        {
+          "heading": "Docker Compose based",
+          "anchor": "docker-compose-based",
+          "ordinal": 1,
+          "excerpt": "`service`: declares the **main** container that will be used for all other operations."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-set-using-the-remoteuser-property-in-all-cases-a-desc-317a6ed2",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "f0208b87acea9476dd0b5edb49d64d2abe1306906c10f069d095ff94f273dab5",
+      "locations": [
+        {
+          "heading": "Users",
+          "anchor": "users",
+          "ordinal": 1,
+          "excerpt": "Set using the `remoteUser` property in all cases and defaults to the container user."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-the-default-mount-point-for-the-source-code-can-desc-53d64f45",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "203b5bba0292db79b4395657e592af2f336640570af37d0e403b1070a33b9c12",
+      "locations": [
+        {
+          "heading": "workspaceFolder and workspaceMount",
+          "anchor": "workspacefolder-and-workspacemount",
+          "ordinal": 1,
+          "excerpt": "The default mount point for the source code can be set with the `workspaceMount` property for **image** and **dockerfile** scenarios or using the built in `mounts` property in **Docker Compose** files."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-the-metadata-is-added-to-the-image-as-a-devconta-io-421635c0",
+      "document": "reference",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "add02a57c14257900762a3455f3c755a65accbe94e4b7ae17d884002eda3a87f",
+      "locations": [
+        {
+          "heading": "Image Metadata",
+          "anchor": "image-metadata",
+          "ordinal": 2,
+          "excerpt": "The metadata is added to the image as a `devcontainer.metadata` label with a JSON string value representing the above array or single object."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-the-only-required-parameter-in-this-case-is-the-desc-2d275895",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "2cdf28eb10aee4505c161108130520b007fa4a5c26906558684b4712b4af93ba",
+      "locations": [
+        {
+          "heading": "Dockerfile based",
+          "anchor": "dockerfile-based",
+          "ordinal": 1,
+          "excerpt": "The only required parameter in this case is the relative reference to the `Dockerfile` in `build.dockerfile`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-the-only-required-parameter-is-image-desc-96bf70dd",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "08c7005c7a8adba02d1f7f58f2ff14e63120aee6899503735768fe2a68e53b74",
+      "locations": [
+        {
+          "heading": "Image based",
+          "anchor": "image-based",
+          "ordinal": 1,
+          "excerpt": "The only required parameter is `image`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-the-project-workspace-folder-is-where-an-impleme-desc-042d067e",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "02377f29b8d1ccbf509a4d223653415f81f644caa28ce08dfbf8d311bab628a2",
+      "locations": [
+        {
+          "heading": "Project Workspace Folder",
+          "anchor": "project-workspace-folder",
+          "ordinal": 1,
+          "excerpt": "The **project workspace folder** is where an implementing tool should begin to search for `devcontainer.json` files."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-these-contents-should-then-be-merged-with-any-lo-algo-a8e77908",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "16ac9c598a90f36d07314cdea67ee02dcf78f0d061633ef07d670de3a827c74a",
+      "locations": [
+        {
+          "heading": "Image Metadata",
+          "anchor": "image-metadata",
+          "ordinal": 1,
+          "excerpt": "These contents should then be merged with any local `devcontainer.json` file contents at the time the container is created."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-these-variables-can-change-during-the-lifetime-o-desc-57c3f38c",
+      "document": "reference",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "ad6a2d9e0afdff1b4346a82330e64fc0477d9e9f1c6cb5814217f8b6495e3086",
+      "locations": [
+        {
+          "heading": "Environment Variables",
+          "anchor": "environment-variables",
+          "ordinal": 1,
+          "excerpt": "These variables can change during the lifetime of the container, and are added after the container's `ENTRYPOINT` has fired."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-this-set-of-commands-is-executed-in-sequence-on-algo-462a5272",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "a840ad364053bfe321cb1661b2c04a63e74681e104513007d242b082fd4f885d",
+      "locations": [
+        {
+          "heading": "Post Container Creation",
+          "anchor": "post-container-creation",
+          "ordinal": 1,
+          "excerpt": "This set of commands is executed in sequence on a container the first time it's created and depending on the creation parameters received."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-true-if-at-least-one-is-true-false-otherwise-algo-219a6637",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "b1bd519c5fe74750f9111905ab5a8084e53d4ad29742f08c08b1ff0f676b44b4",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 1,
+          "excerpt": "`true` if at least one is `true`, `false` otherwise."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-uid-gid-sync-ing-is-an-optional-task-for-linux-o-algo-6c12fea6",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "67b4ceaea76fa7c5e22d87b96de779b86e45fc00a4b33b7028f29ff9265dd22f",
+      "locations": [
+        {
+          "heading": "Container Creation",
+          "anchor": "container-creation",
+          "ordinal": 3,
+          "excerpt": "UID/GID sync'ing is an optional task for Linux (only) and that executes if the `updateRemoteUserUID` property is set to true and a `containerUser` or `remoteUser` is specified."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-union-of-all-capadd-arrays-without-duplicates-algo-2aa7395e",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "cd2926c5d83ce2c6e298f6a6fdca2f936ca453d70babc64be6e5f75f577f7584",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 2,
+          "excerpt": "Union of all `capAdd` arrays without duplicates."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-union-of-all-ports-without-duplicates-last-one-w-algo-28d2b3f8",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "directly-testable",
+      "fingerprint": "709d27d8b84aecfc64b3aa5427a8cd0eaf8ce8bd2b38eb5f370fcdcc7cfd39df",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 5,
+          "excerpt": "Union of all ports without duplicates. Last one wins (when mapping changes)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-validate-that-a-workspace-source-folder-has-been-algo-bb15890d",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "a0cd9b72154b7091458e41c44a80d71ff677aa552ed5af90b215addb3412c5c9",
+      "locations": [
+        {
+          "heading": "Configuration Validation",
+          "anchor": "configuration-validation",
+          "ordinal": 1,
+          "excerpt": "Validate that a workspace source folder has been provided."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-variables-in-string-values-will-be-substituted-a-algo-9107fc1e",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "1d3d1a3dbb5513aa2f766cd8fab3c4e9d4c6d2a15f98119ee7b7b1d104667f3e",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 7,
+          "excerpt": "Variables in string values will be substituted at the time the value is applied."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-reference-when-the-order-matters-the-devcontainer-json-is-algo-b1bacaaf",
+      "document": "reference",
+      "strength": "algorithm",
+      "testability": "indirectly-testable",
+      "fingerprint": "5801475df8d3d59c2b052873c187cd260e733e051bfac52eb6f3feab511ae52a",
+      "locations": [
+        {
+          "heading": "Merge Logic",
+          "anchor": "merge-logic",
+          "ordinal": 8,
+          "excerpt": "When the order matters, the `devcontainer.json` is considered last."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-secrets-support-a-conforming-implementation-should-provide-a-sec-desc-db09d7dc",
+      "document": "secrets-support",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "c89fc64caed2af340a9fda735984610bea1bb5c53fe69b6b57223ee7c0e02b51",
+      "locations": [
+        {
+          "heading": "Passing secrets in",
+          "anchor": "passing-secrets-in",
+          "ordinal": 2,
+          "excerpt": "A conforming implementation should provide a secure mechanism to pass secrets, such as a secrets file, Windows credential manager, Mac keychain, Azure keyvault etc. for example."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-secrets-support-a-supporting-tool-e-g-the-dev-container-cli-refe-desc-e1c78ef9",
+      "document": "secrets-support",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "08e43f6bac19aa818b5b04544bd14bedb78a887b41a42541b41825fa0bd7e7a7",
+      "locations": [
+        {
+          "heading": "Proposal",
+          "anchor": "proposal",
+          "ordinal": 1,
+          "excerpt": "A [supporting tool](https://containers.dev/supporting#tools) (e.g. the [dev container CLI reference implementation](https://github.com/devcontainers/cli)) should behave according to the following properties:"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-secrets-support-password-simple-passwords-io-9f6c9dd8",
+      "document": "secrets-support",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "0c863e3a7752af8d780173040e05fb5433ca1f7e8f0e41365c53f4e6b15263ed",
+      "locations": [
+        {
+          "heading": "Example",
+          "anchor": "example",
+          "ordinal": 1,
+          "excerpt": "\"PASSWORD\": \"Simple Passwords\""
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-secrets-support-secrets-are-not-part-of-dev-containers-specifica-desc-a5be2256",
+      "document": "secrets-support",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "4daae2ae19db9f662b22e6d4b952e53d5cf193e3590eaf1b60eab57ed2052be3",
+      "locations": [
+        {
+          "heading": "Passing secrets in",
+          "anchor": "passing-secrets-in",
+          "ordinal": 1,
+          "excerpt": "Secrets are not part of dev containers specification and we do not expect users to store secrets inside `devcontainer.json` file."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-secrets-support-users-can-change-a-secret-s-value-at-any-time-an-desc-31591036",
+      "document": "secrets-support",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "142b16a56ebe9eeb5fa2b8125818ad72ff0906ede8ada6f188e4645131c58465",
+      "locations": [
+        {
+          "heading": "What are secrets",
+          "anchor": "what-are-secrets",
+          "ordinal": 1,
+          "excerpt": "Users can change a secret's value at any time, and a conforming dev containers implementation should support dynamically changing secrets without having to rebuild the container."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-a-codespace-is-a-development-environment-that-s-desc-d545f89d",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "726d9bb228fa99b20048423b4cbc2aa12dc00ee57727fedfe66ee6016183d971",
+      "locations": [
+        {
+          "heading": "GitHub Codespaces",
+          "anchor": "github-codespaces",
+          "ordinal": 1,
+          "excerpt": "A [codespace](https://docs.github.com/en/codespaces/overview) is a development environment that's hosted in the cloud."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-a-dev-container-command-line-interface-cli-that-desc-b5b7198a",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "ca37d6ad00ed69d8758eea2293189c233aaacec65764a8c63b2c946f7af4e032",
+      "locations": [
+        {
+          "heading": "Dev Container CLI",
+          "anchor": "dev-container-cli",
+          "ordinal": 1,
+          "excerpt": "A dev container command line interface (CLI) that implements this specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-an-array-of-extension-ids-that-specify-the-exten-desc-e843b6ac",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "df2af77f4defbbf2f8fcbb3be5d57030e888bd298609a79bce0de23b72c7b208",
+      "locations": [
+        {
+          "heading": "Visual Studio Code",
+          "anchor": "visual-studio-code",
+          "ordinal": 3,
+          "excerpt": "An array of extension IDs that specify the extensions that should be installed inside the container when it is created. Defaults to `[]`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-codespaces-disableautomaticconfiguration-true-io-38f1cf46",
+      "document": "supporting-tools",
+      "strength": "io-contract",
+      "testability": "not-applicable",
+      "fingerprint": "94771320a48122fef2d652f88ed6982c574fa2228049c55398133ac0fdc66d52",
+      "locations": [
+        {
+          "heading": "Product specific properties",
+          "anchor": "product-specific-properties-1",
+          "ordinal": 2,
+          "excerpt": "\t\"codespaces\": {\n\t\t\"disableAutomaticConfiguration\": true\n\t}"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-supporting-tools-codespaces-will-automatically-perform-some-defau-desc-b9bcfd15",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "b62e520cccab9585ee899652839237d8adb668406811ed45b9c4c5679044e84a",
+      "locations": [
+        {
+          "heading": "Product specific properties",
+          "anchor": "product-specific-properties-1",
+          "ordinal": 1,
+          "excerpt": "Codespaces will automatically perform some default setup when the `devcontainer.json` does not specify a `postCreateCommand`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-lets-you-use-a-container-as-a-full-featured-deve-desc-645f0796",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "97701f2b2b6fde15e958c0bcfdc5116fcda4a7a106dcd6686ecd7570b81b5862",
+      "locations": [
+        {
+          "heading": "Visual Studio Code Dev Containers",
+          "anchor": "visual-studio-code-dev-containers",
+          "ordinal": 1,
+          "excerpt": "lets you use a container as a full-featured development environment."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-mounts-array-codespaces-ignores-bind-mounts-with-desc-1b4957a7",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "3093988dc3bb2c0180325d46c5efb99d0245278a01580be7ad88da07e6b3de52",
+      "locations": [
+        {
+          "heading": "Product specific limitations",
+          "anchor": "product-specific-limitations-1",
+          "ordinal": 1,
+          "excerpt": "| `mounts` | array | Codespaces ignores \"bind\" mounts with the exception of the Docker socket. Volume mounts are still allowed.|"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-set-default-container-specific-settings-json-val-io-fc3a41cd",
+      "document": "supporting-tools",
+      "strength": "io-contract",
+      "testability": "informative",
+      "fingerprint": "7a6eb091fc595ef9d526105a14e46657df76e9f26125daf259ba2bf1ef468958",
+      "locations": [
+        {
+          "heading": "Visual Studio Code",
+          "anchor": "visual-studio-code",
+          "ordinal": 2,
+          "excerpt": "\t\t\t// Set *default* container specific settings.json values on container create.\n\t\t\t\"settings\": {},\n\t\t\t\"extensions\": [],"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-supporting-tools-shutdownaction-enum-does-not-apply-to-codespaces-desc-55b06d3b",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "447fdc31542537a9ec29078a60eee6b06655d5c51aac75bdc1e8f40ecb71a4f9",
+      "locations": [
+        {
+          "heading": "Product specific limitations",
+          "anchor": "product-specific-limitations-1",
+          "ordinal": 2,
+          "excerpt": "| `shutdownAction` | enum | Does not apply to Codespaces. |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-visual-studio-added-dev-container-support-in-vis-desc-7b4f5bd7",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "dfcfd650c5b18b81f3850d922cc8efef2858b1c95be2f1fb57c7e8d0c92700b6",
+      "locations": [
+        {
+          "heading": "Visual Studio",
+          "anchor": "visual-studio",
+          "ordinal": 1,
+          "excerpt": "Visual Studio added dev container support in Visual Studio 2022 17.4 for C++ projects using CMake Presets."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-visual-studio-code-specific-properties-go-under-desc-94ff0710",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "d50c888273a922440fe0d587df293b7d06560c4d706db4859d7feabd8bb483cb",
+      "locations": [
+        {
+          "heading": "Visual Studio Code",
+          "anchor": "visual-studio-code",
+          "ordinal": 1,
+          "excerpt": "Visual Studio Code specific properties go under `vscode` inside `customizations`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-supporting-tools-workspacemount-string-not-yet-supported-when-usi-desc-ea06083a",
+      "document": "supporting-tools",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "07a0f664296c1adab8a6eea2cf147efd9d9a597f7ed53cf1dec5756c24dc2435",
+      "locations": [
+        {
+          "heading": "Product specific limitations",
+          "anchor": "product-specific-limitations",
+          "ordinal": 1,
+          "excerpt": "| `workspaceMount` | string | Not yet supported when using Clone Repository in Container Volume. |"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-a-path-is-relative-to-the-root-of-the-template-s-desc-ec433cf4",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "bf1540345c3fee6bb285215275a5eb06ccc711ec7fd569740a6db85f14c41887",
+      "locations": [
+        {
+          "heading": "The optionalPaths property",
+          "anchor": "the-optionalpaths-property",
+          "ordinal": 2,
+          "excerpt": "A path is relative to the root of the Template source directory."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-a-single-template-is-a-folder-with-at-least-a-de-desc-3aa671bf",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "1f69f28647ea019496c4351db65a503090a88a265df77679375a86942b341baf",
+      "locations": [
+        {
+          "heading": "Folder structure",
+          "anchor": "folder-structure",
+          "ordinal": 1,
+          "excerpt": "A single Template is a folder with at least a `devcontainer-template.json` and"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-a-supporting-tool-will-parse-the-options-object-desc-71357a1f",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "447f8eb1e609e829a8d0fea88e32f8b94ce9b6289ca89ba818f35275dba8cb42",
+      "locations": [
+        {
+          "heading": "Option Resolution",
+          "anchor": "option-resolution",
+          "ordinal": 1,
+          "excerpt": "A supporting tool will parse the `options` object provided by the user. If a value is selected for a Template, it will be replaced in the files (within the sub-directory of the Template)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-before-applying-a-template-tooling-must-inspect-desc-1eb54b25",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "64ecdbacb3ccde194b5282680b7170276fa3bcab6a5cdf97adbfa1bfa69e0de8",
+      "locations": [
+        {
+          "heading": "The optionalPaths property",
+          "anchor": "the-optionalpaths-property",
+          "ordinal": 1,
+          "excerpt": "Before applying a Template, tooling must inspect the `optionalPaths` property of a Template and prompt the user on whether each file or folder should be included in the resulting output workspace folder."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-a-custom-media-type-application-vnd-devcontainer-desc-c254518f",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "80a5eee8a79bb0cd0dd0b47a34ffe6b1a3d592a0a9776e7194b6e1648628acd8",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 3,
+          "excerpt": "A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-a-template-s-source-code-is-stored-in-a-git-repo-desc-897770c2",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "d0f4b2e8e03dd123023eceb1ab9a4a35c94171956d35daebe4080ceb6da18202",
+      "locations": [
+        {
+          "heading": "Source code",
+          "anchor": "source-code",
+          "ordinal": 1,
+          "excerpt": "A Template's source code is stored in a git repository."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-each-packaged-template-is-pushed-to-the-registry-desc-64ee59d8",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "8d5994536d49f6accdbe908cd9fe7da71f386961eaba06468a151fccbef96e36",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 1,
+          "excerpt": "Each packaged Template is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the Template, according to the semver specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-each-sub-directory-should-be-named-such-that-it-desc-a1a13d46",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "fb44c74a127d412dfa16f2aebc2f03e7c249ec7dfbeb4c5c21a3ed9e8b685121",
+      "locations": [
+        {
+          "heading": "Source code",
+          "anchor": "source-code",
+          "ordinal": 3,
+          "excerpt": "Each sub-directory should be named such that it matches the `id` field of the `devcontainer-template.json`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-each-template-s-devcontainer-template-json-metad-desc-b4c50ee8",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "108ccc9dacf3dd239ad69db092f7f0f3ae4b29925dd678a97d13bcebb6b3596d",
+      "locations": [
+        {
+          "heading": "devcontainer-collection.json",
+          "anchor": "devcontainer-collectionjson",
+          "ordinal": 1,
+          "excerpt": "Each Template's `devcontainer-template.json` metadata file is appended into the `templates` top-level array."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-templates-and-features-should-be-placed-in-diffe-desc-e3232a51",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "9a40002387c2d7a7f20d17f3a78fe890d21799f3d2230166de1f1bceadad83ef",
+      "locations": [
+        {
+          "heading": "Source code",
+          "anchor": "source-code",
+          "ordinal": 2,
+          "excerpt": "Templates and [Features](./devcontainer-features.md) should be placed in different git repositories."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-templates-are-distributed-as-tarballs-desc-fa6d9954",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "bde0be1888aad676376d6e9ebccb86a56ec6e5223920c9da5c5267d9232c261e",
+      "locations": [
+        {
+          "heading": "Packaging",
+          "anchor": "packaging",
+          "ordinal": 1,
+          "excerpt": "Templates are distributed as tarballs."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-the-collection-file-is-always-tagged-as-latest-desc-1a1ca07f",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "3b3d085b8c9ebaacc575584e790048d0bec2a7c4dc7257865cedb8dc88d14c8c",
+      "locations": [
+        {
+          "heading": "OCI Registry",
+          "anchor": "oci-registry",
+          "ordinal": 2,
+          "excerpt": "The collection file is always tagged as `latest`."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-the-tarball-is-named-devcontainer-template-id-tg-desc-5e5a3519",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "73e9ac18cab29e1e7eb5f2ad8fa0c2c99d70a292b255b3a0ee3ce83c5460bf3b",
+      "locations": [
+        {
+          "heading": "Packaging",
+          "anchor": "packaging",
+          "ordinal": 2,
+          "excerpt": "The tarball is named `devcontainer-template-<id>.tgz`, where `<id>` is the Templates's `id` field."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-distribution-tooling-that-handles-publishing-templates-will-n-desc-5a60b658",
+      "document": "templates-distribution",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "fa63806c1a594be6273f72484179854aba1b28632711c9afc7ffce641ba98e61",
+      "locations": [
+        {
+          "heading": "Versioning",
+          "anchor": "versioning",
+          "ordinal": 1,
+          "excerpt": "Tooling that handles publishing Templates will not republish Templates if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-for-a-directory-provide-the-full-relative-path-w-desc-6f870ac2",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "438b76ceedf4724879293942dad1d9739896ec881e3db2143dec90066c936698",
+      "locations": [
+        {
+          "heading": "The optionalPaths property",
+          "anchor": "the-optionalpaths-property",
+          "ordinal": 3,
+          "excerpt": "For a directory, provide the full relative path with a trailing slash and asterisk (`/*`) appended to the path.  The directory and its children will be recursively ignored."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-image-mcr-microsoft-com-devcontainers-java-0-tem-io-b5fb90c8",
+      "document": "templates",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "f57726ec988b30efa40692db79bfae2a03a0bd218b8ef9c8d3bb8eac8cef2fa6",
+      "locations": [
+        {
+          "heading": "Option resolution example",
+          "anchor": "option-resolution-example",
+          "ordinal": 1,
+          "excerpt": "\"image\": \"mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}\","
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-templates-proposals-value1-value2-io-6ce0f73c",
+      "document": "templates",
+      "strength": "io-contract",
+      "testability": "not-applicable",
+      "fingerprint": "8ada6ab666cf96d8aab0306d839816f0d453ea582cc8f42af3c999e6478099b1",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 1,
+          "excerpt": "\"proposals\": [\"value1\", \"value2\"],"
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-templates-the-devcontainer-template-json-file-defines-info-desc-0b0e6110",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "7b39113e185a4d36f9abb1a62f9554558960f05e85b78c56195da22ab0527ef5",
+      "locations": [
+        {
+          "heading": "devcontainer-template.json properties",
+          "anchor": "devcontainer-templatejson-properties",
+          "ordinal": 1,
+          "excerpt": "The `devcontainer-template.json` file defines information about the Template to be used by any"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-the-id-format-oci-registry-namespace-template-se-desc-b9423a08",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "4229d86e7f8e41f6127085aa307311b1a66e967b30548cca22ee6d5d2f95d53e",
+      "locations": [
+        {
+          "heading": "Referencing a Template",
+          "anchor": "referencing-a-template",
+          "ordinal": 1,
+          "excerpt": "The `id` format (`<oci-registry>/<namespace>/<template>[:<semantic-version>]`) dictates how a"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-the-options-must-be-unique-for-every-devcontaine-desc-09529bff",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "81d12ee2f8ac72c00d943d79a4ea5db009f4849d713391916fc292170d7d8d35",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 4,
+          "excerpt": "The `options` must be unique for every `devcontainer-template.json`"
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-the-tools-would-replace-the-option-id-with-the-s-desc-8c2b22b7",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "directly-testable",
+      "fingerprint": "9d57f0dc326db3a04c7362bedd4bff46a59b2f7f1b838ea8a4f310b5412c9d81",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 2,
+          "excerpt": "The tools would replace the option ID with the selected value in all the files (within the sub-directory of the Template)."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-this-replacement-would-happen-before-dropping-th-desc-6c8076c4",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "indirectly-testable",
+      "fingerprint": "abc1c13294671f22e57bf9c6b8b57842a03d4b822adb04686be75ce2e1fe2f5f",
+      "locations": [
+        {
+          "heading": "The options property",
+          "anchor": "the-options-property",
+          "ordinal": 3,
+          "excerpt": "This replacement would happen before dropping the `.devcontainer/devcontainer.json` and other files (within the sub-directory of the Template) required to containerize your project."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-templates-tooling-that-handles-releasing-templates-will-no-desc-4d0a3bca",
+      "document": "templates",
+      "strength": "descriptive",
+      "testability": "not-applicable",
+      "fingerprint": "864c4fe876118bf0d7a43add5353c5465387ba262aad1d106562db5250b3d496",
+      "locations": [
+        {
+          "heading": "Versioning",
+          "anchor": "versioning",
+          "ordinal": 1,
+          "excerpt": "Tooling that handles releasing Templates will not republish Templates if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification."
+        }
+      ],
+      "context": null
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/authoring.json
+++ b/conformance/registry/clause-classifications/authoring.json
@@ -1,0 +1,278 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-doc-features",
+      "document": "features",
+      "disposition": "not-applicable",
+      "rationale": "Authoring/distribution document; deacon consumes published features/templates but never authors, validates, or publishes them (constitution II \u2014 consumer-only scope)."
+    },
+    {
+      "id": "clc-doc-features-distribution",
+      "document": "features-distribution",
+      "disposition": "not-applicable",
+      "rationale": "Authoring/distribution document; deacon consumes published features/templates but never authors, validates, or publishes them (constitution II \u2014 consumer-only scope)."
+    },
+    {
+      "id": "clc-doc-templates",
+      "document": "templates",
+      "disposition": "not-applicable",
+      "rationale": "Authoring/distribution document; deacon consumes published features/templates but never authors, validates, or publishes them (constitution II \u2014 consumer-only scope)."
+    },
+    {
+      "id": "clc-doc-templates-distribution",
+      "document": "templates-distribution",
+      "disposition": "not-applicable",
+      "rationale": "Authoring/distribution document; deacon consumes published features/templates but never authors, validates, or publishes them (constitution II \u2014 consumer-only scope)."
+    },
+    {
+      "id": "clc-features-a-feature-s-options-specified-as-the-value-of-a-desc-9028c1c5",
+      "clause": "clu-features-a-feature-s-options-specified-as-the-value-of-a-desc-9028c1c5",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-all-commands-within-that-group-are-executed-in-p-algo-a78f4973",
+      "clause": "clu-features-all-commands-within-that-group-are-executed-in-p-algo-a78f4973",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-any-options-defined-by-a-feature-s-devcontainer-desc-94f2f9f6",
+      "clause": "clu-features-any-options-defined-by-a-feature-s-devcontainer-desc-94f2f9f6",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-applications-should-default-to-bin-sh-for-featur-desc-025df47e",
+      "clause": "clu-features-applications-should-default-to-bin-sh-for-featur-desc-025df47e",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-as-a-shorthand-the-value-of-a-feature-can-be-pro-desc-f3124266",
+      "clause": "clu-features-as-a-shorthand-the-value-of-a-feature-can-be-pro-desc-f3124266",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-by-default-features-are-installed-on-top-of-a-ba-desc-a302b55b",
+      "clause": "clu-features-by-default-features-are-installed-on-top-of-a-ba-desc-a302b55b",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-commands-provided-by-features-are-always-execute-desc-dd4498b0",
+      "clause": "clu-features-commands-provided-by-features-are-always-execute-desc-dd4498b0",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-220fd88c",
+      "clause": "clu-features-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-220fd88c",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-containerenv-is-added-before-the-feature-is-exec-desc-053522a1",
+      "clause": "clu-features-containerenv-is-added-before-the-feature-is-exec-desc-053522a1",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-each-command-contributed-by-a-feature-is-execute-desc-304ca215",
+      "clause": "clu-features-each-command-contributed-by-a-feature-is-execute-desc-304ca215",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-each-feature-script-executes-as-its-own-layer-to-desc-6a08d1b6",
+      "clause": "clu-features-each-feature-script-executes-as-its-own-layer-to-desc-6a08d1b6",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-feature-identifiers-should-be-assumed-to-be-case-desc-68ef18bd",
+      "clause": "clu-features-feature-identifiers-should-be-assumed-to-be-case-desc-68ef18bd",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-feature-scripts-run-as-the-root-user-and-sometim-desc-86913dfe",
+      "clause": "clu-features-feature-scripts-run-as-the-root-user-and-sometim-desc-86913dfe",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-if-any-of-the-features-indicated-in-the-dependso-desc-b94a100f",
+      "clause": "clu-features-if-any-of-the-features-indicated-in-the-dependso-desc-b94a100f",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-if-no-remoteuser-is-configured-remote-user-is-se-desc-fca91b8f",
+      "clause": "clu-features-if-no-remoteuser-is-configured-remote-user-is-se-desc-fca91b8f",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-in-the-snippet-above-myfeature-must-be-installed-must-7630c7ee",
+      "clause": "clu-features-in-the-snippet-above-myfeature-must-be-installed-must-7630c7ee",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-installsafter-is-not-evaluated-recursively-algo-7d30c616",
+      "clause": "clu-features-installsafter-is-not-evaluated-recursively-algo-7d30c616",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ],
+      "notes": "Prose\u2192behavior traceability now flows through this clause; supersedes retired src-spec-lifecycle-up (021 T036)."
+    },
+    {
+      "id": "clc-features-installsafter-only-influences-the-installation-o-algo-6fcd528e",
+      "clause": "clu-features-installsafter-only-influences-the-installation-o-algo-6fcd528e",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-features-it-will-be-emitted-to-a-file-named-devcontainer-io-1d1b4962",
+      "clause": "clu-features-it-will-be-emitted-to-a-file-named-devcontainer-io-1d1b4962",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-features-parameters-like-capadd-securityop-are-concatenat-desc-1b18e10d",
+      "clause": "clu-features-parameters-like-capadd-securityop-are-concatenat-desc-1b18e10d",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-parameters-like-privileged-init-are-included-if-desc-8051176c",
+      "clause": "clu-features-parameters-like-privileged-init-are-included-if-desc-8051176c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-remote-user-and-container-user-environment-varia-desc-2c5cca76",
+      "clause": "clu-features-remote-user-and-container-user-environment-varia-desc-2c5cca76",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-replace-w-g-replace-d-g-touppercase-algo-37933881",
+      "clause": "clu-features-replace-w-g-replace-d-g-touppercase-algo-37933881",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-the-dependson-property-must-be-evaluated-recursi-desc-02808f73",
+      "clause": "clu-features-the-dependson-property-must-be-evaluated-recursi-desc-02808f73",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-the-home-folders-of-the-two-users-are-passed-to-desc-e63de366",
+      "clause": "clu-features-the-home-folders-of-the-two-users-are-passed-to-desc-e63de366",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-the-id-becomes-the-name-of-the-environment-varia-desc-31d4642c",
+      "clause": "clu-features-the-id-becomes-the-name-of-the-environment-varia-desc-31d4642c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-the-install-sh-script-for-each-feature-should-be-desc-b7c920aa",
+      "clause": "clu-features-the-install-sh-script-for-each-feature-should-be-desc-b7c920aa",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-the-latest-version-annotation-is-added-implicitl-desc-60c7b3c7",
+      "clause": "clu-features-the-latest-version-annotation-is-added-implicitl-desc-60c7b3c7",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-the-orchestrating-tool-should-assign-a-roundprio-algo-0de9ab37",
+      "clause": "clu-features-the-orchestrating-tool-should-assign-a-roundprio-algo-0de9ab37",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-the-properties-supporting-devcontainerid-in-the-desc-49ac4346",
+      "clause": "clu-features-the-properties-supporting-devcontainerid-in-the-desc-49ac4346",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-they-must-ensure-that-it-is-unique-among-other-d-desc-3180a890",
+      "clause": "clu-features-they-must-ensure-that-it-is-unique-among-other-d-desc-3180a890",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-to-ensure-that-the-appropriate-shell-is-used-the-desc-69c662f2",
+      "clause": "clu-features-to-ensure-that-the-appropriate-shell-is-used-the-desc-69c662f2",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-use-a-base-32-encoded-representation-left-padded-algo-cf1473ea",
+      "clause": "clu-features-use-a-base-32-encoded-representation-left-padded-algo-cf1473ea",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-templates-a-path-is-relative-to-the-root-of-the-template-s-desc-ec433cf4",
+      "clause": "clu-templates-a-path-is-relative-to-the-root-of-the-template-s-desc-ec433cf4",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-templates-a-supporting-tool-will-parse-the-options-object-desc-71357a1f",
+      "clause": "clu-templates-a-supporting-tool-will-parse-the-options-object-desc-71357a1f",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-templates-before-applying-a-template-tooling-must-inspect-desc-1eb54b25",
+      "clause": "clu-templates-before-applying-a-template-tooling-must-inspect-desc-1eb54b25",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-templates-for-a-directory-provide-the-full-relative-path-w-desc-6f870ac2",
+      "clause": "clu-templates-for-a-directory-provide-the-full-relative-path-w-desc-6f870ac2",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-templates-image-mcr-microsoft-com-devcontainers-java-0-tem-io-b5fb90c8",
+      "clause": "clu-templates-image-mcr-microsoft-com-devcontainers-java-0-tem-io-b5fb90c8",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-templates-the-tools-would-replace-the-option-id-with-the-s-desc-8c2b22b7",
+      "clause": "clu-templates-the-tools-would-replace-the-option-id-with-the-s-desc-8c2b22b7",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-templates-this-replacement-would-happen-before-dropping-th-desc-6c8076c4",
+      "clause": "clu-templates-this-replacement-would-happen-before-dropping-th-desc-6c8076c4",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/declarative-secrets.json
+++ b/conformance/registry/clause-classifications/declarative-secrets.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-declarative-secrets-add-an-optional-secrets-property-to-the-devconta-io-9b453bae",
+      "clause": "clu-declarative-secrets-add-an-optional-secrets-property-to-the-devconta-io-9b453bae",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-secrets-dotenv-superset"
+      ]
+    },
+    {
+      "id": "clc-declarative-secrets-description-string-a-brief-description-of-the-se-io-8536a807",
+      "clause": "clu-declarative-secrets-description-string-a-brief-description-of-the-se-io-8536a807",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-secrets-dotenv-superset"
+      ]
+    },
+    {
+      "id": "clc-declarative-secrets-documentationurl-string-a-url-pointing-to-where-io-58c0bc69",
+      "clause": "clu-declarative-secrets-documentationurl-string-a-url-pointing-to-where-io-58c0bc69",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-secrets-dotenv-superset"
+      ]
+    },
+    {
+      "id": "clc-declarative-secrets-implementations-may-inject-these-secrets-into-th-desc-d00b7761",
+      "clause": "clu-declarative-secrets-implementations-may-inject-these-secrets-into-th-desc-d00b7761",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-declarative-secrets-the-keys-of-this-object-are-the-names-of-the-sec-desc-3b0681c7",
+      "clause": "clu-declarative-secrets-the-keys-of-this-object-are-the-names-of-the-sec-desc-3b0681c7",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-declarative-secrets-these-secrets-are-recommended-to-the-user-but-ar-desc-922bbd63",
+      "clause": "clu-declarative-secrets-these-secrets-are-recommended-to-the-user-but-ar-desc-922bbd63",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/devcontainer-id-variable.json
+++ b/conformance/registry/clause-classifications/devcontainer-id-variable.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-devcontainer-id-variable-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-ff771e6e",
+      "clause": "clu-devcontainer-id-variable-compute-a-sha-256-hash-from-the-utf-8-encoded-in-algo-ff771e6e",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-45721081",
+      "clause": "clu-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-45721081",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-bd0ca7d0",
+      "clause": "clu-devcontainer-id-variable-excluding-boolean-numbers-and-enum-properties-th-desc-bd0ca7d0",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-it-should-only-be-used-in-parts-of-the-configura-desc-556d8d7d",
+      "clause": "clu-devcontainer-id-variable-it-should-only-be-used-in-parts-of-the-configura-desc-556d8d7d",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-the-identifier-must-only-contain-alphanumeric-ch-desc-13534537",
+      "clause": "clu-devcontainer-id-variable-the-identifier-must-only-contain-alphanumeric-ch-desc-13534537",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-they-must-ensure-that-it-is-unique-among-other-d-desc-f5994239",
+      "clause": "clu-devcontainer-id-variable-they-must-ensure-that-it-is-unique-among-other-d-desc-f5994239",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-to-ensure-implementations-get-to-the-same-result-algo-001cb9f4",
+      "clause": "clu-devcontainer-id-variable-to-ensure-implementations-get-to-the-same-result-algo-001cb9f4",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-devcontainer-id-variable-use-a-base-32-encoded-representation-left-padded-algo-26efae91",
+      "clause": "clu-devcontainer-id-variable-use-a-base-32-encoded-representation-left-padded-algo-26efae91",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/feature-dependencies.json
+++ b/conformance/registry/clause-classifications/feature-dependencies.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-feature-dependencies-a-new-property-dependson-can-be-optionally-added-desc-039bf6bd",
+      "clause": "clu-feature-dependencies-a-new-property-dependson-can-be-optionally-added-desc-039bf6bd",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-feature-dependencies-adding-feature-s-to-this-property-tells-the-orch-algo-5150f266",
+      "clause": "clu-feature-dependencies-adding-feature-s-to-this-property-tells-the-orch-algo-5150f266",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-an-orchestrating-tool-should-remove-all-installs-algo-e4d47679",
+      "clause": "clu-feature-dependencies-an-orchestrating-tool-should-remove-all-installs-algo-e4d47679",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-commit-to-installationorder-only-those-nodes-who-algo-bf65dc02",
+      "clause": "clu-feature-dependencies-commit-to-installationorder-only-those-nodes-who-algo-bf65dc02",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-compare-and-sort-each-feature-lexiographically-b-algo-ed9f808d",
+      "clause": "clu-feature-dependencies-compare-and-sort-each-feature-lexiographically-b-algo-ed9f808d",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-dependency-resolution-is-only-performed-on-initi-desc-603bcd42",
+      "clause": "clu-feature-dependencies-dependency-resolution-is-only-performed-on-initi-desc-603bcd42",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-feature-dependencies-dependson-ghcr-io-second-1-flag-true-io-791d2b05",
+      "clause": "clu-feature-dependencies-dependson-ghcr-io-second-1-flag-true-io-791d2b05",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-each-node-in-the-graph-has-an-implicit-default-r-algo-72caf843",
+      "clause": "clu-feature-dependencies-each-node-in-the-graph-has-an-implicit-default-r-algo-72caf843",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-for-dependson-dependencies-the-dependency-will-b-algo-2ba70907",
+      "clause": "clu-feature-dependencies-for-dependson-dependencies-the-dependency-will-b-algo-2ba70907",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-from-the-user-defined-features-the-orchestrating-algo-038fa45f",
+      "clause": "clu-feature-dependencies-from-the-user-defined-features-the-orchestrating-algo-038fa45f",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-if-there-is-ever-a-round-where-no-elements-are-a-algo-eaf1402b",
+      "clause": "clu-feature-dependencies-if-there-is-ever-a-round-where-no-elements-are-a-algo-eaf1402b",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-installsafter-is-not-recursive-algo-6d8aa9e0",
+      "clause": "clu-feature-dependencies-installsafter-is-not-recursive-algo-6d8aa9e0",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-mediatype-application-vnd-oci-image-manifest-v1-io-e17c68d7",
+      "clause": "clu-feature-dependencies-mediatype-application-vnd-oci-image-manifest-v1-io-e17c68d7",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-only-the-features-equal-to-the-max-roundpriority-algo-6e6948bb",
+      "clause": "clu-feature-dependencies-only-the-features-equal-to-the-max-roundpriority-algo-6e6948bb",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-start-with-all-the-elements-from-b2-in-a-worklis-algo-e03a3c04",
+      "clause": "clu-feature-dependencies-start-with-all-the-elements-from-b2-in-a-worklis-algo-e03a3c04",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-the-orchestrating-tool-is-responsible-for-calcul-algo-10e3be9a",
+      "clause": "clu-feature-dependencies-the-orchestrating-tool-is-responsible-for-calcul-algo-10e3be9a",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-the-orchestrating-tool-must-fallback-to-download-must-e98c49b3",
+      "clause": "clu-feature-dependencies-the-orchestrating-tool-must-fallback-to-download-must-e98c49b3",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-the-orchestrating-tool-should-assign-a-roundprio-algo-3ef2e621",
+      "clause": "clu-feature-dependencies-the-orchestrating-tool-should-assign-a-roundprio-algo-3ef2e621",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-the-overridefeatureinstallorder-property-of-devc-algo-116737c8",
+      "clause": "clu-feature-dependencies-the-overridefeatureinstallorder-property-of-devc-algo-116737c8",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-the-set-of-features-to-be-installed-is-the-union-algo-c707f67a",
+      "clause": "clu-feature-dependencies-the-set-of-features-to-be-installed-is-the-union-algo-c707f67a",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-feature-dependencies-this-specification-defines-two-features-as-equal-desc-c6fa6084",
+      "clause": "clu-feature-dependencies-this-specification-defines-two-features-as-equal-desc-c6fa6084",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-feature-dependencies-to-speed-up-dependency-resolution-all-features-p-desc-9ea95360",
+      "clause": "clu-feature-dependencies-to-speed-up-dependency-resolution-all-features-p-desc-9ea95360",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-feature-dependencies-two-feature-are-identical-if-their-manifest-dige-algo-ee493920",
+      "clause": "clu-feature-dependencies-two-feature-are-identical-if-their-manifest-dige-algo-ee493920",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-feature-dependencies-while-the-worklist-is-not-empty-iterate-through-algo-9d7e0a05",
+      "clause": "clu-feature-dependencies-while-the-worklist-is-not-empty-iterate-through-algo-9d7e0a05",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/features-legacy-ids.json
+++ b/conformance/registry/clause-classifications/features-legacy-ids.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-features-legacy-ids-defaults-to-array-of-old-ids-used-to-publish-thi-io-dc47b23f",
+      "clause": "clu-features-legacy-ids-defaults-to-array-of-old-ids-used-to-publish-thi-io-dc47b23f",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-legacy-ids-defaults-to-false-indicates-that-the-feature-is-io-651a4b56",
+      "clause": "clu-features-legacy-ids-defaults-to-false-indicates-that-the-feature-is-io-651a4b56",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-legacy-ids-if-this-property-is-set-to-true-then-it-indicate-desc-cc1c45f4",
+      "clause": "clu-features-legacy-ids-if-this-property-is-set-to-true-then-it-indicate-desc-cc1c45f4",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-legacy-ids-the-cli-tooling-will-be-updated-to-also-look-at-algo-b10031b2",
+      "clause": "clu-features-legacy-ids-the-cli-tooling-will-be-updated-to-also-look-at-algo-b10031b2",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-features-legacy-ids-the-property-is-useful-for-renaming-a-currently-desc-60127c26",
+      "clause": "clu-features-legacy-ids-the-property-is-useful-for-renaming-a-currently-desc-60127c26",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-legacy-ids-the-semantic-version-of-the-feature-defined-by-t-desc-d1b0f722",
+      "clause": "clu-features-legacy-ids-the-semantic-version-of-the-feature-defined-by-t-desc-d1b0f722",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-legacy-ids-will-dual-publish-the-old-ids-defined-by-the-leg-desc-0d5a6b09",
+      "clause": "clu-features-legacy-ids-will-dual-publish-the-old-ids-defined-by-the-leg-desc-0d5a6b09",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/features-lifecycle-scripts.json
+++ b/conformance/registry/clause-classifications/features-lifecycle-scripts.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-features-lifecycle-scripts-all-other-semantics-match-the-existing-lifecycle-desc-c02f9c97",
+      "clause": "clu-features-lifecycle-scripts-all-other-semantics-match-the-existing-lifecycle-desc-c02f9c97",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-as-with-all-lifecycle-hooks-commands-are-execute-desc-fb55e890",
+      "clause": "clu-features-lifecycle-scripts-as-with-all-lifecycle-hooks-commands-are-execute-desc-fb55e890",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-3e112729",
+      "clause": "clu-features-lifecycle-scripts-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-3e112729",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-implementations-are-not-required-to-persist-feat-desc-e70d2cb7",
+      "clause": "clu-features-lifecycle-scripts-implementations-are-not-required-to-persist-feat-desc-e70d2cb7",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-no-subsequent-lifecycle-commands-shall-proceed-u-algo-0aca04ec",
+      "clause": "clu-features-lifecycle-scripts-no-subsequent-lifecycle-commands-shall-proceed-u-algo-0aca04ec",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-note-that-initializecommand-is-omitted-pending-f-desc-15212db2",
+      "clause": "clu-features-lifecycle-scripts-note-that-initializecommand-is-omitted-pending-f-desc-15212db2",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-features-lifecycle-scripts-when-a-dev-container-is-brought-up-for-each-life-algo-91b49557",
+      "clause": "clu-features-lifecycle-scripts-when-a-dev-container-is-brought-up-for-each-life-algo-91b49557",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/features-user-env.json
+++ b/conformance/registry/clause-classifications/features-user-env.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-features-user-env-additionally-the-home-folders-of-the-two-users-a-io-15684a98",
+      "clause": "clu-features-user-env-additionally-the-home-folders-of-the-two-users-a-io-15684a98",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ],
+      "notes": "Prose\u2192behavior traceability now flows through this clause; supersedes retired src-spec-container-metadata-recovery (021 T036)."
+    },
+    {
+      "id": "clc-features-user-env-if-no-remoteuser-is-configured-remote-user-is-se-algo-d105730b",
+      "clause": "clu-features-user-env-if-no-remoteuser-is-configured-remote-user-is-se-algo-d105730b",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ]
+    },
+    {
+      "id": "clc-features-user-env-pass-remote-user-and-container-user-environment-io-3dda5725",
+      "clause": "clu-features-user-env-pass-remote-user-and-container-user-environment-io-3dda5725",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ]
+    },
+    {
+      "id": "clc-features-user-env-the-container-user-can-be-set-with-containeruser-desc-b793399d",
+      "clause": "clu-features-user-env-the-container-user-can-be-set-with-containeruser-desc-b793399d",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/gpu-host-requirement.json
+++ b/conformance/registry/clause-classifications/gpu-host-requirement.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-gpu-host-requirement-a-string-indicating-minimum-memory-requirements-io-1b5d1079",
+      "clause": "clu-gpu-host-requirement-a-string-indicating-minimum-memory-requirements-io-1b5d1079",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-gpu-host-requirement-indicates-the-minimum-required-number-of-cores-io-529e3b33",
+      "clause": "clu-gpu-host-requirement-indicates-the-minimum-required-number-of-cores-io-529e3b33",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-gpu-host-requirement-indicates-whether-or-not-a-gpu-is-required-a-val-io-d8c6d13d",
+      "clause": "clu-gpu-host-requirement-indicates-whether-or-not-a-gpu-is-required-a-val-io-d8c6d13d",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-gpu-host-requirement-we-propose-to-add-a-new-gpu-property-to-the-host-io-6b095695",
+      "clause": "clu-gpu-host-requirement-we-propose-to-add-a-new-gpu-property-to-the-host-io-6b095695",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/image-metadata.json
+++ b/conformance/registry/clause-classifications/image-metadata.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-image-metadata-capadd-string-union-of-all-capadd-arrays-without-io-2f3f3193",
+      "clause": "clu-image-metadata-capadd-string-union-of-all-capadd-arrays-without-io-2f3f3193",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-image-metadata-forwardports-number-string-union-of-all-ports-wi-io-62ee1814",
+      "clause": "clu-image-metadata-forwardports-number-string-union-of-all-ports-wi-io-62ee1814",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-auto-forward-ports"
+      ]
+    },
+    {
+      "id": "clc-image-metadata-id-string-init-boolean-privileged-boolean-capadd-io-8cf55d2d",
+      "clause": "clu-image-metadata-id-string-init-boolean-privileged-boolean-capadd-io-8cf55d2d",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-init-boolean-true-if-at-least-one-is-true-false-io-68bfc594",
+      "clause": "clu-image-metadata-init-boolean-true-if-at-least-one-is-true-false-io-68bfc594",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-image-metadata-mounts-string-type-src-dst-collected-list-of-all-io-a4d7d6d5",
+      "clause": "clu-image-metadata-mounts-string-type-src-dst-collected-list-of-all-io-a4d7d6d5",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-image-metadata-record-dev-container-config-and-feature-metadata-desc-dac9ade3",
+      "clause": "clu-image-metadata-record-dev-container-config-and-feature-metadata-desc-dac9ade3",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-the-metadata-is-added-to-the-image-as-a-devconta-io-721243cf",
+      "clause": "clu-image-metadata-the-metadata-is-added-to-the-image-as-a-devconta-io-721243cf",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-image-metadata-to-apply-the-metadata-together-with-a-user-s-dev-desc-4d54126e",
+      "clause": "clu-image-metadata-to-apply-the-metadata-together-with-a-user-s-dev-desc-4d54126e",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-to-simplify-adding-this-metadata-for-other-tools-desc-8bade94f",
+      "clause": "clu-image-metadata-to-simplify-adding-this-metadata-for-other-tools-desc-8bade94f",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-variables-in-string-values-will-be-substituted-a-desc-31cd8289",
+      "clause": "clu-image-metadata-variables-in-string-values-will-be-substituted-a-desc-31cd8289",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-we-are-adding-support-for-mounts-containerenv-co-desc-dbddd9df",
+      "clause": "clu-image-metadata-we-are-adding-support-for-mounts-containerenv-co-desc-dbddd9df",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-image-metadata-we-propose-to-add-metadata-to-the-image-with-the-desc-b54f56f3",
+      "clause": "clu-image-metadata-we-propose-to-add-metadata-to-the-image-with-the-desc-b54f56f3",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/json-reference.json
+++ b/conformance/registry/clause-classifications/json-reference.json
@@ -1,0 +1,272 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-json-reference-a-command-string-or-list-of-command-arguments-to-desc-dff1da95",
+      "clause": "clu-json-reference-a-command-string-or-list-of-command-arguments-to-desc-dff1da95",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-command-to-run-each-time-a-tool-has-successful-desc-ac507e3c",
+      "clause": "clu-json-reference-a-command-to-run-each-time-a-tool-has-successful-desc-ac507e3c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-command-to-run-each-time-the-container-is-succ-desc-56473251",
+      "clause": "clu-json-reference-a-command-to-run-each-time-the-container-is-succ-desc-56473251",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-default-value-for-when-the-environment-variabl-io-e0533bcb",
+      "clause": "clu-json-reference-a-default-value-for-when-the-environment-variabl-io-e0533bcb",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-json-reference-a-dev-container-configuration-will-inherit-the-r-desc-8967e88c",
+      "clause": "clu-json-reference-a-dev-container-configuration-will-inherit-the-r-desc-8967e88c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-name-for-the-dev-container-displayed-in-the-ui-desc-94cd872c",
+      "clause": "clu-json-reference-a-name-for-the-dev-container-displayed-in-the-ui-desc-94cd872c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-482998a9",
+      "clause": "clu-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-482998a9",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-f73a61bb",
+      "clause": "clu-json-reference-a-set-of-name-value-pairs-that-sets-or-overrides-desc-f73a61bb",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-a-string-indicating-minimum-memory-requirements-io-b29e3295",
+      "clause": "clu-json-reference-a-string-indicating-minimum-memory-requirements-io-b29e3295",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-an-array-of-docker-cli-arguments-that-should-be-io-2f81ef14",
+      "clause": "clu-json-reference-an-array-of-docker-cli-arguments-that-should-be-io-2f81ef14",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-an-array-of-port-numbers-or-host-port-values-io-5bb030ac",
+      "clause": "clu-json-reference-an-array-of-port-numbers-or-host-port-values-io-5bb030ac",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-an-enum-that-specifies-the-command-any-tool-shou-io-805d039b",
+      "clause": "clu-json-reference-an-enum-that-specifies-the-command-any-tool-shou-io-805d039b",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-json-reference-an-object-of-dev-container-feature-ids-and-relat-desc-9adb363c",
+      "clause": "clu-json-reference-an-object-of-dev-container-feature-ids-and-relat-desc-9adb363c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-cross-orchestrator-way-to-add-additional-mounts-io-9f0f755a",
+      "clause": "clu-json-reference-cross-orchestrator-way-to-add-additional-mounts-io-9f0f755a",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-defaults-to-true-for-when-using-an-image-dockerf-io-76d19efa",
+      "clause": "clu-json-reference-defaults-to-true-for-when-using-an-image-dockerf-io-76d19efa",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-compose-project-name-robust"
+      ]
+    },
+    {
+      "id": "clc-json-reference-dictates-when-port-forwarding-is-required-to-map-desc-535d595e",
+      "clause": "clu-json-reference-dictates-when-port-forwarding-is-required-to-map-desc-535d595e",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-each-command-property-is-an-string-or-list-of-co-io-88240d31",
+      "clause": "clu-json-reference-each-command-property-is-an-string-or-list-of-co-io-88240d31",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-state-container-parity"
+      ]
+    },
+    {
+      "id": "clc-json-reference-for-each-command-property-if-the-value-is-a-sing-algo-edd92849",
+      "clause": "clu-json-reference-for-each-command-property-if-the-value-is-a-sing-algo-edd92849",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-cb502f9a",
+      "clause": "clu-json-reference-if-one-of-the-lifecycle-scripts-fails-any-subseq-algo-cb502f9a",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-json-reference-indicates-the-type-of-shell-to-use-to-probe-for-io-896c5f64",
+      "clause": "clu-json-reference-indicates-the-type-of-shell-to-use-to-probe-for-io-896c5f64",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-it-and-subsequent-commands-execute-inside-the-co-desc-c68356ad",
+      "clause": "clu-json-reference-it-and-subsequent-commands-execute-inside-the-co-desc-c68356ad",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-it-executes-inside-the-container-after-oncreatec-desc-5d71a46e",
+      "clause": "clu-json-reference-it-executes-inside-the-container-after-oncreatec-desc-5d71a46e",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-it-happens-after-updatecontentcommand-and-once-t-desc-9d62d901",
+      "clause": "clu-json-reference-it-happens-after-updatecontentcommand-and-once-t-desc-9d62d901",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-notify-is-the-default-and-a-notification-will-ap-io-fbfdc269",
+      "clause": "clu-json-reference-notify-is-the-default-and-a-notification-will-ap-io-fbfdc269",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-object-that-maps-a-port-number-host-port-value-r-desc-b51d0b4f",
+      "clause": "clu-json-reference-object-that-maps-a-port-number-host-port-value-r-desc-b51d0b4f",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-on-linux-if-containeruser-or-remoteuser-is-speci-io-a22a9e99",
+      "clause": "clu-json-reference-on-linux-if-containeruser-or-remoteuser-is-speci-io-a22a9e99",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ]
+    },
+    {
+      "id": "clc-json-reference-overrides-the-user-for-all-operations-run-as-ins-desc-de726edc",
+      "clause": "clu-json-reference-overrides-the-user-for-all-operations-run-as-ins-desc-de726edc",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-overrides-the-user-that-devcontainer-json-suppor-desc-61ec0c65",
+      "clause": "clu-json-reference-overrides-the-user-that-devcontainer-json-suppor-desc-61ec0c65",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-path-that-the-docker-build-should-be-run-from-re-io-a9b5d4b9",
+      "clause": "clu-json-reference-path-that-the-docker-build-should-be-run-from-re-io-a9b5d4b9",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-product-specific-properties-defined-in-supportin-desc-3094d978",
+      "clause": "clu-json-reference-product-specific-properties-defined-in-supportin-desc-3094d978",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-required-when-using-a-dockerfile-the-location-of-io-8a8518c6",
+      "clause": "clu-json-reference-required-when-using-a-dockerfile-the-location-of-io-8a8518c6",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-build-image-parity"
+      ],
+      "notes": "Prose\u2192behavior traceability for this behavior now flows through this clause; supersedes retired src-spec-build-image (021 T036)."
+    },
+    {
+      "id": "clc-json-reference-required-when-using-an-image-the-name-of-an-imag-io-ceb577d8",
+      "clause": "clu-json-reference-required-when-using-an-image-the-name-of-an-imag-io-ceb577d8",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-required-when-using-docker-compose-the-name-of-t-io-910c920c",
+      "clause": "clu-json-reference-required-when-using-docker-compose-the-name-of-t-io-910c920c",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-compose-project-name-robust"
+      ]
+    },
+    {
+      "id": "clc-json-reference-requires-workspacefolder-be-set-as-well-override-io-af28a4ff",
+      "clause": "clu-json-reference-requires-workspacefolder-be-set-as-well-override-io-af28a4ff",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-state-container-parity"
+      ]
+    },
+    {
+      "id": "clc-json-reference-requires-workspacemount-be-set-sets-the-default-desc-76b98b58",
+      "clause": "clu-json-reference-requires-workspacemount-be-set-sets-the-default-desc-76b98b58",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-sets-the-default-path-that-devcontainer-json-sup-desc-51f12465",
+      "clause": "clu-json-reference-sets-the-default-path-that-devcontainer-json-sup-desc-51f12465",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-the-order-of-the-array-matters-since-the-content-io-bdf2bf4c",
+      "clause": "clu-json-reference-the-order-of-the-array-matters-since-the-content-io-bdf2bf4c",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-json-reference-this-property-accepts-a-port-or-array-of-ports-t-desc-3f93bee1",
+      "clause": "clu-json-reference-this-property-accepts-a-port-or-array-of-ports-t-desc-3f93bee1",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-this-property-allows-you-to-override-the-feature-desc-bebdddcd",
+      "clause": "clu-json-reference-this-property-allows-you-to-override-the-feature-desc-bebdddcd",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-json-reference-values-are-none-stopcontainer-default-for-image-io-9ba26e5a",
+      "clause": "clu-json-reference-values-are-none-stopcontainer-default-for-image-io-9ba26e5a",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-compose-project-name-robust"
+      ]
+    },
+    {
+      "id": "clc-json-reference-variables-can-be-referenced-in-certain-string-va-desc-ca54b6fc",
+      "clause": "clu-json-reference-variables-can-be-referenced-in-certain-string-va-desc-ca54b6fc",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/lockfile.json
+++ b/conformance/registry/clause-classifications/lockfile.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-lockfile-dependson-an-array-of-feature-identifiers-equal-io-d7227bc0",
+      "clause": "clu-lockfile-dependson-an-array-of-feature-identifiers-equal-io-d7227bc0",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-lockfile-integrity-sha256-followed-by-the-hex-encoded-sha-io-87cbdc86",
+      "clause": "clu-lockfile-integrity-sha256-followed-by-the-hex-encoded-sha-io-87cbdc86",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-lockfile-local-features-and-the-deprecated-github-release-desc-c92caf0c",
+      "clause": "clu-lockfile-local-features-and-the-deprecated-github-release-desc-c92caf0c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-lockfile-resolved-oci-feature-a-qualified-feature-id-with-io-d5cc5400",
+      "clause": "clu-lockfile-resolved-oci-feature-a-qualified-feature-id-with-io-d5cc5400",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-lockfile-the-feature-identifiers-recorded-as-keys-and-in-desc-5c3b3fc9",
+      "clause": "clu-lockfile-the-feature-identifiers-recorded-as-keys-and-in-desc-5c3b3fc9",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-lockfile-the-lockfile-is-named-devcontainer-lock-json-is-io-0aa47a05",
+      "clause": "clu-lockfile-the-lockfile-is-named-devcontainer-lock-json-is-io-0aa47a05",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-lockfile-version-the-full-version-number-io-3dc63be7",
+      "clause": "clu-lockfile-version-the-full-version-number-io-3dc63be7",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/parallel-lifecycle.json
+++ b/conformance/registry/clause-classifications/parallel-lifecycle.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-parallel-lifecycle-db-mysql-u-root-p-my-database-io-380cf840",
+      "clause": "clu-parallel-lifecycle-db-mysql-u-root-p-my-database-io-380cf840",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-parallel-lifecycle-each-command-must-exit-successfully-for-the-stag-desc-3dfa4a54",
+      "clause": "clu-parallel-lifecycle-each-command-must-exit-successfully-for-the-stag-desc-3dfa4a54",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-parallel-lifecycle-each-entry-in-the-object-will-be-run-in-parallel-algo-9fe15a2e",
+      "clause": "clu-parallel-lifecycle-each-entry-in-the-object-will-be-run-in-parallel-algo-9fe15a2e",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-parallel-lifecycle-the-key-of-the-object-will-be-a-unique-name-for-io-e2509dfa",
+      "clause": "clu-parallel-lifecycle-the-key-of-the-object-will-be-a-unique-name-for-io-e2509dfa",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/reference.json
+++ b/conformance/registry/clause-classifications/reference.json
@@ -1,0 +1,241 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-reference-a-default-mount-should-be-included-so-that-the-s-desc-fc22f151",
+      "clause": "clu-reference-a-default-mount-should-be-included-so-that-the-s-desc-fc22f151",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-additionally-execute-the-poststartcommand-and-po-algo-1e29acde",
+      "clause": "clu-reference-additionally-execute-the-poststartcommand-and-po-algo-1e29acde",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-reference-by-default-postcreatecommand-is-executed-in-the-algo-4585aa1e",
+      "clause": "clu-reference-by-default-postcreatecommand-is-executed-in-the-algo-4585aa1e",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-reference-capadd-string-io-19b2ff76",
+      "clause": "clu-reference-capadd-string-io-19b2ff76",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-collected-list-of-all-mountpoints-conflicts-last-algo-6e3a3659",
+      "clause": "clu-reference-collected-list-of-all-mountpoints-conflicts-last-algo-6e3a3659",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-collected-list-of-all-oncreatecommands-algo-c1f1604c",
+      "clause": "clu-reference-collected-list-of-all-oncreatecommands-algo-c1f1604c",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-reference-container-mounts-environment-variables-and-user-algo-fc512eb6",
+      "clause": "clu-reference-container-mounts-environment-variables-and-user-algo-fc512eb6",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-each-command-must-exit-successfully-for-the-stag-algo-bc7ea234",
+      "clause": "clu-reference-each-command-must-exit-successfully-for-the-stag-algo-bc7ea234",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-each-entry-in-the-object-will-be-run-in-parallel-algo-6d33de69",
+      "clause": "clu-reference-each-entry-in-the-object-will-be-run-in-parallel-algo-6d33de69",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-reference-execution-of-initializecommand-algo-0e0c96b0",
+      "clause": "clu-reference-execution-of-initializecommand-algo-0e0c96b0",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-trust-host-hook-gate"
+      ]
+    },
+    {
+      "id": "clc-reference-however-remote-user-and-environment-variable-con-algo-a74a1d41",
+      "clause": "clu-reference-however-remote-user-and-environment-variable-con-algo-a74a1d41",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-if-the-waitfor-property-is-defined-then-executio-algo-0000032a",
+      "clause": "clu-reference-if-the-waitfor-property-is-defined-then-executio-algo-0000032a",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-up-exec-parity"
+      ]
+    },
+    {
+      "id": "clc-reference-per-variable-last-value-wins-algo-c8dcfd00",
+      "clause": "clu-reference-per-variable-last-value-wins-algo-c8dcfd00",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-probed-environment-variables-should-be-merged-wi-algo-bc58ffe5",
+      "clause": "clu-reference-probed-environment-variables-should-be-merged-wi-algo-bc58ffe5",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-products-using-it-should-expect-to-find-a-devcon-algo-2d2bc8c5",
+      "clause": "clu-reference-products-using-it-should-expect-to-find-a-devcon-algo-2d2bc8c5",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-remote-environment-variables-and-user-configurat-algo-5e726990",
+      "clause": "clu-reference-remote-environment-variables-and-user-configurat-algo-5e726990",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ]
+    },
+    {
+      "id": "clc-reference-server-npm-start-io-c402ff95",
+      "clause": "clu-reference-server-npm-start-io-c402ff95",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-service-declares-the-main-container-that-will-be-desc-63a9b6bf",
+      "clause": "clu-reference-service-declares-the-main-container-that-will-be-desc-63a9b6bf",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-set-using-the-remoteuser-property-in-all-cases-a-desc-317a6ed2",
+      "clause": "clu-reference-set-using-the-remoteuser-property-in-all-cases-a-desc-317a6ed2",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-the-default-mount-point-for-the-source-code-can-desc-53d64f45",
+      "clause": "clu-reference-the-default-mount-point-for-the-source-code-can-desc-53d64f45",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-the-metadata-is-added-to-the-image-as-a-devconta-io-421635c0",
+      "clause": "clu-reference-the-metadata-is-added-to-the-image-as-a-devconta-io-421635c0",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-the-only-required-parameter-in-this-case-is-the-desc-2d275895",
+      "clause": "clu-reference-the-only-required-parameter-in-this-case-is-the-desc-2d275895",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-the-only-required-parameter-is-image-desc-96bf70dd",
+      "clause": "clu-reference-the-only-required-parameter-is-image-desc-96bf70dd",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-the-project-workspace-folder-is-where-an-impleme-desc-042d067e",
+      "clause": "clu-reference-the-project-workspace-folder-is-where-an-impleme-desc-042d067e",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-these-contents-should-then-be-merged-with-any-lo-algo-a8e77908",
+      "clause": "clu-reference-these-contents-should-then-be-merged-with-any-lo-algo-a8e77908",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-these-variables-can-change-during-the-lifetime-o-desc-57c3f38c",
+      "clause": "clu-reference-these-variables-can-change-during-the-lifetime-o-desc-57c3f38c",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-reference-this-set-of-commands-is-executed-in-sequence-on-algo-462a5272",
+      "clause": "clu-reference-this-set-of-commands-is-executed-in-sequence-on-algo-462a5272",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-true-if-at-least-one-is-true-false-otherwise-algo-219a6637",
+      "clause": "clu-reference-true-if-at-least-one-is-true-false-otherwise-algo-219a6637",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-uid-gid-sync-ing-is-an-optional-task-for-linux-o-algo-6c12fea6",
+      "clause": "clu-reference-uid-gid-sync-ing-is-an-optional-task-for-linux-o-algo-6c12fea6",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-exec-container-id-metadata"
+      ]
+    },
+    {
+      "id": "clc-reference-union-of-all-capadd-arrays-without-duplicates-algo-2aa7395e",
+      "clause": "clu-reference-union-of-all-capadd-arrays-without-duplicates-algo-2aa7395e",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-union-of-all-ports-without-duplicates-last-one-w-algo-28d2b3f8",
+      "clause": "clu-reference-union-of-all-ports-without-duplicates-last-one-w-algo-28d2b3f8",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-validate-that-a-workspace-source-folder-has-been-algo-bb15890d",
+      "clause": "clu-reference-validate-that-a-workspace-source-folder-has-been-algo-bb15890d",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-reference-variables-in-string-values-will-be-substituted-a-algo-9107fc1e",
+      "clause": "clu-reference-variables-in-string-values-will-be-substituted-a-algo-9107fc1e",
+      "disposition": "behavior-mapped",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ]
+    },
+    {
+      "id": "clc-reference-when-the-order-matters-the-devcontainer-json-is-algo-b1bacaaf",
+      "clause": "clu-reference-when-the-order-matters-the-devcontainer-json-is-algo-b1bacaaf",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/secrets-support.json
+++ b/conformance/registry/clause-classifications/secrets-support.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-secrets-support-a-conforming-implementation-should-provide-a-sec-desc-db09d7dc",
+      "clause": "clu-secrets-support-a-conforming-implementation-should-provide-a-sec-desc-db09d7dc",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-secrets-support-a-supporting-tool-e-g-the-dev-container-cli-refe-desc-e1c78ef9",
+      "clause": "clu-secrets-support-a-supporting-tool-e-g-the-dev-container-cli-refe-desc-e1c78ef9",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-secrets-support-password-simple-passwords-io-9f6c9dd8",
+      "clause": "clu-secrets-support-password-simple-passwords-io-9f6c9dd8",
+      "disposition": "non-testable",
+      "rationale": "Normative prose clause inventoried at initial triage; classified non-testable pending a dedicated conformance behavior (research Decision 11 \u2014 no evidence-free behavior is minted)."
+    },
+    {
+      "id": "clc-secrets-support-secrets-are-not-part-of-dev-containers-specifica-desc-a5be2256",
+      "clause": "clu-secrets-support-secrets-are-not-part-of-dev-containers-specifica-desc-a5be2256",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-secrets-support-users-can-change-a-secret-s-value-at-any-time-an-desc-31591036",
+      "clause": "clu-secrets-support-users-can-change-a-secret-s-value-at-any-time-an-desc-31591036",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    }
+  ]
+}

--- a/conformance/registry/clause-classifications/supporting-tools.json
+++ b/conformance/registry/clause-classifications/supporting-tools.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "records": [
+    {
+      "id": "clc-supporting-tools-a-codespace-is-a-development-environment-that-s-desc-d545f89d",
+      "clause": "clu-supporting-tools-a-codespace-is-a-development-environment-that-s-desc-d545f89d",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-a-dev-container-command-line-interface-cli-that-desc-b5b7198a",
+      "clause": "clu-supporting-tools-a-dev-container-command-line-interface-cli-that-desc-b5b7198a",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-supporting-tools-an-array-of-extension-ids-that-specify-the-exten-desc-e843b6ac",
+      "clause": "clu-supporting-tools-an-array-of-extension-ids-that-specify-the-exten-desc-e843b6ac",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-supporting-tools-codespaces-disableautomaticconfiguration-true-io-38f1cf46",
+      "clause": "clu-supporting-tools-codespaces-disableautomaticconfiguration-true-io-38f1cf46",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-codespaces-will-automatically-perform-some-defau-desc-b9bcfd15",
+      "clause": "clu-supporting-tools-codespaces-will-automatically-perform-some-defau-desc-b9bcfd15",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-lets-you-use-a-container-as-a-full-featured-deve-desc-645f0796",
+      "clause": "clu-supporting-tools-lets-you-use-a-container-as-a-full-featured-deve-desc-645f0796",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-mounts-array-codespaces-ignores-bind-mounts-with-desc-1b4957a7",
+      "clause": "clu-supporting-tools-mounts-array-codespaces-ignores-bind-mounts-with-desc-1b4957a7",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-set-default-container-specific-settings-json-val-io-fc3a41cd",
+      "clause": "clu-supporting-tools-set-default-container-specific-settings-json-val-io-fc3a41cd",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-supporting-tools-shutdownaction-enum-does-not-apply-to-codespaces-desc-55b06d3b",
+      "clause": "clu-supporting-tools-shutdownaction-enum-does-not-apply-to-codespaces-desc-55b06d3b",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-visual-studio-added-dev-container-support-in-vis-desc-7b4f5bd7",
+      "clause": "clu-supporting-tools-visual-studio-added-dev-container-support-in-vis-desc-7b4f5bd7",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    },
+    {
+      "id": "clc-supporting-tools-visual-studio-code-specific-properties-go-under-desc-94ff0710",
+      "clause": "clu-supporting-tools-visual-studio-code-specific-properties-go-under-desc-94ff0710",
+      "disposition": "non-testable",
+      "rationale": "Descriptive/informative prose; carries no directly testable consumer-runtime obligation."
+    },
+    {
+      "id": "clc-supporting-tools-workspacemount-string-not-yet-supported-when-usi-desc-ea06083a",
+      "clause": "clu-supporting-tools-workspacemount-string-not-yet-supported-when-usi-desc-ea06083a",
+      "disposition": "not-applicable",
+      "rationale": "Authoring, publishing, or tool-specific material outside deacon's consumer-only runtime scope (constitution II)."
+    }
+  ]
+}

--- a/conformance/registry/sources/spec.json
+++ b/conformance/registry/sources/spec.json
@@ -2,14 +2,6 @@
   "schemaVersion": 1,
   "records": [
     {
-      "id": "src-spec-build-image",
-      "inventory": "spec",
-      "revision": "rev-spec-113500f4",
-      "locator": "Image building",
-      "summary": "A devcontainer image is built from the resolved configuration and the build outcome is reported.",
-      "behaviors": ["bhv-build-image-parity"]
-    },
-    {
       "id": "src-spec-container-inspect",
       "inventory": "spec",
       "revision": "rev-spec-113500f4",
@@ -24,22 +16,6 @@
       "locator": "Command execution",
       "summary": "A command is executed inside the container with its output streamed and its exit code propagated.",
       "behaviors": ["bhv-exec-command-parity"]
-    },
-    {
-      "id": "src-spec-container-metadata-recovery",
-      "inventory": "spec",
-      "revision": "rev-spec-113500f4",
-      "locator": "Container metadata label recovery",
-      "summary": "The merged configuration is written to the container's devcontainer.metadata label at create time, so config that lives only in devcontainer.json (e.g. remoteEnv) is recoverable from the running container by exec/read-configuration/set-up without the workspace.",
-      "behaviors": ["bhv-exec-container-id-metadata"]
-    },
-    {
-      "id": "src-spec-lifecycle-up",
-      "inventory": "spec",
-      "revision": "rev-spec-113500f4",
-      "locator": "Up / lifecycle",
-      "summary": "The up flow creates a container from the resolved configuration with the expected environment and remote user.",
-      "behaviors": ["bhv-up-exec-parity"]
     },
     {
       "id": "src-spec-readconfig-resolution",

--- a/conformance/spec/113500f4/declarative-secrets.md
+++ b/conformance/spec/113500f4/declarative-secrets.md
@@ -1,0 +1,62 @@
+# Declarative Secrets
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/198, https://github.com/devcontainers/spec/issues/216
+* Schema PR: https://github.com/devcontainers/spec/pull/303
+
+Below is the original proposal.
+
+## Motivation
+
+Various projects exist in the wild that require various secrets for them to run properly. Examples include:
+
+- https://github.com/lostintangent/codespaces-langchain
+- https://github.com/openai/openai-quickstart-python
+- https://github.com/openai/openai-quickstart-node
+
+Today these projects have to include specific instructions (e.g. in their README) telling users where to procure what they need to run and then how to set it up as a secret or add it as an environment variable. This currently acts as an impediment to adoption and promotion of dev containers for these projects.
+
+## Goal
+
+Simplify using dev containers for these kinds of projects by supporting secrets as a first-class part of the dev container creation flow.
+
+## Proposal
+
+Add an optional `secrets` property to the `devContainer.base.schema.json`. This will be used to declare the secrets needed within the dev container.
+
+Property | Type | Description
+--- | --- | ---
+`secrets` | `object` | The keys of this object are the names of the secrets that are in use. Keys should be [valid Linux environment variable names](https://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html).
+
+The `secrets` property contains a map of secret names and details about those secrets. These `secrets` are recommended to the user but are not _required_ for creation. All properties are optional.
+
+Property | Type | Description
+--- | --- | ---
+`description` | `string` | A brief description of the secret.
+`documentationUrl` | `string` | A URL pointing to where the user can obtain more information about the secret. For example where to find docs on provisioning an API key for a service.
+
+## Example
+
+```json
+{
+    "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+    "secrets": {
+        "CHAT_GPT_API_KEY": {
+            "description": "I'm your super cool API key for ChatGPT.",
+            "documentationUrl": "https://openai.com/api/"
+        },
+        "STABLE_DIFFUSION_API_KEY": {}
+    }
+}
+```
+
+This example would declare that this dev container wants the user to provide two secrets. The `CHAT_GPT_API_KEY` secret also provides some additional metadata that clients can use in displaying a user experience to provide that secret. The `STABLE_DIFFUSION_API_KEY` skips that metadata.
+
+Implementations _may_ inject these secrets into the container as environment variables.
+
+## Possible Future Extensions
+
+These are **out of scope** for this proposal but the following has been discussed in relation:
+
+1. Inclusion of a `type` field per secret. The default, which we are assuming and leveraging here, would be `"environmentVariable"`. This would include an option to specify `"reference"` and then reference the provided secrets in other parts of the dev container.
+2. Prescriptions of _how_ the secrets are injected into the dev container.

--- a/conformance/spec/113500f4/devcontainer-features-distribution.md
+++ b/conformance/spec/113500f4/devcontainer-features-distribution.md
@@ -1,0 +1,215 @@
+# Distribution and Discovery of Dev Container Features
+
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/feature-template) to get started on distributing your own Dev Container Features.**
+
+This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Features](./devcontainer-features.md). 
+
+Goals include:
+
+- For Feature authors, create a "self-service" way to publish a Feature, either publicly or privately, that is not centrally controlled.
+- For users, provide the ability to validate the integrity of fetched Feature assets. 
+- For users, provide the ability to pin to a particular version (absolute, or semantic version) of a Feature to allow for consistent, repeatable environments.
+- Provide the ability to standardize publishing such that [supporting tools](../docs/specs/supporting-tools.md) may implement their own mechanism to aid Feature discoverability as they see fit.
+
+> **Tip:** This section covers details on the Features specification. If you are looking for summarized information on creating your own Features, see the [template](https://github.com/devcontainers/feature-template) and [core Features](https://github.com/devcontainers/features) repositories.
+
+## Source code
+
+Features source code is stored in a git repository.
+
+For ease of authorship and maintenance, [1..n] features can share a single git repository. This set of features is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
+
+Source code for the set follows the example file structure below:
+
+```
+.
+├── README.md
+├── src
+│   ├── dotnet
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── ...
+|   ├
+│   ├── go
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+|   ├── ...
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+├── test
+│   ├── dotnet
+│   │   ├── test.sh
+│   │   └── ...
+│   └── go
+│   |   └── test.sh
+|   ├── ...
+│   │   └── test.sh
+├── ...
+```
+
+...where `src` is a directory containing a sub-folder with the name of the Feature (e.g. `src/dotnet` or `src/go`) with at least a file named `devcontainer-feature.json` that contains the Feature metadata, and an `install.sh` script that implementing tools will use as the entrypoint to install the Feature.
+
+Each sub-directory should be named such that it matches the `id` field of the `devcontainer-feature.json`.  Other files can also be included in the Feature's sub-directory, and will be included during the [packaging step](#packaging) alongside the two required files.  Any files that are not part of the Feature's sub-directory (e.g. outside of `src/dotnet`) will not be included in the [packaging step](#packaging).
+
+Optionally, a mirrored `test` directory can be included with an accompanying `test.sh` script. Implementing tools may use this to run tests against the given Feature.
+
+## Versioning
+
+Each Feature is individually [versioned according to the semver specification](https://semver.org/).  The `version` property in the respective `devcontainer-feature.json` file is parsed to determine if the Feature should be republished.
+
+Tooling that handles publishing Features will not republish features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
+
+## Packaging
+
+Features are distributed as tarballs.  The tarball contains the entire contents of the Feature sub-directory, including the `devcontainer-feature.json`, `install.sh`, and any other files in the directory.
+
+The tarball is named `devcontainer-feature-<id>.tgz`, where `<id>` is the Feature's `id` field.
+
+A reference implementation for packaging and distributing Features is provided as a GitHub Action (https://github.com/devcontainers/action).
+
+### devcontainer-collection.json
+
+The `devcontainer-collection.json` is an auto-generated metadata file.
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `sourceInformation` | object | Metadata from the implementing packaging tool. |
+| `features` | array | The list of features that are contained in this collection.|
+
+Each Features's `devcontainer-feature.json` metadata file is appended into the `features` top-level array.
+
+## Distribution
+
+There are several supported ways to distribute Features. Distribution is handled by the implementing packaging tool such as the [Dev Container CLI](https://github.com/devcontainers/cli) or [Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish). See the [quick start repository](https://github.com/devcontainers/feature-template) for a full working example.
+
+> Feature identifiers should be provided lowercase by an author. If not, an implementing packaging tool should normalize the identifier into lowercase for any internal representation.
+
+A user references a distributed Feature in a `devcontainer.json` as defined in ['referencing a feature'](./devcontainer-features.md#Referencing-a-feature).
+
+### OCI Registry
+
+An OCI registry that implements the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec) serves as the primary distribution mechanism for Features.
+
+Each packaged feature is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the Feature, according to the semver specification.
+
+> **Note:** `namespace` is a unique identifier for the collection of Features.  There are no strict rules for `namespace`; however, one pattern is to set `namespace` equal to source repository's `<owner>/<repo>`.  The `namespace` should be lowercase, following [the regex provided in the OCI specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests).
+
+A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below.
+
+For example, the `go` Feature in the `devcontainers/features` namespace at version `1.2.3` would be pushed to the ghcr.io OCI registry.  
+
+> **Note:** The example below uses [`oras`](https://oras.land/) for demonstration purposes.  A supporting tool should directly implement the required functionality from the aforementioned OCI artifact distribution specification.
+
+```bash
+# ghcr.io/devcontainers/features/go:1 
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/features
+FEATURE=go
+
+ARTIFACT_PATH=devcontainer-feature-go.tgz
+
+for VERSION in 1  1.2  1.2.3  latest
+do
+    oras push ${REGISTRY}/${NAMESPACE}/${FEATURE}:${VERSION} \
+            --manifest-config /dev/null:application/vnd.devcontainers \
+                             ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
+done
+
+```
+
+The "namespace" is the globally identifiable name for the collection of Features (e.g. `owner/repo` for the source code's git repository).
+
+The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `feature` name. The collection file is always tagged as `latest`.
+
+```bash
+# ghcr.io/devcontainers/features
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/features
+
+oras push ${REGISTRY}/${NAMESPACE}:latest \
+        --manifest-config /dev/null:application/vnd.devcontainers \
+                            ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
+```
+
+Additionally, an [annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) named `dev.containers.metadata` should be populated on the manifest when published by an implementing tool.  This annotation is the escaped JSON object of the entire `devcontainer-feature.json` as it appears during the [packaging stage](https://containers.dev/implementors/features-distribution/#packaging).  
+
+An example manifest with the `dev.containers.metadata` annotation:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.devcontainers",
+    "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.devcontainers.layer.v1+tar",
+      "digest": "sha256:738af5504b253dc6de51d2cb1556cdb7ce70ab18b2f32b0c2f12650ed6d2e4bc",
+      "size": 3584,
+      "annotations": {
+        "org.opencontainers.image.title": "devcontainer-feature-myFeature.tgz"
+      }
+    }
+  ],
+  "annotations": {
+    "dev.containers.metadata": "{\"name\": \"My Feature\",\"id\": \"myFeature\",\"version\": \"1.0.0\",\"dependsOn\": {\"ghcr.io/myotherFeature:1\": {\"flag\": true},\"features.azurecr.io/aThirdFeature:1\": {},\"features.azurecr.io/aFourthFeature:1.2.3\": {}}}"
+  }
+}
+```
+
+### Directly referencing a tarball
+
+A Feature can be referenced directly in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) file by HTTPS URI that points to the tarball from the [package step](#packaging).
+
+The `.tgz` archive file must be named `devcontainer-feature-<featureId>.tgz`.
+
+### Locally referenced Features
+
+Instead of publishing a Feature to an OCI registry, a Feature's source code may be referenced from a local folder. Locally referencing a Feature may be useful when first authoring a Feature.
+
+A local Feature is referenced in the devcontainer's `feature` object **relative to the folder containing the project's `devcontainer.json`**.
+
+Additional constraints exists when including local Features in a project:
+
+* The project must have a `.devcontainer/` folder at the root of the [**project workspace folder**](/docs/specs/devcontainer-reference.md#project-workspace-folder).
+
+* A local Feature's source code **must** be contained within a sub-folder of the `.devcontainer/ folder`.
+
+* The sub-folder name **must** match the Feature's `id` field.
+
+* A local Feature may **not** be referenced by absolute path.
+
+* The local Feature's sub-folder **must** contain at least a `devcontainer-feature.json` file and `install.sh` entrypoint script, mirroring the [previously outlined file structure](#Source-code).
+
+The relative path is provided using unix-style path syntax (e.g. `./myFeature`) regardless of the host operating system.
+
+An example project is illustrated below:
+
+```
+.
+├── .devcontainer/
+│   ├── localFeatureA/
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── ...
+│   ├── localFeatureB/
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── ...
+│   ├── devcontainer.json
+```
+
+##### devcontainer.json
+```jsonc
+{
+        // ...
+        "features": {
+                "./localFeatureA": {},
+                "./localFeatureB": {}
+        }
+
+}
+```

--- a/conformance/spec/113500f4/devcontainer-features.md
+++ b/conformance/spec/113500f4/devcontainer-features.md
@@ -1,0 +1,552 @@
+# Dev Container Features reference
+
+**Development Container Features** are self-contained, shareable units of installation code and development container configuration. The name comes from the idea that referencing one of them allows you to quickly and easily add more tooling, runtime, or library "Features" into your development container for you or your collaborators to use.
+
+> **Note:** While Features may be installed on top of any base image, the implementation of a Feature might restrict it to a subset of possible base images.  
+> 
+> For example, some Features may be authored to work with a certain linux distro (e.g. debian-based images that use the `apt` package manager).
+
+Feature metadata is captured by a `devcontainer-feature.json` file in the root folder of the Feature.
+
+> **Tip:** This section covers details on the Features specification. If you are looking for summarized information on creating your own Features, see the [template](https://github.com/devcontainers/feature-template) and [core Features](https://github.com/devcontainers/features) repositories.
+
+## Folder structure 
+
+A Feature is a self contained entity in a folder with at least a `devcontainer-feature.json` and `install.sh` entrypoint script. Additional files are permitted and are packaged along side the required files.
+
+```
++-- feature
+|    +-- devcontainer-feature.json
+|    +-- install.sh
+|    +-- (other files)
+```
+
+## `devcontainer-feature.json` properties
+
+The `devcontainer-feature.json` file defines metadata about a given Feature.
+
+All properties are optional **except for `id`, `version`, and `name`**. 
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `id` | string | **Required**: Identifier of the Feature.  Must be unique in the context of the repository where the Feature exists and must match the name of the directory where the `devcontainer-feature.json` resides. ID should be provided lowercase. |
+| `version` | string | **Required**: The semantic version of the Feature (e.g. `1.0.0`). |
+| `name` | string | **Required**: A "human-friendly" display name for the Feature. |
+| `description` | string | Description of the Feature. |
+| `documentationURL` | string | Url that points to the documentation of the Feature. |
+| `licenseURL` | string | Url that points to the license of the Feature. |
+| `keywords` | array | List of strings relevant to a user that would search for this Feature. |
+| `options` | object | A map of options that will be passed as environment variables to the execution of the script. |
+| `containerEnv` | object | A set of name value pairs that sets or overrides environment variables. |
+| `privileged` | boolean | Sets [privileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) for the container (required by things like docker-in-docker) when the Feature is used. |
+| `init` | boolean | Adds the [tini init](https://github.com/krallin/tini) process to the container (`--init`) when the Feature is used. |
+| `capAdd` | array | Adds container [capabilities](https://docs.docker.com/engine/security/#linux-kernel-capabilities) when the Feature is used. |
+| `securityOpt` | array | Sets container security options like updating the [seccomp profile](https://docs.docker.com/engine/security/seccomp/) when the Feature is used. |
+| `entrypoint` | string | Set if the Feature requires an "entrypoint" script that should fire at container start up. |
+| `customizations` | object | Product specific properties, each namespace under `customizations` is treated as a separate set of properties. For each of this sets the object is parsed, values are replaced while arrays are set as a union. |
+| `dependsOn` | `object` | An object (\**)  of Feature dependencies that **must** be satisified before this Feature is installed. Elements follow the same semantics of the `features` object in `devcontainer.json`. [See *Installation Order* for further information](#installation-order).  |
+| `installsAfter` | array | Array of ID's of Features (omitting a version tag) that should execute before this one. Allows control for Feature authors on soft dependencies between different Features. [See *Installation Order* for further information](#installation-order). |
+| `legacyIds` | array | Array of old IDs used to publish this Feature. The property is useful for renaming a currently published Feature within a single namespace. |
+| `deprecated` | boolean | Indicates that the Feature is deprecated, and will not receive any further updates/support. This property is intended to be used by the supporting tools for highlighting Feature deprecation. |
+| `mounts` | object | Defaults to unset. Cross-orchestrator way to add additional mounts to a container. Each value is an object that accepts the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#mount). The Pre-defined [devcontainerId](./devcontainerjson-reference.md/#variables-in-devcontainerjson) variable may be referenced in the value. For example:<br />`"mounts": [{ "source": "dind-var-lib-docker", "target": "/var/lib/docker", "type": "volume" }]` |
+
+(**) The ID must refer to either a Feature (1) published to an OCI registry, (2) a Feature Tgz URI, or (3) a Feature in the local file tree. Deprecated Feature identifiers (i.e. GitHub Release) are not supported and the presence of this property may be considered a fatal error or ignored. For [local Features (i.e. during development)](https://containers.dev/implementors/features-distribution/#addendum-locally-referenced), you may also depend on other local Features by providing a relative path to the Feature, relative to folder containing the active `devcontainer.json`. This behavior of Features within this property again mirror the `features` object in `devcontainer.json`.
+
+### Lifecycle Hooks
+
+The following lifecycle hooks may be declared as properties of `devcontainer-feature.json`. 
+
+| Property | Type|
+| :--- | :--- |
+| `onCreateCommand` | [string, array, object](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties)|
+| `updateContentCommand` | [string, array, object](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties)|
+| `postCreateCommand` | [string, array, object](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties)|
+| `postStartCommand` | [string, array, object](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties) |
+| `postAttachCommand` | [string, array, object](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties) |
+
+#### Behavior
+
+Each property mirrors the behavior of the matching property in [`devcontainer.json`](/docs/specs/devcontainerjson-reference.md#Lifecycle-scripts), including the behavior that commands are executed from the context of the [project workspace folder](https://containers.dev/implementors/spec/#project-workspace-folder).
+
+For each lifecycle hook (in [Feature installation order](https://containers.dev/implementors/features/#installation-order)), each command contributed by a Feature is executed in sequence (blocking the next command from executing).   Commands provided by Features are always executed _before_ any user-provided lifecycle commands (i.e. in the `devcontainer.json`).
+
+If a Feature provides a given command with the [object syntax](/docs/specs/devcontainerjson-reference.md#formatting-string-vs-array-properties), all commands within that group are executed in parallel, but still blocking commands from subsequent Features and/or the `devcontainer.json`.
+
+> **Note:** These properties are stored within [image metadata](https://github.com/devcontainers/spec/blob/joshspicer/lifecycle_hook_feature_spec/docs/specs/devcontainer-reference.md#merge-logic).
+
+### The `options` property
+
+The options property is contains a map of option IDs and their related configuration settings. The ID becomes the name of the environment variable in all caps. See [option resolution](#option-resolution) for more details. For example:
+
+```json
+{
+  "options": {
+    "optionIdGoesHere": {
+      "type": "string",
+      "description": "Description of the option",
+      "proposals": ["value1", "value2"],
+      "default": "value1"
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `optionId` | string | ID of the option that is converted into an all-caps environment variable with the selected value in it. |
+| `optionId.type` | string | Type of the option. Valid types are currently: `boolean`, `string` |
+| `optionId.proposals` | array | A list of suggested string values. Free-form values **are** allowed. Omit when using `optionId.enum`. |
+| `optionId.enum` | array | A strict list of allowed string values. Free-form values are **not** allowed. Omit when using `optionId.proposals`. |
+| `optionId.default` | string or boolean | Default value for the option. |
+| `optionId.description` | string | Description for the option. |
+
+### User environment variables
+
+Feature scripts run as the `root` user and sometimes need to know which user account the dev container will be used with.
+
+`_REMOTE_USER` and `_CONTAINER_USER` environment variables are passed to the Features scripts with `_CONTAINER_USER` being the container's user and `_REMOTE_USER` being the configured `remoteUser`. If no `remoteUser` is configured, `_REMOTE_USER` is set to the same value as `_CONTAINER_USER`.
+
+Additionally, the home folders of the two users are passed to the Feature scripts as `_REMOTE_USER_HOME` and `_CONTAINER_USER_HOME` environment variables.
+
+The container user can be set with `containerUser` in the devcontainer.json and image metadata, `user` in the docker-compose.yml, `USER` in the Dockerfile, and can be passed down from the base image.
+
+### Dev Container ID
+
+An identifier will be referred to as `${devcontainerId}` in the `devcontainer.json` and the Feature metadata and that will be replaced with the dev container's id. It should only be used in parts of the configuration and metadata that is not used for building the image because that would otherwise prevent pre-building the image at a time when the dev container's id is not known yet. Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the Feature metadata are: `entrypoint`, `mounts`, `customizations`.
+
+Implementations can choose how to compute this identifier. They must ensure that it is unique among other dev containers on the same Docker host and that it is stable across rebuilds of dev containers. The identifier must only contain alphanumeric characters. We describe a way to do this below.
+
+#### Label-based Implementation 
+
+The following assumes that a dev container can be identified among other dev containers on the same Docker host by a set of labels on the container. Implementations may choose to follow this approach.
+
+The identifier is derived from the set of container labels uniquely identifying the dev container. It is up to the implementation to choose these labels. For example, if the dev container is based on a local folder, the label could be named `devcontainer.local_folder` and have the local folder's path as its value.
+
+For example, the [`ghcr.io/devcontainers/features/docker-in-docker` Feature](https://github.com/devcontainers/features/blob/main/src/docker-in-docker/devcontainer-feature.json) could use the dev container id with:
+
+```jsonc
+{
+    "id": "docker-in-docker",
+    "version": "1.0.4",
+    // ...
+    "mounts": [
+        {
+            "source": "dind-var-lib-docker-${devcontainerId}",
+            "target": "/var/lib/docker",
+            "type": "volume"
+        }
+    ]
+}
+```
+
+#### Label-based Computation
+
+- Input the labels as a JSON object with the object's keys being the label names and the object's values being the labels' values.
+	- To ensure implementations get to the same result, the object keys must be sorted and any optional whitespace outside of the keys and values must be removed.
+- Compute a SHA-256 hash from the UTF-8 encoded input string.
+- Use a base-32 encoded representation left-padded with '0' to 52 characters as the result.
+
+JavaScript implementation taking an object with the labels as argument and returning a string as the result:
+
+```js
+const crypto = require('crypto');
+function uniqueIdForLabels(idLabels) {
+	const stringInput = JSON.stringify(idLabels, Object.keys(idLabels).sort()); // sort properties
+	const bufferInput = Buffer.from(stringInput, 'utf-8');
+	const hash = crypto.createHash('sha256')
+		.update(bufferInput)
+		.digest();
+	const uniqueId = BigInt(`0x${hash.toString('hex')}`)
+		.toString(32)
+		.padStart(52, '0');
+	return uniqueId;
+}
+```
+
+## devcontainer.json properties
+
+Features are referenced in a user's [`devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) under the top level `features` object. 
+
+A user can specify an arbitrary number of Features. At build time, these Features will be installed in an order defined by a combination of the [installation order rules and implementation](#Installation-Order). 
+
+A single Feature is provided as a key/value pair, where the key is the Feature identifier, and the value is an object containing "options" (or empty for "default"). Each key in the Feature object must be unique.
+
+These options are sourced as environment variables at build-time, as specified in [Option Resolution](#Option-Resolution).
+
+Below is a valid `features` object provided as an example.
+```jsonc
+"features": {
+  "ghcr.io/user/repo/go": {},
+  "ghcr.io/user/repo1/go:1": {},
+  "ghcr.io/user/repo2/go:latest": {},
+  "https://github.com/user/repo/releases/devcontainer-feature-go.tgz": { 
+        "optionA": "value" 
+  },
+  "./myGoFeature": { 
+        "optionA": true,
+        "optionB": "hello",
+        "version" : "1.0.0"
+  }
+}
+```
+
+> **Note:** The `:latest` version annotation is added implicitly if omitted. To pin to a specific package version ([example](https://github.com/devcontainers/features/pkgs/container/features/go/versions)), append it to the end of the Feature.
+
+An option's value can be provided as either a `string` or `boolean`, and should match what is expected by the Feature in the `devcontainer-feature.json` file.
+
+As a shorthand, the value of a `feature` can be provided as a single string. This string is mapped to an option called `version`.  In the example below, both examples are equivalent. 
+
+```jsonc
+"features": {
+  "ghcr.io/owner/repo/go": "1.18"
+}
+```
+```jsonc
+"features": {
+  "ghcr.io/owner/repo/go": {
+    "version": "1.18"
+  }
+}
+```
+
+### Referencing a feature 
+
+The `id` format specified dictates how a supporting tool will locate and download a given Feature. `id` is one of the following:
+
+| Type | Description | Example |
+| :--- | :--- | :--- |
+| `<oci-registry>/<namespace>/<feature>[:<semantic-version>]` | Reference to feature in OCI registry(*) | `ghcr.io/user/repo/go` <br> `ghcr.io/user/repo/go:1` <br> `ghcr.io/user/repo/go:latest`|
+| `https://<uri-to-feature-tgz>` | Direct HTTPS URI to a tarball. | `https://github.com/user/repo/releases/devcontainer-feature-go.tgz` |
+| `./<path-to-feature-dir>`| A relative directory(**) to folder containing a devcontainer-feature.json. | `./myGoFeature` |
+
+Feature identifiers should be assumed to be case-insensitive and should be normalized to lowercase.
+
+(*) OCI registry must implement the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec).  Some implementors can be [found here](https://oras.land/implementors/).
+
+(**) The provided path is always relative to the folder containing the `devcontainer.json`.  Further requirements are outlined in the [Locally Referenced Addendum](./devcontainer-features-distribution.md#locally-referenced-features)
+
+## Versioning
+
+Each Feature is individually [versioned according to the semver specification](https://semver.org/).  The `version` property in the respective `devcontainer-feature.json` file is updated to increment the Feature's version.
+
+Tooling that handles releasing Features will not republish Features if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
+
+## Authoring
+
+Features can be authored in a number of languages, the most straightforward being bash scripts. If a Feature is authored in a different language information about it should be included in the metadata so that users can make an informed choice about it.
+
+Reference information about the application required to execute the Feature should be included in `devcontainer-feature.json` in the metadata section.
+
+Applications should default to `/bin/sh` for Features that do not include this information.
+
+If the Feature is included in a folder as part of the repository that contains `devcontainer.json`, no other steps are necessary.
+
+## Release
+
+_For information on distributing Features, see [devcontainer-features-distribution.md](./devcontainer-features-distribution.md)._
+
+## Execution
+
+### Invoking `install.sh`
+
+The `install.sh` script for each Feature should be executed as `root` during a container image build. This allows the script to add needed OS dependencies or settings that could not otherwise be modified. This also allows the script to switch into another user's context using the `su` command (e.g. `su ${USERNAME} -c "command-goes-here"`). In combination, this allows both root and non-root image modifications to occur even if `sudo` is not present in the base image for security reasons.
+
+To ensure that the appropriate shell is used, the execute bit should be set on `install.sh` and the file invoked directly (e.g. `chmod +x install.sh && ./install.sh`). 
+
+> **Note:** It is recommended that Feature authors write `install.sh` using a shell available by default in their supported distributions (e.g. `bash` in Debian/Ubuntu or Fedora, `sh` in Alpine). In the event a different shell is required (e.g. `fish`), `install.sh` can be used to boostrap by checking for the presence of the desired shell, installing it if needed, and then invoking a secondary script using the shell.
+>
+> The `install.sh` file can similarly be used to bootstrap something written in a compiled language like Go. Given the increasing likelihood that a Feature needs to work on both x86_64 and arm64-based devices (e.g. Apple Silicon Macs), `install.sh` can detect the current architecture (e.g. using something like `uname -m` or `dpkg --print-architecture`), and then invoke the right executable for that architecture.
+
+### Installation order
+
+By default, Features are installed on top of a base image in an order determined as optimal by the implementing tool.
+
+If any of the following properties are provided in the Feature's `devcontainer-feature.json`, or the user's `devcontainer.json`, the order indicated by these propert(ies) are respected.
+
+* The `dependsOn` property defined as a part of a Feature's `devcontainer-feature.json`.
+* The `installsAfter` property defined as part of a Feature's `devcontainer-feature.json`.
+* The `overrideFeatureInstallOrder` property in user's `devcontainer.json`. Allows users to control the order of execution of their Features.
+
+#### The `dependsOn` property
+
+The optional `dependsOn` property indicates a set of required, "hard" dependencies for a given Feature.  
+
+The `dependsOn` property is declared in a Feature's `devcontainer-feature.json` metadata file. Elements of this property mirror the semantics of the `features` object in `devcontainer.json`.  Therefore, all dependencies may provide the relevant options, or an empty object (e.g. `"bar:123": {}`) if the Feature's default options are sufficient.  Identical Features that provide different options are treated as _different_ Features (see [Feature equality](#definition-feature-equality) for more info).
+
+All Features indicated in the `dependsOn` property **must** be satisfied (a Feature [equal](#definition-feature-equality) to each dependency is present in the installation order) _before_ the given Feature is set to be installed.  If any of the Features indicated in the `dependsOn` property cannot be installed (e.g. due to circular dependency, failure to resolve the Feature, etc) the entire dev container creation should fail.
+
+The `dependsOn` property must be evaluated recursively.  Therefore, if a Feature dependency has its own `dependsOn` property, that Feature's dependencies must also be satisfied before the given Feature is installed.
+
+```json
+{
+    "name": "My Feature",
+    "id": "myFeature",
+    "version": "1.0.0",
+    "dependsOn": {
+        "foo:1": {
+            "flag": true
+        },
+        "bar:1.2.3": {},
+        "baz@sha256:a4cdc44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {},
+    }
+}
+```
+
+In the snippet above, `myfeature` MUST be installed after `foo`, `bar`, and `baz`.  If the Features provided via the `dependsOn` property declare their own dependencies, those must also be satisfied before the Feature is installed.
+
+#### The `installsAfter` Property
+
+The `installsAfter` property indicates a "soft dependency" that influences the installation order of Features that are already queued to be installed. The effective behavior of this property is the same as `dependsOn`, with the following differences:
+
+- `installsAfter` is **not** evaluated recursively.
+- `installsAfter` only influences the installation order of Features that are **already set to be installed**.  Any Feature not set to be installed after (1) resolving the `dependsOn` dependency tree or (2) indicated by the user's `devcontainer.json` should not be added to the installation list.
+- The Feature indicated by `installsAfter` can **not** provide options, nor are they able to be pinned to a specific version tag or digest.  Resolution to the canonical name should still be performed (e.g. if the Feature has been [renamed](#steps-to-rename-a-feature)).
+
+```
+{
+    "name": "My Feature",
+    "id": "myFeature",
+    "version": "1.0.0",
+    "installsAfter": [
+        "foo",
+        "bar"
+    ]
+}
+```
+
+In the snippet above, `myfeature` must be installed after `foo` and `bar` **if** the Feature is already queued to be installed. If `foo` and `bar` are not already queued to be installed, this dependency relationship should be ignored.
+
+#### The 'overrideFeatureInstallOrder' property
+
+The `overrideFeatureInstallOrder` property of `devcontainer.json` is an array of Feature IDs that are to be installed in descending priority order as soon as its dependencies outlined above are installed.
+
+> This property may not indicate an installation order that is inconsistent with the resolved dependency graph (see [dependency algorithm](#dependency-installation-order-algorithm)).  If the `overrideFeatureInstallOrder` property is inconsistent with the dependency graph, the implementing tool should fail the dependency resolution step.
+
+This evaluation is performed by assigning a [`roundPriority`](#2-assigning-round-priority) to all nodes that match the Feature identifier (version omitted) present in the property. 
+
+For example, given `n` Features in the `overrideFeatureInstallOrder` array, the orchestrating tool should assign a `roundPriority` of `n - idx` to each Feature, where `idx` is the zero-based index of the Feature in the array.
+
+For example:
+
+```javascript
+overrideFeatureInstallOrder = [
+  "foo",
+  "bar",
+  "baz"
+]
+```
+
+would result in the following `roundPriority` assignments:
+
+```javascript
+const roundPriority = {
+  "foo": 3,
+  "bar": 2,
+  "baz": 1
+}
+```
+
+This property must not influence the dependency relationship as defined by the dependency graph (see [dependency graph](#1-build-a-dependency-graph)) and shall only be evaulated at the round-based sorting step (see [round sort](#3-round-based-sorting)).  Put another way, this property cannot "pull forward" a Feature until all of its dependencies (both soft and hard) have been installed. After a Feature's dependencies have been installed in other rounds, this property should "pull forward" each Feature as early as possible (given the order of identifiers in the array).
+
+Similar to `installsAfter`, this property's members may not provide options, nor are they able to be pinned to a specific version tag or digest.
+
+If a Feature is indicated in `overrideFeatureInstallOrder` but not a member of the dependency graph (i.e. it is not queued to be installed), the orchestrating tool may fail the dependency resolution step.
+
+> ## Definitions
+> ### Definition: Feature Equality
+>
+> This specification defines two Features as equal if both Features point to the same exact contents and are executed with the same options.
+> 
+> **For Features published to an OCI registry**, two Feature are identical if their manifest digests are equal, and the options executed against the Feature are equal (compared value by value).  Identical manifest digests implies that the tgz  contents of the Feature and its entire `devcontainer-feature.json` are identical.  If any of these conditions are not met,  the Features are considered not equal.
+> 
+> **For Features fetched by HTTPS URI**, two Features are identical if the contents of the tgz are identical (hash to the same value), and the options executed against the Feature are equal (compared value by value).  If any of these conditions  are not met, the Features are considered not equal.
+> 
+> **For local Features**, each Feature is considered unique and not equal to any other local Feature.
+> 
+> ### Definition: Round Stable Sort
+> 
+> To prevent non-deterministic behavior, the algorithm will sort each **round** according to the following rules:
+> 
+> - Compare and sort each Feature lexiographically by their fully qualified resource name (For OCI-published Features, that  means the ID without version or digest.).  If the comparison is equal:
+> - Compare and sort each Feature from oldest to newest tag (`latest` being the "most new").  If the comparision is equal:
+> - Compare and sort each Feature by their options by:
+>   - Greatest number of user-defined options (note omitting an option will default that value to the Feature's default value  and is not considered a user-defined option). If the comparison is equal:
+>   - Sort the provided option keys lexicographically.  If the comparison is equal:
+>   - Sort the provided option values lexicographically. If the comparision is equal:
+> - Sort Features by their canonical name (For OCI-published Features, the Feature ID resolved to the digest hash).
+> 
+> If there is no difference based on these comparator rules, the Features are considered equal.
+>
+> 
+
+> ## Dependency installation order algorithm
+>
+> An implementing tool is responsible for calculating the Feature installation order (or providing an error if no valid installation order can be resolved). The set of Features to be installed is the union of user-defined Features (those directly indicated in the user's `devcontainer.json` and their dependencies (those indicated by the `dependsOn` or `installsAfter` property, taking into account the user dev container's `overrideFeatureInstallOrder` property).  The implmenting tool will perform the following steps:
+> ### (1) Build a dependency graph
+> 
+> From the user-defined Features, the orchestrating tool will build a dependency graph.  The graph will be built by traversing the `dependsOn` and `installsAfter` properties of each Feature.  The metadata for each dependency is then fetched and the node added as an edge to to the dependent Feature.  For `dependsOn`  dependencies, the dependency will be fed back into the worklist to be recursively resolved. 
+> 
+> An accumulator is maintained with all uniquely discovered and user-provided Features, each with a reference to its dependencies.  If the exact Feature (see **Feature Equality**) has already been added to the accumulator, it will not be added again.  The accumulator will be fed into (B3) after the Feature tree has  been resolved.
+> 
+> The graph may be stored as an adjacency list with two kinds of edges (1) `dependsOn` edges or "hard dependencies" and (2) `installsAfter` edges or "soft dependencies".
+> 
+> ### (2) Assigning round priority
+> 
+> Each node in the graph has an implicit, default `roundPriority` of 0.
+> 
+> To influence installation order globally while still honoring the dependency graph of built in **(1)**, `roundPriority` values may be tweaks for each Feature.  When each round is calculated in **(3)**, only the Features equal to the max `roundPriority` of that set will be committed (the remaining will be uncommitted and reevaulated in subsequent rounds).
+> 
+> The `roundPriority` is set to a non-zero value in the following instances:
+> 
+> - If the [`devcontainer.json` contains an `overrideFeatureInstallOrder`](#the-overridefeatureinstallorder-property).
+> 
+> ### (3) Round-based sorting
+> 
+> Perform a sort on the result of **(1)** in rounds. This sort will rearrange Features, producing a sorted list of Features to install.  The sort will be performed as follows: 
+> 
+> Start with all the elements from **(2)** in a `worklist` and an empty list `installationOrder`.  While the `worklist` is not empty, iterate through each element in the `worklist` and check if all its dependencies (if any) are already members of `installationOrder`.  If the check is true, add it to an intermediate  list `round` If not, skip it.  Equality is determined in **Feature Equality**.
+> 
+> Then for each intermediate `round` list, commit to `installationOrder` only those nodes who share the maximum `roundPriority`.  Return all nodes in `round` with a strictly lower `roundPriority` to the `worklist` to be reprocessed in subsequent iterations.  If there are multiple nodes with the same `roundPriority`,  commit them to `installationOrder` with a final sort according to **Round Stable Sort**.
+> 
+> Repeat for as many rounds as necessary until `worklist` is empty.  If there is ever a round where no elements are added to `installationOrder`, the algorithm should terminate and return an error.  This indicates a circular dependency or other fatal error in the dependency graph.  Implementations should attempt to  provide the user with information about the error and possible mitigation strategies.
+>
+> ### Notes
+>
+> From an implementation point of view, `installsAfter` nodes may be added as a separate set of directed edges, just as `dependsOn` nodes are added as directed edges (see **(1)**).  Before round-based installation and sorting **(3)**, an orchestrating tool should remove all `installsAfter` directed edges that do not correspond with a Feature in the `worklist` that is set to be installed.  In each round, a Feature can then be installed if all its requirements (both `dependsOn` and `installsAfter` dependencies) have been fulfilled in previous rounds.
+> 
+> An implemention should fail the dependency resolution step if the evaluation of the `installsAfter` property results in an inconsistent state (e.g. a circular dependency).
+>
+
+
+### Option Resolution
+
+A Feature's 'options' - specified as the value of a single Feature key/value pair in the user's `devcontainer.json` - are passed to the Feature as environment variables.
+
+A supporting tool will parse the `options` object provided by the user.  If a value is provided for a Feature, it will be emitted to a file named `devcontainer-features.env` following the format `<OPTION_NAME>=<value>`.  
+
+To ensure a option that is valid as an environment variable, the follow substitutions are performed.
+
+```javascript
+(str: string) => str
+	.replace(/[^\w_]/g, '_')
+	.replace(/^[\d_]+/g, '_')
+	.toUpperCase();
+```
+
+This file is sourced at build-time for the Feature `install.sh` entrypoint script to handle.
+
+Any options defined by a Feature's `devcontainer-feature.json` that are omitted in the user's `devcontainer.json` will be implicitly exported as its default value.
+
+### Option resolution example
+
+Suppose a `python` Feature has the following `options` parameters declared in the `devcontainer-feature.json` file:
+
+```jsonc
+// ...
+"options": {
+    "version": {
+        "type": "string",
+        "enum": ["latest", "3.10", "3.9", "3.8", "3.7", "3.6"],
+        "default": "latest",
+        "description": "Select a Python version to install."
+    },
+    "pip": {
+        "type": "boolean",
+        "default": true,
+        "description": "Installs pip"
+    },
+    "optimize": {
+        "type": "boolean",
+        "default": true,
+        "description": "Optimize python installation"
+    }
+}
+```
+
+The user's `devcontainer.json` declared the python Feature like so
+
+```jsonc
+
+"features": {
+    "ghcr.io/devcontainers/features/python:1": {
+        "version": "3.10",
+        "pip": false
+    }
+}
+```
+The emitted environment variables will be:
+
+```env
+VERSION="3.10"
+PIP="false"
+OPTIMIZE="true"
+```
+
+These will be sourced and visible to the `install.sh` entrypoint script.  The following `install.sh`...
+
+
+```bash
+#!/usr/bin/env bash
+
+echo "Version is $VERSION"
+echo "Pip? $PIP"
+echo "Optimize? $OPTIMIZE"
+```
+
+... outputs the following:
+```
+Version is 3.10
+Pip? false
+Optimize? true
+```
+
+### Steps to rename a Feature
+
+1. Update the Feature [source code](./devcontainer-features-distribution.md#source-code) folder and the `id` property in the [devcontainer-feature.json properties](#devcontainer-featurejson-properties) to reflect the new `id`. Other properties (`name`, `documentationUrl`, etc.) can optionally be updated during this step.
+2. Add or update the `legacyIds` property to the Feature, including the previously used `id`.
+3. Bump the semantic version of the Feature.  
+4. Rerun the `devcontainer features publish` command, or equivalent tool that implements the [Features distribution specification](./features-distribution/#distribution).
+
+#### Example: Renaming a Feature
+
+Let's say we currently have a `docker-from-docker` Feature 👇 
+
+Current `devcontainer-feature.json` : 
+
+```jsonc
+{
+    "id": "docker-from-docker",
+    "version": "2.0.1",
+    "name": "Docker (Docker-from-Docker)",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-from-docker",
+    ....
+}
+```
+
+We'd want to rename this Feature to `docker-outside-of-docker`. The source code folder of the Feature will be updated to `docker-outside-of-docker` and the updated `devcontainer-feature.json` will look like 👇 
+
+```jsonc
+{
+    "id": "docker-outside-of-docker",
+    "version": "2.0.2",
+    "name": "Docker (Docker-outside-of-Docker)",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
+    "legacyIds": [
+        "docker-from-docker"
+    ]
+    ....
+}
+```
+
+**Note** - The semantic version of the Feature defined by the `version` property should be **continued** and should not be restarted at `1.0.0`.
+
+### Implementation notes
+
+There are several things to keep in mind for an application that implements Features:
+
+- The order of execution of Features is determined by the application, based on the `installsAfter` property used by feature authors. It can be overridden by users if necessary with the `overrideFeatureInstallOrder` in `devcontainer.json`.
+- Features are used to create an image that can be used to create a container or not.
+- Parameters like `privileged`, `init` are included if just 1 Feature requires them.
+- Parameters like `capAdd`, `securityOp`  are concatenated.
+- `containerEnv` is added before the Feature is executed as `ENV` commands in the Dockerfile.
+- Each Feature script executes as its own layer to aid in caching and rebuilding.

--- a/conformance/spec/113500f4/devcontainer-id-variable.md
+++ b/conformance/spec/113500f4/devcontainer-id-variable.md
@@ -1,0 +1,68 @@
+# Dev Container ID
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/62
+* CLI PR: https://github.com/devcontainers/cli/pull/242
+
+Below is the original proposal.
+
+## Goal
+
+Allow features to refer to an identifier that is unique to the dev container they are installed into and that is stable across rebuilds.
+
+E.g., the `docker-in-docker` feature needs a way to mount a volume per dev container.
+
+## Proposal
+
+The identifier will be referred to as `${devcontainerId}` in the devcontainer.json and the feature metadata and that will be replaced with the dev container's id. It should only be used in parts of the configuration and metadata that is not used for building the image because that would otherwise prevent pre-building the image at a time when the dev container's id is not known yet. Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the devcontainer.json are: `name`, `runArgs`, `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `workspaceFolder`, `workspaceMount`, `mounts`, `containerEnv`, `remoteEnv`, `containerUser`, `remoteUser`, `customizations`. Excluding boolean, numbers and enum properties the properties supporting `${devcontainerId}` in the feature metadata are: `entrypoint`, `mounts`, `customizations`.
+
+Implementations can choose how to compute this identifier. They must ensure that it is unique among other dev containers on the same Docker host and that it is stable across rebuilds of dev containers. The identifier must only contain alphanumeric characters. We describe a way to do this below.
+
+### Label-based Implementation 
+
+The following assumes that a dev container can be identified among other dev containers on the same Docker host by a set of labels on the container. Implementations may choose to follow this approach.
+
+The identifier is derived from the set of container labels uniquely identifying the dev container. It is up to the implementation to choose these labels. For example, if the dev container is based on a local folder, the label could be named `devcontainer.local_folder` and have the local folder's path as its value.
+
+For example, the [`ghcr.io/devcontainers/features/docker-in-docker` feature](https://github.com/devcontainers/features/blob/main/src/docker-in-docker/devcontainer-feature.json) could use the dev container id with:
+
+```jsonc
+{
+    "id": "docker-in-docker",
+    "version": "1.0.4",
+    // ...
+    "mounts": [
+        {
+            "source": "dind-var-lib-docker-${devcontainerId}",
+            "target": "/var/lib/docker",
+            "type": "volume"
+        }
+    ]
+}
+```
+
+### Label-based Computation
+
+- Input the labels as a JSON object with the object's keys being the label names and the object's values being the labels' values.
+	- To ensure implementations get to the same result, the object keys must be sorted and any optional whitespace outside of the keys and values must be removed.
+- Compute a SHA-256 hash from the UTF-8 encoded input string.
+- Use a base-32 encoded representation left-padded with '0' to 52 characters as the result.
+
+JavaScript implementation taking an object with the labels as argument and returning a string as the result:
+```js
+const crypto = require('crypto');
+
+function uniqueIdForLabels(idLabels) {
+	const stringInput = JSON.stringify(idLabels, Object.keys(idLabels).sort()); // sort properties
+	const bufferInput = Buffer.from(stringInput, 'utf-8');
+
+	const hash = crypto.createHash('sha256')
+		.update(bufferInput)
+		.digest();
+
+	const uniqueId = BigInt(`0x${hash.toString('hex')}`)
+		.toString(32)
+		.padStart(52, '0');
+	return uniqueId;
+}
+```

--- a/conformance/spec/113500f4/devcontainer-lockfile.md
+++ b/conformance/spec/113500f4/devcontainer-lockfile.md
@@ -1,0 +1,75 @@
+# Lockfiles
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/236
+* CLI PR: https://github.com/devcontainers/cli/issues/564
+
+Below is the original proposal.
+
+## Goal
+
+Introduce a lockfile that records the exact version, download information and checksums for each feature listed in the devcontainer.json.
+
+This will allow for:
+- Improved reproducibility of image builds (installing "latest" of a tool will still have different outcomes as the tool publishes new releases).
+- Improved cachability of image builds (image cache checksums will remain stable when the lockfile pins a feature to a particular version).
+- Improved security by detecting when a feature's release artifact changes after its checksum was first recorded in the lockfile ("trust on first use").
+
+## Proposal
+
+(The following is inspired by NPM's `package-lock.json` and Yarn's `yarn.lock`.)
+
+Each feature is recorded with the identifier and version it is referred to in the devcontainer.json as its key and the following properties as its values:
+- `resolved`:
+    - OCI feature: A qualified feature id with the sha256 hash (not the version number).
+    - tarball feature: The `https:` URL used to download the feature.
+- `version`: The full version number.
+- `integrity`: `sha256:` followed by the hex encoded SHA-256 checksum of the download artifact.
+- `dependsOn`: An array of feature identifiers equal to the feature's `dependsOn` keys in its `devcontainer-feature.json` including any version or checksum suffix. If the array is empty, this property can be omitted. For every feature listed here, the lockfile will also have a feature record.
+
+The feature identifiers recorded as keys and in the `dependsOn` arrays are converted to lowercase to simplify lookups and comparisons. Note that the `devcontainer.json` and `devcontainer-features.json` may refer to the same features with different casing because these identifiers are not case-senstive.
+
+Local features and the deprecated GitHub releases features are not recorded in the lockfile.
+
+The lockfile is named `devcontainer-lock.json`, is located in the same folder as the `devcontainer.json` and contains a JSON object with a `"features"` property holding the above keys.
+
+Example:
+
+```jsonc
+{
+    "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "1.0.4",
+            "resolved": "ghcr.io/devcontainers/features/node@sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8",
+            "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+        },
+        "https://mycustomdomain.com/devcontainer-feature-myfeature.tgz": {
+            "version": "1.2.3",
+            "resolved": "https://mycustomdomain.com/devcontainer-feature-myfeature.tgz",
+            "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+        }
+    }
+}
+```
+
+Example with dependency:
+
+```jsonc
+{
+  "features": {
+    "ghcr.io/codspace/dependson/a": {
+      "version": "1.2.1",
+      "resolved": "ghcr.io/codspace/dependson/a@sha256:932027ef71da186210e6ceb3294c3459caaf6b548d2b547d5d26be3fc4b2264a",
+      "integrity": "sha256:932027ef71da186210e6ceb3294c3459caaf6b548d2b547d5d26be3fc4b2264a",
+      "dependsOn": [
+        "ghcr.io/codspace/dependson/e:2"
+      ]
+    },
+    "ghcr.io/codspace/dependson/e:2": {
+      "version": "2.3.4",
+      "resolved": "ghcr.io/codspace/dependson/e@sha256:9f36f159c70f8bebff57f341904b030733adb17ef12a5d58d4b3d89b2a6c7d5a",
+      "integrity": "sha256:9f36f159c70f8bebff57f341904b030733adb17ef12a5d58d4b3d89b2a6c7d5a"
+    }
+  }
+}
+```

--- a/conformance/spec/113500f4/devcontainer-reference.md
+++ b/conformance/spec/113500f4/devcontainer-reference.md
@@ -1,0 +1,286 @@
+# Dev Container Specification
+
+The purpose of the **Development Container Specification** is to provide a way to enrich containers with the content and metadata necessary to enable development inside them. These container **environments** should be easy to use, create, and recreate. 
+
+A **development container** is a container in which a user can develop an application.  Tools that want to implement this specification should provide a set of features/commands that give more flexibility to users and allow **development containers** to scale to large development groups.
+
+An **environment** is defined as a logical instance of one or more **development containers**, along with any needed side-car containers. An environment is based on one set of metadata that can be managed as a single unit. Users can create multiple **environments** from the same configuration metadata for different purposes.
+
+# Metadata
+
+Development containers allow one to define a repeatable development environment for a user or team of developers that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy. While deployment and development containers may resemble one another, you may not want to include tools in a deployment image that you use during development and you may need to use different secrets or other settings. 
+
+Furthermore, working inside a development container can require additional **metadata** to drive tooling or service experiences than you would normally need with a production container. Providing a structured and consistent form for this metadata is a core part of this specification.
+
+## devcontainer.json
+
+While the structure of this metadata is critical, it is also important to call out how this data can be represented on disk where appropriate. While other representations may be added over time, metadata can be stored in a JSON with Comments file called `devcontainer.json` today. Products using it should expect to find a `devcontainer.json` file in one or more of the following locations (in order of precedence):
+
+- .devcontainer/devcontainer.json
+- .devcontainer.json
+- .devcontainer/`<folder>`/devcontainer.json (where `<folder>` is a sub-folder, one level deep)
+
+It is valid that these files may exist in more than one location, so consider providing a mechanism for users to select one when appropriate.
+
+## Image Metadata
+
+Certain dev container metadata properties can be stored in an image label as an array of metadata snippets. This allows them to be stored in prebuilt images, such that, the image and its related configuration are self-contained. These contents should then be merged with any local `devcontainer.json` file contents at the time the container is created. An array is used so subsequent image builds can simply append changes to the array rather than attempting to merge at that point - which improves compatibility with arbitrary image build systems.
+
+Metadata should be representative of with the following structure, using one entry per [Dev Container Feature](../features) and `devcontainer.json` (see table below for the full list):
+
+```json
+[
+	{
+		"id"?: string,
+		"init"?: boolean,
+		"privileged"?: boolean,
+		"capAdd"?: string[],
+		"securityOpt"?: string[],
+		"entrypoint"?: string,
+		"mounts"?: [],
+		...
+		"customizations"?: {
+			...
+		}
+	},
+	...
+]
+```
+
+To simplify adding this metadata for other tools, we also support having a single top-level object with the same properties.
+
+The metadata is added to the image as a `devcontainer.metadata` label with a JSON string value representing the above array or single object.
+
+### Merge Logic
+
+To apply the metadata together with a user's `devcontainer.json` at runtime the following merge logic by property is used. The table also notes which properties are currently supported coming from the `devcontainer.json` and which from the Feature metadata, this will change over time as we add more properties.
+
+| Property | Type/Format | Merge Logic | devcontainer.json | devcontainer-feature.json |
+| -------- | ----------- | ----------- | :---------------: | :--------------: |
+| `id` | E.g., `ghcr.io/devcontainers/features/node:1` | Not merged. |   | ✓ |
+| `init` | `boolean` | `true` if at least one is `true`, `false` otherwise. | ✓ | ✓ |
+| `privileged` | `boolean` | `true` if at least one is `true`, `false` otherwise. | ✓ | ✓ |
+| `capAdd` | `string[]` | Union of all `capAdd` arrays without duplicates. | ✓ | ✓ |
+| `securityOpt` | `string[]` | Union of all `securityOpt` arrays without duplicates. | ✓ | ✓ |
+| `entrypoint` | `string` | Collected list of all entrypoints. |   | ✓ |
+| `mounts` | `(string \| { type, src, dst })[]` | Collected list of all mountpoints. Conflicts: Last source wins. | ✓ | ✓ |
+| `onCreateCommand` | `string \| string[] \| {[key: string]: string \| string[]}` | Collected list of all onCreateCommands. | ✓ | ✓ |
+| `updateContentCommand` | `string \| string[] \| {[key: string]: string \| string[]}` | Collected list of all updateContentCommands. | ✓ | ✓ |
+| `postCreateCommand` | `string \| string[] \| {[key: string]: string \| string[]}` | Collected list of all postCreateCommands. | ✓ | ✓ |
+| `postStartCommand` | `string \| string[] \| {[key: string]: string \| string[]}` | Collected list of all postStartCommands. | ✓ | ✓ |
+| `postAttachCommand` | `string \| string[] \| {[key: string]: string \| string[]}` | Collected list of all postAttachCommands. | ✓ | ✓ |
+| `waitFor` | enum | Last value wins. | ✓ |   |
+| `customizations` | Object of tool-specific customizations. | Merging is left to the tools. | ✓ | ✓ |
+| `containerUser` | `string` | Last value wins. | ✓ |   |
+| `remoteUser` | `string` | Last value wins. | ✓ |   |
+| `userEnvProbe` | `string` (enum) | Last value wins. | ✓ |   |
+| `remoteEnv` | Object of strings. | Per variable, last value wins. | ✓ |   |
+| `containerEnv` | Object of strings. | Per variable, last value wins. | ✓ |   |
+| `overrideCommand` | `boolean` | Last value wins. | ✓ |   |
+| `portsAttributes` | Map of ports to attributes. | Per port (not per port attribute), last value wins. | ✓ |   |
+| `otherPortsAttributes` | Port attributes. | Last value wins (not per port attribute). | ✓ |   |
+| `forwardPorts` | `(number \| string)[]` | Union of all ports without duplicates. Last one wins (when mapping changes). | ✓ |   |
+| `shutdownAction` | `string` (enum) | Last value wins. | ✓ |   |
+| `updateRemoteUserUID` | `boolean` | Last value wins. | ✓ |   |
+| `hostRequirements` | `cpus`, `memory`, `storage`, `gpu` | Max value wins. | ✓ |   |
+
+Variables in string values will be substituted at the time the value is applied. When the order matters, the `devcontainer.json` is considered last.
+
+### Notes
+
+- Passing the label as a `LABEL` instruction in the Dockerfile:
+	- The size limit on Dockerfiles is around 1.3MB. The line length is limited to 65k characters.
+	- Using one line per Feature should allow for making full use of these limits.
+- Passing the label as a command line argument:
+	- There is no size limit documented for labels, but the daemon returns an error when the request header is >500kb.
+	- The 500kb limit is shared, so we cannot use a second label in the same build to avoid it.
+	- If/when this becomes an issue we could embed the metadata as a file in the image (e.g. with a label indicating it).
+
+# Orchestration options
+
+A core principle of this specification is to seek to enrich existing container orchestrator formats with development container metadata where appropriate rather than replacing them. As a result, the metadata schema includes a set of optional properties for interoperating with different orchestrators. Today, the specification includes scenario-specific properties for working without a container orchestrator (by directly referencing an image or Dockerfile) and for using Docker Compose as a simple multi-container orchestrator. At the same time, this specification leaves space for further development and implementation of other orchestrator mechanisms and file formats. 
+
+The following section describes the differences between those that are supported now. 
+
+## Image based
+
+Image based configurations only reference an image that should be reachable and downloadable through `docker pull` commands. Logins and tokens required for these operations are execution environment specific. The only required parameter is `image`. The details are [here](devcontainerjson-reference.md#image-or-dockerfile-specific-properties).
+
+## Dockerfile based
+
+These configurations are defined as using a `Dockerfile` to define the starting point of the development containers. As with image based configurations, it is assumed that any base images are already reachable by **Docker** when performing a `docker build` command. The only required parameter in this case is the relative reference to the `Dockerfile` in `build.dockerfile`. The details are [here](devcontainerjson-reference.md#image-or-dockerfile-specific-properties).
+
+There are multiple properties that allow users to control how `docker build` works:
+
+- `build.context` 
+- `build.args`
+- `build.options`
+- `build.target`
+- `build.cacheFrom`
+
+## Docker Compose based
+
+Docker Compose configurations use `docker-compose` (which may be Docker Compose V1 or aliased Docker Compose V2) to create and manage a set of containers required for an application. As with the other configurations, any images required for this operation are assumed to be reachable. The required parameters are:
+
+- `dockerComposeFile`: the reference to the Docker Compose file(s) to be used.
+- `service`: declares the **main** container that will be used for all other operations. Tools are assumed to also use this parameter to connect to the development container, although they can provide facilities to connect to the other containers as required by the user.
+- `runServices`: an optional property that indicates the set of services in the `docker-compose` configuration that should be started or stopped with the environment.
+
+It is important to note that `image` and `dockerfile` properties are not needed since Docker Compose supports them natively in the format. 
+
+# Other options
+
+In addition to the configuration options explained above, there are other settings that apply when creating development containers to facilitate their use by developers. 
+
+A complete list of available metadata properties and their purposes can be found in the [`devcontainer.json` reference](devcontainerjson-reference.md). However, we will describe the critical ones below in more detail.
+
+## Environment Variables
+
+Environment variables can be set at different points in the dev container lifecycle. With this in mind, **development containers** support two classes of environment variables:
+
+* **Container**: These variables are part of the container when it is created and are available at all points in its lifecycle. This concept is native to containers and can be set in the container image itself, using `containerEnv` for **image** and **Dockerfile** scenarios or using orchestrator specific properties like `env` in **Docker Compose** files.
+* **Remote**: These variables should be set by a **development container** supporting tool as part of configuring its runtime environment. Users can set these using the `remoteEnv` property and implementing tools or services may add their own for specific scenarios (e.g. secrets). These variables can change during the lifetime of the container, and are added after the container's `ENTRYPOINT` has fired.
+
+The reason for this separation is it allows for the use of information not available at image build time and simplifies updating the environment for project/repository specific needs without modifying an image. With this in mind, it's important to note that implementing tools should also support the [dynamic variable syntax](devcontainerjson-reference.md#variables-in-devcontainerjson) described in the metadata reference document.
+
+Another notable and important environment variable related property is **`userEnvProbe`**. Implementing tools should use this property to "probe" for expected environment variables using the specified type of shell. However, it does not specify that this type of shell needs to be used for all sub-processes (given the performance impact). Instead, "probed" environment variables should be merged with Remote environment variables for any processes the implementer injects after the container is created. This allows implementors to emulate developer expected behaviors around values added to their profile and rc files. 
+
+## Mounts
+
+Mounts allow containers to have access to the underlying machine, share data between containers and to persist information between development containers. 
+
+A default mount should be included so that the source code is accessible from inside the container. Source code is stored outside of the container so that a developer's in-flight edits can be extracted, or a new container created in the event a container no longer starts.
+
+While this "workspace mount" is often a "bind" mount, this is not a requirement of this specification. It is also important to note that these mounts may be "bind" mounts that connect to the underlying filesystem and thus cloud environments might not have access to the same data as a local machine.
+
+Inside the container this mount defaults to `/workspace`.
+
+## workspaceFolder and workspaceMount
+
+The default mount point for the source code can be set with the `workspaceMount` property for **image** and **dockerfile** scenarios or using the built in `mounts` property in **Docker Compose** files. This folder should point to the root of a repository (where the `.git` folder is found) so that source control operations work correctly inside the container.
+
+The `workspaceFolder` can then be set to the default folder inside the container that should used in the container. Typically this is either the mount point in the container, or a sub-folder under it. Allowing a sub-folder to be used is particularly important for monorepos given you need the `.git` folder to interact with source control but developers are typically interacting with a specific sub-project within the overall repository. 
+
+See [`workspaceMount` and `workspaceFolder`](devcontainerjson-reference.md#image-or-dockerfile-specific-properties) for reference.
+
+## Users
+
+Users control the permissions of applications executed in the containers, allowing the developer to control them. The specification takes into account two types of user definitions:
+
+* **Container User**: The user that will be used for all operations that run inside a container. This concept is native to containers. It may be set in the container image, using the `containerUser` property for  **image** and **dockerfile** scenarios, or using an orchestratric specific property like `user` property in Docker Compose files.
+* **Remote User**: Used to run the [lifecycle](#lifecycle) scripts inside the container. This is also the user tools and editors that connect to the container should use to run their processes. This concept is not native to containers. Set using the `remoteUser` property in all cases and defaults to the container user.
+
+This separation allows the ENTRYPOINT for the image to execute with different permissions than the developer and allows for developers to switch users without recreating their containers.
+
+# Lifecycle
+
+A development environment goes through different lifecycle events during its use in the outer and inner loop of development.
+
+- Configuration Validation
+- Environment Creation
+- Environment Stop
+- Environment Resume
+
+## Configuration Validation
+
+The exact steps required to validate configuration can vary based on exactly where the development container metadata is persisted. However, when considering a `devcontainer.json` file, the following validation should occur:
+
+1. Validate that a workspace source folder has been provided. It is up to the implementing tool to determine what to do if no source folder is provided.
+2. Search for a `devcontainer.json` file in one of the locations [above](#devcontainerjson) in the workspace source folder. 
+3. If no `devcontainer.json` is found, it is up to the implementing tool or service to determine what to do. This specification does not dictate this behavior.
+4. Validate that the metadata (for example `devcontainer.json`) contains all parameters required for the selected configuration type.
+
+## Environment Creation
+
+The creation process goes through the steps necesarry to go from the user configuration to a working **environment** that is ready to be used.
+
+### Initialization
+
+During this step, the following is executed:
+- Validate access to the container orchestrator specified by the configuration.
+- Execution of `initializeCommand`.
+
+### Image creation
+
+The first part of environment creation is generating the final image(s) that the development containers are going to use. This step is orchestrator dependent and can consist of just pulling a Docker image, running Docker build, or docker-compose build. Additionally, this step is useful on its own since it permits the creation of intermediate images that can be uploaded and used by other users, thus cutting down on creation time. It is encouraged that tools implementing this specification give access to a command that just executes this step.
+
+This step executes the following tasks:
+
+1. [Configuration Validation](#configuration-validation) 
+2. Pull/build/execute of the defined container orchestration format to create images.
+3. Validate the result of these operations.
+
+### Container Creation
+
+After image creation, containers are created based on that image and setup.
+
+This step executes the following tasks:
+
+1. [Optional] Perform any required user UID/GID sync'ing (more next)
+2. Create the container(s) based on the properties specified above.
+3. Validate the container(s) were created successfully.
+
+Note that container [mounts](#mounts), [environment variables](#environment-variables), and [user](#users) configuration should be applied at this point. However, remote user and environment variable configuration should **not** be.
+
+UID/GID sync'ing is an optional task for Linux (only) and that executes if the `updateRemoteUserUID` property is set to true and a `containerUser` or `remoteUser` is specified. In this case, an image update should be made prior to creating the container to set the specified user's UID and GID to match the current local user’s UID/GID to avoid permission problems with bind mounts. Implementations **may** skip this task if they do not use bind mounts on Linux, or use a container engine that does this translation automatically.
+
+### Post Container Creation
+
+At the end of the container creation step, a set of commands are executed inside the **main** container: 
+- `onCreateCommand`, `updateContentCommand` and `postCreateCommand`. This set of commands is executed in sequence on a container the first time it's created and depending on the creation parameters received. You can learn more in the [documentation on lifecycle scripts](devcontainerjson-reference.md#lifecycle-scripts). By default, `postCreateCommand` is executed in the background after reporting the successful creation of the development environment.
+- If the `waitFor` property is defined, then execution should block until all commands in the sequence up to the specified property have executed. This property defaults to `updateContentCommand`.
+
+Remote [environment variables](#environment-variables) and [user](#users) configuration should be applied to all created processes in the container (inclusive of `userEnvProbe`).
+
+### Implementation specific steps
+
+After these steps have been executed, any implementation specific commands can safely execute. Specifically, any processes required by the implementation to support other properties in this specification should be started at this point. These may occur in parallel to any non-blocking, background post-container creation commands (as dictated by the `waitFor` property).
+
+Any user facing processes should have remote [environment variables](#environment-variables) and [user](#users) configuration applied (inclusive of `userEnvProbe`).
+
+For example, in the [CLI reference implementation](https://github.com/devcontainers/cli), this is the point in which anything executed with `devcontainer exec` would run.
+
+Typically, this is also the step where implementors would apply config or settings from the `customizations` section of the dev container metadata (e.g. VS Code installs extensions based on the `customizations.vscode.extensions` property). Examples of these can be found in the [supporting tools section](supporting-tools.md) reference. However, applying these at this point is not strictly required or mandated by this specification.
+
+Once these final steps have occurred, implementing tools or services may connect to the environment as they see fit.
+
+## Environment Stop
+
+The intention of this step is to ensure all containers are stopped correctly based on the appropriate orchestrator specific steps to ensure no data is lost. It is up to the implementing tool or service to determine when this event should happen.
+
+## Environment Resume
+
+While it is not a strict requirement to keep a **development container** after it has been stopped, this is the most common scenario.
+
+To resume the environment from a stopped state:
+
+1. Restart all related containers.
+2. Follow the appropriate [implementation specific steps](#implementation-specific-steps).
+3. Additionally, execute the `postStartCommand` and `postAttachCommand` in the container.
+
+Like during the create process, remote [environment variables](#environment-variables) and [user](#users) configuration should be applied to all created processes in the container (inclusive of `userEnvProbe`).
+
+## Parallel lifecycle script execution </a>
+
+Dev containers support a single command for each of its lifecycle scripts. While serial execution of multiple commands can be achieved with `;`, `&&`, etc., parallel execution deserves first-class support.
+
+All lifecycle scripts have been extended to support `object` types. The key of the `object` will be a unique name for the command and the value will be the `string` or `array` command. Each command must exit successfully for the stage to be considered successful.
+
+Each entry in the `object` will be run in parallel during that lifecycle step.
+
+### Example
+
+```json
+{
+  "postCreateCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```
+
+# Definitions
+
+#### **Project Workspace Folder**
+
+The **project workspace folder** is where an implementing tool should begin to search for `devcontainer.json` files. If the target project on disk is using git, the **project workspace folder** is typically the root of the git repository. 

--- a/conformance/spec/113500f4/devcontainer-templates-distribution.md
+++ b/conformance/spec/113500f4/devcontainer-templates-distribution.md
@@ -1,0 +1,129 @@
+# Distribution and Discovery of Dev Container Templates
+
+**TL;DR Check out the [quick start repository](https://github.com/devcontainers/template-starter) to get started on distributing your own Dev Container Templates.**
+
+This specification defines a pattern where community members and organizations can author and self-publish [Dev Container Templates](./devcontainer-templates.md). 
+
+Goals include:
+
+- For Template authors, create a "self-service" way to publish a Template, either publicly or privately, that is not centrally controlled.
+- Provide the ability to standardize publishing such that supporting tools may implement their own mechanism to aid Template discoverability as they see fit.
+
+## Source code
+
+A Template's source code is stored in a git repository.
+
+For ease of authorship and maintenance, [1..n] Templates can share a single git repository. This set of Templates is referred to as a "collection," and will share the same [`devcontainer-collection.json`](#devcontainer-collection.json) file and "namespace" (eg. `<owner>/<repo>`).
+
+> **Note:** Templates and [Features](./devcontainer-features.md) should be placed in different git repositories. 
+
+Source code for a set of Templates follows the example file structure below:
+
+```
+.
+├── README.md
+├── src
+│   ├── dotnet
+│   │   ├── devcontainer-template.json
+│   │   ├── .devcontainer
+│   │       ├── devcontainer.json
+│   │       └── ...
+│   │   ├── ...
+|   ├
+│   ├── docker-from-docker
+│   │   ├── devcontainer-template.json
+│   │   ├── .devcontainer
+│   │       ├── devcontainer.json
+│   │       ├── Dockerfile
+│   │       └── ...
+│   │   ├── ...
+|   ├
+│   ├── go-postgres
+│   │   ├── devcontainer-template.json
+│   │   ├── .devcontainer
+│   │       ├── devcontainer.json
+│   │       ├── docker-compose.yml
+│   │       ├── Dockerfile
+│   │       └── ...
+│   │   ├── ...
+```
+
+...where `src` is a directory containing a sub-folder with the name of the Template (e.g. `src/dotnet` or `src/docker-from-docker`) with at least a file named `devcontainer-template.json` that contains the Template metadata, and a `.devcontainer/devcontainer.json` that the supporting tools will drop into an existing project or folder.
+
+Each sub-directory should be named such that it matches the `id` field of the `devcontainer-template.json`.  Other files can also be included in the Templates's sub-directory, and will be included during the [packaging step](#packaging) alongside the two required files.  Any files that are not part of the Templates's sub-directory (e.g. outside of `src/dotnet`) will not be included in the [packaging step](#packaging).
+
+## Versioning
+
+Each Template is individually [versioned according to the semver specification](https://semver.org/). The `version` property in the respective `devcontainer-template.json` file is parsed to determine if the Template should be republished.
+
+Tooling that handles publishing Templates will not republish Templates if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
+
+## Packaging
+
+Templates are distributed as tarballs. The tarball contains the entire contents of the Template sub-directory, including the `devcontainer-template.json`, `.devcontainer/devcontainer.json`, and any other files in the directory.
+
+The tarball is named `devcontainer-template-<id>.tgz`, where `<id>` is the Templates's `id` field.
+
+A reference implementation for packaging and distributing Templates is provided as a GitHub Action (https://github.com/devcontainers/action).
+
+### devcontainer-collection.json
+
+The `devcontainer-collection.json` is an auto-generated metadata file.
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `sourceInformation` | object | Metadata from the implementing packaging tool. |
+| `templates` | array | The list of Templates that are contained in this collection.|
+
+Each Template's `devcontainer-template.json` metadata file is appended into the `templates` top-level array.
+
+## Distribution
+
+There are several supported ways to distribute Templates. Distribution is handled by the implementing packaging tool such as the **[Dev Container CLI](https://github.com/devcontainers/cli)** or **[Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish)**.
+
+A user can add a Template in to their projects as defined by the [supporting Tools](../docs/specs/supporting-tools.md#supporting-tools-and-services).
+
+### OCI Registry
+
+An OCI registry that implements the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec) serves as the primary distribution mechanism for Templates.
+
+Each packaged Template is pushed to the registry following the naming convention `<registry>/<namespace>/<id>[:version]`, where version is the major, minor, and patch version of the Template, according to the semver specification.
+
+> **Note:** `namespace` is a unique identifier for the collection of Templates and must be different than the collection of [Features](./devcontainer-features.md). There are no strict rules for `namespace`; however, one pattern is to set `namespace` equal to source repository's `<owner>/<repo>`. 
+
+A custom media type `application/vnd.devcontainers` and `application/vnd.devcontainers.layer.v1+tar` are used as demonstrated below.
+
+For example, the `go` Template in the `devcontainers/templates` namespace at version `1.2.3` would be pushed to the ghcr.io OCI registry.
+
+> **Note:** The example below uses [`oras`](https://oras.land/) for demonstration purposes.  A supporting tool should directly implement the required functionality from the aforementioned OCI artifact distribution specification.
+
+```bash
+# ghcr.io/devcontainers/templates/go:1
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/templates
+TEMPLATE=go
+
+ARTIFACT_PATH=devcontainer-template-go.tgz
+
+for VERSION in 1  1.2  1.2.3  latest
+do
+        oras push ${REGISTRY}/${NAMESPACE}/${TEMPLATE}:${VERSION} \
+                --config /dev/null:application/vnd.devcontainers \
+                        ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
+done
+
+```
+
+The "namespace" is the globally identifiable name for the collection of Templates (e.g. `owner/repo` for the source code's git repository).
+
+The auto-generated `devcontainer-collection.json` is pushed to the registry with the same `namespace` as above and no accompanying `template` name. The collection file is always tagged as `latest`.
+
+```bash
+# ghcr.io/devcontainers/templates
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/templates
+
+oras push ${REGISTRY}/${NAMESPACE}:latest \
+        --config /dev/null:application/vnd.devcontainers \
+                            ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
+```

--- a/conformance/spec/113500f4/devcontainer-templates.md
+++ b/conformance/spec/113500f4/devcontainer-templates.md
@@ -1,0 +1,210 @@
+# Dev Container Templates reference
+
+**Development Container Templates** are source files packaged together that encode configuration for a complete development environment. A Template can be used in a new or existing project, and a [supporting tool](https://containers.dev/supporting) will use the configuration from the Template to build a development container.
+
+The configuration is placed in [`.devcontainer/devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson) which can also reference other files within the Template. A Template can also provide additional source files (e.g. boilerplate code or a [lifecycle script](https://containers.dev/implementors/json_reference/#lifecycle-scripts).
+
+Template metadata is captured by a `devcontainer-template.json` file in the root folder of the Template.
+
+## Folder structure 
+
+A single Template is a folder with at least a `devcontainer-template.json` and [`.devcontainer/devcontainer.json`](/docs/specs/devcontainer-reference.md#devcontainerjson).  Additional files are permitted and are packaged along side the required files.
+
+```
++-- template
+|   +-- devcontainer-template.json
+|   +-- .devcontainer
+|       +-- devcontainer.json
+|       +-- (other files)
+|   +-- (other files)
+```
+
+## devcontainer-template.json properties
+
+The `devcontainer-template.json` file defines information about the Template to be used by any [supporting tools](../docs/specs/supporting-tools.md#supporting-tools-and-services).
+
+The properties of the file are as follows:
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `id` | string | ID of the Template. The `id` should be unique in the context of the repository/published package where the Template exists and must match the name of the directory where the `devcontainer-template.json` resides. |
+| `version` | string | The semantic version of the Template. |
+| `name` | string | Name of the Template. |
+| `description` | string | Description of the Template. |
+| `documentationURL` | string | Url that points to the documentation of the Template. |
+| `licenseURL` | string | Url that points to the license of the Template. |
+| [`options`](#the-options-property) | object | A map of options that the supporting tools should use to populate different configuration options for the Template. |
+| `platforms` | array | Languages and platforms supported by the Template. |
+| `publisher` | string | Name of the publisher/maintainer of the Template. |
+| `keywords` | array | List of strings relevant to a user that would search for this Template. |
+| [`optionalPaths`](#the-optionalpaths-property) | array | An array of files or directories that tooling may consider "optional" when applying a Template. Directories are indicated with a trailing `/*` (e.g. `.github/*`).
+
+### The `options` property
+
+The `options` property contains a map of option IDs and their related configuration settings. These `options` are used by the supporting tools to prompt the user to choose from different Template configuration options. The tools would replace the option ID with the selected value in all the files (within the sub-directory of the Template). This replacement would happen before dropping the `.devcontainer/devcontainer.json` and other files (within the sub-directory of the Template) required to containerize your project. See [option resolution](#option-resolution) for more details. For example:
+
+```json
+{
+  "options": {
+    "optionId": {
+      "type": "string",
+      "description": "Description of the option",
+      "proposals": ["value1", "value2"],
+      "default": "value1"
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `optionId` | string | ID of the option used by the supporting tools to replace the selected value in the files within the sub-directory of the Template. |
+| `optionId.type` | string | Type of the option. Valid types are currently: `boolean`, `string` |
+| `optionId.description` | string | Description for the option. |
+| `optionId.proposals` | array | A list of suggested string values. Free-form values **are** allowed. Omit when using `optionId.enum`. |
+| `optionId.enum` | array | A strict list of allowed string values. Free-form values are **not** allowed. Omit when using `optionId.proposals`. |
+| `optionId.default` | string | Default value for the option. |
+
+> **Note:** The `options` must be unique for every `devcontainer-template.json`
+
+### The `optionalPaths` property
+
+Before applying a Template, tooling must inspect the `optionalPaths` property of a Template and prompt the user on whether each file or folder should be included in the resulting output workspace folder.  A path is relative to the root of the Template source directory.
+
+- For a single file, provide the full relative path (without any leading or trailing path delimiters).  
+- For a directory, provide the full relative path with a trailing slash and asterisk (`/*`) appended to the path.  The directory and its children will be recursively ignored.
+
+Examples are shown below:
+
+```jsonc
+{
+    "id": "cpp",
+    "version": "3.0.0",
+    "name": "C++",
+    "description": "Develop C++ applications",
+    "optionalPaths": [
+         "GETTING-STARTED.md",                 // Single file
+         "example-project-1/MyProject.csproj", // Single file in nested directory
+         ".github/*"                           // Entire recursive contents of directory
+     ]
+}
+```
+
+### Referencing a Template 
+
+The `id` format (`<oci-registry>/<namespace>/<template>[:<semantic-version>]`) dictates how a [supporting tool](https://containers.dev/supporting) will locate and download a given Template from an OCI registry. For example:
+
+- `ghcr.io/user/repo/go`
+- `ghcr.io/user/repo/go:1`
+- `ghcr.io/user/repo/go:latest`
+
+The registry must implement the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec). Some implementors can be [found here](https://oras.land/implementors/).
+
+## Versioning
+
+Each Template is individually [versioned according to the semver specification](https://semver.org/). The `version` property in the respective `devcontainer-template.json` file is updated to increment the Template's version.
+
+Tooling that handles releasing Templates will not republish Templates if that exact version has already been published; however, tooling must republish major and minor versions in accordance with the semver specification.
+
+## Release
+
+_For information on distributing Templates, see [devcontainer-templates-distribution.md](./devcontainer-templates-distribution.md)._
+
+### Option Resolution
+
+A Template's `options` property is used by a supporting tool to prompt for different configuration options. A supporting tool will parse the `options` object provided by the user. If a value is selected for a Template, it will be replaced in the files (within the sub-directory of the Template).
+
+### Option resolution example
+
+Consider a `java` Template with the following folder structure:
+
+```
++-- java
+|   +-- devcontainer-template.json
+|   +-- .devcontainer
+|       +-- devcontainer.json
+```
+
+Suppose the `java` Template has the following `options` parameters declared in the `devcontainer-template.json` file:
+
+```json
+// ...
+"options": {
+    "imageVariant": {
+        "type": "string",
+        "description": "Specify version of java.",
+        "proposals": [
+          "17-bullseye",
+          "17-buster",
+          "11-bullseye",
+          "11-buster",
+          "17",
+          "11"
+        ],
+			  "default": "17-bullseye"
+    },
+    "nodeVersion": {
+        "type": "string", 
+        "proposals": [
+          "latest",
+          "16",
+          "14",
+          "10",
+          "none"
+        ],
+        "default": "latest",
+        "description": "Specify version of node, or 'none' to skip node installation."
+    },
+    "installMaven": {
+        "type": "boolean", 
+        "description": "Install Maven, a management tool for Java.",
+        "default": "false"
+    },
+}
+```
+
+...and it has the following `.devcontainer/devcontainer.json` file:
+
+```json
+{
+	"name": "Java",
+	"image": "mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "${templateOption:nodeVersion}",
+      "installMaven": "${templateOption:installMaven}"
+		}
+	},
+//	...
+}
+```
+
+A user tries to add the `java` Template to their project using the [supporting tools](../docs/specs/supporting-tools.md#supporting-tools-and-services) and selects `17-bullseye` when prompted for `"Specify version of Go"` and the `default` values when prompted for `"Specify version of node, or 'none' to skip node installation"` and `"Install Maven, a management tool for Java"`.
+
+The supporting tool could then use a string replacer for all the files within the sub-directory of the Template. In this example, `.devcontainer/devcontainer.json` needs to be modified and hence, the inputs can provided to it as follows:
+
+```
+{
+  imageVariant:"17-bullseye",
+  nodeVersion: "latest",
+  installMaven: "false"
+}
+```
+
+The modified `.devcontainer/devcontainer.json` will be as follows:
+
+```json
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:0-17-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "latest",
+      "installMaven": "false"
+		}
+	},
+	...
+}
+```
+
+The modified `.devcontainer/devcontainer.json` would be dropped into any existing folder as a starting point for containerizing your project.

--- a/conformance/spec/113500f4/devcontainerjson-reference.md
+++ b/conformance/spec/113500f4/devcontainerjson-reference.md
@@ -1,0 +1,176 @@
+# Dev Container Metadata Reference
+
+The `devcontainer.json` file contains any needed metadata and settings required to configurate a **development container** for a given well-defined tool and runtime stack. It can be used by [tools and services that support the dev container spec](supporting-tools.md) to create a **development environment** that contains one or more **development containers**.
+
+Metadata properties marked with a 🏷️ can be stored in the `devcontainer.metadata` **container image label** in addition to `devcontainer.json`. This label can contain an array of json snippets that will be automatically merged with `devcontainer.json` contents (if any) when a container is created.
+
+## General devcontainer.json properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | string | A name for the dev container displayed in the UI |
+| `forwardPorts` 🏷️ | array | An array of port numbers or `"host:port"` values  (e.g. `[3000, "db:5432"]`) that should always be forwarded from inside the primary container to the local machine (including on the web). The property is most useful for forwarding ports that cannot be auto-forwarded because the related process that starts before the `devcontainer.json` supporting service / tool connects or for forwarding a service not in the primary container in Docker Compose scenarios (e.g. `"db:5432"`). Defaults to `[]`. |
+| `portsAttributes` 🏷️ | object | Object that maps a port number, `"host:port"` value, range, or regular expression to a set of default options. See [port attributes](#port-attributes) for available options. For example: <br />`"portsAttributes": {"3000": {"label": "Application port"}}` |
+| `otherPortsAttributes` 🏷️ | object | Default options for ports, port ranges, and hosts that aren't configured using `portsAttributes`. See [port attributes](#port-attributes) for available options. For example: <br /> `"otherPortsAttributes": {"onAutoForward": "silent"}` |
+| `containerEnv` 🏷️ | object | A set of name-value pairs that sets or overrides environment variables for the container. Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the values. For example:<br/> `"containerEnv": { "MY_VARIABLE": "${localEnv:MY_VARIABLE}" }`<br /> If you want to reference an existing container variable while setting this one (like updating the `PATH`), use `remoteEnv` instead. <br /> `containerEnv` will set the variable on the Docker container itself, so all processes spawned in the container will have access to it. But it will also be static for the life of the container - you must rebuild the container to update the value. <br /> We recommend using `containerEnv` (over `remoteEnv`) as much as possible since it allows all processes to see the variable and isn't client-specific. |
+| `remoteEnv` 🏷️ | object | A set of name-value pairs that sets or overrides environment variables for the `devcontainer.json` supporting service / tool (or sub-processes like terminals) but not the container as a whole. Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the values. <br /> You may want to use `remoteEnv` (over `containerEnv`) if the value isn't static since you can update its value without having to rebuild the full container. |
+| `remoteUser` 🏷️ | string | Overrides the user that `devcontainer.json` supporting services tools / runs as in the container (along with sub-processes like terminals, tasks, or debugging). Does not change the user the container as a whole runs as which can be set using `containerUser`. Defaults to the user the container as a whole is running as (often `root`). <br /> You may learn more in the [remoteUser section below](#remoteUser). |
+| `containerUser` 🏷️ | string | Overrides the user for all operations run as inside the container. Defaults to either `root` or the last `USER` instruction in the related Dockerfile used to create the image. If you want any connected tools or related processes to use a different user than the one for the container, see `remoteUser`. |
+| `updateRemoteUserUID` 🏷️ | boolean | On Linux, if `containerUser` or `remoteUser` is specified, the user's UID/GID will be updated to match the local user's UID/GID to avoid permission problems with bind mounts. Defaults to `true`. |
+| `userEnvProbe` 🏷️ | enum | Indicates the type of shell to use to "probe" for user environment variables to include in `devcontainer.json` supporting services' / tools' processes: `none`, `interactiveShell`, `loginShell`, or `loginInteractiveShell` (default). The specific shell used is based on the default shell for the user (typically bash). For example, bash interactive shells will typically include variables set in `/etc/bash.bashrc` and `~/.bashrc` while login shells usually include variables from `/etc/profile` and `~/.profile`. Setting this property to `loginInteractiveShell` will get variables from all four files. |
+| `overrideCommand` 🏷️ | boolean | Tells `devcontainer.json` supporting services / tools whether they should run `/bin/sh -c "while sleep 1000; do :; done"` when starting the container instead of the container's default command (since the container can shut down if the default command fails). Set to `false` if the default command must run for the container to function properly. Defaults to `true` for when using an image Dockerfile and `false` when referencing a Docker Compose file. |
+| `shutdownAction` 🏷️ | enum | Indicates whether `devcontainer.json` supporting tools should stop the containers when the related tool window is closed / shut down.<br>Values are  `none`, `stopContainer` (default for image or Dockerfile), and `stopCompose` (default for Docker Compose). |
+| `init` 🏷️ | boolean | Defaults to `false`. Cross-orchestrator way to indicate whether the [tini init process](https://github.com/krallin/tini) should be used to help deal with zombie processes. |
+| `privileged` 🏷️ | boolean | Defaults to `false`. Cross-orchestrator way to cause the container to run in privileged mode (`--privileged`). Required for things like Docker-in-Docker, but has security implications particularly when running directly on Linux.  |
+| `capAdd` 🏷️ | array | Defaults to `[]`. Cross-orchestrator way to add capabilities typically disabled for a container. Most often used to add the `ptrace` capability required to debug languages like C++, Go, and Rust. For example: <br />`"capAdd": ["SYS_PTRACE"]` |
+| `securityOpt` 🏷️ | array | Defaults to `[]`. Cross-orchestrator way to set container security options. For example: <br /> `"securityOpt": [ "seccomp=unconfined" ]` |
+| `mounts` 🏷️ | string or object | Defaults to unset. Cross-orchestrator way to add additional mounts to a container. Each value is a string that accepts the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#mount). Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the value. For example:<br />`"mounts": [{ "source": "dind-var-lib-docker", "target": "/var/lib/docker", "type": "volume" }]` |
+| `features` | object | An object of [Dev Container Feature IDs](https://containers.dev/features) and related options to be added into your primary container. The specific options that are available varies by feature, so see its documentation for additional details. For example: <br />`"features": { "ghcr.io/devcontainers/features/github-cli": {} }` |
+| `overrideFeatureInstallOrder` | array | By default, Features will attempt to automatically set the order they are installed based on a `installsAfter` property within each of them. This property allows you to override the Feature install order when needed. For example: <br />`"overrideFeatureInstallОrder": [ "ghcr.io/devcontainers/features/common-utils", "ghcr.io/devcontainers/features/github-cli" ]` |
+| `customizations` 🏷️| object | Product specific properties, defined in [supporting tools](supporting-tools.md) |
+
+## Scenario specific properties
+
+The focus of `devcontainer.json` is to describe how to enrich a container for the purposes of development rather than acting as a multi-container orchestrator format. Instead, container orchestrator formats can be referenced when needed to manage multiple containers and their lifecycles. Today, `devcontainer.json` includes scenario specific properties for working without a container orchestrator (by directly referencing an image or Dockerfile) and for using Docker Compose as a simple multi-container orchestrator.
+
+### Image or Dockerfile specific properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `image` | string | **Required** when using an image. The name of an image in a container registry ([DockerHub](https://hub.docker.com), [GitHub Container Registry](https://docs.github.com/packages/guides/about-github-container-registry), [Azure Container Registry](https://azure.microsoft.com/services/container-registry/)) that `devcontainer.json` supporting services / tools should use to create the dev container. |
+| `build.dockerfile` | string |**Required** when using a Dockerfile. The location of a [Dockerfile](https://docs.docker.com/engine/reference/builder/) that defines the contents of the container. The path is relative to the `devcontainer.json` file. |
+| `build.context` | string | Path that the Docker build should be run from relative to `devcontainer.json`. For example, a value of `".."` would allow you to reference content in sibling directories. Defaults to `"."`. |
+| `build.args` | Object | A set of name-value pairs containing [Docker image build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) that should be passed when building a Dockerfile.  Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the values. Defaults to not set. For example: `"build": { "args": { "MYARG": "MYVALUE", "MYARGFROMENVVAR": "${localEnv:VARIABLE_NAME}" } }` |
+| `build.options` | array | An array of [Docker image build options](https://docs.docker.com/engine/reference/commandline/build/#options) that should be passed to the build command when building a Dockerfile. Defaults to `[]`. For example: `"build": { "options": [ "--add-host=host.docker.internal:host-gateway" ] }` |
+| `build.target` | string | A string that specifies a [Docker image build target](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) that should be passed when building a Dockerfile. Defaults to not set. For example: `"build": { "target": "development" }` |
+| `build.cacheFrom` | string,<br>array | A string or array of strings that specify one or more images to use as caches when building the image. Cached image identifiers are passed to the `docker build` command with `--cache-from`. |
+| `appPort` | integer,<br>string,<br>array |  In most cases, we recommend using the new [forwardPorts property](#general-devcontainerjson-properties). This property accepts a port or array of ports that should be published locally when the container is running. Unlike `forwardPorts`, your application may need to listen on all interfaces (`0.0.0.0`) not just `localhost` for it to be available externally. Defaults to `[]`.<br>Learn more about publishing vs forwarding ports [here](#publishing-vs-forwarding-ports).<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array properties. |
+| `workspaceMount` | string | Requires `workspaceFolder` be set as well. Overrides the default local mount point for the workspace when the container is created. Supports the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#add-bind-mounts-or-volumes-using-the---mount-flag). Environment and [pre-defined variables](#variables-in-devcontainerjson) may be referenced in the value. For example: <br />`"workspaceMount": "source=${localWorkspaceFolder}/sub-folder,target=/workspace,type=bind,consistency=cached", "workspaceFolder": "/workspace"` |
+| `workspaceFolder` | string | Requires `workspaceMount` be set. Sets the default path that `devcontainer.json` supporting services / tools should open when connecting to the container. Defaults to the automatic source code mount location. |
+| `runArgs` | array | An array of [Docker CLI arguments](https://docs.docker.com/engine/reference/commandline/run/) that should be used when running the container. Defaults to `[]`. For example, this allows ptrace based debuggers like C++ to work in the container:<br /> `"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ]` . |
+
+### Docker Compose specific properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `dockerComposeFile` | string,<br>array | **Required** when [using Docker Compose](https://docs.docker.com/compose/). Path or an ordered list of paths to Docker Compose files relative to the `devcontainer.json` file. Using an array is useful [when extending your Docker Compose configuration](https://docs.docker.com/compose/extends/#multiple-compose-files). The order of the array matters since the contents of later files can override values set in previous ones.<br>The default `.env` file is picked up from the root of the project, but you can use `env_file` in your Docker Compose file to specify an alternate location. |
+| `service` | string | **Required** when [using Docker Compose](https://docs.docker.com/compose/). The name of the service `devcontainer.json` supporting services / tools should connect to once running.  |
+| `runServices` | array | An array of services in your Docker Compose configuration that should be started by `devcontainer.json` supporting services / tools. These will also be stopped when you disconnect unless `"shutdownAction"` is `"none"`. Defaults to all services. |
+| `workspaceFolder` | string | Sets the default path that `devcontainer.json` supporting services / tools should open when connecting to the container (which is often the path to a volume mount where the source code can be found in the container). Defaults to `"/"`. |
+
+## Tool-specific properties
+
+While most properties apply to any `devcontainer.json` supporting tool or service, a few are specific to certain tools. You may explore this in the [supporting tools and services document](supporting-tools.md).
+
+## Lifecycle scripts
+
+When creating or working with a dev container, you may need different commands to be run at different points in the container's lifecycle. The table below lists a set of command properties you can use to update what the container's contents in the order in which they are run (for example, `onCreateCommand` will run after `initializeCommand`). Each command property is an string or list of command arguments that should execute from the `workspaceFolder`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `initializeCommand` | string,<br>array,<br>object | A command string or list of command arguments to run on the **host machine** during initialization, including during container creation and on subsequent starts.  The command may run more than once during a given session.<br /><br /> ⚠️ The command is run wherever the source code is located on the host. For cloud services, this is in the cloud.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `onCreateCommand` 🏷️ | string,<br>array,<br>object | This command is the first of three (along with `updateContentCommand` and `postCreateCommand`) that finalizes container setup when a dev container is created. It and subsequent commands execute **inside** the container immediately after it has started for the first time.<br /><br> Cloud services can use this command when caching or prebuilding a container. This means that it will not typically have access to user-scoped assets or secrets.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `updateContentCommand` 🏷️ | string,<br>array,<br>object  | This command is the second of three that finalizes container setup when a dev container is created. It executes inside the container after `onCreateCommand` whenever new content is available in the source tree during the creation process.<br><br />It will execute at least once, but cloud services will also periodically execute the command to refresh cached or prebuilt containers. Like cloud services using `onCreateCommand`, it can only take advantage of repository and org scoped secrets or permissions.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `postCreateCommand` 🏷️ | string,<br>array,<br>object | This command is the last of three that finalizes container setup when a dev container is created. It happens after `updateContentCommand` and once the dev container has been assigned to a user for the first time.<br><br />Cloud services can use this command to take advantage of user specific secrets and permissions.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `postStartCommand` 🏷️ | string,<br>array,<br>object | A command to run each time the container is successfully started.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `postAttachCommand` 🏷️ | string,<br>array,<br>object | A command to run each time a tool has successfully attached to the container.<br>Note that the array syntax will execute the command without a shell. You can [learn more](#formatting-string-vs-array-properties) about formatting string vs array vs object properties. |
+| `waitFor` 🏷️ | enum | An enum that specifies the command any tool should wait for before connecting. Defaults to `updateContentCommand`. This allows you to use `onCreateCommand` or `updateContentCommand` for steps that must happen before `devcontainer.json` supporting tools connect while still using `postCreateCommand` for steps that can happen behind the scenes afterwards. |
+
+For each command property, if the value is a single string, it will be run in `/bin/sh`. Use `&&` in a string to execute multiple commands. For example, `"yarn install"` or `"apt-get update && apt-get install -y curl"`. The array syntax `["yarn", "install"]` will invoke the command (in this case `yarn`) directly without using a shell. Each fires after your source code has been mounted, so you can also run shell scripts from your source tree. For example: `bash scripts/install-dev-tools.sh`
+
+If one of the lifecycle scripts fails, any subsequent scripts will not be executed. For instance, if `postCreateCommand` fails, `postStartCommand` and any following scripts will be skipped.
+
+## Minimum host requirements
+
+While `devcontainer.json` does not focus on hardware or VM provisioning, it can be useful to know your container's minimum RAM, CPU, and storage requirements. This is what the `hostRequirements` properties allow you to do. Cloud services can use these properties to automatically default to the best compute option available, while in other cases, you will be presented with a warning if the requirements are not met.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hostRequirements.cpus` 🏷️ | integer | Indicates the minimum required number of CPUs / virtual CPUs / cores. For example: `"hostRequirements": {"cpus": 2}` |
+| `hostRequirements.memory` 🏷️ | string |  A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"memory": "4gb"}` |
+| `hostRequirements.storage` 🏷️ | string | A string indicating minimum storage requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"storage": "32gb"}` |
+
+## Port attributes
+
+The `portsAttributes` and `otherPortsAttributes` properties allow you to map default port options for one or more manually or automatically forwarded ports. The following is a list of options that can be set in the configuration object assigned to the property.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `label` 🏷️ | string | Display name for the port in the ports view. Defaults to not set. |
+| `protocol` 🏷️ | enum | Controls protocol handling for forwarded ports. When not set, the port is assumed to be a raw TCP stream which, if forwarded to `localhost`, supports any number of protocols. However, if the port is forwarded to a web URL (e.g. from a cloud service on the web), only HTTP ports in the container are supported. Setting this property to `https` alters handling by ignoring any SSL/TLS certificates present when communicating on the port and using the correct certificate for the forwarded URL instead (e.g. `https://*.githubpreview.dev`). If set to `http`, processing is the same as if the protocol is not set. Defaults to not set. |
+| `onAutoForward` 🏷️ | enum | Controls what should happen when a port is auto-forwarded once you've connected to the container. `notify` is the default, and a notification will appear when the port is auto-forwarded. If set to `openBrowser`, the port will be opened in the system's default browser. A value of `openBrowserOnce` will open the browser only once. `openPreview` will open the URL in `devcontainer.json` supporting services' / tools' embedded preview browser. A value of `silent` will forward the port, but take no further action. A value of `ignore` means that this port should not be auto-forwarded at all. |
+| `requireLocalPort` 🏷️ | boolean | Dictates when port forwarding is required to map the port in the container to the same port locally or not. If set to `false`, the `devcontainer.json` supporting services /  tools will attempt to use the specified port forward to `localhost`, and silently map to a different one if it is unavailable. If set to `true`, you will be notified if it is not possible to use the same port. Defaults to `false`. |
+| `elevateIfNeeded` 🏷️ | boolean | Forwarding low ports like 22, 80, or 443 to `localhost` on the same port from `devcontainer.json` supporting services / tools may require elevated permissions on certain operating systems. Setting this property to `true` will automatically try to elevate the `devcontainer.json` supporting tool's permissions in this situation. Defaults to `false`. |
+
+## Formatting string vs. array properties
+
+The format of certain properties will vary depending on the involvement of a shell.
+
+`postCreateCommand`, `postStartCommand`, `postAttachCommand`, and `initializeCommand` all have 3 types: 
+* Array: Passed to the OS for execution without going through a shell
+* String: Goes through a shell (it needs to be parsed into command and arguments)
+* Object: All lifecycle scripts have been extended to support `object` types to allow for [parallel execution](../specs/devcontainer-reference.md/#parallel-lifecycle-script-execution)
+
+`runArgs` only has the array type. Using `runArgs` via a typical command line, you'll need single quotes if the shell runs into parameters with spaces. However, these single quotes aren't passed on to the executable. Thus, in your `devcontainer.json`, you'd follow the array format and leave out the single quotes:
+
+```json
+"runArgs": ["--device-cgroup-rule=my rule here"]
+```
+
+Rather than:
+
+```json
+"runArgs": ["--device-cgroup-rule='my rule here'"]
+```
+
+We can compare the string, array, and object versions of `postAttachCommand` as well. You can use the following string format, which will remove the single quotes as part of the shell's parsing:
+
+```json
+"postAttachCommand": "echo foo='bar'"
+```
+
+By contrast, the array format will keep the single quotes and write them to standard out (you can see the output in the dev container log):
+
+```json
+"postAttachCommand": ["echo", "foo='bar'"]
+```
+
+Finally, you may use an object format:
+
+```json
+{
+  "postAttachCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```
+
+## Variables in devcontainer.json
+
+Variables can be referenced in certain string values in `devcontainer.json` in the following format: **${variableName}**. The following is a list of available variables you can use.
+
+| Variable | Properties | Description |
+|----------|---------|----------------------|
+| `${localEnv:VARIABLE_NAME}` | Any | Value of an environment variable on the **host machine** (in the examples below, called `VARIABLE_NAME`). Unset variables are left blank. <br /><br />  ⚠️ Clients (like VS Code) may need to be **restarted** to pick up newly set variables. <br /><br /> ⚠️ For a cloud service, the host is in the cloud rather than your local machine. <br /><br /> **Examples** <br /><br /> **1.** Set a variable containing your local home folder on Linux / macOS or the user folder on Windows:<br/> `"remoteEnv": { "LOCAL_USER_PATH": "${localEnv:HOME}${localEnv:USERPROFILE}" }`.   <br /><br /> A default value for when the environment variable is not set can be given with `${localEnv:VARIABLE_NAME:default_value}`.  <br /><br />  **2.** In modern versions of macOS, default configurations allow setting local variables with the command `echo 'export VARIABLE_NAME=my-value' >> ~/.zshenv`.  |
+| `${containerEnv:VARIABLE_NAME}` | `remoteEnv` | Value of an existing environment variable inside the container once it is up and running (in this case, called `VARIABLE_NAME`). For example:<br /> `"remoteEnv": { "PATH": "${containerEnv:PATH}:/some/other/path" }` <br /><br /> A default value for when the environment variable is not set can be given with `${containerEnv:VARIABLE_NAME:default_value}`. |
+| `${localWorkspaceFolder}`  | Any | Path of the local folder that was opened in the `devcontainer.json` supporting service / tool (that contains `.devcontainer/devcontainer.json`). |
+| `${containerWorkspaceFolder}` | Any | The path that the workspaces files can be found in the container. |
+| `${localWorkspaceFolderBasename}` | Any | Name of the local folder that was opened in the `devcontainer.json` supporting service / tool (that contains `.devcontainer/devcontainer.json`). |
+| `${containerWorkspaceFolderBasename}` | Any | Name of the folder where the workspace files can be found in the container. |
+| `${devcontainerId}` | Any | Allow features to refer to an identifier that is unique to the dev container they are installed into and that is stable across rebuilds.<br> The properties supporting it in devcontainer.json are: `name`, `runArgs`, `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `workspaceFolder`, `workspaceMount`, `mounts`, `containerEnv`, `remoteEnv`, `containerUser`, `remoteUser`, and `customizations`. |
+
+## Schema
+
+You can see the dev container schema [here](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
+
+
+## Publishing vs forwarding ports
+
+Docker has the concept of "publishing" ports when the container is created. Published ports behave very much like ports you make available to your local network. If your application only accepts calls from `localhost`, it will reject connections from published ports just as your local machine would for network calls. Forwarded ports, on the other hand, actually look like `localhost` to the application.
+
+## remoteUser
+
+A dev container configuration will inherit the `remoteUser` property from the base image it uses.
+
+Using the [images](https://github.com/devcontainers/images) and [Templates](https://github.com/devcontainers/templates) part of the spec as an example: `remoteUser` in these images is set to a custom value - you may view an example in the [C++ image](https://github.com/devcontainers/images/blob/main/src/cpp/.devcontainer/devcontainer.json#L34). The [C++ Template](https://github.com/devcontainers/templates/tree/main/src/cpp) will then inherit the custom `remoteUser` value from [its base C++ image](https://github.com/devcontainers/templates/blob/main/src/cpp/.devcontainer/Dockerfile#L1).

--- a/conformance/spec/113500f4/feature-dependencies.md
+++ b/conformance/spec/113500f4/feature-dependencies.md
@@ -1,0 +1,240 @@
+# Feature Dependencies
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/109
+* CLI PR: https://github.com/devcontainers/cli/commit/236b85162a945a1af9e72fcbe02eb5c7c864b31d
+
+Below is the original proposal.
+
+## Motivation
+
+We've seen significant interest in the ability to "reuse" or "extend" a given Feature with one or more additional Features.  Often in software a given tool depends on another (or several) tool(s)/framework(s).  As the dev container Feature ecosystem has grown, there has been a growing need to reduce redundant code in Features by first installing a set of dependent Features.
+
+## Goal
+
+The solution shall provide a way to publish a Feature that "depends" on >= 1 other published Features. Dependent Features will be installed by the orchestrating tool following this specification.
+
+The solution outlined shall not only execute the installation scripts, but also merge the additional development container config, as outlined in the documented [merging logic](https://containers.dev/implementors/spec/#merge-logic).
+
+The solution should provide guidelines for Feature authorship, and prefer solutions that enable simple authoring of Features, as well as easy consumption by end-users.
+
+A non-goal is to require the use or implementation of a full-blown dependency management system (such as `npm` or `apt`).  The solution should allow Features to operate as "self-contained, shareable units of installation code and development container configuration"[(1)](https://containers.dev/implementors/features/). 
+
+## Definitions
+
+- **User-defined Feature**.  Features defined explicitly by the user in the `features` object of `devcontainer.json`.
+- **Published Feature**.  Features published to an OCI registry or a direct HTTPS link to a Feature tgz.
+
+## Existing Solutions
+
+See https://github.com/devcontainers/spec/pull/208/files#diff-a29ffaac693437b6fbf001066b97896f7aef4d6d37dc65b8b98b22a5e19f6c7aR26 for existing solutions and alternative approaches.
+
+## Proposed Specification
+
+### (A) Add `dependsOn` property
+
+A new property `dependsOn` can be optionally added to the `devcontainer-feature.json`.  This property mirrors the `features` object in `devcontainer.json`.  Adding Feature(s) to this property tells the orchestrating tool to install the Feature(s) (with the associated options, if provided) before installing the Feature that declares the dependency.
+
+> This property is similar to the existing `installsAfter` property, with the key distinctions that `installsAfter` (1) is **not** recursive, (2) indicates a soft dependency to influence installation order **if and only if a given Feature is already set to be installed via a user-defined Feature or transitively through a user-defined Feature**, and (3) Features indicated by `installsAfter` can not provide options, nor are they able to be pinned to a specific version tag or digest.
+
+The installation order is subject to the algorithm set forth in this document. Where there is ambiguity, it is up to the orchestrating tool to decide the order of installation. Implementing tools should provide a consistent installation order in instances of ambiguity (i.e. sort alphanumerically by identifier).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `dependsOn` | `object` | The ID and options of the Feature dependency.  Pinning to version tags or digests are honored.  When published, the ID must refer to either a Feature (1) published to an OCI registry, (2) a Feature Tgz URI, or (3) a Feature in the local file tree (**).  Otherwise, IDs follow the same semantics of the `features` object in `devcontainer.json`.  (a.k.a "Hard Dependency") |
+
+
+(**) Deprecated Feature identifiers (i.e. GitHub Release) are not supported and the presence of this property may be considered a fatal error or ignored. For [local Features (i.e. during development)](https://containers.dev/implementors/features-distribution/#addendum-locally-referenced), you may also depend on other local Features by providing a relative path to the Feature, relative to folder containing the active `devcontainer.json`. This behavior of Features within this property again mirror the `features` object in `devcontainer.json`.
+
+An example `devcontainer-feature.json` file with a dependency on four other published Features:
+
+```json
+{
+    "name": "My Feature",
+    "id": "myFeature",
+    "version": "1.0.0",
+    "dependsOn": {
+        "ghcr.io/second:1": {
+            "flag": true
+        },
+        "features.azurecr.io/third:1": {},
+        "features.azurecr.io/fourth:1.2.3": {},
+        "features.azurecr.io/fifth@sha256:a4cdc44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {}
+    }
+}
+```
+
+`myfeature` will be installed after `second`, `third`, `fourth`, and `fifth`.
+
+The following three sections will illustrate how an orchestrating tool shouuld identify dependencies between Features, depending on [how the Feature is referenced](https://containers.dev/implementors/features/#referencing-a-feature).
+
+#### Identifying Dependencies - OCI Registry
+
+To speed up dependency resolution, all Features [published to an OCI registry](https://containers.dev/implementors/features-distribution/#oci-registry) will have their entire `devcontainer-feature.json` serialized and added as an [annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
+
+The orchestrating tool can use this annotation to resolve the Feature's dependencies without having to download and extract the Feature's tarball.
+
+More specifically, an [annotation](https://github.com/opencontainers/image-spec/blob/main/annotations.md) named `dev.containers.metadata` will be populated on the manifest when published by an implementing tool.  This annotation is the escaped JSON object of the entire `devcontainer-feature.json` as it appears during the [packaging stage](https://containers.dev/implementors/features-distribution/#packaging).  
+
+An example manifest with the `dev.containers.metadata` annotation:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.devcontainers",
+    "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.devcontainers.layer.v1+tar",
+      "digest": "sha256:738af5504b253dc6de51d2cb1556cdb7ce70ab18b2f32b0c2f12650ed6d2e4bc",
+      "size": 3584,
+      "annotations": {
+        "org.opencontainers.image.title": "devcontainer-feature-myFeature.tgz"
+      }
+    }
+  ],
+  "annotations": {
+    "dev.containers.metadata": "{\"name\": \"My Feature\",\"id\": \"myFeature\",\"version\": \"1.0.0\",\"dependsOn\": {\"ghcr.io/myotherFeature:1\": {\"flag\": true},\"features.azurecr.io/aThirdFeature:1\": {},\"features.azurecr.io/aFourthFeature:1.2.3\": {}}}"
+  }
+}
+```
+
+> If no annotation is present on a Feature's manifest, the orchestrating tool MUST fallback to downloading and extracting the Feature's contents to read the metadata properties. Failure to do so may result in a Feature being installed without its dependencies (e.g. `installsAfter`).
+
+In summary, supporting tools may choose to identify the dependencies of the declared user-defined Features by fetching the manifest of the Features and reading the `dependsOn` and `installsAfter` properties from the `dev.containers.metadata` annotation.  This will allow the orchestrating tool to recursively resolve all dependencies without having to download and extract each Feature's tarball. 
+
+#### Identifying Dependencies - HTTPS Direct Tarball
+
+Published Features referenced directly by [HTTPS URI pointing to the packaged tarball archive](https://containers.dev/implementors/features-distribution/#directly-reference-tarball) will need to be fully downloaded an extracted to read the `dependsOn` property.
+
+#### Identifying Dependencies - Local Features
+
+[Local Features](https://containers.dev/implementors/features-distribution/#addendum-locally-referenced) dependencies are identified by directly reading the `dependsOn` property in the associated `devcontainer-feature.json` metadata file.
+
+### (B) `dependsOn` install order algorithm
+
+The orchestrating tool is responsible for calculating a Feature installation order (or error, if no valid installation order can be resolved). The set of Features to be installed is the union of user-defined Features and their dependencies.  The orchestrating tool will perform the following steps:
+
+#### **(B1) Building dependency graph**
+
+From the user-defined Features, the orchestrating tool will build a dependency graph.  The graph will be built by traversing the `dependsOn` and `installsAfter` properties of each Feature.  The metadata for each dependency is then fetched and the node added as an edge to to the dependent Feature.  For `dependsOn` dependencies, the dependency will be fed back into the worklist to be recursively resolved. 
+
+An accumulator is maintained with all uniquely discovered and user-provided Features, each with a reference to its dependencies.  If the exact Feature (see **Feature Equality**) has already been added to the accumulator, it will not be added again.  The accumulator will be fed into (B3) after the Feature tree has been resolved.
+
+The graph may be stored as an adjacency list with two kinds of edges (1) `dependsOn` edges or "hard dependencies" and (2) `installsAfter` edges or "soft dependencies".
+
+#### **(B2) Assigning `roundPriority`**
+
+Each node in the graph has an implicit, default `roundPriority` of 0.
+
+To influence installation order globally while still honoring the dependency graph of built in **(B1)**, `roundPriority` values may be tweaks for each Feature.  When each round is calculated in **(B3)**, only the Features equal to the max `roundPriority` of that set will be committed (the remaining will be uncommitted and reevaulated in subsequent rounds).
+
+The `roundPriority` is set to a non-zero value in the following instances:
+
+- If the [`devcontainer.json` contains an `overrideFeatureInstallOrder`](#overridefeatureinstallorder).
+
+#### **(B3) Round-based sorting**
+
+Perform a sort on the result of **(B1)** in rounds. This sort will rearrange Features, producing a sorted list of Features to install.  The sort will be performed as follows: 
+
+Start with all the elements from **(B2)** in a `worklist` and an empty list `installationOrder`.  While the `worklist` is not empty, iterate through each element in the `worklist` and check if all its dependencies (if any) are already members of `installationOrder`.  If the check is true, add it to an intermediate list `round` If not, skip it.  Equality is determined in **Feature Equality**.
+
+Then for each intermediate `round` list, commit to `installationOrder` only those nodes who share the maximum `roundPriority`.  Return all nodes in `round` with a strictly lower `roundPriority` to the `worklist` to be reprocessed in subsequent iterations.  If there are multiple nodes with the same `roundPriority`, commit them to `installationOrder` with a final sort according to **Round Stable Sort**.
+
+Repeat for as many rounds as necessary until `worklist` is empty.  If there is ever a round where no elements are added to `installationOrder`, the algorithm should terminate and return an error.  This indicates a circular dependency or other fatal error in the dependency graph.  Implementations should attempt to provide the user with information about the error and possible mitigation strategies.
+
+
+#### Definition: Feature Equality
+
+This specification defines two Features as equal if both Features point to the same exact contents and are executed with the same options.
+
+**For Features published to an OCI registry**, two Feature are identical if their manifest digests are equal, and the options executed against the Feature are equal (compared value by value).  Identical manifest digests implies that the tgz contents of the Feature and its entire `devcontainer-feature.json` are identical.  If any of these conditions are not met, the Features are considered not equal.
+
+**For Features fetched by HTTPS URI**, two Features are identical if the contents of the tgz are identical (hash to the same value), and the options executed against the Feature are equal (compared value by value).  If any of these conditions are not met, the Features are considered not equal.
+
+**For local Features**, each Feature is considered unique and not equal to any other local Feature.
+
+#### Definition: Round Stable Sort
+
+To prevent non-deterministic behavior, the algorithm will sort each **round** according to the following rules:
+
+- Compare and sort each Feature lexiographically by their fully qualified resource name (For OCI-published Features, that means the ID without version or digest.).  If the comparison is equal:
+- Compare and sort each Feature from oldest to newest tag (`latest` being the "most new").  If the comparision is equal:
+- Compare and sort each Feature by their options by:
+  - Greatest number of user-defined options (note omitting an option will default that value to the Feature's default value and is not considered a user-defined option). If the comparison is equal:
+  - Sort the provided option keys lexicographically.  If the comparison is equal:
+  - Sort the provided option values lexicographically. If the comparision is equal:
+- Sort Features by their canonical name (For OCI-published Features, the Feature ID resolved to the digest hash).
+
+If there is no difference based on these comparator rules, the Features are considered equal.
+
+## Note: Existing methods of altering Feature installation order
+
+Two existing properties (1) `installsAfter` on the Feature metadata, and  (2) `overrideFeatureInstallationOrder` in the `devcontainer.json` both exist to alter the installation order of user-defined Features.  The behavior of these properties are carried forward in this proposal.
+
+### installsAfter
+
+The `installsAfter` property is a "soft dependency" that influences the installation order of Features that are queued to be installed.  The effective behavior of this property is the same as `dependsOn`, with the following differences:
+
+- `installsAfter` is not recursive.  
+- `installsAfter` only influences the installation order of Features that are already set to be installed after resolving the dependency tree.
+- The Feature indicated by `installsAfter` can not provide options, nor are they able to be pinned to a specific version tag or digest.  This is unchanged from the current specification.
+
+From an implementation point of view, `installsAfter` nodes may be added as a seperate set of directed edges, just as `dependsOn` nodes are added as directed edges (see **(B1)**).  Before round-based installation and sorting **(B3)**, an orchestrating tool should remove all `installsAfter` directed edges that do not correspond with a Feature in the `worklist` that is set to be installed.  In each round, a Feature can then be installed if all its requirements (both `dependsOn` and `installsAfter` dependencies) have been fulfilled in previous rounds.
+
+An implemention should fail the dependency resolution step if the evaluation of the `installsAfter` property results in an inconsistent state (e.g. a circular dependency).
+
+### overrideFeatureInstallOrder
+
+The `overrideFeatureInstallOrder` property of `devcontainer.json` is an array of Feature IDs that are to be installed in descending priority order as soon as its dependencies outlined above are installed.  
+
+This evaluation is performed by assigning a [`roundPriority`](#b2-assigning-roundpriority) to all nodes that match the Feature identifier present in the property. 
+
+For example, given `n` Features in the `overrideFeatureInstallOrder` array, the orchestrating tool should assign a `roundPriority` of `n - idx` to each Feature, where `idx` is the zero-based index of the Feature in the array.
+
+For example:
+
+```json
+overrideFeatureInstallOrder = [
+  "foo",
+  "bar",
+  "baz"
+]
+```
+
+would result in the following `roundPriority` assignments:
+
+```json
+const roundPriority = {
+  "foo": 3,
+  "bar": 2,
+  "baz": 1
+}
+```
+
+This property must not influence the dependency relationship as defined by the dependency graph (see **(B1)**) and shall only be evaulated at the round-based sorting step (see **(B3)**).  Put another way, this property cannot "pull forward" a Feature until all of its dependencies (both soft and hard) have been installed.  After a Feature's dependencies have been installed in other rounds, this property should "pull forward" each Feature as early as possible (given the order of identifiers in the array).
+
+Similar to `installsAfter`, this property's members may not provide options, nor are they able to be pinned to a specific version tag or digest.  This is unchanged from the current specification.
+
+If a Feature is indicated in `overrideFeatureInstallOrder` but not a member of the dependency graph (i.e. it is not queued to be installed), the orchestrating tool may fail the dependency resolution step.
+
+## Additional Remarks
+
+### Feature authorship
+
+Features should be authored with the following considerations:
+
+- Features should be authored with the assumption that they will be installed in any order, so long as the dependencies are met at some point beforehand.
+- Since two Features with different options are considered different, a single Feature may be installed more than once.  Features should be idempotent.
+- Features that require updating shared state in the container (e.g. updating the `$PATH`), should be aware that the same Feature may be run multiple times. Consider a method for previous runs of the Feature to communicate with future runs, updating the shared state in the intended way.
+
+
+### Image Metadata
+
+Dependency resolution is only performed on initial container creation by reading the `features` object of `devcontainer.json` and resolving the Features in that point in time.  For subsequent creations from an image (or resumes of a dev container), the dependency tree is **not** re-calculated.  To re-calculate the dependency tree, the user must delete the image (or dev container) and recreate it from a `devcontainer.json`.
+
+Once Feature dependencies are resolved, they are treated the same as if members of the user-defined Features.  That means both user-defined Features and their dependencies are stored in the image's metadata.

--- a/conformance/spec/113500f4/features-contribute-lifecycle-scripts.md
+++ b/conformance/spec/113500f4/features-contribute-lifecycle-scripts.md
@@ -1,0 +1,126 @@
+# Allow Dev Container Features to contribute lifecycle scripts
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/60, https://github.com/devcontainers/spec/issues/181
+* CLI PR: https://github.com/devcontainers/cli/pull/390
+
+Below is the original proposal.
+
+## Goal
+
+Allow Feature authors to provide lifecycle hooks for their Features during a dev container build.
+
+## Proposal
+
+Introduce the following properties to [devcontainer-feature.json](https://containers.dev/implementors/features/#devcontainer-feature-json-properties), mirroring the behavior and syntax of the `devcontainer.json` lifecycle hooks.
+
+- "onCreateCommand"
+- "updateContentCommand"
+- "postCreateCommand"
+- "postStartCommand"
+- "postAttachCommand"
+
+Note that `initializeCommand` is omitted, pending further discussions around a secure design.
+
+As with all lifecycle hooks, commands are executed from the context (cwd) of the [project workspace folder](https://containers.dev/implementors/spec/#project-workspace-folder). 
+
+> **Note:** To use any assets (a script, etc...) embedded within a Feature in a lifecycle hook property, it is the Feature author's reponsibility to copy that assert to somewhere on the container where it will persist (outside of `/tmp`.) Implementations are not required to persist Feature install scripts beyond the initial build.
+
+All other semantics match the existing [Lifecycle Scripts](https://containers.dev/implementors/json_reference/#lifecycle-scripts) and [lifecycle script parallel execution](https://containers.dev/implementors/spec/#parallel-exec) behavior exactly.
+
+###  Execution
+
+When a dev container is brought up, for each lifecycle hook, each Feature that contributes a command to a lifecycle hook shall have the command executed in sequence, following the same execution order as outlined in [Feature installation order](https://containers.dev/implementors/features/#installation-order), and always before any user-provided lifecycle commands.
+
+## Examples
+
+
+### Executing a script in the workspace folder
+
+The follow example illustrates contributing an `onCreateCommand` and `postCreateCommand` script to `featureA`.  At each lifecycle hook during the build, the provided script will be executed in the [project workspace folder](https://containers.dev/implementors/spec/#project-workspace-folder), following the same semantics as [user-defined lifecycle hooks](https://containers.dev/implementors/json_reference/#lifecycle-scripts).
+
+```jsonc
+{
+   "id": "featureA",
+   "version": "1.0.0",
+   "onCreateCommand": "myOnCreate.sh && myOnCreate2.sh",
+   "postCreateCommand": "myPostCreate.sh",
+    "postAttachCommand": {
+        "command01": "myPostAttach.sh arg01",
+        "command02": "myPostAttach.sh arg02",
+    },
+}
+
+```
+
+### Executing a script bundled with the Feature
+
+The following example illustrates executing a `postCreateCommand` script bundled with the Feature.
+
+```jsonc
+{
+   "id": "featureB",
+   "version": "1.0.0",
+   "postCreateCommand": "/usr/myDir/bundledScript.sh",
+   "installsAfter": [
+        "featureA"
+   ]
+}
+```
+
+The `install.sh` will need to move this script to `/usr/myDir`.
+
+```
+#!/bin/sh
+
+cp ./bundleScript /usr/myDir
+...
+...
+```
+
+Given this example, `featureB`'s file structure would look something like:
+
+```
+.
+├── src
+│   ├── featureB
+│   │   ├── bundledScript.sh
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+```
+
+### Installation
+
+Given the following `devcontainer.json` and the two example Features above.
+
+```jsonc
+{
+    "image": "ubuntu",
+    "features": {
+        "featureA":  {},
+        "featureB":  {},
+    },
+    "postCreateCommand":  "userPostCreate.sh",
+    "postAttachCommand": {
+        "server": "npm start",
+        "db": ["mysql", "-u", "root", "-p", "my database"]
+    },
+}
+```
+
+The following timeline of events would occur. 
+
+> Note that:
+>
+>1. Each bullet point below is _blocking_. No subsequent lifecycle commands shall proceed until the current command completes.
+> 2.  If one of the lifecycle scripts fails, any subsequent scripts will not be executed. For instance, if a given `postCreate` command fails, the `postStart` hook and any following hooks will be skipped.
+>
+
+- `featureA`'s onCreateCommand
+- `featureA`'s postCreateCommand 
+- `featureB`'s postCreateCommand
+-  The user's postCreateCommand
+- `featureA`'s postAttachCommand **(parallel syntax, each command running in parallel)**
+-  The user's postAttachCommand **(parallel syntax, each command running in parallel)**
+
+Suppose `featureB`'s postCreateCommand exited were to exit unsuccessfully (non-zero exit code).  In this case, the `postAttachCommand` will never fire.

--- a/conformance/spec/113500f4/features-legacyIds-deprecated-properties.md
+++ b/conformance/spec/113500f4/features-legacyIds-deprecated-properties.md
@@ -1,0 +1,90 @@
+# Renaming and Deprecating Features
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/146
+* CLI PR: https://github.com/devcontainers/cli/pull/346, https://github.com/devcontainers/cli/pull/335
+
+Below is the original proposal.
+
+## Goal
+
+Adds support for renaming and deprecating a Feature.
+
+Adding two new properties to the [devcontainer-feature.json](../docs/specs/devcontainer-features.md#devcontainer-featurejson-properties) 👇 
+
+## 1. legacyIds
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `legacyIds` | array | Defaults to `[]`. Array of old IDs used to publish this Feature. The property is useful for renaming a currently published Feature within a single namespace. |
+
+### Steps to rename a Feature
+
+1. Update the Feature [source code](../docs/specs/features-distribution/#source-code) folder and the `id` property in the [devcontainer-feature.json properties](../docs/specs/devcontainer-features.md#devcontainer-featurejson-properties) to reflect the new `id`. Other properties (`name`, `documentationUrl`, etc.) can optionally be updated during this step.
+2. Add or update the `legacyIds` property to the Feature, including the previously used `id`.
+3. Bump the semantic version of the Feature.  
+4. Rerun the `devcontainer features publish` command, or equivalent tool that implements the [Features distribution specification](../docs/specs/features-distribution/#distribution).
+
+#### Example: Renaming a Feature
+
+Let's say we currently have a `docker-from-docker` Feature 👇 
+
+Current `devcontainer-feature.json` : 
+
+```jsonc
+{
+    "id": "docker-from-docker",
+    "version": "2.0.1",
+    "name": "Docker (Docker-from-Docker)",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-from-docker",
+    ....
+}
+```
+
+We'd want to rename this Feature to `docker-outside-of-docker`. The source code folder of the Feature will be updated to `docker-outside-of-docker` and the updated `devcontainer-feature.json` will look like 👇 
+
+```jsonc
+{
+    "id": "docker-outside-of-docker",
+    "version": "2.0.2",
+    "name": "Docker (Docker-outside-of-Docker)",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
+    "legacyIds": [
+        "docker-from-docker"
+    ]
+    ....
+}
+```
+
+**Note** - The semantic version of the Feature defined by the `version` property should be **continued** and should not be restarted at `1.0.0`.
+
+#### Changes to the Features distribution specification
+
+- [Tools implementing the Dev Container Features Distribution Specification](../docs/specs/features-distribution/#distribution) (e.g. [Dev Container CLI](https://github.com/devcontainers/cli) and [Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish)) will dual publish the old `id`s (defined by the `legacyIds` property), and the new `id`.
+  - The [putManifestWithTags](https://github.com/devcontainers/cli/blob/main/src/spec-configuration/containerCollectionsOCIPush.ts#L172) will be modified. The same `tgz` file for the `id` will be pushed to the `id`s  mentioned by the `legacyIds` property for all the [tags](https://github.com/devcontainers/cli/blob/main/src/spec-configuration/containerCollectionsOCIPush.ts#L175).
+
+#### Supporting backwards compatibility for [`installsAfter`](../docs/specs/devcontainer-features.md#2-the-installsafter-feature-property) property
+
+- Currently the `installsAfter` property is defined as an array consisting of the Feature `id` that should be installed before the given Feature.
+- The Feature to be renamed could be already defined by other Feature authors in their `installsAfter` property. Renaming the `id` could change the installation order for them if the `installsAfter` property is not updated with the new `id`. In order to avoid this unexpected behavior and to support back compat, the CLI tooling will be updated to also look at the `legacyIds` property along with the `id` for determining the installation order.
+ 
+ #### Supporting tools
+ 
+This property can be used by the supporting tools to indicate Feature rename in few ways 
+ - [Dev Container Publish GitHub Action](https://github.com/devcontainers/action) which auto-generates the README files can add a note with a list of old `id`s which were used to publish this Feature.
+ -  In the scenarios where Dev Configs are referencing the old `id`s,  the VS Code extension hints could be enhanced to deliver this warning that the `id` was renamed to a new one.
+- The [containers.dev/features](https://containers.dev/features) website, and [supporting tools](https://containers.dev/supporting) like [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [GitHub Codespaces](https://github.com/features/codespaces) wouldn't list the old `id`, instead list the new `id` of Features.
+ 
+## 2. deprecated
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `deprecated` | boolean | Defaults to `false`. Indicates that the Feature is deprecated, and will not receive any further updates/support. This property is intended to be used by the supporting tools to highlight Feature deprecation. |
+
+- If this property is set to `true`, then it indicates that the Feature is deprecated and won't be receiving any further updates/support. The OCI artifacts would exist, hence, the current dev configs will continue to work.
+- In case of security or other ciritical updates, the Feature author could still publish a new version of the deprecated Feature by bumping the semantic version of the Feature.
+- This property could be used by the supporting tools to indicate Feature deprecation in few ways -
+    - [Dev Container Publish GitHub Action](https://github.com/devcontainers/action) which auto-generates the README files can be updated to add a top-level header mentioning it's deprecation.
+    - The [containers.dev/features](https://containers.dev/features) website, and [supporting tools](https://containers.dev/supporting) like [VS Code Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [GitHub Codespaces](https://github.com/features/codespaces) wouldn't list the deprecated Features.
+    -  VS Code extension hints could be enhanced to deliver this information about it's deprecation.
+   

--- a/conformance/spec/113500f4/features-user-env-variables.md
+++ b/conformance/spec/113500f4/features-user-env-variables.md
@@ -1,0 +1,23 @@
+# User Env Variables for Features
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/91
+* CLI PR: https://github.com/devcontainers/cli/pull/228
+
+Below is the original proposal.
+
+## Goal
+
+Feature scripts run as the `root` user and sometimes need to know which user account the dev container will be used with.
+
+(The dev container user can be configured through the `remoteUser` property in the devcontainer.json. If that is not set, the container user will be used.)
+
+## Proposal
+
+Pass `_REMOTE_USER` and `_CONTAINER_USER` environment variables to the features scripts with `_CONTAINER_USER` being the container's user and `_REMOTE_USER` being the configured `remoteUser`. If no `remoteUser` is configured, `_REMOTE_USER` is set to the same value as `_CONTAINER_USER`.
+
+Additionally the home folders of the two users are passed to the feature scripts as `_REMOTE_USER_HOME` and `_CONTAINER_USER_HOME` environment variables.
+
+## Notes
+
+- The container user can be set with `containerUser` in the devcontainer.json and image metadata, `user` in the docker-compose.yml, `USER` in the Dockerfile and can be passed down from the base image.

--- a/conformance/spec/113500f4/gpu-host-requirement.md
+++ b/conformance/spec/113500f4/gpu-host-requirement.md
@@ -1,0 +1,29 @@
+# GPU Host Requirement
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/82
+* CLI PR: https://github.com/devcontainers/cli/pull/173
+
+Below is the original proposal.
+
+## Goal
+
+This proposal adds GPU support to the existing host requirements properties.
+- Issue: https://github.com/devcontainers/spec/issues/82
+- Community PR: https://github.com/devcontainers/cli/pull/173
+
+## Proposal
+
+We propose to add a new `gpu` property to the `hostRequirements` object in the devcontainer.json schema. The property can be a boolean value, the string `optional` or an object:
+
+(Additional row for the existing table in the spec.)
+| Property | Type | Description |
+|----------|------|-------------|
+| `hostRequirements.gpu` 🏷️ | boolean \| 'optional' | Indicates whether or not a GPU is required. A value 'optional' indicates that might be used if available. The object is described in the table below. The default is false. For example: `"hostRequirements": "optional"` |
+
+The object value can have the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hostRequirements.gpu.cores` 🏷️ | integer | Indicates the minimum required number of cores. For example: `"hostRequirements": { "gpu": {"cores": 2} }` |
+| `hostRequirements.gpu.memory` 🏷️ | string |  A string indicating minimum memory requirements with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"hostRequirements": {"memory": "4gb"}` |

--- a/conformance/spec/113500f4/image-metadata.md
+++ b/conformance/spec/113500f4/image-metadata.md
@@ -1,0 +1,93 @@
+# Image Metadata
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/18
+* CLI PR: https://github.com/devcontainers/cli/pull/188
+
+Below is the original proposal.
+
+## Goal
+
+Record dev container config and feature metadata in prebuilt images, such that, the image and the built-in features can be used with a devcontainer.json (image-, Dockerfile- or Docker Compose-based) that does not repeat the dev container config or feature metadata. Other tools should be able to record the same metadata without necessarily using features themselves.
+
+Current dev container config that can be recorded in the image: `mounts`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `customizations`, `remoteUser`, `userEnvProbe`, `remoteEnv`, `containerEnv`, `overrideCommand`, `portsAttributes`, `otherPortsAttributes`, `forwardPorts`, `shutdownAction`, `updateRemoteUserUID` and `hostRequirements`.
+
+Current feature metadata relevant for using the feature when it is already part of the image: `mounts`, `init`, `privileged`, `capAdd`, `securityOpt`, `entrypoint` and `customizations`.
+
+We can add to these lists as we add more properties to the dev container configuration and the feature metadata.
+
+## Proposal
+
+We propose to add metadata to the image with the following structure using one entry per feature and devcontainer.json (see table below for the full list):
+
+```
+[
+	{
+		"id"?: string,
+		"init"?: boolean,
+		"privileged"?: boolean,
+		"capAdd"?: string[],
+		"securityOpt"?: string[],
+		"entrypoint"?: string,
+		"mounts"?: [],
+		...
+		"customizations"?: {
+			...
+		}
+	},
+	...
+]
+```
+
+To simplify adding this metadata for other tools, we also support having a single top-level object with the same properties.
+
+The metadata is added to the image as a `devcontainer.metadata` label with a JSON string value representing the above array or single object.
+
+## Merge Logic
+
+To apply the metadata together with a user's devcontainer.json at runtime the following merge logic by property is used. The table also notes which properties are currently supported coming from the devcontainer.json and which from the feature metadata, this will change over time as we add more properties.
+
+| Property | Type/Format | Merge Logic | devcontainer.json | Feature Metadata |
+| -------- | ----------- | ----------- | :---------------: | :--------------: |
+| `id` | E.g., `ghcr.io/devcontainers/features/node:1` | Not merged. |   | x |
+| `init` | `boolean` | `true` if at least one is `true`, `false` otherwise. | x | x |
+| `privileged` | `boolean` | `true` if at least one is `true`, `false` otherwise. | x | x |
+| `capAdd` | `string[]` | Union of all `capAdd` arrays without duplicates. | x | x |
+| `securityOpt` | `string[]` | Union of all `securityOpt` arrays without duplicates. | x | x |
+| `entrypoint` | `string` | Collected list of all entrypoints. |   | x |
+| `mounts` | `(string \| { type, src, dst })[]` | Collected list of all mountpoints. Conflicts: Last source wins. | x | x |
+| `onCreateCommand` | `string \| string[]` | Collected list of all onCreateCommands. | x |   |
+| `updateContentCommand` | `string \| string[]` | Collected list of all updateContentCommands. | x |   |
+| `postCreateCommand` | `string \| string[]` | Collected list of all postCreateCommands. | x |   |
+| `postStartCommand` | `string \| string[]` | Collected list of all postStartCommands. | x |   |
+| `postAttachCommand` | `string \| string[]` | Collected list of all postAttachCommands. | x |   |
+| `waitFor` | enum | Last value wins. | x |   |
+| `customizations` | Object of tool-specific customizations. | Merging is left to the tools. | x | x |
+| `containerUser` | `string` | Last value wins. | x |   |
+| `remoteUser` | `string` | Last value wins. | x |   |
+| `userEnvProbe` | `string` (enum) | Last value wins. | x |   |
+| `remoteEnv` | Object of strings. | Per variable, last value wins. | x |   |
+| `containerEnv` | Object of strings. | Per variable, last value wins. | x |   |
+| `overrideCommand` | `boolean` | Last value wins. | x |   |
+| `portsAttributes` | Map of ports to attributes. | Per port (not per port attribute), last value wins. | x |   |
+| `otherPortsAttributes` | Port attributes. | Last value wins (not per port attribute). | x |   |
+| `forwardPorts` | `(number \| string)[]` | Union of all ports without duplicates. Last one wins (when mapping changes). | x |   |
+| `shutdownAction` | `string` (enum) | Last value wins. | x |   |
+| `updateRemoteUserUID` | `boolean` | Last value wins. | x |   |
+| `hostRequirements` | `cpus`, `memory`, `storage` | Max value wins. | x |   |
+
+Variables in string values will be substituted at the time the value is applied. When the order matters, the devcontainer.json is considered last.
+
+## Additional devcontainer.json Properties
+
+We are adding support for `mounts`, `containerEnv`, `containerUser`, `init`, `privileged`, `capAdd`, and `securityOpt` to the devcontainer.json (also with Docker Compose) the same way these properties are already supported in the feature metadata.
+
+## Notes
+
+- Passing the label as a `LABEL` instruction in the Dockerfile:
+	- The size limit on Dockerfiles is around 1.3MB. The line length is limited to 65k characters.
+	- Using one line per feature should allow for making full use of these limits.
+- Passing the label as a command line argument:
+	- There is no size limit documented for labels, but the daemon returns an error when the request header is >500kb.
+	- The 500kb limit is shared, so we cannot use a second label in the same build to avoid it.
+	- If/when this becomes an issue we could embed the metadata as a file in the image (e.g., with a label indicating it).

--- a/conformance/spec/113500f4/manifest.json
+++ b/conformance/spec/113500f4/manifest.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "documents": [
+    {
+      "key": "reference",
+      "file": "devcontainer-reference.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-reference.md",
+      "sha256": "daef12b6b61d91322c84fadffce188646fcfb067660803e1b622154b02b6185f",
+      "scope": "consumer"
+    },
+    {
+      "key": "json-reference",
+      "file": "devcontainerjson-reference.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainerjson-reference.md",
+      "sha256": "d1f7f3620d5caf82497c6972da6ea8139984b8108f47eefa5d67e4b3a12caa8a",
+      "scope": "consumer"
+    },
+    {
+      "key": "supporting-tools",
+      "file": "supporting-tools.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/supporting-tools.md",
+      "sha256": "716c01e66cf12dd4e50e9ecc71f6c1fa7d3b772975ab4fa9749fa196fa84dc76",
+      "scope": "consumer"
+    },
+    {
+      "key": "image-metadata",
+      "file": "image-metadata.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/image-metadata.md",
+      "sha256": "433503201027ccc01d2cff83c9c84e084739d281c2bbab6e55c7f472c4a36da6",
+      "scope": "consumer"
+    },
+    {
+      "key": "lockfile",
+      "file": "devcontainer-lockfile.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-lockfile.md",
+      "sha256": "a24d8571fddce54f2b4e320926928066c7efcae56d42dd17570daab2b199f800",
+      "scope": "consumer"
+    },
+    {
+      "key": "devcontainer-id-variable",
+      "file": "devcontainer-id-variable.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-id-variable.md",
+      "sha256": "ea9174aecefff9f1becb61d3b186bebe4609639505c65ef08e2c172c79ce9d48",
+      "scope": "consumer"
+    },
+    {
+      "key": "parallel-lifecycle",
+      "file": "parallel-lifecycle-script-execution.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/parallel-lifecycle-script-execution.md",
+      "sha256": "9e5274c9079e6fd6b595ddc74b867195b3612a2805fa3c516e29ba943a27ab16",
+      "scope": "consumer"
+    },
+    {
+      "key": "features-lifecycle-scripts",
+      "file": "features-contribute-lifecycle-scripts.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/features-contribute-lifecycle-scripts.md",
+      "sha256": "024976b7db816a955ba8116fbdd67c97702186a834938cce39706950830c466e",
+      "scope": "consumer"
+    },
+    {
+      "key": "features-user-env",
+      "file": "features-user-env-variables.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/features-user-env-variables.md",
+      "sha256": "4fc549b9390efe6a6ad21b7cfc966ab4a1e0b8377b3af92f508aa0a99edaf190",
+      "scope": "consumer"
+    },
+    {
+      "key": "feature-dependencies",
+      "file": "feature-dependencies.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/feature-dependencies.md",
+      "sha256": "e5a37893d9cab790499860abad25f2c90006a2180dae6e43679ddbd52e50810a",
+      "scope": "consumer"
+    },
+    {
+      "key": "gpu-host-requirement",
+      "file": "gpu-host-requirement.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/gpu-host-requirement.md",
+      "sha256": "fdf3741b2e5d33e026b609b0657746403dacfcf0ff6a450fca5daa44ee649fe6",
+      "scope": "consumer"
+    },
+    {
+      "key": "declarative-secrets",
+      "file": "declarative-secrets.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/declarative-secrets.md",
+      "sha256": "ea4acc0cc9a557ace68fa28e22b56006bb6c34ce4c2eabdb99a2c0d0a05abf82",
+      "scope": "consumer"
+    },
+    {
+      "key": "secrets-support",
+      "file": "secrets-support.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/secrets-support.md",
+      "sha256": "af4775cbe1984a1e05a6cc3f32c3bac3da65d544a92d3c4fc5be86e9d8d9e65c",
+      "scope": "consumer"
+    },
+    {
+      "key": "features-legacy-ids",
+      "file": "features-legacyIds-deprecated-properties.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/features-legacyIds-deprecated-properties.md",
+      "sha256": "021b198f6305142b60ac5b3731f4704cd4546ab21e250af2b73bd4f0deab7852",
+      "scope": "consumer"
+    },
+    {
+      "key": "features",
+      "file": "devcontainer-features.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-features.md",
+      "sha256": "c054b4fd79c3f88673e6254c67d485f910fc464bd8c1785be6db48e1ffdc9f3a",
+      "scope": "authoring"
+    },
+    {
+      "key": "features-distribution",
+      "file": "devcontainer-features-distribution.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-features-distribution.md",
+      "sha256": "64e6555816dbf43c9af2610def74191bbe8a7de834acf39bf1cf516b8109a5ba",
+      "scope": "authoring"
+    },
+    {
+      "key": "templates",
+      "file": "devcontainer-templates.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-templates.md",
+      "sha256": "fe4757e34f74073830d619ac35af11003bee4ee69a50a02c152c59f468be7efd",
+      "scope": "authoring"
+    },
+    {
+      "key": "templates-distribution",
+      "file": "devcontainer-templates-distribution.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-templates-distribution.md",
+      "sha256": "9a2a27514a37ce8d89af841f3137815b8cd925737904c71a668c64087f4bb960",
+      "scope": "authoring"
+    }
+  ]
+}

--- a/conformance/spec/113500f4/parallel-lifecycle-script-execution.md
+++ b/conformance/spec/113500f4/parallel-lifecycle-script-execution.md
@@ -1,0 +1,32 @@
+# Parallel Lifecycle Script Execution
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/83
+* CLI PR: https://github.com/devcontainers/cli/pull/172
+
+Below is the original proposal.
+
+## Goal
+
+Support executing multiple lifecycle scripts in parallel by providing them in `object` form.
+
+## Motivation
+
+Dev containers support a single command for each of their lifecycle scripts. While serial execution of multiple commands can be achieved with `;`, `&&`, etc. parallel is less straightforward and so deserves first-class support.
+
+## Spec changes
+
+All lifecycle scripts will be extended to support `object` types. The key of the `object` will be a unique name for the command and the value will be the `string` or `array` command. Each command must exit successfully for the stage to be considered successful.
+
+Each entry in the `object` will be run in parallel during that lifecycle step.
+
+### Example
+
+```json
+{
+  "postCreateCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```

--- a/conformance/spec/113500f4/secrets-support.md
+++ b/conformance/spec/113500f4/secrets-support.md
@@ -1,0 +1,44 @@
+# First Class Secrets Support
+
+This has now been implemented:
+* Discussion issue: https://github.com/devcontainers/spec/issues/219
+* CLI PR: https://github.com/devcontainers/cli/pull/493
+
+Below is the original proposal.
+
+## What are secrets
+Secrets are variables that hold sensitive values and need to be handled securely at all times (API keys, passwords etc.). Users can change a secret's value at any time, and a conforming dev containers implementation should support dynamically changing secrets without having to rebuild the container.
+
+## Goal
+
+Support secrets as a first class feature in dev containers implementations.
+
+This feature should consist of the ability to securely pass in the secrets, make them available for users to consume similar to remoteEnv and containerEnv, and be processed and handled securely at all times.
+This functionality will allow consumers to be able to use secrets more predictably and securely with their dev containers implementation.
+
+## Motivation
+
+Today many consumers pass secret variables as `remoteEnv`, since there are no other mechanisms to pass them explicitly as secrets. The dev containers reference implementation do not (and need not) treat `remoteEnv` as secrets. Having explicit support for secrets will help eliminate security threats such as leaking secrets, as well as in improving customer confidence.
+
+## Proposal
+
+A [supporting tool](https://containers.dev/supporting#tools) (e.g. the [dev container CLI reference implementation](https://github.com/devcontainers/cli)) should behave according to the following properties:
+
+  1. Ability to pass secrets to commands
+  2. Apply/use secrets similar to `remoteEnv`
+  3. Securely handle secrets
+
+### Passing secrets in
+Secrets are not part of dev containers specification and we do not expect users to store secrets inside `devcontainer.json` file. A conforming implementation should provide a secure mechanism to pass secrets, such as a secrets file, Windows credential manager, Mac keychain, Azure keyvault etc. for example.
+
+#### **Example**
+
+Using a file to pass in the secrets can be one of the simple approaches to adopt. In this example the supporting tool can input secrets in a JSON file format.
+
+```json
+{
+	"API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
+	"NUGET_CONFIG": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n    <add key=\"http_proxy\" value=\"http://company-squid:3128@contoso.com\" />\n</config>",
+	"PASSWORD": "Simple Passwords"
+}
+```

--- a/conformance/spec/113500f4/supporting-tools.md
+++ b/conformance/spec/113500f4/supporting-tools.md
@@ -1,0 +1,148 @@
+# Supporting Tools and Services
+
+**Note: For the latest set of supporting tools, please check out https://containers.dev/supporting.**
+
+This page outlines tools and services that currently support the Development Container Specification, including the `devcontainer.json` format. A `devcontainer.json` file in your project tells tools and services that support the dev container spec how to access (or create) a dev container with a well-defined tool and runtime stack. 
+
+While most [dev container properties](devcontainerjson-reference.md) apply to any supporting tool or service, a few are specific to certain tools, which are outlined below.
+
+## Editors
+
+### Visual Studio Code
+
+Visual Studio Code specific properties go under `vscode` inside `customizations`.
+
+
+```jsonc
+"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {},
+			"extensions": [],
+		}
+}
+```
+
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `extensions` | array | An array of extension IDs that specify the extensions that should be installed inside the container when it is created. Defaults to `[]`. |
+| `settings` | object | Adds default `settings.json` values into a container/machine specific settings file. Defaults to `{}`. |
+
+Please note that the VS Code [Dev Containers](#visual-studio-code-remote---containers) extension and [GitHub Codespaces](#github-codespaces) support the VS Code properties.
+
+### Visual Studio
+
+Visual Studio added dev container support in Visual Studio 2022 17.4 for C++ projects using CMake Presets. It is part of the Linux and embedded development with C++ workload, so make sure it is selected in your VS installation. Visual Studio manages the lifecycle of dev containers it uses as you work, but it treats them as remote targets in a similar way to other Linux or WSL targets.
+
+You may learn more in the [announcement blog post](https://devblogs.microsoft.com/cppblog/dev-containers-for-c-in-visual-studio/).
+
+## Tools
+
+### Dev Container CLI
+
+A dev container command line interface (CLI) that implements this specification. It is in development in the [devcontainers/cli](https://github.com/devcontainers/cli) repo.
+
+### VS Code extension CLI
+
+VS Code has a [CLI](https://code.visualstudio.com/docs/remote/devcontainer-cli) which may be installed within the Dev Containers extension or through the command line.
+
+### Cachix devenv
+
+Cachix's [devenv](https://devenv.sh/) supports automatically generating a `.devcontainer.json` file so you can use it with any Dev Container Spec supporting tool. See [devenv documentation](https://devenv.sh/integrations/codespaces-devcontainer/) for detais. 
+
+### Jetpack.io Devbox
+
+[Jetpack.io's VS Code extension](https://marketplace.visualstudio.com/items?itemName=jetpack-io.devbox) supports a **Generate Dev Container files** command so you can use Jetpack.io from Dev Container Spec supporting tools.
+
+### Visual Studio Code Dev Containers
+
+The [**Visual Studio Code Dev Containers** extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) lets you use a container as a full-featured development environment. It allows you to open any folder inside (or mounted into) a container and take advantage of Visual Studio Code's full feature set. There is more information in the Dev Containers [documentation](https://code.visualstudio.com/docs/remote/containers).
+
+> **Tip:** If you've already built a container and connected to it, be sure to run **Dev Containers: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
+
+#### Product specific properties
+
+Dev Containers implements the [VS Code](#visual-studio-code) specific properties.
+
+#### Product specific limitations
+
+Some properties may also have certain limitations in the Dev Containers extension.
+
+| Property or variable | Type | Description |
+|----------|------|-------------|
+| `workspaceMount` | string | Not yet supported when using Clone Repository in Container Volume. |
+| `workspaceFolder` | string | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolder}`  | Any | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolderBasename}` | Any | Not yet supported when using Clone Repository in Container Volume. |
+
+### GitHub Codespaces
+
+A [codespace](https://docs.github.com/en/codespaces/overview) is a development environment that's hosted in the cloud. Codespaces run on a variety of VM-based compute options hosted by GitHub.com, which you can configure from 2 core machines up to 32 core machines. You can connect to your codespaces from the browser or locally using Visual Studio Code.
+
+> **Tip:** If you've already built a codespace and connected to it, be sure to run **Codespaces: Rebuild Container** from the Command Palette (`kbstyle(F1)`) to pick up any changes you make.
+
+> **Tip:** Codespaces implements an auto `workspaceFolder` mount in **Docker Compose** scenarios.
+
+#### Product specific properties
+GitHub Codespaces works with a growing number of tools and, where applicable, their `devcontainer.json` properties. For example, connecting the codespaces web editor or VS Code enables the use of [VS Code properties](#visual-studio-code).
+
+If your codespaces project needs additional permissions for other repositories, you can configure this through the `repositories` and `permissions` properties. You may learn more about this in the [Codespaces documentation](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-repository-access-for-your-codespaces). As with other tools, Codespaces specific properties are placed within a `codespaces` namespace inside the `customizations` property.
+
+```jsonc
+"customizations": {
+	// Configure properties specific to Codespaces.
+	"codespaces": {
+		"repositories": {
+			"my_org/my_repo": {
+				"permissions": {
+					"issues": "write"
+				}
+			}
+		}
+	}
+}
+```
+
+You can customize which files are initially opened when the codespace is created:
+```jsonc
+"customizations": {
+	// Configure properties specific to Codespaces.
+	"codespaces": {
+		"openFiles": [
+			"README"
+			"src/index.js"
+		]
+	}
+}
+```
+
+The paths are relative to the root of the repository. They will be opened in order, with the first file activated.
+
+Codespaces will automatically perform some default setup when the `devcontainer.json` does not specify a `postCreateCommand`. This can be disabled with the `disableAutomaticConfiguration` setting:
+
+```jsonc
+"customizations": {
+	// Configure properties specific to Codespaces.
+	"codespaces": {
+		"disableAutomaticConfiguration": true
+	}
+}
+```
+
+Note that currently codespaces reads these properties from `devcontainer.json`, not image metadata.
+
+#### Product specific limitations
+
+Some properties may apply differently to codespaces.
+
+| Property or variable | Type | Description |
+|----------|---------|----------------------|
+| `mounts` | array | Codespaces ignores "bind" mounts with the exception of the Docker socket. Volume mounts are still allowed.|
+| `forwardPorts` | array | Codespaces does not yet support the `"host:port"` variation of this property. |
+| `portsAttributes` | object | Codespaces does not yet support the `"host:port"` variation of this property.|
+| `shutdownAction` | enum | Does not apply to Codespaces. |
+| `${localEnv:VARIABLE_NAME}` | Any | For Codespaces, the host is in the cloud rather than your local machine.|
+| `customizations.codespaces` | object | Codespaces reads this property from devcontainer.json, not image metadata. |
+| `hostRequirements` | object | Codespaces reads this property from devcontainer.json, not image metadata. |

--- a/crates/conformance/src/bin/conformance.rs
+++ b/crates/conformance/src/bin/conformance.rs
@@ -18,21 +18,27 @@ use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
 
 use deacon_conformance::certify::certify;
+use deacon_conformance::clause::{generate_clauses, render as render_clauses, write_clauses};
+use deacon_conformance::clause_diff::{
+    diff as clause_diff, render_json as render_clause_diff_json, render_md as render_clause_diff_md,
+};
 use deacon_conformance::diff::{
     diff, render_json as render_diff_json, render_md as render_diff_md,
 };
 use deacon_conformance::inventory::{
     InventoryDrift, compare, generate_inventory, render, write_inventory,
 };
-use deacon_conformance::load::{LoadError, Registry, load_inventory};
-use deacon_conformance::model::ConstraintInventory;
+use deacon_conformance::load::{
+    LoadError, Registry, load_clause_inventory, load_inventory, load_spec_manifest,
+};
+use deacon_conformance::model::{ClauseInventory, ConstraintInventory, DocumentScope};
 use deacon_conformance::report::write_reports;
 use deacon_conformance::validate::{
-    InventoryInputs, Violation, validate_path, validate_path_with_inventory,
+    ClauseInputs, InventoryInputs, Violation, validate_path, validate_path_with_inventory,
 };
 use deacon_conformance::{
-    CURRENT_SCHEMA_PIN, default_inventory_file, default_pinned_schemas_dir, default_registry_dir,
-    workspace_root,
+    CURRENT_SCHEMA_PIN, clause_paths_for, default_clauses_file, default_inventory_file,
+    default_pinned_schemas_dir, default_pinned_spec_dir, default_registry_dir, workspace_root,
 };
 
 /// Structural conformance-registry tooling (dev-only).
@@ -85,6 +91,67 @@ enum Command {
     Inventory {
         #[command(subcommand)]
         command: InventoryCommand,
+    },
+    /// Normative clause inventory tooling (021-normative-clause-inventory).
+    Clause {
+        #[command(subcommand)]
+        command: ClauseCommand,
+    },
+}
+
+/// `clause <generate|check|diff|scaffold>` — machine-owned prose-clause inventory
+/// operations (contracts/cli-clause.md). NEVER performs network IO and NEVER invokes
+/// an LLM — pure functions of the committed records and the vendored pinned prose.
+#[derive(Debug, Subcommand)]
+enum ClauseCommand {
+    /// Canonicalize the committed clause records against the vendored pinned prose
+    /// (recomputes ids/fingerprints, verifies each excerpt is present at its heading).
+    Generate {
+        /// Pinned-spec directory (holds `manifest.json` + the vendored Markdown files).
+        /// Defaults to `<workspace>/conformance/spec/<pin>/`.
+        #[arg(long, value_name = "DIR")]
+        spec: Option<PathBuf>,
+        /// Output clause-inventory file. Defaults to
+        /// `<workspace>/conformance/inventory/clauses.json`.
+        #[arg(long, value_name = "FILE")]
+        clauses: Option<PathBuf>,
+    },
+    /// Regenerate in memory and byte-compare against the committed clause inventory.
+    Check {
+        /// Pinned-spec directory (see `generate`).
+        #[arg(long, value_name = "DIR")]
+        spec: Option<PathBuf>,
+        /// Committed clause-inventory file to compare against (see `generate --clauses`).
+        #[arg(long, value_name = "FILE")]
+        clauses: Option<PathBuf>,
+    },
+    /// Deterministically diff two clause-inventory files (data-model §4, match key:
+    /// substance-anchored id): new / removed / moved / changed / non-material.
+    Diff {
+        /// The old (left) clause-inventory file.
+        #[arg(value_name = "OLD")]
+        old: PathBuf,
+        /// The new (right) clause-inventory file.
+        #[arg(value_name = "NEW")]
+        new: PathBuf,
+        /// Output format. Defaults to `json`; `md` renders the human review document.
+        #[arg(long, value_name = "FORMAT", default_value = "json")]
+        format: DiffFormat,
+        /// Write the diff to a file instead of stdout.
+        #[arg(long, value_name = "FILE")]
+        out: Option<PathBuf>,
+    },
+    /// Emit skeleton `clc-` records (stdout only) for every currently unclassified
+    /// clause, with the sentinel `disposition: "UNREVIEWED"` (loader-rejected). Per-clause
+    /// skeletons for consumer/ambiguous clauses; one per-document skeleton for authoring
+    /// documents. Never writes into the registry.
+    Scaffold {
+        /// Committed clause-inventory file to scaffold from (see `generate --clauses`).
+        #[arg(long, value_name = "FILE")]
+        clauses: Option<PathBuf>,
+        /// Pinned-spec directory (for per-document `scope`). Defaults to the pinned dir.
+        #[arg(long, value_name = "DIR")]
+        spec: Option<PathBuf>,
     },
 }
 
@@ -187,6 +254,333 @@ fn run(cli: Cli) -> i32 {
                 inventory_scaffold(&registry_dir, inventory)
             }
         },
+        Command::Clause { command } => match command {
+            ClauseCommand::Generate { spec, clauses } => clause_generate(spec, clauses),
+            ClauseCommand::Check { spec, clauses } => clause_check(spec, clauses),
+            ClauseCommand::Diff {
+                old,
+                new,
+                format,
+                out,
+            } => clause_diff_cmd(&old, &new, format, out.as_deref()),
+            ClauseCommand::Scaffold { clauses, spec } => {
+                clause_scaffold(&registry_dir, clauses, spec)
+            }
+        },
+    }
+}
+
+/// `clause generate` (contracts/cli-clause.md): fingerprint-verify the spec manifest,
+/// canonicalize the committed clause records against the vendored prose, and write the
+/// byte-stable inventory atomically. Exit `0` on success, `1` on any integrity error
+/// (never a partial file), `2` on a write IO failure.
+fn clause_generate(spec: Option<PathBuf>, clauses: Option<PathBuf>) -> i32 {
+    let spec_dir = spec.unwrap_or_else(default_pinned_spec_dir);
+    let out_file = clauses.unwrap_or_else(default_clauses_file);
+
+    let inventory = match generate_clauses(&spec_dir, &out_file) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!("error: clause generation failed: {e}");
+            return 1;
+        }
+    };
+    match write_clauses(&out_file, &inventory) {
+        Ok(()) => {
+            println!("{}", out_file.display());
+            eprintln!(
+                "wrote {} clause unit(s) to {}",
+                inventory.units.len(),
+                out_file.display()
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!(
+                "error: could not write clauses to {}: {e}",
+                out_file.display()
+            );
+            2
+        }
+    }
+}
+
+/// `clause check` (contracts/cli-clause.md): regenerate in memory and byte-compare
+/// against the committed clause inventory. Exit `0` if identical, `1` if it differs or
+/// on any generate-class error, `2` if the committed file is unreadable.
+fn clause_check(spec: Option<PathBuf>, clauses: Option<PathBuf>) -> i32 {
+    let spec_dir = spec.unwrap_or_else(default_pinned_spec_dir);
+    let clauses_file = clauses.unwrap_or_else(default_clauses_file);
+
+    let regenerated = match generate_clauses(&spec_dir, &clauses_file) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!("error: clause regeneration failed: {e}");
+            return 1;
+        }
+    };
+    let committed_raw = match std::fs::read_to_string(&clauses_file) {
+        Ok(raw) => raw,
+        Err(e) => {
+            eprintln!(
+                "error: could not read committed clause inventory {}: {e}",
+                clauses_file.display()
+            );
+            return 2;
+        }
+    };
+
+    if committed_raw == render_clauses(&regenerated) {
+        eprintln!("ok: {} matches regeneration", clauses_file.display());
+        return 0;
+    }
+
+    // Compute a compact new/removed/moved/changed summary for diagnosis.
+    match serde_json::from_str::<ClauseInventory>(&committed_raw) {
+        Ok(committed) => {
+            let d = clause_diff(&committed, &regenerated);
+            eprintln!(
+                "error: committed clause inventory {} is out of date (new {}, removed {}, moved {}, \
+                 changed {}, non-material {})",
+                clauses_file.display(),
+                d.new_clauses.len(),
+                d.removed.len(),
+                d.moved.len(),
+                d.changed.len(),
+                d.non_material.len(),
+            );
+            for e in &d.new_clauses {
+                eprintln!("  + {}", e.id);
+            }
+            for e in &d.removed {
+                eprintln!("  - {}", e.id);
+            }
+            for e in &d.changed {
+                eprintln!("  ~ {} -> {}", e.old_id, e.new_id);
+            }
+        }
+        Err(e) => eprintln!(
+            "error: committed clause inventory is out of date and unparseable: {}: {e}",
+            clauses_file.display()
+        ),
+    }
+    1
+}
+
+/// `clause diff <old> <new>` (contracts/cli-clause.md): load two clause-inventory files,
+/// compute the deterministic revision diff, and write it to stdout or `--out`. Exit `0`
+/// on success (incl. an empty diff), `1` on unreadable/malformed input, `2` on `--out`
+/// write failure. NEVER performs network IO.
+fn clause_diff_cmd(old: &Path, new: &Path, format: DiffFormat, out: Option<&Path>) -> i32 {
+    let old_inv = match load_clause_diff_input(old) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+    let new_inv = match load_clause_diff_input(new) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+
+    let result = clause_diff(&old_inv, &new_inv);
+    let rendered = match format {
+        DiffFormat::Json => render_clause_diff_json(&result),
+        DiffFormat::Md => render_clause_diff_md(&result),
+    };
+    let summary = format!(
+        "new {}, removed {}, moved {}, changed {}, non-material {}",
+        result.new_clauses.len(),
+        result.removed.len(),
+        result.moved.len(),
+        result.changed.len(),
+        result.non_material.len(),
+    );
+
+    match out {
+        Some(path) => match std::fs::write(path, &rendered) {
+            Ok(()) => {
+                println!("{}", path.display());
+                eprintln!("wrote clause diff to {} ({summary})", path.display());
+                0
+            }
+            Err(e) => {
+                eprintln!(
+                    "error: could not write clause diff to {}: {e}",
+                    path.display()
+                );
+                2
+            }
+        },
+        None => {
+            print!("{rendered}");
+            eprintln!("clause diff: {summary}");
+            0
+        }
+    }
+}
+
+/// Read one `clause diff` input file into a [`ClauseInventory`] (a missing file is a hard
+/// error — the diff has two required positional inputs).
+fn load_clause_diff_input(path: &Path) -> Result<ClauseInventory, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read clause inventory {}: {e}", path.display()))?;
+    serde_json::from_str::<ClauseInventory>(&raw)
+        .map_err(|e| format!("could not parse clause inventory {}: {e}", path.display()))
+}
+
+/// `clause scaffold` (contracts/cli-clause.md): emit skeleton `clc-` records to stdout for
+/// every currently unclassified clause. Per-clause skeletons for consumer/ambiguous
+/// clauses; ONE per-document skeleton for an authoring document that has no covering
+/// document-scope record yet. Each carries the sentinel `disposition: "UNREVIEWED"` — a
+/// value the loader rejects. Never writes into the registry.
+///
+/// Exit `0` on success (possibly zero skeletons); `1` if the inventory/registry/manifest
+/// is unreadable.
+fn clause_scaffold(registry_dir: &Path, clauses: Option<PathBuf>, spec: Option<PathBuf>) -> i32 {
+    let (default_spec, default_clauses) = clause_paths_for(registry_dir);
+    let clauses_file = clauses.unwrap_or(default_clauses);
+    let spec_dir = spec.unwrap_or(default_spec);
+
+    let committed = match load_clause_inventory(&clauses_file) {
+        Ok(Some(inv)) => inv,
+        Ok(None) => {
+            eprintln!(
+                "error: committed clause inventory {} does not exist",
+                clauses_file.display()
+            );
+            return 1;
+        }
+        Err(e) => {
+            eprintln!(
+                "error: could not read committed clause inventory {}: {e}",
+                clauses_file.display()
+            );
+            return 1;
+        }
+    };
+    let manifest = match load_spec_manifest(&spec_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!(
+                "error: could not read spec manifest {}: {e}",
+                spec_dir.display()
+            );
+            return 1;
+        }
+    };
+    let scope: HashSet<&str> = manifest
+        .documents
+        .iter()
+        .filter(|d| d.scope == DocumentScope::Authoring)
+        .map(|d| d.key.as_str())
+        .collect();
+    let registry = match Registry::load(registry_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!(
+                "error: could not read registry {}: {e}",
+                registry_dir.display()
+            );
+            return 1;
+        }
+    };
+    // Already-covered: per-clause classifications by clause id; document defaults by key.
+    let classified_clauses: HashSet<&str> = registry
+        .clause_classifications
+        .iter()
+        .filter_map(|c| c.clause.as_deref())
+        .collect();
+    let classified_docs: HashSet<&str> = registry
+        .clause_classifications
+        .iter()
+        .filter_map(|c| c.document.as_deref())
+        .collect();
+
+    use deacon_conformance::model::Testability;
+    let mut skeletons: Vec<ClauseScaffoldRecord> = Vec::new();
+    let mut emitted_doc_defaults: HashSet<String> = HashSet::new();
+    for unit in &committed.units {
+        if classified_clauses.contains(unit.id.as_str()) {
+            continue;
+        }
+        let authoring = scope.contains(unit.document.as_str());
+        let ambiguous = unit.testability == Testability::Ambiguous;
+        // Authoring, non-ambiguous clauses are covered by a per-document default.
+        if authoring && !ambiguous {
+            if classified_docs.contains(unit.document.as_str())
+                || emitted_doc_defaults.contains(&unit.document)
+            {
+                continue;
+            }
+            emitted_doc_defaults.insert(unit.document.clone());
+            skeletons.push(ClauseScaffoldRecord::for_document(&unit.document));
+        } else {
+            skeletons.push(ClauseScaffoldRecord::for_clause(&unit.id));
+        }
+    }
+
+    match serde_json::to_string_pretty(&skeletons) {
+        Ok(doc) => println!("{doc}"),
+        Err(e) => {
+            eprintln!("error: could not serialize scaffold records: {e}");
+            return 1;
+        }
+    }
+    eprintln!(
+        "emitted {} skeleton clause-classification record(s) for {} (sentinel disposition \
+         \"UNREVIEWED\" — edit before committing)",
+        skeletons.len(),
+        clauses_file.display()
+    );
+    0
+}
+
+/// A skeleton clause-classification record emitted by `clause scaffold` (sentinel
+/// `disposition: "UNREVIEWED"`, loader-rejected). Not the typed `ClauseClassification`.
+#[derive(Debug, serde::Serialize)]
+struct ClauseScaffoldRecord {
+    id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    clause: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    document: Option<String>,
+    disposition: &'static str,
+    behaviors: Vec<String>,
+    rationale: Option<String>,
+    notes: Option<String>,
+}
+
+impl ClauseScaffoldRecord {
+    const SENTINEL: &'static str = "UNREVIEWED";
+
+    fn for_clause(clause_id: &str) -> ClauseScaffoldRecord {
+        let tail = clause_id.strip_prefix("clu-").unwrap_or(clause_id);
+        ClauseScaffoldRecord {
+            id: format!("clc-{tail}"),
+            clause: Some(clause_id.to_string()),
+            document: None,
+            disposition: ClauseScaffoldRecord::SENTINEL,
+            behaviors: Vec::new(),
+            rationale: None,
+            notes: None,
+        }
+    }
+
+    fn for_document(document: &str) -> ClauseScaffoldRecord {
+        ClauseScaffoldRecord {
+            id: format!("clc-doc-{document}"),
+            clause: None,
+            document: Some(document.to_string()),
+            disposition: ClauseScaffoldRecord::SENTINEL,
+            behaviors: Vec::new(),
+            rationale: None,
+            notes: None,
+        }
     }
 }
 
@@ -505,7 +899,18 @@ fn validate(registry_dir: &Path, today: &str, json: bool) -> i32 {
         schemas_dir: &schemas_dir,
         inventory_file: &inventory_file,
     };
-    let violations = match validate_path_with_inventory(registry_dir, today, &repo_root, &inputs) {
+    let (spec_dir, clauses_file) = clause_paths_for(registry_dir);
+    let clause_inputs = ClauseInputs {
+        spec_dir: &spec_dir,
+        clauses_file: &clauses_file,
+    };
+    let violations = match validate_path_with_inventory(
+        registry_dir,
+        today,
+        &repo_root,
+        &inputs,
+        &clause_inputs,
+    ) {
         Ok(violations) => violations,
         Err(LoadError::Root { path, cause }) => {
             eprintln!("error: cannot read registry root {path:?}: {cause}");
@@ -593,8 +998,50 @@ fn report(registry_dir: &Path, today: &str, out_dir: Option<PathBuf>) -> i32 {
         }
     };
 
+    // The committed clause inventory + spec manifest are siblings of the registry dir.
+    let (spec_dir, clauses_file) = clause_paths_for(registry_dir);
+    let clause_inventory = match load_clause_inventory(&clauses_file) {
+        Ok(inv) => inv,
+        Err(e) => {
+            eprintln!(
+                "error: could not load clause inventory {}: {e}",
+                clauses_file.display()
+            );
+            return 2;
+        }
+    };
+    // Document-scope sets for the clause join (empty when the manifest is absent).
+    let (authoring_docs, covered_docs) = match load_spec_manifest(&spec_dir) {
+        Ok(manifest) => {
+            let authoring: std::collections::HashSet<String> = manifest
+                .documents
+                .iter()
+                .filter(|d| d.scope == DocumentScope::Authoring)
+                .map(|d| d.key.clone())
+                .collect();
+            let covered: std::collections::HashSet<String> = registry
+                .clause_classifications
+                .iter()
+                .filter_map(|c| c.document.clone())
+                .filter(|d| authoring.contains(d))
+                .collect();
+            (authoring, covered)
+        }
+        Err(_) => (
+            std::collections::HashSet::new(),
+            std::collections::HashSet::new(),
+        ),
+    };
+
     let out_dir = out_dir.unwrap_or_else(default_report_dir);
-    match write_reports(&registry, inventory.as_ref(), &out_dir) {
+    match write_reports(
+        &registry,
+        inventory.as_ref(),
+        clause_inventory.as_ref(),
+        &authoring_docs,
+        &covered_docs,
+        &out_dir,
+    ) {
         Ok((json_path, md_path)) => {
             // Human-readable result on stdout; diagnostics on stderr.
             println!("{}", json_path.display());
@@ -630,7 +1077,12 @@ fn certify_cmd(registry_dir: &Path, today: &str, json: bool) -> i32 {
         schemas_dir: &schemas_dir,
         inventory_file: &inventory_file,
     };
-    let result = certify(&registry, &inputs);
+    let (spec_dir, clauses_file) = clause_paths_for(registry_dir);
+    let clause_inputs = ClauseInputs {
+        spec_dir: &spec_dir,
+        clauses_file: &clauses_file,
+    };
+    let result = certify(&registry, &inputs, &clause_inputs);
 
     if json {
         match serde_json::to_string_pretty(&result) {
@@ -648,6 +1100,11 @@ fn certify_cmd(registry_dir: &Path, today: &str, json: bool) -> i32 {
                 BlockingKind::Uncovered => println!("blocking uncovered: {}", item.id),
                 BlockingKind::Constraint => println!(
                     "blocking constraint ({}): {}",
+                    item.code.as_deref().unwrap_or("?"),
+                    item.id
+                ),
+                BlockingKind::Clause => println!(
+                    "blocking clause ({}): {}",
                     item.code.as_deref().unwrap_or("?"),
                     item.id
                 ),

--- a/crates/conformance/src/certify.rs
+++ b/crates/conformance/src/certify.rs
@@ -28,7 +28,7 @@ use serde::Serialize;
 
 use crate::coverage::Coverage;
 use crate::load::Registry;
-use crate::validate::{InventoryInputs, check_inventory};
+use crate::validate::{ClauseInputs, InventoryInputs, check_clause_inventory, check_inventory};
 
 /// Why a certification is blocked: an unresolved gap record, an in-profile behavior
 /// with no structural coverage, or a schema-constraint-inventory join violation
@@ -46,6 +46,11 @@ pub enum BlockingKind {
     /// breakage). The [`Blocking::code`] carries the specific class
     /// (020-schema-constraint-inventory T037; contracts/cli-inventory.md).
     Constraint,
+    /// A normative-clause-inventory join violation (V11 stale, V12 unclassified/ambiguous/
+    /// duplicated clause, V13 malformed classification, V14 provenance, V15 clause↔source
+    /// integrity). The [`Blocking::code`] carries the specific class
+    /// (021-normative-clause-inventory; contracts/clause-classification-schema.md).
+    Clause,
 }
 
 /// One blocking item: its `kind`, the offending record ID, and — for a `constraint`
@@ -87,7 +92,11 @@ pub struct Certification {
 /// For a fixture registry that ships neither a committed inventory nor a vendored
 /// schemas directory, [`check_inventory`] scopes itself out and contributes nothing —
 /// certification then reduces to the gap/uncovered gate exactly as before this wiring.
-pub fn certify(registry: &Registry, inventory: &InventoryInputs) -> Certification {
+pub fn certify(
+    registry: &Registry,
+    inventory: &InventoryInputs,
+    clauses: &ClauseInputs,
+) -> Certification {
     let coverage = Coverage::evaluate(registry);
 
     let profile = coverage.profile.map(|p| p.id.clone()).unwrap_or_default();
@@ -107,10 +116,16 @@ pub fn certify(registry: &Registry, inventory: &InventoryInputs) -> Certificatio
     // which of stale/unclassified/malformed/provenance failed.
     let inventory_blockers = check_inventory(registry, inventory);
 
+    // Normative-clause-inventory join violations (V11–V15) block certification
+    // (021-normative-clause-inventory; wired last per research Decision 10). The SAME
+    // implementation `validate` runs.
+    let clause_blockers = check_clause_inventory(registry, clauses);
+
     // Blocking order: all gaps first, then all uncovered, then all constraint
-    // violations (each group already deterministically ordered).
-    let mut blocking: Vec<Blocking> =
-        Vec::with_capacity(gap_ids.len() + uncovered_ids.len() + inventory_blockers.len());
+    // violations, then all clause violations (each group deterministically ordered).
+    let mut blocking: Vec<Blocking> = Vec::with_capacity(
+        gap_ids.len() + uncovered_ids.len() + inventory_blockers.len() + clause_blockers.len(),
+    );
     blocking.extend(gap_ids.into_iter().map(|id| Blocking {
         kind: BlockingKind::Gap,
         id: id.to_string(),
@@ -123,6 +138,11 @@ pub fn certify(registry: &Registry, inventory: &InventoryInputs) -> Certificatio
     }));
     blocking.extend(inventory_blockers.into_iter().map(|v| Blocking {
         kind: BlockingKind::Constraint,
+        id: v.record,
+        code: Some(v.code),
+    }));
+    blocking.extend(clause_blockers.into_iter().map(|v| Blocking {
+        kind: BlockingKind::Clause,
         id: v.record,
         code: Some(v.code),
     }));
@@ -160,12 +180,21 @@ mod tests {
         }
     }
 
+    /// Clause inputs pointing at absent paths, so [`check_clause_inventory`] scopes itself
+    /// out (these fixtures ship no committed clause inventory / vendored prose).
+    fn no_clauses() -> ClauseInputs<'static> {
+        ClauseInputs {
+            spec_dir: Path::new("/nonexistent-conformance/spec"),
+            clauses_file: Path::new("/nonexistent-conformance/inventory/clauses.json"),
+        }
+    }
+
     #[test]
     fn valid_fixture_with_a_gap_is_not_certified() {
         // The valid fixture carries `gap-readconfig-remote-user`, so it is structurally
         // valid yet NOT certified — a gap always blocks (FR-020, FR-025).
         let registry = valid_registry();
-        let result = certify(&registry, &no_inventory());
+        let result = certify(&registry, &no_inventory(), &no_clauses());
         assert!(!result.certified, "a registry with a gap must not certify");
         assert!(
             result
@@ -188,7 +217,7 @@ mod tests {
     fn empty_registry_certifies_cleanly() {
         // Nothing in-profile, no gaps → certified (mirrors the real seed registry).
         let registry = Registry::default();
-        let result = certify(&registry, &no_inventory());
+        let result = certify(&registry, &no_inventory(), &no_clauses());
         assert!(result.certified, "empty registry must certify");
         assert!(result.blocking.is_empty());
         assert!(result.waived.is_empty());

--- a/crates/conformance/src/clause.rs
+++ b/crates/conformance/src/clause.rs
@@ -1,0 +1,451 @@
+//! Clause canonicalization, substance-anchored IDs, and atomic write
+//! (021-normative-clause-inventory, research Decisions 1–4; T014/T015).
+//!
+//! [`generate_clauses`] drives the CI-facing pipeline: load + fingerprint-verify the
+//! spec manifest, parse each vendored prose document, then **canonicalize** the committed
+//! (human-authored) clause records against that prose — recompute each clause's
+//! normalized-substance fingerprint and substance-anchored ID, verify the excerpt is
+//! present in the pinned document under its recorded heading, cross-check the strength
+//! label against the excerpt's RFC-2119 keywords, merge records that share a normalized
+//! substance into one unit with combined `locations`, and sort canonically. It invents no
+//! clauses and invokes no model or network — segmentation is out-of-band authoring work
+//! (research Decision 1). [`render`] serializes canonically and [`write_clauses`] commits
+//! atomically (temp file + rename), mirroring [`crate::inventory`].
+//!
+//! ## Stable ID scheme (research Decision 2)
+//!
+//! `clu-<doc>-<substance-slug>-<strength>-<hash8>`:
+//! - `<doc>` — manifest document key;
+//! - `<substance-slug>` — a bounded readable slug of the normalized substance's LEADING
+//!   tokens (identity is NOT carried here);
+//! - `<strength>` — a short strength code;
+//! - `<hash8>` — the first 8 lowercase-hex chars of SHA-256 over
+//!   `document ‖ normalize_substance(excerpt)` joined by the `0x1f` unit separator.
+//!   **Location is excluded**, so a pure move preserves the ID (and its disposition); a
+//!   material change (obligation or strength reworded ⇒ different normalized substance)
+//!   mints a new ID (drift-forcing).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use crate::load::{LoadError, load_clause_inventory, load_spec_manifest};
+use crate::model::{
+    ClauseInventory, ClauseLocation, ClauseUnit, SpecManifest, Strength, Testability,
+};
+use crate::prose::Document;
+use crate::prose::normalize::{fingerprint, normalize_substance};
+use crate::prose::strength::{has_family, hides_mandatory_keyword};
+
+/// The clause-inventory schema version (data-model.md §2).
+const SCHEMA_VERSION: u32 = 1;
+
+/// The fixed separator byte for the ID hash inputs (`0x1f`), matching 020's discipline —
+/// it cannot appear in a document key or in normalized substance text.
+const HASH_SEPARATOR: u8 = 0x1f;
+
+/// The maximum substance-slug length (readability only — identity lives in the hash).
+const SLUG_MAX: usize = 48;
+
+// ---------------------------------------------------------------------------
+// Generation pipeline
+// ---------------------------------------------------------------------------
+
+/// Canonicalize the committed clause records under `clauses_file` against the vendored,
+/// fingerprint-verified prose under `spec_dir`. Fail-loud on every integrity error
+/// (fingerprint mismatch, missing excerpt at anchor, strength/keyword contradiction,
+/// inconsistent merge); never produces a partial result. An absent `clauses_file` is
+/// treated as an empty authored set (an empty inventory under the manifest revision).
+pub fn generate_clauses(
+    spec_dir: &Path,
+    clauses_file: &Path,
+) -> Result<ClauseInventory, LoadError> {
+    let manifest = load_spec_manifest(spec_dir)?;
+    let documents = parse_documents(spec_dir, &manifest)?;
+
+    let committed = load_clause_inventory(clauses_file)?;
+    let raw: Vec<RawClause> = committed.as_ref().map(flatten).unwrap_or_default();
+
+    let units = canonicalize(raw, &documents, &manifest)?;
+    Ok(ClauseInventory {
+        schema_version: SCHEMA_VERSION,
+        revision: manifest.revision,
+        units,
+    })
+}
+
+/// Parse every vendored prose document named by the manifest into a [`Document`], keyed by
+/// document key. The manifest fingerprints are already verified by [`load_spec_manifest`].
+fn parse_documents(
+    spec_dir: &Path,
+    manifest: &SpecManifest,
+) -> Result<HashMap<String, Document>, LoadError> {
+    let mut docs = HashMap::with_capacity(manifest.documents.len());
+    for doc in &manifest.documents {
+        let path = spec_dir.join(&doc.file);
+        let raw = std::fs::read_to_string(&path).map_err(|e| LoadError::MalformedSchema {
+            document: doc.key.clone(),
+            cause: format!("could not read vendored prose {path:?}: {e}"),
+        })?;
+        docs.insert(doc.key.clone(), Document::parse(&raw));
+    }
+    Ok(docs)
+}
+
+/// One authored clause location flattened out of a committed unit — the atomic input to
+/// canonicalization. Strength/testability/context are inherited from the owning unit.
+struct RawClause {
+    document: String,
+    strength: Strength,
+    testability: Testability,
+    context: Option<serde_json::Value>,
+    location: ClauseLocation,
+}
+
+/// Flatten a committed inventory into per-location raw clauses (canonicalization regroups
+/// them by derived ID, which is idempotent for an already-canonical file).
+fn flatten(inventory: &ClauseInventory) -> Vec<RawClause> {
+    let mut out = Vec::new();
+    for unit in &inventory.units {
+        for location in &unit.locations {
+            out.push(RawClause {
+                document: unit.document.clone(),
+                strength: unit.strength,
+                testability: unit.testability,
+                context: unit.context.clone(),
+                location: location.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// Canonicalize raw clauses into sorted, merged [`ClauseUnit`]s with the fail-loud
+/// integrity checks (T015). Returns every unit sorted by `id`; identical inputs produce
+/// byte-identical output.
+fn canonicalize(
+    raws: Vec<RawClause>,
+    documents: &HashMap<String, Document>,
+    manifest: &SpecManifest,
+) -> Result<Vec<ClauseUnit>, LoadError> {
+    let manifest_keys: std::collections::HashSet<&str> =
+        manifest.documents.iter().map(|d| d.key.as_str()).collect();
+
+    // Accumulate by derived ID, merging locations.
+    let mut by_id: HashMap<String, ClauseUnit> = HashMap::new();
+    // Track (strength, testability, context) per id so an inconsistent merge is fail-loud.
+    for raw in raws {
+        // The document key must be a real manifest document.
+        if !manifest_keys.contains(raw.document.as_str()) {
+            return Err(LoadError::MalformedSchema {
+                document: raw.document.clone(),
+                cause: format!(
+                    "clause references document key {:?}, absent from the spec manifest",
+                    raw.document
+                ),
+            });
+        }
+        let doc = documents
+            .get(&raw.document)
+            .ok_or_else(|| LoadError::MalformedSchema {
+                document: raw.document.clone(),
+                cause: "no parsed prose for this document key".to_string(),
+            })?;
+
+        let normalized = normalize_substance(&raw.location.excerpt);
+        let id = derive_clause_id(&raw.document, raw.strength, &normalized);
+
+        // Integrity: strength ↔ excerpt keyword agreement (V15, Decision 4).
+        check_strength(&id, raw.strength, &raw.location.excerpt)?;
+
+        // Integrity: excerpt present in the pinned document under its recorded heading (V15).
+        if !doc.contains_excerpt_at(&raw.location.anchor, &raw.location.excerpt) {
+            return Err(LoadError::ExcerptNotFoundAtAnchor {
+                clause: id,
+                heading: raw.location.heading.clone(),
+            });
+        }
+
+        let fp = fingerprint(&raw.location.excerpt);
+        match by_id.get_mut(&id) {
+            Some(existing) => {
+                // A merge is only sound when the merged records agree on strength,
+                // testability, and context (identical substance ⇒ identical obligation).
+                if existing.testability != raw.testability || existing.context != raw.context {
+                    return Err(LoadError::MalformedSchema {
+                        document: raw.document.clone(),
+                        cause: format!(
+                            "clause id {id:?} merges records with conflicting testability/context; \
+                             identical substance must carry an identical disposition"
+                        ),
+                    });
+                }
+                existing.locations.push(raw.location);
+            }
+            None => {
+                by_id.insert(
+                    id.clone(),
+                    ClauseUnit {
+                        id,
+                        document: raw.document,
+                        strength: raw.strength,
+                        testability: raw.testability,
+                        fingerprint: fp,
+                        locations: vec![raw.location],
+                        context: raw.context,
+                    },
+                );
+            }
+        }
+    }
+
+    let mut units: Vec<ClauseUnit> = by_id.into_values().collect();
+    for unit in &mut units {
+        // Locations sorted by (anchor, ordinal); dedup byte-identical duplicates.
+        unit.locations
+            .sort_by(|a, b| a.anchor.cmp(&b.anchor).then(a.ordinal.cmp(&b.ordinal)));
+        unit.locations.dedup();
+    }
+    units.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(units)
+}
+
+/// The strength ↔ excerpt keyword cross-check (V15, research Decision 4): a
+/// `must`/`should`/`may` clause MUST carry the corresponding keyword family; a
+/// `descriptive` clause MUST NOT hide a mandatory keyword.
+fn check_strength(id: &str, strength: Strength, excerpt: &str) -> Result<(), LoadError> {
+    match strength {
+        Strength::Must | Strength::Should | Strength::May => {
+            if !has_family(excerpt, strength) {
+                return Err(LoadError::StrengthKeywordMismatch {
+                    clause: id.to_string(),
+                    labeled: strength_wire(strength).to_string(),
+                    detected: crate::prose::strength::detect_strength(excerpt)
+                        .map(|s| strength_wire(s).to_string())
+                        .unwrap_or_else(|| "none".to_string()),
+                });
+            }
+        }
+        Strength::Descriptive => {
+            if hides_mandatory_keyword(excerpt) {
+                return Err(LoadError::StrengthKeywordMismatch {
+                    clause: id.to_string(),
+                    labeled: "descriptive".to_string(),
+                    detected: "must".to_string(),
+                });
+            }
+        }
+        // `algorithm` / `io-contract` carry no single-keyword contract.
+        Strength::Algorithm | Strength::IoContract => {}
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Stable ID derivation (research Decision 2)
+// ---------------------------------------------------------------------------
+
+/// Derive the substance-anchored `clu-…` id: `clu-<doc>-<substance-slug>-<strength>-<hash8>`.
+/// `normalized` MUST be `normalize_substance(excerpt)`.
+pub fn derive_clause_id(document: &str, strength: Strength, normalized: &str) -> String {
+    let slug = slugify_leading(normalized);
+    let code = strength_code(strength);
+    let hash8 = hash8(document, normalized);
+    format!("clu-{document}-{slug}-{code}-{hash8}")
+}
+
+/// First 8 lowercase-hex chars of SHA-256 over `document ‖ normalized` (location excluded).
+fn hash8(document: &str, normalized: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(document.as_bytes());
+    hasher.update([HASH_SEPARATOR]);
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(8);
+    for b in &digest[..4] {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// A short, stable strength code for the ID (single ID segment — no internal hyphen).
+fn strength_code(strength: Strength) -> &'static str {
+    match strength {
+        Strength::Must => "must",
+        Strength::Should => "should",
+        Strength::May => "may",
+        Strength::Algorithm => "algo",
+        Strength::IoContract => "io",
+        Strength::Descriptive => "desc",
+    }
+}
+
+/// The wire spelling of a strength (for diagnostics).
+fn strength_wire(strength: Strength) -> &'static str {
+    match strength {
+        Strength::Must => "must",
+        Strength::Should => "should",
+        Strength::May => "may",
+        Strength::Algorithm => "algorithm",
+        Strength::IoContract => "io-contract",
+        Strength::Descriptive => "descriptive",
+    }
+}
+
+/// Slugify the LEADING tokens of the normalized substance for readability: keep
+/// `[a-z0-9]`, collapse everything else to `-`, bound to [`SLUG_MAX`] at a clean hyphen
+/// boundary. The empty/keyword-free case slugs to `clause`.
+fn slugify_leading(normalized: &str) -> String {
+    let mut slug = String::with_capacity(normalized.len().min(SLUG_MAX + 8));
+    let mut prev_dash = false;
+    for ch in normalized.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            slug.push('-');
+            prev_dash = true;
+        }
+        if slug.trim_matches('-').len() >= SLUG_MAX {
+            break;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        return "clause".to_string();
+    }
+    if slug.len() <= SLUG_MAX {
+        return slug.to_string();
+    }
+    // Keep the leading SLUG_MAX chars, trimmed to a clean trailing hyphen boundary.
+    let head = &slug[..SLUG_MAX];
+    let trimmed = match head.rfind('-') {
+        Some(i) if i > 0 => &head[..i],
+        _ => head,
+    };
+    trimmed.trim_matches('-').to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Serialization + atomic write
+// ---------------------------------------------------------------------------
+
+/// Render the clause inventory to its canonical string form: 2-space indent, LF endings,
+/// trailing newline. Identical inputs render byte-identically (research Decision 3).
+pub fn render(inventory: &ClauseInventory) -> String {
+    let mut out = serde_json::to_string_pretty(inventory)
+        .unwrap_or_else(|e| unreachable!("clause inventory serialization is infallible: {e}"));
+    out.push('\n');
+    out
+}
+
+/// Atomically write the rendered inventory to `path` (temp file + rename), creating the
+/// parent directory if needed. Never leaves a partial file (mirrors
+/// `inventory::write_inventory` / `cache/disk.rs::save_index`).
+pub fn write_clauses(path: &Path, inventory: &ClauseInventory) -> std::io::Result<()> {
+    let contents = render(inventory);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("clauses.json");
+
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = parent.join(format!("{file_name}.tmp.{}.{}", std::process::id(), seq));
+
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn id_is_substance_anchored_and_location_independent() {
+        let a = derive_clause_id(
+            "reference",
+            Strength::Must,
+            &normalize_substance("MUST do X."),
+        );
+        // Whitespace/markdown reflow → same normalized substance → same id (a pure move
+        // keeps identity).
+        let b = derive_clause_id(
+            "reference",
+            Strength::Must,
+            &normalize_substance("MUST   do **X**."),
+        );
+        assert_eq!(a, b, "immaterial reflow keeps the id");
+        // A material substance change mints a new id.
+        let c = derive_clause_id(
+            "reference",
+            Strength::Must,
+            &normalize_substance("MUST do Y."),
+        );
+        assert_ne!(a, c);
+        assert!(a.starts_with("clu-reference-"));
+        assert!(a.contains("-must-"));
+        assert_eq!(a.rsplit('-').next().unwrap().len(), 8, "hash8 is 8 chars");
+    }
+
+    #[test]
+    fn slugify_leading_is_bounded_and_uses_the_start() {
+        let s = slugify_leading(
+            "the oncreatecommand command must be run only once during the container lifecycle",
+        );
+        assert!(s.len() <= SLUG_MAX, "slug bounded: {s} ({})", s.len());
+        assert!(
+            s.starts_with("the-oncreatecommand"),
+            "slug uses the start: {s}"
+        );
+        assert_eq!(slugify_leading(""), "clause");
+    }
+
+    #[test]
+    fn strength_codes_are_single_segments() {
+        for s in [
+            Strength::Must,
+            Strength::Should,
+            Strength::May,
+            Strength::Algorithm,
+            Strength::IoContract,
+            Strength::Descriptive,
+        ] {
+            assert!(!strength_code(s).contains('-'), "code {s:?} has no hyphen");
+        }
+    }
+
+    #[test]
+    fn render_is_deterministic_and_newline_terminated() {
+        let inv = ClauseInventory {
+            schema_version: 1,
+            revision: "rev-spec-113500f4".to_string(),
+            units: vec![ClauseUnit {
+                id: "clu-reference-x-must-00000000".to_string(),
+                document: "reference".to_string(),
+                strength: Strength::Must,
+                testability: Testability::DirectlyTestable,
+                fingerprint: "ab".to_string(),
+                locations: vec![ClauseLocation {
+                    heading: "H".to_string(),
+                    anchor: "h".to_string(),
+                    ordinal: 1,
+                    excerpt: "MUST x".to_string(),
+                }],
+                context: Some(json!({ "inCodeFence": true })),
+            }],
+        };
+        let a = render(&inv);
+        let b = render(&inv);
+        assert_eq!(a, b);
+        assert!(a.ends_with('\n'));
+    }
+}

--- a/crates/conformance/src/clause_diff.rs
+++ b/crates/conformance/src/clause_diff.rs
@@ -1,0 +1,553 @@
+//! Deterministic revision diff between two clause inventories
+//! (021-normative-clause-inventory, research Decision 9 / data-model.md §4).
+//!
+//! Unlike 020's `(document, pointer, kind)` match key, [`diff`] matches units on their
+//! **substance-anchored ID** (⇔ the normalized-substance fingerprint, location excluded),
+//! which is what makes **moves first-class**: a clause whose substance is unchanged but
+//! whose heading moved keeps its ID and is reported as `moved` (old/new locations) —
+//! non-blocking, disposition preserved. A unit present only on the right is `new`; only on
+//! the left is `removed`. A material rewrite mints a new ID, so it surfaces as a `removed`
+//! old-ID + a `new` new-ID sharing a heading — paired into `changed` for the reviewer. A
+//! same-ID pair whose excerpt bytes differ at the same heading (whitespace/reflow) is
+//! `nonMaterial`. Every bucket is deterministically sorted by `(document, heading, id)`;
+//! both renderers mirror `diff.rs`'s byte-stable discipline.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use serde::Serialize;
+
+use crate::model::{ClauseInventory, ClauseLocation, ClauseUnit, Strength};
+
+/// The revision-diff schema version.
+const SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Output model (camelCase on the wire)
+// ---------------------------------------------------------------------------
+
+/// The complete `clause diff` document (data-model.md §4). Command-only output, never
+/// committed; deterministic for identical inputs.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClauseRevisionDiff {
+    pub schema_version: u32,
+    pub old: DiffSide,
+    pub new: DiffSide,
+    /// Clause IDs present only in `new`.
+    pub new_clauses: Vec<ClauseEntry>,
+    /// Clause IDs present only in `old` (that were not paired into `changed`).
+    pub removed: Vec<ClauseEntry>,
+    /// Same-ID pairs whose locations moved (heading changed) — disposition preserved.
+    pub moved: Vec<MovedEntry>,
+    /// A removed old-ID + a new new-ID sharing a heading (a material rewrite).
+    pub changed: Vec<ChangedEntry>,
+    /// Same-ID pairs whose excerpt bytes differ but the substance is unchanged.
+    pub non_material: Vec<NonMaterialEntry>,
+}
+
+/// One side's revision identity.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct DiffSide {
+    pub revision: String,
+}
+
+/// An added-or-removed clause — the full unit shape.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ClauseEntry {
+    pub id: String,
+    pub document: String,
+    pub strength: Strength,
+    pub locations: Vec<ClauseLocation>,
+}
+
+/// A moved clause: same ID, different locations (old/new shown).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MovedEntry {
+    pub id: String,
+    pub document: String,
+    pub old_locations: Vec<ClauseLocation>,
+    pub new_locations: Vec<ClauseLocation>,
+}
+
+/// A material rewrite: a removed old-ID + a new new-ID sharing a heading.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangedEntry {
+    pub document: String,
+    pub heading: String,
+    pub old_id: String,
+    pub new_id: String,
+    pub old_excerpt: String,
+    pub new_excerpt: String,
+}
+
+/// A same-ID immaterial excerpt change (whitespace/reflow at the same heading).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NonMaterialEntry {
+    pub id: String,
+    pub old_excerpt: String,
+    pub new_excerpt: String,
+}
+
+// ---------------------------------------------------------------------------
+// Diffing
+// ---------------------------------------------------------------------------
+
+/// Compute the deterministic diff of `new` against `old` (data-model.md §4).
+pub fn diff(old: &ClauseInventory, new: &ClauseInventory) -> ClauseRevisionDiff {
+    let old_by_id: BTreeMap<&str, &ClauseUnit> =
+        old.units.iter().map(|u| (u.id.as_str(), u)).collect();
+    let new_by_id: BTreeMap<&str, &ClauseUnit> =
+        new.units.iter().map(|u| (u.id.as_str(), u)).collect();
+
+    let mut new_clauses: Vec<ClauseEntry> = Vec::new();
+    let mut removed: Vec<ClauseEntry> = Vec::new();
+    let mut moved: Vec<MovedEntry> = Vec::new();
+    let mut non_material: Vec<NonMaterialEntry> = Vec::new();
+
+    // IDs in both: unchanged / moved / non-material.
+    for (id, nu) in &new_by_id {
+        let Some(ou) = old_by_id.get(id) else {
+            new_clauses.push(clause_entry(nu));
+            continue;
+        };
+        let old_anchors = anchor_set(ou);
+        let new_anchors = anchor_set(nu);
+        if old_anchors != new_anchors {
+            moved.push(MovedEntry {
+                id: (*id).to_string(),
+                document: nu.document.clone(),
+                old_locations: ou.locations.clone(),
+                new_locations: nu.locations.clone(),
+            });
+        } else if ou.locations != nu.locations {
+            // Same headings, excerpt bytes changed — immaterial (substance unchanged).
+            non_material.push(NonMaterialEntry {
+                id: (*id).to_string(),
+                old_excerpt: first_excerpt(ou),
+                new_excerpt: first_excerpt(nu),
+            });
+        }
+        // else: fully unchanged.
+    }
+
+    // IDs only in old are removals (some pair into `changed` below).
+    for (id, ou) in &old_by_id {
+        if !new_by_id.contains_key(id) {
+            removed.push(clause_entry(ou));
+        }
+    }
+
+    // Pair removed old-IDs and new new-IDs that share a heading anchor into `changed`.
+    let changed = pair_changed(&mut removed, &mut new_clauses);
+
+    // Deterministic ordering.
+    new_clauses.sort_by(clause_sort_key);
+    removed.sort_by(clause_sort_key);
+    moved.sort_by(|a, b| (&a.document, &a.id).cmp(&(&b.document, &b.id)));
+    non_material.sort_by(|a, b| a.id.cmp(&b.id));
+
+    ClauseRevisionDiff {
+        schema_version: SCHEMA_VERSION,
+        old: DiffSide {
+            revision: old.revision.clone(),
+        },
+        new: DiffSide {
+            revision: new.revision.clone(),
+        },
+        new_clauses,
+        removed,
+        moved,
+        changed,
+        non_material,
+    }
+}
+
+impl ClauseRevisionDiff {
+    /// Whether the two inventories are clause-identical (every bucket empty).
+    pub fn is_empty(&self) -> bool {
+        self.new_clauses.is_empty()
+            && self.removed.is_empty()
+            && self.moved.is_empty()
+            && self.changed.is_empty()
+            && self.non_material.is_empty()
+    }
+}
+
+/// Pair a removed old clause with a new clause under the same leading heading anchor into a
+/// `changed` entry (a material rewrite reads as "changed" for the reviewer). A pairing is
+/// made ONLY when an anchor carries exactly one removed and one added clause — an
+/// unambiguous 1:1 rewrite. When an anchor has more than one removed or added clause we
+/// cannot tell which removal corresponds to which addition, so those clauses are left in
+/// the `removed`/`new_clauses` buckets rather than paired arbitrarily: an arbitrary pairing
+/// would both fabricate a spurious "change" and hide the genuine add/remove of unrelated
+/// clauses that merely share a heading. Paired entries are drained from
+/// `removed`/`new_clauses`; unpaired ones stay. Deterministic.
+fn pair_changed(
+    removed: &mut Vec<ClauseEntry>,
+    new_clauses: &mut Vec<ClauseEntry>,
+) -> Vec<ChangedEntry> {
+    use std::collections::BTreeMap;
+
+    // Group indices by leading anchor.
+    let mut rem_by_anchor: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, e) in removed.iter().enumerate() {
+        rem_by_anchor
+            .entry(leading_anchor(e).to_string())
+            .or_default()
+            .push(i);
+    }
+    let mut new_by_anchor: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, e) in new_clauses.iter().enumerate() {
+        new_by_anchor
+            .entry(leading_anchor(e).to_string())
+            .or_default()
+            .push(i);
+    }
+
+    let mut changed: Vec<ChangedEntry> = Vec::new();
+    let mut removed_taken: Vec<bool> = vec![false; removed.len()];
+    let mut new_taken: Vec<bool> = vec![false; new_clauses.len()];
+
+    for (anchor, rem_idx) in &rem_by_anchor {
+        let Some(new_idx) = new_by_anchor.get(anchor) else {
+            continue;
+        };
+        // Only an unambiguous 1:1 rewrite pairs. With more than one removed or added clause
+        // under this anchor the correspondence is ambiguous, so leave every one of them as a
+        // distinct removed/new entry (never mispaired, never hidden).
+        if rem_idx.len() != 1 || new_idx.len() != 1 {
+            continue;
+        }
+        let ri = rem_idx[0];
+        let ni = new_idx[0];
+        let old_e = &removed[ri];
+        let new_e = &new_clauses[ni];
+        changed.push(ChangedEntry {
+            document: new_e.document.clone(),
+            heading: heading_for_anchor(new_e, anchor),
+            old_id: old_e.id.clone(),
+            new_id: new_e.id.clone(),
+            old_excerpt: excerpt_for_anchor(old_e, anchor),
+            new_excerpt: excerpt_for_anchor(new_e, anchor),
+        });
+        removed_taken[ri] = true;
+        new_taken[ni] = true;
+    }
+
+    // Drain paired entries.
+    let mut i = 0;
+    removed.retain(|_| {
+        let keep = !removed_taken[i];
+        i += 1;
+        keep
+    });
+    let mut j = 0;
+    new_clauses.retain(|_| {
+        let keep = !new_taken[j];
+        j += 1;
+        keep
+    });
+
+    changed.sort_by(|a, b| {
+        (&a.document, &a.heading, &a.new_id).cmp(&(&b.document, &b.heading, &b.new_id))
+    });
+    changed
+}
+
+fn clause_entry(unit: &ClauseUnit) -> ClauseEntry {
+    ClauseEntry {
+        id: unit.id.clone(),
+        document: unit.document.clone(),
+        strength: unit.strength,
+        locations: unit.locations.clone(),
+    }
+}
+
+fn anchor_set(unit: &ClauseUnit) -> std::collections::BTreeSet<&str> {
+    unit.locations.iter().map(|l| l.anchor.as_str()).collect()
+}
+
+fn first_excerpt(unit: &ClauseUnit) -> String {
+    unit.locations
+        .first()
+        .map(|l| l.excerpt.clone())
+        .unwrap_or_default()
+}
+
+fn leading_anchor(e: &ClauseEntry) -> &str {
+    e.locations.first().map(|l| l.anchor.as_str()).unwrap_or("")
+}
+
+fn heading_for_anchor(e: &ClauseEntry, anchor: &str) -> String {
+    e.locations
+        .iter()
+        .find(|l| l.anchor == anchor)
+        .map(|l| l.heading.clone())
+        .unwrap_or_default()
+}
+
+fn excerpt_for_anchor(e: &ClauseEntry, anchor: &str) -> String {
+    e.locations
+        .iter()
+        .find(|l| l.anchor == anchor)
+        .map(|l| l.excerpt.clone())
+        .unwrap_or_default()
+}
+
+fn clause_sort_key(a: &ClauseEntry, b: &ClauseEntry) -> std::cmp::Ordering {
+    (&a.document, leading_anchor(a), &a.id).cmp(&(&b.document, leading_anchor(b), &b.id))
+}
+
+// ---------------------------------------------------------------------------
+// Serialization — JSON + Markdown
+// ---------------------------------------------------------------------------
+
+/// Render the diff to its canonical JSON string (2-space indent, newline-terminated).
+pub fn render_json(diff: &ClauseRevisionDiff) -> String {
+    let mut out = serde_json::to_string_pretty(diff)
+        .unwrap_or_else(|e| unreachable!("clause diff serialization is infallible: {e}"));
+    out.push('\n');
+    out
+}
+
+/// Render the diff to a human-review Markdown document (deterministic, LF, trailing
+/// newline).
+pub fn render_md(diff: &ClauseRevisionDiff) -> String {
+    let mut md = String::new();
+    md.push_str("# Clause Inventory Diff\n\n");
+    let _ = writeln!(md, "**Old revision:** `{}`", diff.old.revision);
+    let _ = writeln!(md, "**New revision:** `{}`\n", diff.new.revision);
+
+    md.push_str("## Summary\n\n");
+    md.push_str("| Bucket | Count |\n|--------|-------|\n");
+    let _ = writeln!(md, "| New | {} |", diff.new_clauses.len());
+    let _ = writeln!(md, "| Removed | {} |", diff.removed.len());
+    let _ = writeln!(md, "| Moved | {} |", diff.moved.len());
+    let _ = writeln!(md, "| Changed | {} |", diff.changed.len());
+    let _ = writeln!(md, "| Non-material | {} |", diff.non_material.len());
+
+    render_clause_section(&mut md, "New", &diff.new_clauses);
+    render_clause_section(&mut md, "Removed", &diff.removed);
+
+    let _ = write!(md, "\n## Moved\n\n");
+    if diff.moved.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        md.push_str("| ID | Document | Old heading | New heading |\n");
+        md.push_str("|----|----------|-------------|-------------|\n");
+        for m in &diff.moved {
+            let _ = writeln!(
+                md,
+                "| `{}` | `{}` | {} | {} |",
+                m.id,
+                m.document,
+                headings_of(&m.old_locations),
+                headings_of(&m.new_locations),
+            );
+        }
+    }
+
+    let _ = write!(md, "\n## Changed\n\n");
+    if diff.changed.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        md.push_str("| Document | Heading | Old ID | New ID |\n");
+        md.push_str("|----------|---------|--------|--------|\n");
+        for c in &diff.changed {
+            let _ = writeln!(
+                md,
+                "| `{}` | {} | `{}` | `{}` |",
+                c.document, c.heading, c.old_id, c.new_id
+            );
+        }
+    }
+
+    let _ = write!(md, "\n## Non-material\n\n");
+    if diff.non_material.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        for n in &diff.non_material {
+            let _ = writeln!(md, "- `{}`", n.id);
+        }
+    }
+
+    md
+}
+
+fn render_clause_section(md: &mut String, title: &str, entries: &[ClauseEntry]) {
+    let _ = write!(md, "\n## {title}\n\n");
+    if entries.is_empty() {
+        md.push_str("None.\n");
+        return;
+    }
+    md.push_str("| ID | Document | Strength | Heading |\n");
+    md.push_str("|----|----------|----------|---------|\n");
+    for e in entries {
+        let _ = writeln!(
+            md,
+            "| `{}` | `{}` | `{}` | {} |",
+            e.id,
+            e.document,
+            strength_wire(e.strength),
+            headings_of(&e.locations),
+        );
+    }
+}
+
+fn headings_of(locations: &[ClauseLocation]) -> String {
+    locations
+        .iter()
+        .map(|l| l.heading.clone())
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn strength_wire(strength: Strength) -> &'static str {
+    match strength {
+        Strength::Must => "must",
+        Strength::Should => "should",
+        Strength::May => "may",
+        Strength::Algorithm => "algorithm",
+        Strength::IoContract => "io-contract",
+        Strength::Descriptive => "descriptive",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Testability;
+
+    fn unit(id: &str, anchor: &str, excerpt: &str) -> ClauseUnit {
+        ClauseUnit {
+            id: id.to_string(),
+            document: "reference".to_string(),
+            strength: Strength::Must,
+            testability: Testability::DirectlyTestable,
+            fingerprint: "fp".to_string(),
+            locations: vec![ClauseLocation {
+                heading: anchor.to_string(),
+                anchor: anchor.to_string(),
+                ordinal: 1,
+                excerpt: excerpt.to_string(),
+            }],
+            context: None,
+        }
+    }
+
+    fn inv(rev: &str, units: Vec<ClauseUnit>) -> ClauseInventory {
+        ClauseInventory {
+            schema_version: 1,
+            revision: rev.to_string(),
+            units,
+        }
+    }
+
+    #[test]
+    fn pure_add_and_remove() {
+        let old = inv(
+            "rev-spec-a",
+            vec![unit("clu-a-x-must-11111111", "h1", "MUST a")],
+        );
+        let new = inv(
+            "rev-spec-b",
+            vec![unit("clu-a-y-must-22222222", "h2", "MUST b")],
+        );
+        // Different anchors → not paired into changed.
+        let d = diff(&old, &new);
+        assert_eq!(d.new_clauses.len(), 1);
+        assert_eq!(d.removed.len(), 1);
+        assert!(d.changed.is_empty() && d.moved.is_empty());
+    }
+
+    #[test]
+    fn moved_keeps_id_and_is_not_changed() {
+        let mut old_u = unit("clu-a-x-must-11111111", "old-heading", "MUST a");
+        let mut new_u = old_u.clone();
+        new_u.locations[0].heading = "new-heading".to_string();
+        new_u.locations[0].anchor = "new-heading".to_string();
+        old_u.locations[0].anchor = "old-heading".to_string();
+        let d = diff(&inv("r-a", vec![old_u]), &inv("r-b", vec![new_u]));
+        assert_eq!(d.moved.len(), 1, "same id, different anchor → moved: {d:?}");
+        assert_eq!(d.moved[0].id, "clu-a-x-must-11111111");
+        assert!(d.new_clauses.is_empty() && d.removed.is_empty() && d.changed.is_empty());
+    }
+
+    #[test]
+    fn reworded_at_same_heading_is_changed_with_new_id() {
+        let old = inv(
+            "r-a",
+            vec![unit("clu-a-x-must-11111111", "same", "MUST do X")],
+        );
+        let new = inv(
+            "r-b",
+            vec![unit("clu-a-x-must-99999999", "same", "MUST do Y")],
+        );
+        let d = diff(&old, &new);
+        assert_eq!(
+            d.changed.len(),
+            1,
+            "shared heading pairs into changed: {d:?}"
+        );
+        assert_eq!(d.changed[0].old_id, "clu-a-x-must-11111111");
+        assert_eq!(d.changed[0].new_id, "clu-a-x-must-99999999");
+        assert!(d.new_clauses.is_empty() && d.removed.is_empty());
+    }
+
+    #[test]
+    fn ambiguous_multi_clause_heading_is_not_mispaired() {
+        // Under a single heading anchor 'same', two clauses are removed and one UNRELATED
+        // clause is added. The correspondence is ambiguous (2 vs 1), so nothing is paired
+        // into `changed`: both genuine removals and the genuine addition are reported
+        // truthfully instead of fabricating a rewrite and hiding an add/remove.
+        let old = inv(
+            "r-a",
+            vec![
+                unit("clu-a-x-must-11111111", "same", "MUST do X"),
+                unit("clu-a-z-must-33333333", "same", "MUST do Z"),
+            ],
+        );
+        let new = inv(
+            "r-b",
+            vec![unit("clu-a-y-must-22222222", "same", "MUST do Y")],
+        );
+        let d = diff(&old, &new);
+        assert!(
+            d.changed.is_empty(),
+            "ambiguous multi-clause anchor must not pair: {d:?}"
+        );
+        assert_eq!(d.removed.len(), 2, "both removals reported: {d:?}");
+        assert_eq!(d.new_clauses.len(), 1, "the addition reported: {d:?}");
+        assert!(d.moved.is_empty() && d.non_material.is_empty());
+    }
+
+    #[test]
+    fn immaterial_excerpt_change_at_same_heading_is_non_material() {
+        let old = inv(
+            "r-a",
+            vec![unit("clu-a-x-must-11111111", "same", "MUST do X")],
+        );
+        // Same id (substance unchanged) but excerpt bytes differ.
+        let mut new_u = unit("clu-a-x-must-11111111", "same", "MUST  do X");
+        new_u.locations[0].excerpt = "MUST  do X".to_string();
+        let d = diff(&old, &inv("r-b", vec![new_u]));
+        assert_eq!(d.non_material.len(), 1, "reflow → nonMaterial: {d:?}");
+        assert!(d.changed.is_empty() && d.moved.is_empty());
+    }
+
+    #[test]
+    fn empty_diff_and_determinism() {
+        let i = inv("r-a", vec![unit("clu-a-x-must-11111111", "h", "MUST a")]);
+        let d = diff(&i, &i);
+        assert!(d.is_empty());
+        let j1 = render_json(&diff(&i, &i));
+        let j2 = render_json(&diff(&i, &i));
+        assert_eq!(j1, j2);
+        assert!(j1.ends_with('\n'));
+        assert!(render_md(&diff(&i, &i)).contains("# Clause Inventory Diff"));
+    }
+}

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -18,11 +18,14 @@
 //!   (US3, T030–T031).
 
 pub mod certify;
+pub mod clause;
+pub mod clause_diff;
 pub mod coverage;
 pub mod diff;
 pub mod inventory;
 pub mod load;
 pub mod model;
+pub mod prose;
 pub mod report;
 pub mod schema;
 pub mod validate;
@@ -78,6 +81,51 @@ pub fn default_inventory_file() -> std::path::PathBuf {
         .join("conformance")
         .join("inventory")
         .join("constraints.json")
+}
+
+/// The default spec-prose root: `<workspace_root>/conformance/spec`. Contains one
+/// `<rev-pin>/` subdirectory per vendored spec revision (each with a `manifest.json`
+/// and the byte-exact vendored Markdown documents). The CLI's `--spec <dir>` flag
+/// overrides it (tests point it at fixtures) (021-normative-clause-inventory).
+pub fn default_spec_dir() -> std::path::PathBuf {
+    workspace_root().join("conformance").join("spec")
+}
+
+/// The pin of the currently vendored mandatory spec revision (the subdirectory of
+/// [`default_spec_dir`] holding the manifest + byte-exact prose files). Matches the
+/// `pin` of the `rev-spec-<pin>` revision record. Bumped only on a conscious
+/// re-vendoring (quickstart.md "Re-vendoring") (021-normative-clause-inventory).
+pub const CURRENT_SPEC_PIN: &str = "113500f4";
+
+/// The default pinned-spec directory for `clause generate`/`check`:
+/// `<workspace_root>/conformance/spec/<CURRENT_SPEC_PIN>/`. The CLI's `--spec <dir>`
+/// flag overrides it (021-normative-clause-inventory).
+pub fn default_pinned_spec_dir() -> std::path::PathBuf {
+    default_spec_dir().join(CURRENT_SPEC_PIN)
+}
+
+/// The default committed clause inventory file:
+/// `<workspace_root>/conformance/inventory/clauses.json` — the machine-owned,
+/// byte-stable prose-clause inventory (sibling of `constraints.json`). The CLI's
+/// `--clauses <file>` flag overrides it (021-normative-clause-inventory).
+pub fn default_clauses_file() -> std::path::PathBuf {
+    workspace_root()
+        .join("conformance")
+        .join("inventory")
+        .join("clauses.json")
+}
+
+/// Resolve the `(spec_dir, clauses_file)` that belong to a registry, as siblings under
+/// the same `conformance/` tree: `<registry>/../spec/<CURRENT_SPEC_PIN>` and
+/// `<registry>/../inventory/clauses.json`. Mirrors the schema-inventory sibling
+/// resolution `inventory_paths_for` uses in the CLI (021-normative-clause-inventory).
+pub fn clause_paths_for(
+    registry_dir: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let base = registry_dir.parent().unwrap_or(registry_dir);
+    let spec_dir = base.join("spec").join(CURRENT_SPEC_PIN);
+    let clauses_file = base.join("inventory").join("clauses.json");
+    (spec_dir, clauses_file)
 }
 
 #[cfg(test)]

--- a/crates/conformance/src/load.rs
+++ b/crates/conformance/src/load.rs
@@ -23,9 +23,9 @@ use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 
 use crate::model::{
-    BehaviorUnit, CertificationProfile, Classification, Collection, ConstraintInventory,
-    ContextDimension, DeaconExtension, Gap, ObservableChannel, SchemasManifest, SourceRevision,
-    SourceUnit, TestCase, Waiver,
+    BehaviorUnit, CertificationProfile, Classification, ClauseClassification, ClauseInventory,
+    Collection, ConstraintInventory, ContextDimension, DeaconExtension, Gap, ObservableChannel,
+    SchemasManifest, SourceRevision, SourceUnit, SpecManifest, TestCase, Waiver,
 };
 
 /// A schema-class load failure for a single file: an unreadable file, malformed
@@ -125,6 +125,53 @@ pub enum LoadError {
     /// hand edit to the machine-owned file or a stale commit.
     #[error("committed inventory is out of date: regeneration differs from {path:?}")]
     InventoryOutOfDate { path: PathBuf },
+
+    // --- Normative clause inventory (021) ---------------------------------
+    /// A vendored prose file's SHA-256 does not match the spec-manifest fingerprint
+    /// (V14). Blocking: the vendored copy no longer matches the claimed revision.
+    #[error("spec manifest fingerprint mismatch for {file:?}: manifest {expected}, file {actual}")]
+    SpecFingerprintMismatch {
+        file: PathBuf,
+        expected: String,
+        actual: String,
+    },
+
+    /// A clause's `excerpt` is not a verbatim substring of the pinned document under
+    /// its recorded heading anchor (V15). Fail-loud provenance-in-source failure.
+    #[error(
+        "clause {clause:?}: excerpt not found in the pinned document under heading {heading:?}"
+    )]
+    ExcerptNotFoundAtAnchor { clause: String, heading: String },
+
+    /// A clause's authored `strength` label contradicts its excerpt's RFC-2119
+    /// keywords, or a `descriptive` clause hides a mandatory keyword (V15,
+    /// research Decision 4).
+    #[error(
+        "clause {clause:?}: strength label {labeled:?} contradicts excerpt keywords \
+         (detected {detected:?})"
+    )]
+    StrengthKeywordMismatch {
+        clause: String,
+        labeled: String,
+        detected: String,
+    },
+
+    /// An `ambiguous` clause carries no per-clause classification (Decision 5/7). A
+    /// document-scope default never clears ambiguity.
+    #[error("clause {clause:?} is ambiguous and has no per-clause classification")]
+    AmbiguousClauseUnclassified { clause: String },
+
+    /// The committed clause inventory does not byte-match a fresh canonicalization
+    /// (V14). Either a hand edit to the machine-owned file or a stale commit.
+    #[error("committed clause inventory is out of date: canonicalization differs from {path:?}")]
+    ClauseInventoryOutOfDate { path: PathBuf },
+
+    /// A document-scope classification default targets a `consumer`-scope document,
+    /// which must be classified clause-by-clause (V13, Decision 7).
+    #[error(
+        "document-scope classification targets consumer document {document:?} (only authoring documents may carry a document-scope default)"
+    )]
+    DocumentScopeOnConsumerDoc { document: String },
 }
 
 /// Render a collected batch of schema errors, one per line, for `LoadError::Schema`.
@@ -159,6 +206,10 @@ pub struct Registry {
     /// per manifest document key (020-schema-constraint-inventory). A missing
     /// directory is empty (loaded before any classifications are authored).
     pub classifications: Vec<Classification>,
+    /// Hand-authored clause-classification records — `clause-classifications/*.json`,
+    /// one file per document key plus `authoring.json` for document-scope defaults
+    /// (021-normative-clause-inventory). A missing directory is empty.
+    pub clause_classifications: Vec<ClauseClassification>,
 }
 
 impl Registry {
@@ -205,6 +256,11 @@ impl Registry {
             waivers: load_waivers(&root.join("waivers"), &mut errors),
             // classifications/*.json — one collection per manifest document key.
             classifications: load_dir_collections(&root.join("classifications"), &mut errors),
+            // clause-classifications/*.json — per-document + authoring.json defaults.
+            clause_classifications: load_dir_collections(
+                &root.join("clause-classifications"),
+                &mut errors,
+            ),
         };
 
         if errors.is_empty() {
@@ -447,6 +503,93 @@ pub fn load_inventory(path: &Path) -> Result<Option<ConstraintInventory>, LoadEr
     }
     let raw = read_file(path).map_err(|e| LoadError::Schema(vec![e]))?;
     let inventory: ConstraintInventory =
+        deserialize_located(path, &raw).map_err(|e| LoadError::Schema(vec![e]))?;
+    Ok(Some(inventory))
+}
+
+/// Load and fingerprint-verify a spec-prose manifest at `spec_dir/manifest.json`
+/// (data-model.md §1, 021-normative-clause-inventory).
+///
+/// For every `documents[]` entry, reads the sibling vendored Markdown file, verifies it
+/// carries no CR bytes (cross-platform byte-stability), computes its SHA-256, and
+/// compares it to the manifest's recorded `sha256`; a mismatch is a blocking
+/// [`LoadError::SpecFingerprintMismatch`] (V14). The `key`/`scope` shapes are enforced
+/// too (unique lowercase `[a-z0-9-]` keys). A missing or malformed manifest, or an
+/// unreadable vendored file, is a located [`LoadError::Schema`].
+pub fn load_spec_manifest(spec_dir: &Path) -> Result<SpecManifest, LoadError> {
+    let manifest_path = spec_dir.join("manifest.json");
+    let raw = read_file(&manifest_path).map_err(|e| LoadError::Schema(vec![e]))?;
+    let manifest: SpecManifest =
+        deserialize_located(&manifest_path, &raw).map_err(|e| LoadError::Schema(vec![e]))?;
+
+    let mut seen_keys: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    for doc in &manifest.documents {
+        if doc.key.is_empty()
+            || !doc
+                .key
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        {
+            return Err(LoadError::MalformedSchema {
+                document: doc.key.clone(),
+                cause: format!(
+                    "manifest document key {:?} is not a valid `<doc>` id component \
+                     (require non-empty lowercase [a-z0-9-])",
+                    doc.key
+                ),
+            });
+        }
+        if !seen_keys.insert(doc.key.as_str()) {
+            return Err(LoadError::MalformedSchema {
+                document: doc.key.clone(),
+                cause: format!(
+                    "duplicate manifest document key {:?} (keys must be unique)",
+                    doc.key
+                ),
+            });
+        }
+    }
+
+    for doc in &manifest.documents {
+        let file = spec_dir.join(&doc.file);
+        let bytes = std::fs::read(&file).map_err(|e| {
+            LoadError::Schema(vec![SchemaError {
+                file: file.clone(),
+                location: None,
+                message: format!("could not read vendored prose: {e}"),
+            }])
+        })?;
+        if bytes.contains(&b'\r') {
+            return Err(LoadError::MalformedSchema {
+                document: doc.key.clone(),
+                cause: format!(
+                    "vendored prose {:?} contains a CR byte; vendored docs MUST be LF-only \
+                     for cross-platform byte-stability",
+                    doc.file
+                ),
+            });
+        }
+        let actual = sha256_hex(&bytes);
+        if actual != doc.sha256 {
+            return Err(LoadError::SpecFingerprintMismatch {
+                file,
+                expected: doc.sha256.clone(),
+                actual,
+            });
+        }
+    }
+    Ok(manifest)
+}
+
+/// Load the committed clause inventory at `path` (data-model.md §2). Returns
+/// `Ok(None)` when the file is absent (later phases generate it). A present-but-malformed
+/// file is a located [`LoadError::Schema`].
+pub fn load_clause_inventory(path: &Path) -> Result<Option<ClauseInventory>, LoadError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = read_file(path).map_err(|e| LoadError::Schema(vec![e]))?;
+    let inventory: ClauseInventory =
         deserialize_located(path, &raw).map_err(|e| LoadError::Schema(vec![e]))?;
     Ok(Some(inventory))
 }
@@ -730,6 +873,102 @@ mod tests {
             load_inventory(&path).unwrap_err(),
             LoadError::Schema(_)
         ));
+    }
+
+    #[test]
+    fn load_spec_manifest_verifies_fingerprints_and_rejects_cr() {
+        let dir = tempfile::tempdir().unwrap();
+        let prose = b"# Heading\n\nThe tool MUST do X.\n";
+        let good = sha256_hex(prose);
+        fs::write(dir.path().join("doc.md"), prose).unwrap();
+        let manifest_json = format!(
+            r#"{{ "schemaVersion": 1, "revision": "rev-spec-113500f4", "documents": [
+                {{ "key": "reference", "file": "doc.md",
+                   "upstreamUrl": "https://example/doc.md", "sha256": "{good}",
+                   "scope": "consumer" }}
+            ] }}"#
+        );
+        fs::write(dir.path().join("manifest.json"), &manifest_json).unwrap();
+        let manifest = load_spec_manifest(dir.path()).expect("verified manifest loads");
+        assert_eq!(manifest.revision, "rev-spec-113500f4");
+        assert_eq!(manifest.documents[0].key, "reference");
+
+        // Tampered bytes → fingerprint mismatch.
+        fs::write(
+            dir.path().join("doc.md"),
+            b"# Heading\n\nThe tool MUST do Y.\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            load_spec_manifest(dir.path()).unwrap_err(),
+            LoadError::SpecFingerprintMismatch { .. }
+        ));
+
+        // A CR byte is rejected outright.
+        let cr = b"# Heading\r\n\r\nThe tool MUST do X.\r\n";
+        let cr_hash = sha256_hex(cr);
+        fs::write(dir.path().join("doc.md"), cr).unwrap();
+        let cr_manifest = format!(
+            r#"{{ "schemaVersion": 1, "revision": "rev-spec-113500f4", "documents": [
+                {{ "key": "reference", "file": "doc.md",
+                   "upstreamUrl": "https://example/doc.md", "sha256": "{cr_hash}",
+                   "scope": "consumer" }}
+            ] }}"#
+        );
+        fs::write(dir.path().join("manifest.json"), &cr_manifest).unwrap();
+        assert!(matches!(
+            load_spec_manifest(dir.path()).unwrap_err(),
+            LoadError::MalformedSchema { .. }
+        ));
+    }
+
+    #[test]
+    fn load_clause_inventory_missing_is_none_and_present_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("clauses.json");
+        assert!(
+            load_clause_inventory(&path)
+                .expect("missing is ok")
+                .is_none()
+        );
+
+        fs::write(
+            &path,
+            r#"{ "schemaVersion": 1, "revision": "rev-spec-113500f4", "units": [
+                { "id": "clu-reference-x-must-a1b2c3d4", "document": "reference",
+                  "strength": "must", "testability": "directly-testable",
+                  "fingerprint": "ab", "locations": [
+                    { "heading": "H", "anchor": "h", "ordinal": 1, "excerpt": "MUST x" }
+                  ], "context": null }
+            ] }"#,
+        )
+        .unwrap();
+        let inv = load_clause_inventory(&path)
+            .expect("present")
+            .expect("some");
+        assert_eq!(inv.units.len(), 1);
+        assert_eq!(inv.units[0].document, "reference");
+    }
+
+    #[test]
+    fn loads_clause_classifications_collection() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "clause-classifications/reference.json",
+            r#"{ "schemaVersion": 1, "records": [
+                { "id": "clc-reference-x-must-a1b2c3d4",
+                  "clause": "clu-reference-x-must-a1b2c3d4",
+                  "disposition": "behavior-mapped",
+                  "behaviors": ["bhv-up-lifecycle-oncreate-once"] }
+            ] }"#,
+        );
+        let reg = Registry::load(dir.path()).expect("loads");
+        assert_eq!(reg.clause_classifications.len(), 1);
+        assert_eq!(
+            reg.clause_classifications[0].clause.as_deref(),
+            Some("clu-reference-x-must-a1b2c3d4")
+        );
     }
 
     #[test]

--- a/crates/conformance/src/model.rs
+++ b/crates/conformance/src/model.rs
@@ -56,6 +56,8 @@ pub enum RecordType {
     Extension,
     Constraint,
     Classification,
+    ClauseUnit,
+    ClauseClassification,
 }
 
 impl RecordType {
@@ -74,6 +76,8 @@ impl RecordType {
             RecordType::Extension => "ext",
             RecordType::Constraint => "cst",
             RecordType::Classification => "cls",
+            RecordType::ClauseUnit => "clu",
+            RecordType::ClauseClassification => "clc",
         }
     }
 
@@ -92,6 +96,8 @@ impl RecordType {
             "ext" => RecordType::Extension,
             "cst" => RecordType::Constraint,
             "cls" => RecordType::Classification,
+            "clu" => RecordType::ClauseUnit,
+            "clc" => RecordType::ClauseClassification,
             _ => return None,
         })
     }
@@ -105,7 +111,7 @@ pub enum IdError {
     /// uppercase, or disallowed characters.
     #[error(
         "id {id:?} is malformed: expected \
-         `^(rev|src|dim|chan|prof|bhv|case|gap|wvr|ext|cst|cls)-[a-z0-9]+(-[a-z0-9]+)*$`"
+         `^(rev|src|dim|chan|prof|bhv|case|gap|wvr|ext|cst|cls|clu|clc)-[a-z0-9]+(-[a-z0-9]+)*$`"
     )]
     Format { id: String },
     /// The id is well-formed but its leading segment is not a known record prefix.
@@ -658,6 +664,180 @@ pub enum Disposition {
     NotApplicable,
 }
 
+// ---------------------------------------------------------------------------
+// Normative clause inventory (021-normative-clause-inventory, data-model.md §1–§3)
+// ---------------------------------------------------------------------------
+
+/// The spec-prose manifest — `conformance/spec/<rev-pin>/manifest.json`
+/// (data-model.md §1). Records the vendored pinned prose documents, their SHA-256
+/// fingerprints, and a per-document consumer/authoring `scope`, keyed to a
+/// `spec`-kind [`SourceRevision`]. The prose companion to [`SchemasManifest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SpecManifest {
+    /// Schema version of the manifest format.
+    pub schema_version: u32,
+    /// MUST name an existing `rev-` record of kind `spec` in `revisions.json`
+    /// (V14 on mismatch).
+    pub revision: String,
+    /// One entry per vendored prose document, in file order.
+    pub documents: Vec<SpecDocument>,
+}
+
+/// One vendored prose document within a [`SpecManifest`] (data-model.md §1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SpecDocument {
+    /// Document key used in clause IDs, classification files, and diff sort order.
+    /// Lowercase `[a-z0-9-]+`, unique within the manifest.
+    pub key: String,
+    /// Filename of the vendored Markdown document, a sibling of the manifest.
+    pub file: String,
+    /// Upstream URL at the pinned commit — provenance only, never fetched.
+    pub upstream_url: String,
+    /// SHA-256 of the vendored file bytes; verified before every parse
+    /// (V14 / [`crate::load::LoadError::SpecFingerprintMismatch`] on mismatch).
+    pub sha256: String,
+    /// Consumer vs authoring scope. Gates the document-scope disposition default:
+    /// a document-scope `not-applicable` record is permitted only for `authoring`
+    /// documents (research Decision 7; V13 otherwise).
+    pub scope: DocumentScope,
+}
+
+/// A vendored prose document's scope under deacon's consumer-only mandate
+/// (constitution II). `authoring` documents may carry a document-scope disposition
+/// default (research Decision 7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DocumentScope {
+    /// A consumer-facing document — every clause is classified per-clause.
+    Consumer,
+    /// An authoring/distribution document — a document-scope not-applicable default
+    /// is permitted (with per-clause overrides for consumer install/apply clauses).
+    Authoring,
+}
+
+/// The generated, committed clause inventory —
+/// `conformance/inventory/clauses.json` (data-model.md §2). The prose companion to
+/// [`ConstraintInventory`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClauseInventory {
+    /// Schema version of the inventory format.
+    pub schema_version: u32,
+    /// Equals the manifest's revision (and therefore the registry spec pin).
+    pub revision: String,
+    /// Canonicalized clause units, sorted by `id` in the committed artifact.
+    pub units: Vec<ClauseUnit>,
+}
+
+/// One atomic normative clause (data-model.md §2). Identity is **substance-anchored**
+/// (`hash8` over `document ‖ normalize_substance(excerpt)`, location excluded —
+/// research Decision 2): a pure move keeps the `id` (and its disposition), a material
+/// change mints a new `id` (drift-forcing).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClauseUnit {
+    /// `clu-<doc>-<substance-slug>-<strength>-<hash8>` — grammar-valid per
+    /// [`parse_id`] with the new `clu` prefix.
+    pub id: String,
+    /// Manifest document key this clause was drawn from.
+    pub document: String,
+    /// Detected/authored normative strength.
+    pub strength: Strength,
+    /// Proposed testability class.
+    pub testability: Testability,
+    /// Full lowercase-hex SHA-256 of `normalize_substance(excerpt)` — the distinct
+    /// fingerprint field the clarification requires; drift reads it (Decision 3).
+    pub fingerprint: String,
+    /// Non-empty; one entry per place the same normalized substance appears. Sorted
+    /// by `(anchor, ordinal)`. Multiple locations = the same obligation stated in
+    /// several places (they merge into one unit).
+    pub locations: Vec<ClauseLocation>,
+    /// Optional structural note (e.g. `{ "inCodeFence": true }`).
+    #[serde(default)]
+    pub context: Option<Value>,
+}
+
+/// The closed normative-strength taxonomy (data-model.md §2, research Decision 4).
+/// `must`/`should`/`may` are RFC-2119 keyword families; `algorithm`/`io-contract`/
+/// `descriptive` are authored labels not derivable from a single keyword.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Strength {
+    Must,
+    Should,
+    May,
+    Algorithm,
+    IoContract,
+    Descriptive,
+}
+
+/// The closed testability taxonomy (data-model.md §2, research Decision 5).
+/// `ambiguous` means the strength/meaning could not be confidently determined; it
+/// requires a per-clause classification before `certify` passes (no document-scope
+/// cover — Decision 7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Testability {
+    DirectlyTestable,
+    IndirectlyTestable,
+    Informative,
+    Ambiguous,
+    NotApplicable,
+}
+
+/// One provenance location of a [`ClauseUnit`] (data-model.md §2). `ordinal` and
+/// `heading`/`anchor` are provenance/order only — never identity inputs (Decision 2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClauseLocation {
+    /// Human-readable heading path (e.g. `Lifecycle scripts > onCreateCommand`).
+    pub heading: String,
+    /// GitHub-style slug of the owning heading — the excerpt-present-at-anchor key.
+    pub anchor: String,
+    /// 1-based position of this excerpt within its heading (provenance/order only).
+    pub ordinal: u32,
+    /// Verbatim source substring — the human-readable field. MUST be present in the
+    /// pinned document under `anchor` (V15 / `ExcerptNotFoundAtAnchor` otherwise).
+    pub excerpt: String,
+}
+
+/// A hand-authored clause-classification record (`clc-`) —
+/// `conformance/registry/clause-classifications/<doc>.json` (data-model.md §3).
+/// Closed model; exactly one of `clause` / `document` present (the XOR invariant is
+/// enforced structurally by V13, not by serde). Joins to the inventory by ID.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClauseClassification {
+    /// Per-clause: `clc-` + the exact tail of the referenced `clu-` id (structural
+    /// mirror; V13 if mismatched). Document-scope: `clc-doc-<document key>`.
+    pub id: String,
+    /// The `clu-` clause id this classifies (per-clause records); MUST exist in the
+    /// committed inventory (V11 when stale). Mutually exclusive with `document`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clause: Option<String>,
+    /// The manifest document key this dispositions wholesale (document-scope default);
+    /// MUST be an `authoring`-scope document (V13 otherwise). Mutually exclusive with
+    /// `clause`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub document: Option<String>,
+    /// The disposition under the consumer-only scope (reuses 020's [`Disposition`];
+    /// `non-testable` is prose "informative").
+    pub disposition: Disposition,
+    /// Non-empty and every id an existing behavior iff `behavior-mapped`; absent/empty
+    /// otherwise (V13). Several clauses MAY map to one behavior (FR-010).
+    #[serde(default)]
+    pub behaviors: Vec<String>,
+    /// REQUIRED non-empty for `non-testable` / `not-applicable`; optional for
+    /// `behavior-mapped` (V13).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rationale: Option<String>,
+    /// Free-form notes (e.g. supersession of a retired prose source unit).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -694,6 +874,18 @@ mod tests {
         assert_eq!(
             parse_id("cls-base-forwardports-type-3fa9c214").unwrap(),
             RecordType::Classification
+        );
+        assert_eq!(
+            parse_id("clu-reference-oncreatecommand-run-once-must-a1b2c3d4").unwrap(),
+            RecordType::ClauseUnit
+        );
+        assert_eq!(
+            parse_id("clc-reference-oncreatecommand-run-once-must-a1b2c3d4").unwrap(),
+            RecordType::ClauseClassification
+        );
+        assert_eq!(
+            parse_id("clc-doc-features").unwrap(),
+            RecordType::ClauseClassification
         );
     }
 
@@ -766,6 +958,8 @@ mod tests {
             RecordType::Extension,
             RecordType::Constraint,
             RecordType::Classification,
+            RecordType::ClauseUnit,
+            RecordType::ClauseClassification,
         ] {
             assert_eq!(RecordType::from_prefix(ty.prefix()), Some(ty));
             // A valid id built from the prefix parses back to the same type
@@ -1130,6 +1324,159 @@ mod tests {
         assert!(
             serde_json::from_str::<Classification>(
                 r#"{ "id": "cls-x", "constraint": "cst-x", "disposition": "UNREVIEWED" }"#
+            )
+            .is_err()
+        );
+    }
+
+    // ---- Normative clause inventory (021) ---------------------------------
+
+    #[test]
+    fn strength_spellings() {
+        round_trip(Strength::Must, json!("must"));
+        round_trip(Strength::Should, json!("should"));
+        round_trip(Strength::May, json!("may"));
+        round_trip(Strength::Algorithm, json!("algorithm"));
+        round_trip(Strength::IoContract, json!("io-contract"));
+        round_trip(Strength::Descriptive, json!("descriptive"));
+    }
+
+    #[test]
+    fn testability_spellings() {
+        round_trip(Testability::DirectlyTestable, json!("directly-testable"));
+        round_trip(
+            Testability::IndirectlyTestable,
+            json!("indirectly-testable"),
+        );
+        round_trip(Testability::Informative, json!("informative"));
+        round_trip(Testability::Ambiguous, json!("ambiguous"));
+        round_trip(Testability::NotApplicable, json!("not-applicable"));
+    }
+
+    #[test]
+    fn document_scope_spellings() {
+        round_trip(DocumentScope::Consumer, json!("consumer"));
+        round_trip(DocumentScope::Authoring, json!("authoring"));
+    }
+
+    #[test]
+    fn spec_manifest_round_trips() {
+        let manifest = SpecManifest {
+            schema_version: 1,
+            revision: "rev-spec-113500f4".into(),
+            documents: vec![
+                SpecDocument {
+                    key: "reference".into(),
+                    file: "devcontainer-reference.md".into(),
+                    upstream_url: "https://example/reference.md".into(),
+                    sha256: "daef12b6".into(),
+                    scope: DocumentScope::Consumer,
+                },
+                SpecDocument {
+                    key: "features".into(),
+                    file: "devcontainer-features.md".into(),
+                    upstream_url: "https://example/features.md".into(),
+                    sha256: "abcd1234".into(),
+                    scope: DocumentScope::Authoring,
+                },
+            ],
+        };
+        let value = serde_json::to_value(&manifest).unwrap();
+        assert_eq!(value["documents"][0]["scope"], json!("consumer"));
+        assert_eq!(value["documents"][1]["scope"], json!("authoring"));
+        assert_eq!(
+            value["documents"][0]["upstreamUrl"],
+            json!("https://example/reference.md")
+        );
+        let back: SpecManifest = serde_json::from_value(value).unwrap();
+        assert_eq!(back, manifest);
+    }
+
+    #[test]
+    fn clause_inventory_round_trips() {
+        let inventory = ClauseInventory {
+            schema_version: 1,
+            revision: "rev-spec-113500f4".into(),
+            units: vec![ClauseUnit {
+                id: "clu-reference-oncreatecommand-run-once-must-a1b2c3d4".into(),
+                document: "reference".into(),
+                strength: Strength::Must,
+                testability: Testability::DirectlyTestable,
+                fingerprint: "9f2a".into(),
+                locations: vec![ClauseLocation {
+                    heading: "Lifecycle scripts > onCreateCommand".into(),
+                    anchor: "oncreatecommand".into(),
+                    ordinal: 1,
+                    excerpt: "`onCreateCommand` ... MUST be run only once.".into(),
+                }],
+                context: None,
+            }],
+        };
+        let value = serde_json::to_value(&inventory).unwrap();
+        assert_eq!(value["units"][0]["strength"], json!("must"));
+        assert_eq!(value["units"][0]["context"], json!(null));
+        assert_eq!(value["units"][0]["locations"][0]["ordinal"], json!(1));
+        let back: ClauseInventory = serde_json::from_value(value).unwrap();
+        assert_eq!(back, inventory);
+    }
+
+    #[test]
+    fn clause_classification_per_clause_and_document_scope_round_trip() {
+        let per_clause = ClauseClassification {
+            id: "clc-reference-oncreatecommand-run-once-must-a1b2c3d4".into(),
+            clause: Some("clu-reference-oncreatecommand-run-once-must-a1b2c3d4".into()),
+            document: None,
+            disposition: Disposition::BehaviorMapped,
+            behaviors: vec!["bhv-up-lifecycle-oncreate-once".into()],
+            rationale: None,
+            notes: Some("Supersedes retired prose source link.".into()),
+        };
+        let value = serde_json::to_value(&per_clause).unwrap();
+        assert_eq!(value["disposition"], json!("behavior-mapped"));
+        assert!(
+            value.get("document").is_none(),
+            "document skipped when None"
+        );
+        assert!(value.get("rationale").is_none());
+        let back: ClauseClassification = serde_json::from_value(value).unwrap();
+        assert_eq!(back, per_clause);
+
+        let doc_scope = ClauseClassification {
+            id: "clc-doc-features".into(),
+            clause: None,
+            document: Some("features".into()),
+            disposition: Disposition::NotApplicable,
+            behaviors: vec![],
+            rationale: Some("Feature-authoring document; consumer-only scope.".into()),
+            notes: None,
+        };
+        let value = serde_json::to_value(&doc_scope).unwrap();
+        assert!(value.get("clause").is_none(), "clause skipped when None");
+        assert_eq!(value["document"], json!("features"));
+        let back: ClauseClassification = serde_json::from_value(value).unwrap();
+        assert_eq!(back, doc_scope);
+    }
+
+    #[test]
+    fn clause_records_reject_unknown_fields_and_sentinel() {
+        assert!(
+            serde_json::from_str::<SpecManifest>(
+                r#"{ "schemaVersion": 1, "revision": "rev-spec-x", "documents": [], "oops": 1 }"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<ClauseUnit>(
+                r#"{ "id": "clu-x-y-must-00000000", "document": "reference", "strength": "must",
+                 "testability": "directly-testable", "fingerprint": "ab", "locations": [],
+                 "context": null, "typo": true }"#
+            )
+            .is_err()
+        );
+        // The scaffold sentinel disposition is a hard schema failure at load.
+        assert!(
+            serde_json::from_str::<ClauseClassification>(
+                r#"{ "id": "clc-x", "clause": "clu-x", "disposition": "UNREVIEWED" }"#
             )
             .is_err()
         );

--- a/crates/conformance/src/prose/mod.rs
+++ b/crates/conformance/src/prose/mod.rs
@@ -1,0 +1,317 @@
+//! Byte-deterministic Markdown prose model (021-normative-clause-inventory,
+//! research Decision 1 / data-model.md §2).
+//!
+//! A tiny, in-crate ATX-heading reader (no Markdown crate — the surface needed is small
+//! and must be byte-deterministic across platforms). [`Document::parse`] builds an ordered
+//! list of [`Heading`]s with GitHub-style anchors and, for each, the raw text span of its
+//! section **including descendants** (the text from the heading to the next heading of the
+//! same or a higher level). Parsing is **code-fence aware**: a `#` inside a fenced code
+//! block is never mistaken for a heading.
+//!
+//! The one behavior every command needs is [`Document::contains_excerpt_at`]: the
+//! excerpt-present-at-anchor check behind V15 (a clause's verbatim excerpt MUST appear in
+//! the pinned document under its recorded heading). Matching is whitespace-normalized so a
+//! line-wrapped excerpt still resolves, while remaining a strict substring check.
+
+pub mod normalize;
+pub mod strength;
+
+/// One ATX heading and the raw text span of its section (including descendants).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Heading {
+    /// ATX level (1 for `#`, 2 for `##`, …).
+    pub level: usize,
+    /// The heading's rendered text (Markdown inline formatting stripped).
+    pub text: String,
+    /// GitHub-style slug of `text`, deduplicated with a numeric suffix on collision.
+    pub anchor: String,
+    /// Raw Markdown of this section's body including descendant subsections — from just
+    /// after the heading line to the next heading of the same or a higher level.
+    pub body: String,
+}
+
+/// A parsed Markdown document: its headings (in document order) and any preamble text
+/// before the first heading.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document {
+    /// Text before the first heading (often empty for spec docs).
+    pub preamble: String,
+    /// Headings in document order.
+    pub headings: Vec<Heading>,
+}
+
+impl Document {
+    /// Parse `markdown` into a [`Document`]. Deterministic and code-fence aware.
+    pub fn parse(markdown: &str) -> Document {
+        let lines: Vec<&str> = markdown.split('\n').collect();
+
+        // First pass: locate heading lines (level, text, line index), skipping fences.
+        struct RawHeading {
+            level: usize,
+            text: String,
+            line: usize,
+        }
+        let mut raw: Vec<RawHeading> = Vec::new();
+        let mut in_fence = false;
+        let mut fence_marker: &str = "";
+        for (idx, line) in lines.iter().enumerate() {
+            let trimmed = line.trim_start();
+            if let Some(marker) = fence_open(trimmed) {
+                if !in_fence {
+                    in_fence = true;
+                    fence_marker = marker;
+                } else if trimmed.starts_with(fence_marker) {
+                    in_fence = false;
+                    fence_marker = "";
+                }
+                continue;
+            }
+            if in_fence {
+                continue;
+            }
+            if let Some((level, text)) = parse_atx_heading(line) {
+                raw.push(RawHeading {
+                    level,
+                    text,
+                    line: idx,
+                });
+            }
+        }
+
+        // Preamble: everything before the first heading line.
+        let preamble = if let Some(first) = raw.first() {
+            lines[..first.line].join("\n")
+        } else {
+            markdown.to_string()
+        };
+
+        // Second pass: assign each heading its subtree body and a deduplicated anchor.
+        let mut headings: Vec<Heading> = Vec::with_capacity(raw.len());
+        let mut used_anchors: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for (i, h) in raw.iter().enumerate() {
+            // Body ends at the next heading of the same or higher level (subtree).
+            let body_end = raw
+                .iter()
+                .skip(i + 1)
+                .find(|nxt| nxt.level <= h.level)
+                .map(|nxt| nxt.line)
+                .unwrap_or(lines.len());
+            let body = lines[(h.line + 1)..body_end].join("\n");
+
+            let base = github_slug(&h.text);
+            let anchor = match used_anchors.get_mut(&base) {
+                Some(count) => {
+                    *count += 1;
+                    format!("{base}-{count}")
+                }
+                None => {
+                    used_anchors.insert(base.clone(), 0);
+                    base
+                }
+            };
+            headings.push(Heading {
+                level: h.level,
+                text: h.text.clone(),
+                anchor,
+                body,
+            });
+        }
+
+        Document { preamble, headings }
+    }
+
+    /// The heading with the given anchor, if any.
+    pub fn heading(&self, anchor: &str) -> Option<&Heading> {
+        self.headings.iter().find(|h| h.anchor == anchor)
+    }
+
+    /// All heading anchors in document order.
+    pub fn anchors(&self) -> impl Iterator<Item = &str> {
+        self.headings.iter().map(|h| h.anchor.as_str())
+    }
+
+    /// Whether `excerpt` appears (whitespace-normalized substring) in the section owned by
+    /// `anchor` — the V15 excerpt-present-at-anchor check. Returns `false` if the anchor
+    /// is unknown or the excerpt is absent from that section's body.
+    pub fn contains_excerpt_at(&self, anchor: &str, excerpt: &str) -> bool {
+        let Some(heading) = self.heading(anchor) else {
+            return false;
+        };
+        // Search the section body plus the heading text itself (a clause can quote its own
+        // heading, e.g. a property name that IS the heading).
+        let haystack = collapse_ws(&format!("{}\n{}", heading.text, heading.body));
+        let needle = collapse_ws(excerpt);
+        !needle.is_empty() && haystack.contains(&needle)
+    }
+}
+
+/// Collapse every ASCII/Unicode whitespace run in `s` to a single space and trim — the
+/// matching basis for [`Document::contains_excerpt_at`] (tolerant of line wrapping, still
+/// a strict substring check).
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !prev_space && !out.is_empty() {
+                out.push(' ');
+            }
+            prev_space = true;
+        } else {
+            prev_space = false;
+            out.push(ch);
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// The fenced-code-block opener marker (```` ``` ```` or `~~~`, ≥3) at the head of a
+/// (left-trimmed) line, or `None`.
+fn fence_open(trimmed: &str) -> Option<&'static str> {
+    if trimmed.starts_with("```") {
+        Some("```")
+    } else if trimmed.starts_with("~~~") {
+        Some("~~~")
+    } else {
+        None
+    }
+}
+
+/// Parse an ATX heading line (`#`..`######` followed by a space and text), returning
+/// `(level, rendered text)`. Trailing `#` runs are stripped (ATX closing sequence).
+fn parse_atx_heading(line: &str) -> Option<(usize, String)> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+    let hashes = trimmed.chars().take_while(|&c| c == '#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    let rest = &trimmed[hashes..];
+    // A valid ATX heading requires a space (or end of line) after the `#` run.
+    if !rest.is_empty() && !rest.starts_with(' ') {
+        return None;
+    }
+    let text = rest.trim().trim_end_matches('#').trim();
+    Some((hashes, strip_inline_markdown(text)))
+}
+
+/// Strip inline Markdown from heading text for the rendered form used in slugs/headings:
+/// links → label, inline-code backticks and emphasis markers removed.
+fn strip_inline_markdown(text: &str) -> String {
+    let delinked = normalize::normalize_links_public(text);
+    delinked.chars().filter(|&c| c != '`' && c != '*').collect()
+}
+
+/// The GitHub-style anchor slug of heading `text`: lowercase; drop every character that is
+/// not a letter, digit, space, or hyphen; replace spaces with hyphens. (Duplicate handling
+/// is applied by the caller.)
+fn github_slug(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            out.extend(ch.to_lowercase());
+        } else if ch == ' ' || ch == '-' {
+            out.push('-');
+        } else if ch == '_' {
+            out.push('_');
+        }
+        // else: dropped (punctuation, backticks, …).
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DOC: &str = "\
+# Title
+
+Intro paragraph.
+
+## Lifecycle scripts
+
+Lead-in text.
+
+### `onCreateCommand`
+
+The `onCreateCommand` command MUST be run only once.
+
+## Another section
+
+```
+# not a heading (inside a fence)
+```
+
+Text after the fence.
+";
+
+    #[test]
+    fn parses_headings_with_levels_and_anchors() {
+        let doc = Document::parse(DOC);
+        let anchors: Vec<&str> = doc.anchors().collect();
+        assert_eq!(
+            anchors,
+            vec![
+                "title",
+                "lifecycle-scripts",
+                "oncreatecommand",
+                "another-section"
+            ]
+        );
+        assert_eq!(doc.heading("oncreatecommand").unwrap().level, 3);
+    }
+
+    #[test]
+    fn code_fence_hash_is_not_a_heading() {
+        let doc = Document::parse(DOC);
+        assert!(
+            doc.anchors().all(|a| a != "not-a-heading"),
+            "a # inside a fence must not be parsed as a heading"
+        );
+    }
+
+    #[test]
+    fn subtree_body_includes_descendants() {
+        let doc = Document::parse(DOC);
+        // `## Lifecycle scripts` owns its `### onCreateCommand` subsection text.
+        let body = &doc.heading("lifecycle-scripts").unwrap().body;
+        assert!(body.contains("onCreateCommand"), "subtree body: {body}");
+    }
+
+    #[test]
+    fn contains_excerpt_at_matches_verbatim_and_reflowed() {
+        let doc = Document::parse(DOC);
+        assert!(doc.contains_excerpt_at(
+            "oncreatecommand",
+            "The `onCreateCommand` command MUST be run only once."
+        ));
+        // Whitespace-tolerant.
+        assert!(doc.contains_excerpt_at(
+            "oncreatecommand",
+            "The `onCreateCommand` command\nMUST be run only once."
+        ));
+        // A sibling section that does not contain the clause → not found (subtree
+        // matching means a level-1 ancestor DOES own descendant text, by design).
+        assert!(!doc.contains_excerpt_at("another-section", "MUST be run only once."));
+        // Fabricated excerpt → not found even under the right anchor.
+        assert!(!doc.contains_excerpt_at("oncreatecommand", "MUST be run three times."));
+    }
+
+    #[test]
+    fn duplicate_headings_get_numeric_suffixes() {
+        let md = "# Foo\n\ntext\n\n# Foo\n\nmore\n";
+        let doc = Document::parse(md);
+        let anchors: Vec<&str> = doc.anchors().collect();
+        assert_eq!(anchors, vec!["foo", "foo-1"]);
+    }
+
+    #[test]
+    fn slug_strips_backticks_and_punctuation() {
+        assert_eq!(github_slug("`onCreateCommand`"), "oncreatecommand");
+        assert_eq!(github_slug("Feature options (v2)"), "feature-options-v2");
+    }
+}

--- a/crates/conformance/src/prose/normalize.rs
+++ b/crates/conformance/src/prose/normalize.rs
@@ -1,0 +1,219 @@
+//! The deterministic substance normalizer and fingerprint (021-normative-clause-inventory,
+//! research Decision 3).
+//!
+//! [`normalize_substance`] is a fixed, pure function that reduces a verbatim Markdown
+//! excerpt to its normalized substance: lowercase, Markdown formatting stripped
+//! (emphasis, inline-code backticks, link syntax, list bullets, block-quote and heading
+//! markers), whitespace runs collapsed to a single space, trimmed — while RFC-2119
+//! keywords, code-span *contents*, identifiers, and meaningful punctuation (`/`, `.`,
+//! `:`) are preserved. [`fingerprint`] is the lowercase-hex SHA-256 of that normalized
+//! string.
+//!
+//! This one small function is the sole source of clause identity, material-vs-immaterial
+//! change detection, and immateriality tolerance (SC-005): two excerpts that differ only
+//! in whitespace or Markdown reflow normalize to the same string and therefore the same
+//! fingerprint.
+
+use sha2::{Digest, Sha256};
+
+/// Reduce a verbatim Markdown `excerpt` to its normalized substance (research
+/// Decision 3). Pure and deterministic.
+pub fn normalize_substance(excerpt: &str) -> String {
+    // 1. Line-oriented pre-pass: strip leading block-quote / list / heading markers so
+    //    a bullet or quote wrapper never becomes part of the substance. Whitespace is
+    //    collapsed globally afterwards, so per-line trimming here is only about markers.
+    let mut cleaned_lines: Vec<String> = Vec::new();
+    for raw_line in excerpt.split('\n') {
+        let mut line = raw_line.trim_start();
+        // Strip any run of block-quote markers ("> ", ">> ", …).
+        loop {
+            let t = line.trim_start();
+            if let Some(rest) = t.strip_prefix('>') {
+                line = rest;
+            } else {
+                line = t;
+                break;
+            }
+        }
+        let trimmed = line.trim_start();
+        // Strip a leading ATX heading marker run (`#`, `##`, …).
+        let after_heading = trimmed.trim_start_matches('#').trim_start();
+        // Strip a leading unordered-list bullet (`- `, `* `, `+ `).
+        let after_bullet = strip_list_bullet(after_heading);
+        cleaned_lines.push(after_bullet.to_string());
+    }
+    let joined = cleaned_lines.join("\n");
+
+    // 2. Inline-formatting pass: resolve links to their label, drop inline-code backticks
+    //    and emphasis markers, keeping the meaningful content.
+    let delinked = strip_links(&joined);
+
+    // 3. Character pass: lowercase; drop backticks and `*`; collapse all whitespace runs
+    //    to a single space.
+    let mut out = String::with_capacity(delinked.len());
+    let mut prev_space = false;
+    for ch in delinked.chars() {
+        if ch.is_whitespace() {
+            if !prev_space && !out.is_empty() {
+                out.push(' ');
+            }
+            prev_space = true;
+            continue;
+        }
+        prev_space = false;
+        match ch {
+            '`' | '*' => {} // inline-code / emphasis markers — drop, keep content
+            _ => out.extend(ch.to_lowercase()),
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// The lowercase-hex SHA-256 of `normalize_substance(excerpt)` — the clause fingerprint.
+pub fn fingerprint(excerpt: &str) -> String {
+    let normalized = normalize_substance(excerpt);
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// Strip a single leading unordered-list bullet (`- `, `* `, `+ `) from a line, leaving
+/// ordered-list numerals alone (their digits carry meaning as identifiers).
+fn strip_list_bullet(line: &str) -> &str {
+    for marker in ["- ", "* ", "+ "] {
+        if let Some(rest) = line.strip_prefix(marker) {
+            return rest;
+        }
+    }
+    line
+}
+
+/// Public wrapper over [`strip_links`] for the heading-text renderer in [`super`].
+pub(crate) fn normalize_links_public(text: &str) -> String {
+    strip_links(text)
+}
+
+/// Replace Markdown link syntax `[label](target)` with just `label` (the visible text),
+/// leaving all other text untouched. A malformed/partial link is left verbatim.
+fn strip_links(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'[' {
+            if let Some((label, consumed)) = parse_link(&text[i..]) {
+                out.push_str(&label);
+                i += consumed;
+                continue;
+            }
+        }
+        // Push one UTF-8 char starting at i.
+        let ch = text[i..].chars().next().expect("valid utf-8 boundary");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Parse a `[label](target)` link starting at the head of `s`, returning the label and
+/// the number of bytes consumed, or `None` if `s` does not open a complete link.
+fn parse_link(s: &str) -> Option<(String, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.first() != Some(&b'[') {
+        return None;
+    }
+    let close = s[1..].find(']')? + 1;
+    // The `]` must be immediately followed by `(`.
+    if bytes.get(close + 1) != Some(&b'(') {
+        return None;
+    }
+    let paren_close_rel = s[close + 2..].find(')')?;
+    let paren_close = close + 2 + paren_close_rel;
+    let label = s[1..close].to_string();
+    Some((label, paren_close + 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whitespace_and_reflow_are_immaterial() {
+        let a = "The   tool  MUST    do X.";
+        let b = "The tool\nMUST do X.";
+        let c = "The tool MUST do X.";
+        assert_eq!(normalize_substance(a), normalize_substance(b));
+        assert_eq!(normalize_substance(b), normalize_substance(c));
+        assert_eq!(fingerprint(a), fingerprint(c));
+    }
+
+    #[test]
+    fn markdown_formatting_is_immaterial() {
+        let plain = "the onCreateCommand property runs onCreate.";
+        let formatted = "The `onCreateCommand` property runs **onCreate**.";
+        assert_eq!(
+            normalize_substance(plain),
+            normalize_substance(formatted),
+            "backticks/emphasis/case must not change substance"
+        );
+    }
+
+    #[test]
+    fn links_reduce_to_label() {
+        let a = "See [the reference](https://example/ref) for details.";
+        let b = "See the reference for details.";
+        assert_eq!(normalize_substance(a), normalize_substance(b));
+    }
+
+    #[test]
+    fn bullets_and_blockquotes_and_headings_are_stripped() {
+        assert_eq!(
+            normalize_substance("- The tool MUST do X."),
+            normalize_substance("The tool MUST do X.")
+        );
+        assert_eq!(
+            normalize_substance("> The tool MUST do X."),
+            normalize_substance("The tool MUST do X.")
+        );
+        assert_eq!(
+            normalize_substance("## The tool MUST do X."),
+            normalize_substance("The tool MUST do X.")
+        );
+    }
+
+    #[test]
+    fn meaningful_punctuation_and_keywords_preserved() {
+        let n = normalize_substance("The path `/workspaces/foo`: it MUST exist.");
+        assert!(n.contains('/'), "slashes preserved: {n}");
+        assert!(n.contains(':'), "colon preserved: {n}");
+        assert!(n.contains("must"), "keyword preserved (lowercased): {n}");
+        assert!(!n.contains('`'), "backticks stripped: {n}");
+    }
+
+    #[test]
+    fn material_difference_changes_fingerprint() {
+        assert_ne!(
+            fingerprint("The tool MUST do X."),
+            fingerprint("The tool MUST do Y.")
+        );
+        // A strength change is a substance change.
+        assert_ne!(
+            fingerprint("The tool MUST do X."),
+            fingerprint("The tool SHOULD do X.")
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_64_hex_chars_and_deterministic() {
+        let f = fingerprint("The tool MUST do X.");
+        assert_eq!(f.len(), 64);
+        assert!(f.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(f, fingerprint("The   tool MUST do X."));
+    }
+}

--- a/crates/conformance/src/prose/strength.rs
+++ b/crates/conformance/src/prose/strength.rs
@@ -1,0 +1,164 @@
+//! Deterministic RFC-2119 strength detection (021-normative-clause-inventory,
+//! research Decision 4).
+//!
+//! [`detect_strength`] maps the presence of an UPPERCASE RFC-2119 keyword to a
+//! [`Strength`], returning `None` when no keyword is present (the honest "ambiguous"
+//! outcome a human must resolve). [`has_family`] answers the per-label V15 cross-check:
+//! a clause the author labeled `must`/`should`/`may` MUST carry the corresponding keyword
+//! family in its excerpt, and a `descriptive` clause MUST NOT hide a mandatory keyword.
+//!
+//! Keywords are matched only in their UPPERCASE RFC-2119 form (maximal runs of ASCII
+//! uppercase letters), so lowercase hedge words ("should generally", "may want to") never
+//! auto-promote a clause to a strict requirement — they surface as ambiguous (`None`).
+
+use crate::model::Strength;
+
+/// The three keyword families detectable from a single RFC-2119 keyword.
+/// `algorithm` / `io-contract` / `descriptive` are authored labels, not keyword-derived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Family {
+    Must,
+    Should,
+    May,
+}
+
+/// Whether a maximal uppercase run is an RFC-2119 keyword of a given family.
+fn family_of_keyword(word: &str) -> Option<Family> {
+    match word {
+        "MUST" | "REQUIRED" | "SHALL" => Some(Family::Must),
+        "SHOULD" | "RECOMMENDED" => Some(Family::Should),
+        "MAY" | "OPTIONAL" => Some(Family::May),
+        _ => None,
+    }
+}
+
+/// Every RFC-2119 keyword family present in `excerpt` (matched only in UPPERCASE form).
+fn families_present(excerpt: &str) -> (bool, bool, bool) {
+    let (mut must, mut should, mut may) = (false, false, false);
+    for word in uppercase_runs(excerpt) {
+        match family_of_keyword(word) {
+            Some(Family::Must) => must = true,
+            Some(Family::Should) => should = true,
+            Some(Family::May) => may = true,
+            None => {}
+        }
+    }
+    (must, should, may)
+}
+
+/// Detect the primary normative strength of an excerpt from its RFC-2119 keywords,
+/// with priority `must` > `should` > `may`. Returns `None` when no keyword is present
+/// (ambiguous — a human decision, never auto-promoted; research Decision 5).
+pub fn detect_strength(excerpt: &str) -> Option<Strength> {
+    let (must, should, may) = families_present(excerpt);
+    if must {
+        Some(Strength::Must)
+    } else if should {
+        Some(Strength::Should)
+    } else if may {
+        Some(Strength::May)
+    } else {
+        None
+    }
+}
+
+/// Whether `excerpt` carries the RFC-2119 keyword family corresponding to `strength`
+/// (the per-label V15 cross-check). Returns `true` for the non-keyword strengths
+/// (`algorithm`, `io-contract`, `descriptive`) — those are authored labels this function
+/// does not police here; `descriptive` is policed separately by [`hides_mandatory_keyword`].
+pub fn has_family(excerpt: &str, strength: Strength) -> bool {
+    let (must, should, may) = families_present(excerpt);
+    match strength {
+        Strength::Must => must,
+        Strength::Should => should,
+        Strength::May => may,
+        Strength::Algorithm | Strength::IoContract | Strength::Descriptive => true,
+    }
+}
+
+/// Whether `excerpt` contains an unqualified mandatory (MUST-family) RFC-2119 keyword —
+/// used to reject a `descriptive` label that hides a requirement (FR-005, V15).
+pub fn hides_mandatory_keyword(excerpt: &str) -> bool {
+    families_present(excerpt).0
+}
+
+/// Iterate maximal runs of ASCII uppercase letters in `text` (length ≥ 2), the candidate
+/// RFC-2119 keyword tokens. A run must be delimited by non-uppercase-letter boundaries so
+/// `MUST` inside `MUSTARDY` (were it uppercase) is one run and never a keyword match.
+fn uppercase_runs(text: &str) -> impl Iterator<Item = &str> {
+    text.split(|c: char| !c.is_ascii_uppercase())
+        .filter(|w| w.len() >= 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_must_family() {
+        assert_eq!(detect_strength("The tool MUST do X."), Some(Strength::Must));
+        assert_eq!(
+            detect_strength("The tool MUST NOT do X."),
+            Some(Strength::Must)
+        );
+        assert_eq!(detect_strength("This is REQUIRED."), Some(Strength::Must));
+        assert_eq!(
+            detect_strength("The tool SHALL do X."),
+            Some(Strength::Must)
+        );
+    }
+
+    #[test]
+    fn detects_should_and_may_families() {
+        assert_eq!(
+            detect_strength("The tool SHOULD do X."),
+            Some(Strength::Should)
+        );
+        assert_eq!(
+            detect_strength("This is RECOMMENDED."),
+            Some(Strength::Should)
+        );
+        assert_eq!(detect_strength("The tool MAY do X."), Some(Strength::May));
+        assert_eq!(detect_strength("This is OPTIONAL."), Some(Strength::May));
+    }
+
+    #[test]
+    fn priority_is_must_then_should_then_may() {
+        assert_eq!(
+            detect_strength("The tool MUST do X but MAY do Y."),
+            Some(Strength::Must)
+        );
+        assert_eq!(
+            detect_strength("The tool SHOULD do X but MAY do Y."),
+            Some(Strength::Should)
+        );
+    }
+
+    #[test]
+    fn lowercase_hedges_are_ambiguous() {
+        assert_eq!(detect_strength("The tool should generally do X."), None);
+        assert_eq!(detect_strength("The tool may want to do X."), None);
+        assert_eq!(detect_strength("The tool is expected to do X."), None);
+        assert_eq!(detect_strength("Purely descriptive prose."), None);
+    }
+
+    #[test]
+    fn has_family_cross_check() {
+        assert!(has_family("The tool MUST do X.", Strength::Must));
+        assert!(!has_family("The tool SHOULD do X.", Strength::Must));
+        assert!(has_family("The tool SHOULD do X.", Strength::Should));
+        assert!(has_family("The tool MAY do X.", Strength::May));
+        // Non-keyword strengths are not policed by has_family.
+        assert!(has_family(
+            "Compute the id as follows.",
+            Strength::Algorithm
+        ));
+    }
+
+    #[test]
+    fn descriptive_hiding_a_mandatory_keyword_is_detectable() {
+        assert!(hides_mandatory_keyword("The tool MUST do X."));
+        assert!(!hides_mandatory_keyword("The tool is described here."));
+        assert!(!hides_mandatory_keyword("The tool may do X."));
+    }
+}

--- a/crates/conformance/src/report.rs
+++ b/crates/conformance/src/report.rs
@@ -25,8 +25,9 @@ use serde::Serialize;
 use crate::coverage::{BehaviorCoverage, Coverage, CoverageState};
 use crate::load::Registry;
 use crate::model::{
-    Classification, Condition, ConstraintInventory, ConstraintKind, Decision, Disposition,
-    ExpectedOutcome, GapKind, ReferenceStatus, RevisionKind, SpecStatus,
+    Classification, ClauseClassification, ClauseInventory, Condition, ConstraintInventory,
+    ConstraintKind, Decision, Disposition, ExpectedOutcome, GapKind, ReferenceStatus, RevisionKind,
+    SpecStatus, Strength, Testability,
 };
 use crate::validate::join_inventory;
 
@@ -60,7 +61,58 @@ pub struct ReportJson {
     /// records. Present-but-zeroed when the registry ships no sibling inventory
     /// (mirrors the validate V11–V14 scoping).
     pub inventory: InventorySection,
+    /// The normative-clause inventory summary (021-normative-clause-inventory, T026):
+    /// clause counts by strength/testability/document, disposition tallies, and the
+    /// unclassified + ambiguous-pending review queues. Present-but-zeroed when the
+    /// registry ships no sibling clause inventory.
+    pub clauses: ClauseSection,
 }
+
+/// The normative-clause-inventory section of `report.json`
+/// (021-normative-clause-inventory, FR-017). Deterministic: strength/testability counts
+/// in enum-declaration order, document counts document-key-sorted, listings ID-sorted.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClauseSection {
+    /// The manifest revision the clause inventory was canonicalized from; empty when none.
+    pub revision: String,
+    /// Total clause units across all documents.
+    pub total_units: usize,
+    /// Clause counts keyed by document, document-key-sorted.
+    pub units_by_document: IndexMap<String, usize>,
+    /// Clause counts for every `Strength`, in declaration order (all six always present).
+    pub units_by_strength: IndexMap<String, usize>,
+    /// Clause counts for every `Testability`, in declaration order (all five present).
+    pub units_by_testability: IndexMap<String, usize>,
+    /// Clause-classification disposition tallies.
+    pub dispositions: DispositionTally,
+    /// Clause IDs with no effective disposition (the V12 review queue), ID-sorted.
+    pub unclassified: Vec<String>,
+    /// Ambiguous-testability clause IDs still awaiting a per-clause decision, ID-sorted.
+    pub ambiguous_pending: Vec<String>,
+    /// Clause-classification IDs whose clause is absent from the inventory (V11 stale),
+    /// ID-sorted.
+    pub stale: Vec<String>,
+}
+
+/// Every `Strength` in declaration order (deterministic emission).
+const ALL_STRENGTHS: [Strength; 6] = [
+    Strength::Must,
+    Strength::Should,
+    Strength::May,
+    Strength::Algorithm,
+    Strength::IoContract,
+    Strength::Descriptive,
+];
+
+/// Every `Testability` in declaration order (deterministic emission).
+const ALL_TESTABILITIES: [Testability; 5] = [
+    Testability::DirectlyTestable,
+    Testability::IndirectlyTestable,
+    Testability::Informative,
+    Testability::Ambiguous,
+    Testability::NotApplicable,
+];
 
 /// The constraint-inventory section of `report.json` (020-schema-constraint-inventory,
 /// FR-014). Summarizes the committed inventory (`conformance/inventory/constraints.json`)
@@ -221,8 +273,35 @@ pub struct WaiverEntry {
 /// registry ships no sibling inventory (e.g. the V1–V10 acceptance fixtures), in
 /// which case that section is present-but-zeroed.
 pub fn build_report(registry: &Registry, inventory: Option<&ConstraintInventory>) -> ReportJson {
+    build_report_full(
+        registry,
+        inventory,
+        None,
+        &Default::default(),
+        &Default::default(),
+    )
+}
+
+/// Build the report model, including the normative-clause-inventory section. `clauses` is
+/// the committed clause inventory (`None` → present-but-zeroed); `authoring_docs` and
+/// `covered_docs` drive the document-scope resolution of the clause join (mirroring
+/// `validate::join_clauses`).
+pub fn build_report_full(
+    registry: &Registry,
+    inventory: Option<&ConstraintInventory>,
+    clauses: Option<&ClauseInventory>,
+    authoring_docs: &std::collections::HashSet<String>,
+    covered_docs: &std::collections::HashSet<String>,
+) -> ReportJson {
     let coverage = Coverage::evaluate(registry);
-    build_report_from_coverage(registry, &coverage, inventory)
+    build_report_from_coverage(
+        registry,
+        &coverage,
+        inventory,
+        clauses,
+        authoring_docs,
+        covered_docs,
+    )
 }
 
 /// Build the report model from a registry and its already-computed coverage.
@@ -230,6 +309,9 @@ fn build_report_from_coverage(
     registry: &Registry,
     coverage: &Coverage<'_>,
     inventory: Option<&ConstraintInventory>,
+    clauses: Option<&ClauseInventory>,
+    authoring_docs: &std::collections::HashSet<String>,
+    covered_docs: &std::collections::HashSet<String>,
 ) -> ReportJson {
     let profile = coverage.profile.map(|p| {
         // Emit the context map in dimension-ID-sorted order (determinism rule).
@@ -324,6 +406,12 @@ fn build_report_from_coverage(
     unclassified_source_units.sort();
 
     let inventory_section = build_inventory_section(inventory, &registry.classifications);
+    let clause_section = build_clause_section(
+        clauses,
+        &registry.clause_classifications,
+        authoring_docs,
+        covered_docs,
+    );
 
     ReportJson {
         schema_version: SCHEMA_VERSION,
@@ -337,6 +425,84 @@ fn build_report_from_coverage(
         waivers,
         unclassified_source_units,
         inventory: inventory_section,
+        clauses: clause_section,
+    }
+}
+
+/// Summarize the committed clause inventory joined against the hand-authored
+/// clause-classification records (021-normative-clause-inventory, T026). Deterministic;
+/// present-but-zeroed when `clauses` is `None`.
+fn build_clause_section(
+    clauses: Option<&ClauseInventory>,
+    classifications: &[ClauseClassification],
+    authoring_docs: &std::collections::HashSet<String>,
+    covered_docs: &std::collections::HashSet<String>,
+) -> ClauseSection {
+    use crate::validate::join_clauses;
+
+    let mut units_by_strength: IndexMap<String, usize> = IndexMap::new();
+    for s in ALL_STRENGTHS {
+        units_by_strength.insert(enum_str(&s), 0);
+    }
+    let mut units_by_testability: IndexMap<String, usize> = IndexMap::new();
+    for t in ALL_TESTABILITIES {
+        units_by_testability.insert(enum_str(&t), 0);
+    }
+
+    let mut units_by_document: IndexMap<String, usize> = IndexMap::new();
+    let mut revision = String::new();
+    let mut total_units = 0usize;
+    let mut ambiguous_pending: Vec<String> = Vec::new();
+
+    // A clause counts as "pending" when ambiguous AND lacking a per-clause classification.
+    let per_clause: std::collections::HashSet<&str> = classifications
+        .iter()
+        .filter_map(|c| c.clause.as_deref())
+        .collect();
+
+    if let Some(inv) = clauses {
+        revision = inv.revision.clone();
+        total_units = inv.units.len();
+        for unit in &inv.units {
+            *units_by_document.entry(unit.document.clone()).or_insert(0) += 1;
+            *units_by_strength
+                .entry(enum_str(&unit.strength))
+                .or_insert(0) += 1;
+            *units_by_testability
+                .entry(enum_str(&unit.testability))
+                .or_insert(0) += 1;
+            if unit.testability == Testability::Ambiguous && !per_clause.contains(unit.id.as_str())
+            {
+                ambiguous_pending.push(unit.id.clone());
+            }
+        }
+    }
+    units_by_document.sort_keys();
+    ambiguous_pending.sort();
+
+    let mut dispositions = DispositionTally::default();
+    for c in classifications {
+        match c.disposition {
+            Disposition::BehaviorMapped => dispositions.behavior_mapped += 1,
+            Disposition::NonTestable => dispositions.non_testable += 1,
+            Disposition::NotApplicable => dispositions.not_applicable += 1,
+        }
+    }
+
+    let join = clauses
+        .map(|inv| join_clauses(&inv.units, classifications, authoring_docs, covered_docs))
+        .unwrap_or_default();
+
+    ClauseSection {
+        revision,
+        total_units,
+        units_by_document,
+        units_by_strength,
+        units_by_testability,
+        dispositions,
+        unclassified: join.unclassified,
+        ambiguous_pending,
+        stale: join.stale,
     }
 }
 
@@ -634,7 +800,85 @@ fn render_md(report: &ReportJson) -> String {
     // 8. Constraint inventory — committed units joined against classifications.
     render_inventory_md(&mut md, &report.inventory);
 
+    // 9. Normative clause inventory — committed clauses joined against classifications.
+    render_clause_md(&mut md, &report.clauses);
+
     md
+}
+
+/// Render the normative-clause-inventory section of `report.md`
+/// (021-normative-clause-inventory, T026). Deterministic; empty-inventory renders "none".
+fn render_clause_md(md: &mut String, section: &ClauseSection) {
+    md.push_str("\n## Normative clause inventory\n\n");
+    if section.total_units == 0 {
+        md.push_str("No committed clause inventory.\n");
+        return;
+    }
+    let _ = writeln!(md, "**Revision:** `{}`\n", section.revision);
+    let _ = writeln!(md, "**Total clauses:** {}\n", section.total_units);
+
+    md.push_str("### Clauses by document\n\n");
+    md.push_str("| Document | Clauses |\n|----------|---------|\n");
+    for (doc, count) in &section.units_by_document {
+        let _ = writeln!(md, "| `{doc}` | {count} |");
+    }
+
+    md.push_str("\n### Clauses by strength\n\n");
+    md.push_str("| Strength | Clauses |\n|----------|---------|\n");
+    for (strength, count) in &section.units_by_strength {
+        let _ = writeln!(md, "| `{strength}` | {count} |");
+    }
+
+    md.push_str("\n### Clauses by testability\n\n");
+    md.push_str("| Testability | Clauses |\n|-------------|---------|\n");
+    for (testability, count) in &section.units_by_testability {
+        let _ = writeln!(md, "| `{testability}` | {count} |");
+    }
+
+    md.push_str("\n### Dispositions\n\n");
+    md.push_str("| Disposition | Count |\n|-------------|-------|\n");
+    let _ = writeln!(
+        md,
+        "| `behavior-mapped` | {} |",
+        section.dispositions.behavior_mapped
+    );
+    let _ = writeln!(
+        md,
+        "| `non-testable` | {} |",
+        section.dispositions.non_testable
+    );
+    let _ = writeln!(
+        md,
+        "| `not-applicable` | {} |",
+        section.dispositions.not_applicable
+    );
+
+    md.push_str("\n### Unclassified clauses\n\n");
+    if section.unclassified.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        for id in &section.unclassified {
+            let _ = writeln!(md, "- `{id}`");
+        }
+    }
+
+    md.push_str("\n### Ambiguous pending review\n\n");
+    if section.ambiguous_pending.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        for id in &section.ambiguous_pending {
+            let _ = writeln!(md, "- `{id}`");
+        }
+    }
+
+    md.push_str("\n### Stale clause classifications\n\n");
+    if section.stale.is_empty() {
+        md.push_str("None.\n");
+    } else {
+        for id in &section.stale {
+            let _ = writeln!(md, "- `{id}`");
+        }
+    }
 }
 
 /// Render the constraint-inventory section of `report.md`
@@ -738,10 +982,13 @@ fn conditions_str(conditions: &[Condition]) -> String {
 pub fn write_reports(
     registry: &Registry,
     inventory: Option<&ConstraintInventory>,
+    clauses: Option<&ClauseInventory>,
+    authoring_docs: &std::collections::HashSet<String>,
+    covered_docs: &std::collections::HashSet<String>,
     out_dir: &Path,
 ) -> std::io::Result<(std::path::PathBuf, std::path::PathBuf)> {
     std::fs::create_dir_all(out_dir)?;
-    let report = build_report(registry, inventory);
+    let report = build_report_full(registry, inventory, clauses, authoring_docs, covered_docs);
 
     let json_path = out_dir.join("report.json");
     std::fs::write(&json_path, render_json(&report))?;

--- a/crates/conformance/src/validate.rs
+++ b/crates/conformance/src/validate.rs
@@ -49,13 +49,19 @@ use std::path::Path;
 
 use serde::Serialize;
 
+use crate::clause::{generate_clauses, render as render_clauses};
 use crate::inventory::{generate_inventory, render};
-use crate::load::{LoadError, Registry, SchemaError, load_inventory};
-use crate::model::{
-    BehaviorUnit, CertificationProfile, Classification, Condition, ConstraintInventory,
-    ConstraintUnit, Decision, Disposition, RecordType, ReferenceStatus, RevisionKind, SpecStatus,
-    parse_id,
+use crate::load::{
+    LoadError, Registry, SchemaError, load_clause_inventory, load_inventory, load_spec_manifest,
 };
+use crate::model::{
+    BehaviorUnit, CertificationProfile, Classification, ClauseClassification, ClauseInventory,
+    ClauseUnit, Condition, ConstraintInventory, ConstraintUnit, Decision, Disposition,
+    DocumentScope, RecordType, ReferenceStatus, RevisionKind, SpecManifest, SpecStatus, Strength,
+    Testability, parse_id,
+};
+use crate::prose::Document;
+use crate::prose::strength::{has_family, hides_mandatory_keyword};
 
 /// A single structural violation. `code` is the stable class (`"V1"`..`"V10"` or
 /// `"SCHEMA"`); `record` names the offending registry record (or, for SCHEMA, the
@@ -133,6 +139,18 @@ pub struct InventoryInputs<'a> {
     pub inventory_file: &'a Path,
 }
 
+/// Where to find the normative-clause-inventory provenance inputs for the V11–V15 clause
+/// join (021-normative-clause-inventory). The committed clause inventory is the join
+/// target; the pinned spec directory drives the V14 regeneration/fingerprint verification
+/// and the V15 excerpt-present-at-anchor checks. Tests point both at fixtures.
+#[derive(Debug, Clone, Copy)]
+pub struct ClauseInputs<'a> {
+    /// The pinned spec directory (`manifest.json` + the vendored Markdown files).
+    pub spec_dir: &'a Path,
+    /// The committed clause inventory file.
+    pub clauses_file: &'a Path,
+}
+
 /// Load the registry at `root`, validate it (V1–V10 via [`run`]), AND enforce the
 /// schema-constraint-inventory join classes (V11–V14 via [`check_inventory`]) in the
 /// SAME single pass, returning ALL violations sorted by code then record ID.
@@ -148,11 +166,13 @@ pub fn validate_path_with_inventory(
     today: &str,
     repo_root: &Path,
     inputs: &InventoryInputs,
+    clause_inputs: &ClauseInputs,
 ) -> Result<Vec<Violation>, LoadError> {
     match Registry::load(root) {
         Ok(registry) => {
             let mut violations = run(&registry, today, repo_root);
             violations.extend(check_inventory(&registry, inputs));
+            violations.extend(check_clause_inventory(&registry, clause_inputs));
             sort_violations(&mut violations);
             Ok(violations)
         }
@@ -493,6 +513,512 @@ fn check_provenance(
     }
 }
 
+// ===========================================================================
+// Normative clause inventory join (V11–V15) — 021-normative-clause-inventory
+// ===========================================================================
+
+/// The join of the committed clause inventory against the hand-authored
+/// clause-classification records, with the document-scope resolution rule (research
+/// Decision 7). The clause analogue of [`InventoryJoin`] — the same conceptual V11/V12
+/// classes generalized from a constraint unit to a clause unit.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClauseJoin {
+    /// Clause IDs with no effective disposition (V12), ID-sorted. Includes an unresolved
+    /// `ambiguous` clause (no document-scope cover permitted) and a clause whose only
+    /// cover would be an invalid document-scope default.
+    pub unclassified: Vec<String>,
+    /// Per-clause classification IDs whose `clause` is absent from the inventory (V11),
+    /// ID-sorted.
+    pub stale: Vec<String>,
+    /// Clauses classified more than once by per-clause records (V12): `(clause id,
+    /// offending classification ids)`, both ID-sorted.
+    pub duplicated: Vec<(String, Vec<String>)>,
+}
+
+/// Join `units` against `classifications` with the document-scope resolution rule. Pure
+/// and total (no filesystem access): a per-clause record wins; else, if the clause's
+/// document is `authoring`-scope AND its testability ≠ `ambiguous`, a document-scope
+/// default applies; else the clause is unclassified. `authoring_docs` is the set of
+/// document keys the manifest marks `authoring`; `covered_docs` is the set of document
+/// keys carrying a (valid) document-scope default record.
+pub fn join_clauses(
+    units: &[ClauseUnit],
+    classifications: &[ClauseClassification],
+    authoring_docs: &HashSet<String>,
+    covered_docs: &HashSet<String>,
+) -> ClauseJoin {
+    // Per-clause records, keyed by clause id.
+    let mut per_clause: HashMap<&str, Vec<&str>> = HashMap::new();
+    for cls in classifications {
+        if let Some(clause) = cls.clause.as_deref() {
+            per_clause.entry(clause).or_default().push(cls.id.as_str());
+        }
+    }
+    let unit_ids: HashSet<&str> = units.iter().map(|u| u.id.as_str()).collect();
+
+    let mut join = ClauseJoin::default();
+    for unit in units {
+        match per_clause.get(unit.id.as_str()) {
+            Some(ids) if ids.len() > 1 => {
+                let mut ids: Vec<String> = ids.iter().map(|s| s.to_string()).collect();
+                ids.sort();
+                join.duplicated.push((unit.id.clone(), ids));
+            }
+            Some(_) => {} // exactly one per-clause record wins.
+            None => {
+                // No per-clause record: a document-scope default may cover it, but ONLY
+                // for an authoring document AND a non-ambiguous clause (Decision 7).
+                let ambiguous = unit.testability == Testability::Ambiguous;
+                let covered = authoring_docs.contains(&unit.document)
+                    && !ambiguous
+                    && covered_docs.contains(&unit.document);
+                if !covered {
+                    join.unclassified.push(unit.id.clone());
+                }
+            }
+        }
+    }
+    for cls in classifications {
+        if let Some(clause) = cls.clause.as_deref() {
+            if !unit_ids.contains(clause) {
+                join.stale.push(cls.id.clone());
+            }
+        }
+    }
+
+    join.unclassified.sort();
+    join.stale.sort();
+    join.duplicated.sort();
+    join
+}
+
+/// Enforce the normative-clause-inventory join classes (V11–V15) by joining the loaded
+/// registry's clause-classification records against the committed clause inventory and the
+/// vendored pinned prose (021-normative-clause-inventory). Returns every violation found
+/// (sorted); an empty vector means the join is clean. The V11–V14 classes are the
+/// *generalized* inventory-unit classes; V15 is prose-specific source integrity.
+pub fn check_clause_inventory(registry: &Registry, inputs: &ClauseInputs) -> Vec<Violation> {
+    let mut out: Vec<Violation> = Vec::new();
+
+    // Scope out entirely when neither a committed clause inventory nor a vendored spec
+    // directory exists (e.g. the V1–V10 acceptance fixtures). Not a silent fallback — the
+    // real `conformance/` tree always has both, so the full V11–V15 set runs there.
+    if !inputs.clauses_file.exists() && !inputs.spec_dir.exists() {
+        return out;
+    }
+
+    // Load the spec manifest (for per-document scope) and the committed inventory.
+    let manifest: Option<SpecManifest> = match load_spec_manifest(inputs.spec_dir) {
+        Ok(m) => Some(m),
+        Err(LoadError::SpecFingerprintMismatch {
+            file,
+            expected,
+            actual,
+        }) => {
+            out.push(Violation::new(
+                "V14",
+                file.display().to_string(),
+                format!(
+                    "spec manifest fingerprint mismatch: manifest records {expected}, vendored \
+                     file is {actual}"
+                ),
+            ));
+            None
+        }
+        Err(e) => {
+            out.push(Violation::new(
+                "V14",
+                inputs.spec_dir.display().to_string(),
+                format!("could not load the spec manifest for the clause join: {e}"),
+            ));
+            None
+        }
+    };
+
+    let committed: Option<ClauseInventory> = match load_clause_inventory(inputs.clauses_file) {
+        Ok(inv) => inv,
+        Err(e) => {
+            out.push(Violation::new(
+                "V14",
+                inputs.clauses_file.display().to_string(),
+                format!("could not load the committed clause inventory for the join: {e}"),
+            ));
+            None
+        }
+    };
+
+    let units: &[ClauseUnit] = committed
+        .as_ref()
+        .map(|c| c.units.as_slice())
+        .unwrap_or(&[]);
+    let behavior_ids: HashSet<&str> = registry.behaviors.iter().map(|b| b.id.as_str()).collect();
+
+    // Document scope + which authoring documents actually carry a valid doc-scope default.
+    let authoring_docs: HashSet<String> = manifest
+        .as_ref()
+        .map(|m| {
+            m.documents
+                .iter()
+                .filter(|d| d.scope == DocumentScope::Authoring)
+                .map(|d| d.key.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let all_docs: HashSet<String> = manifest
+        .as_ref()
+        .map(|m| m.documents.iter().map(|d| d.key.clone()).collect())
+        .unwrap_or_default();
+    let covered_docs: HashSet<String> = registry
+        .clause_classifications
+        .iter()
+        .filter_map(|c| c.document.clone())
+        .filter(|d| authoring_docs.contains(d))
+        .collect();
+
+    let join = join_clauses(
+        units,
+        &registry.clause_classifications,
+        &authoring_docs,
+        &covered_docs,
+    );
+
+    // V11 (stale per-clause), from the shared join.
+    let stale: HashSet<&str> = join.stale.iter().map(String::as_str).collect();
+    for cls in &registry.clause_classifications {
+        if stale.contains(cls.id.as_str()) {
+            out.push(Violation::new(
+                "V11",
+                &cls.id,
+                format!(
+                    "clause classification references clause {:?}, which is absent from the \
+                     committed inventory (stale — delete or re-point it)",
+                    cls.clause.as_deref().unwrap_or("")
+                ),
+            ));
+        }
+        // V13 (shape/linkage), per classification record.
+        check_clause_classification_shape(cls, &behavior_ids, &authoring_docs, &all_docs, &mut out);
+    }
+
+    // V12 (unclassified / duplicated), per clause unit.
+    for id in &join.unclassified {
+        out.push(Violation::new(
+            "V12",
+            id,
+            "clause has no effective disposition (unclassified — a per-clause classification \
+             is required, or a document-scope default for a non-ambiguous authoring clause)",
+        ));
+    }
+    for (id, cls_ids) in &join.duplicated {
+        out.push(Violation::new(
+            "V12",
+            id,
+            format!(
+                "clause is classified by {} per-clause records ({}); exactly one is required \
+                 (duplicated)",
+                cls_ids.len(),
+                cls_ids.join(", ")
+            ),
+        ));
+    }
+
+    // V15 (clause↔source integrity), per clause unit — needs the parsed prose.
+    if let (Some(manifest), Some(committed)) = (manifest.as_ref(), committed.as_ref()) {
+        check_clause_source_integrity(manifest, inputs.spec_dir, committed, &mut out);
+    }
+
+    // V14 (provenance): fingerprint (surfaced above), revision pin, and byte-identity.
+    check_clause_provenance(registry, inputs, committed.as_ref(), &mut out);
+
+    sort_violations(&mut out);
+    out
+}
+
+/// V13 shape/linkage checks for a single clause-classification record
+/// (contracts/clause-classification-schema.md).
+fn check_clause_classification_shape(
+    cls: &ClauseClassification,
+    behavior_ids: &HashSet<&str>,
+    authoring_docs: &HashSet<String>,
+    all_docs: &HashSet<String>,
+    out: &mut Vec<Violation>,
+) {
+    // `clause` XOR `document`.
+    match (&cls.clause, &cls.document) {
+        (Some(clause), None) => {
+            // Per-clause: id = `clc-` + the exact tail of the `clu-` id.
+            match clause.strip_prefix("clu-") {
+                Some(tail) => {
+                    let expected = format!("clc-{tail}");
+                    if cls.id != expected {
+                        out.push(Violation::new(
+                            "V13",
+                            &cls.id,
+                            format!(
+                                "clause classification id must mirror its clause tail (expected \
+                                 {expected:?} for clause {clause:?})"
+                            ),
+                        ));
+                    }
+                }
+                None => out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    format!(
+                        "clause {clause:?} is not a `clu-` id; the id-tail mirror is undefined"
+                    ),
+                )),
+            }
+        }
+        (None, Some(document)) => {
+            // Document-scope: id = `clc-doc-<key>`, only for an authoring document.
+            let expected = format!("clc-doc-{document}");
+            if cls.id != expected {
+                out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    format!("document-scope classification id must be {expected:?}"),
+                ));
+            }
+            if !all_docs.contains(document) {
+                out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    format!("document-scope classification targets unknown document {document:?}"),
+                ));
+            } else if !authoring_docs.contains(document) {
+                out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    format!(
+                        "document-scope classification targets consumer document {document:?}; \
+                         only authoring documents may carry a document-scope default"
+                    ),
+                ));
+            }
+        }
+        (Some(_), Some(_)) => out.push(Violation::new(
+            "V13",
+            &cls.id,
+            "clause classification has BOTH `clause` and `document` (exactly one is required)",
+        )),
+        (None, None) => out.push(Violation::new(
+            "V13",
+            &cls.id,
+            "clause classification has NEITHER `clause` nor `document` (exactly one is required)",
+        )),
+    }
+
+    // `behaviors` arity + existence, keyed to disposition.
+    match cls.disposition {
+        Disposition::BehaviorMapped => {
+            if cls.behaviors.is_empty() {
+                out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    "disposition `behavior-mapped` requires a non-empty `behaviors` list",
+                ));
+            }
+            for behavior in &cls.behaviors {
+                if !behavior_ids.contains(behavior.as_str()) {
+                    out.push(Violation::new(
+                        "V13",
+                        &cls.id,
+                        format!(
+                            "maps to behavior {behavior:?}, which is not an existing `bhv-` record"
+                        ),
+                    ));
+                }
+            }
+        }
+        Disposition::NonTestable | Disposition::NotApplicable => {
+            if !cls.behaviors.is_empty() {
+                out.push(Violation::new(
+                    "V13",
+                    &cls.id,
+                    format!(
+                        "disposition {} must have an empty `behaviors` list",
+                        disposition_name(cls.disposition)
+                    ),
+                ));
+            }
+        }
+    }
+
+    // `non-testable` / `not-applicable` require a non-empty `rationale`.
+    if matches!(
+        cls.disposition,
+        Disposition::NonTestable | Disposition::NotApplicable
+    ) {
+        let has_rationale = cls
+            .rationale
+            .as_deref()
+            .is_some_and(|r| !r.trim().is_empty());
+        if !has_rationale {
+            out.push(Violation::new(
+                "V13",
+                &cls.id,
+                format!(
+                    "disposition {} requires a non-empty `rationale`",
+                    disposition_name(cls.disposition)
+                ),
+            ));
+        }
+    }
+}
+
+/// V15 clause↔source integrity: strength ↔ excerpt keyword agreement, descriptive clauses
+/// not hiding a mandatory keyword, and each excerpt present under its recorded heading.
+fn check_clause_source_integrity(
+    manifest: &SpecManifest,
+    spec_dir: &Path,
+    committed: &ClauseInventory,
+    out: &mut Vec<Violation>,
+) {
+    // Parse each vendored document once.
+    let mut docs: HashMap<&str, Document> = HashMap::new();
+    for doc in &manifest.documents {
+        let path = spec_dir.join(&doc.file);
+        if let Ok(raw) = std::fs::read_to_string(&path) {
+            docs.insert(doc.key.as_str(), Document::parse(&raw));
+        }
+    }
+
+    for unit in &committed.units {
+        // Strength ↔ keyword agreement over the FIRST location's excerpt (all locations
+        // of a unit share the same normalized substance, so any is representative).
+        if let Some(loc) = unit.locations.first() {
+            match unit.strength {
+                Strength::Must | Strength::Should | Strength::May => {
+                    if !has_family(&loc.excerpt, unit.strength) {
+                        out.push(Violation::new(
+                            "V15",
+                            &unit.id,
+                            format!(
+                                "strength label {:?} is not supported by the excerpt's RFC-2119 \
+                                 keywords",
+                                strength_name(unit.strength)
+                            ),
+                        ));
+                    }
+                }
+                Strength::Descriptive => {
+                    if hides_mandatory_keyword(&loc.excerpt) {
+                        out.push(Violation::new(
+                            "V15",
+                            &unit.id,
+                            "descriptive clause hides an unqualified mandatory RFC-2119 keyword",
+                        ));
+                    }
+                }
+                Strength::Algorithm | Strength::IoContract => {}
+            }
+        }
+        // Every location's excerpt MUST be present in the pinned document under its anchor.
+        let Some(doc) = docs.get(unit.document.as_str()) else {
+            out.push(Violation::new(
+                "V15",
+                &unit.id,
+                format!("clause document {:?} has no vendored prose", unit.document),
+            ));
+            continue;
+        };
+        for loc in &unit.locations {
+            if !doc.contains_excerpt_at(&loc.anchor, &loc.excerpt) {
+                out.push(Violation::new(
+                    "V15",
+                    &unit.id,
+                    format!(
+                        "excerpt not present in the pinned document under heading {:?} (anchor {:?})",
+                        loc.heading, loc.anchor
+                    ),
+                ));
+            }
+        }
+    }
+}
+
+/// V14 provenance for clauses: byte-identity vs canonicalized regeneration, and the
+/// inventory revision ↔ registry `spec`-kind revision pin. (The spec-manifest fingerprint
+/// is surfaced by [`check_clause_inventory`] via [`load_spec_manifest`].)
+fn check_clause_provenance(
+    registry: &Registry,
+    inputs: &ClauseInputs,
+    committed: Option<&ClauseInventory>,
+    out: &mut Vec<Violation>,
+) {
+    match generate_clauses(inputs.spec_dir, inputs.clauses_file) {
+        Ok(regenerated) => match std::fs::read_to_string(inputs.clauses_file) {
+            Ok(committed_raw) => {
+                if committed_raw != render_clauses(&regenerated) {
+                    out.push(Violation::new(
+                        "V14",
+                        inputs.clauses_file.display().to_string(),
+                        "committed clause inventory does not byte-match a fresh canonicalization \
+                         from the pinned prose (run `clause generate`)",
+                    ));
+                }
+            }
+            Err(e) => out.push(Violation::new(
+                "V14",
+                inputs.clauses_file.display().to_string(),
+                format!("could not read the committed clause inventory for comparison: {e}"),
+            )),
+        },
+        // A fingerprint/integrity error is already reported (fingerprint by
+        // check_clause_inventory; excerpt/strength by V15). Report other regeneration
+        // failures as provenance breakage.
+        Err(
+            LoadError::SpecFingerprintMismatch { .. }
+            | LoadError::ExcerptNotFoundAtAnchor { .. }
+            | LoadError::StrengthKeywordMismatch { .. },
+        ) => {}
+        Err(e) => out.push(Violation::new(
+            "V14",
+            inputs.spec_dir.display().to_string(),
+            format!("could not regenerate the clause inventory from the pinned prose: {e}"),
+        )),
+    }
+
+    if let Some(committed) = committed {
+        let spec_revisions: Vec<&str> = registry
+            .revisions
+            .iter()
+            .filter(|r| r.kind == RevisionKind::Spec)
+            .map(|r| r.id.as_str())
+            .collect();
+        if spec_revisions.is_empty() {
+            out.push(Violation::new(
+                "V14",
+                committed.revision.clone(),
+                "the registry declares no `spec`-kind revision to pin the clause inventory against",
+            ));
+        } else if !spec_revisions.contains(&committed.revision.as_str()) {
+            out.push(Violation::new(
+                "V14",
+                committed.revision.clone(),
+                format!(
+                    "clause inventory revision {:?} names no `spec`-kind revision record (declared: \
+                     {})",
+                    committed.revision,
+                    spec_revisions.join(", ")
+                ),
+            ));
+        }
+    }
+}
+
+fn strength_name(strength: Strength) -> &'static str {
+    match strength {
+        Strength::Must => "must",
+        Strength::Should => "should",
+        Strength::May => "may",
+        Strength::Algorithm => "algorithm",
+        Strength::IoContract => "io-contract",
+        Strength::Descriptive => "descriptive",
+    }
+}
+
 /// Convert the loader's located schema errors into `SCHEMA`-class violations. The
 /// `record` field carries the file path (with `line:column` when the loader
 /// captured one) so a schema failure names its location like every other violation.
@@ -606,6 +1132,18 @@ impl<'a> Checker<'a> {
         for src in &reg.sources {
             for b in &src.behaviors {
                 sourced.insert(b.as_str());
+            }
+        }
+        // A behavior-mapped clause classification is ALSO provenance (021 T036, FR-026):
+        // once a prose clause maps to a behavior via a `clc-` record, the behavior
+        // back-traces to the pinned prose through that clause, so the hand-written
+        // `src-spec-*` prose source unit is redundant and may be retired without orphaning
+        // the behavior. This is the single-path traceability the retirement establishes.
+        for clc in &reg.clause_classifications {
+            if matches!(clc.disposition, Disposition::BehaviorMapped) {
+                for b in &clc.behaviors {
+                    sourced.insert(b.as_str());
+                }
             }
         }
 
@@ -1260,6 +1798,8 @@ fn record_type_name(ty: RecordType) -> &'static str {
         RecordType::Extension => "extension",
         RecordType::Constraint => "constraint-unit",
         RecordType::Classification => "classification",
+        RecordType::ClauseUnit => "clause-unit",
+        RecordType::ClauseClassification => "clause-classification",
     }
 }
 

--- a/crates/conformance/tests/clause_baseline.rs
+++ b/crates/conformance/tests/clause_baseline.rs
@@ -1,0 +1,145 @@
+//! Pinned-baseline acceptance tests for the committed clause inventory (US1, T013;
+//! FR-028, SC-001). Asserts observable facts about the REAL extracted inventory of the
+//! pinned `113500f4` prose — specific well-known clauses with their expected strength and
+//! provenance, plus per-document coverage — so a regression in extraction/canonicalization
+//! logic surfaces against real inputs, not only fixtures. Hermetic — no Docker, no
+//! network, no model.
+
+use std::collections::BTreeSet;
+
+use deacon_conformance::model::{ClauseUnit, Strength};
+use deacon_conformance::{default_clauses_file, default_pinned_spec_dir};
+
+fn units() -> Vec<ClauseUnit> {
+    deacon_conformance::clause::generate_clauses(
+        &default_pinned_spec_dir(),
+        &default_clauses_file(),
+    )
+    .expect("committed clause inventory canonicalizes")
+    .units
+}
+
+fn find<'a>(units: &'a [ClauseUnit], document: &str, needle: &str) -> &'a ClauseUnit {
+    units
+        .iter()
+        .find(|u| u.document == document && u.locations.iter().any(|l| l.excerpt.contains(needle)))
+        .unwrap_or_else(|| panic!("no {document} clause with excerpt containing {needle:?}"))
+}
+
+#[test]
+fn all_eighteen_pinned_documents_are_represented() {
+    let units = units();
+    let docs: BTreeSet<&str> = units.iter().map(|u| u.document.as_str()).collect();
+    let expected = [
+        "reference",
+        "json-reference",
+        "supporting-tools",
+        "image-metadata",
+        "lockfile",
+        "devcontainer-id-variable",
+        "parallel-lifecycle",
+        "features-lifecycle-scripts",
+        "features-user-env",
+        "feature-dependencies",
+        "gpu-host-requirement",
+        "declarative-secrets",
+        "secrets-support",
+        "features-legacy-ids",
+        "features",
+        "features-distribution",
+        "templates",
+        "templates-distribution",
+    ];
+    for doc in expected {
+        assert!(
+            docs.contains(doc),
+            "document {doc:?} is missing from the inventory"
+        );
+    }
+    assert_eq!(
+        docs.len(),
+        18,
+        "exactly the 18 ratified docs/specs documents"
+    );
+}
+
+#[test]
+fn the_feature_dependencies_install_order_must_is_present_with_must_strength() {
+    // The one genuine uppercase RFC-2119 MUST in the Features authoring doc's dependency
+    // discussion: `myfeature` MUST be installed after its declared dependencies.
+    let units = units();
+    let clause = find(&units, "features", "MUST be installed after");
+    assert_eq!(
+        clause.strength,
+        Strength::Must,
+        "an uppercase MUST is `must` strength"
+    );
+    assert!(
+        clause.id.contains("-must-"),
+        "the id encodes the strength code: {}",
+        clause.id
+    );
+}
+
+#[test]
+fn the_devcontainer_id_hash_algorithm_is_recorded_as_an_algorithm() {
+    // `${devcontainerId}` is computed by a defined SHA-256 → base-32 procedure.
+    let units = units();
+    let clause = find(&units, "devcontainer-id-variable", "SHA-256 hash");
+    assert_eq!(clause.strength, Strength::Algorithm);
+    assert_eq!(clause.locations[0].anchor, "label-based-computation");
+}
+
+#[test]
+fn the_image_metadata_label_shape_is_recorded_as_an_io_contract() {
+    // The `devcontainer.metadata` image label carries an array/object value contract.
+    let units = units();
+    let clause = find(&units, "image-metadata", "devcontainer.metadata");
+    assert!(
+        matches!(
+            clause.strength,
+            Strength::IoContract | Strength::Descriptive | Strength::Algorithm
+        ),
+        "the metadata label clause is a source-shape/merge clause, got {:?}",
+        clause.strength
+    );
+}
+
+#[test]
+fn every_clause_carries_verifiable_provenance() {
+    // FR-008 / SC-006: each clause resolves to a real document + a non-empty
+    // heading/anchor/excerpt and a full-length fingerprint.
+    for u in units() {
+        assert!(!u.document.is_empty());
+        assert_eq!(
+            u.fingerprint.len(),
+            64,
+            "fingerprint is a full SHA-256: {}",
+            u.id
+        );
+        assert!(!u.locations.is_empty(), "clause {} has no locations", u.id);
+        for loc in &u.locations {
+            assert!(
+                !loc.anchor.is_empty(),
+                "clause {} location has no anchor",
+                u.id
+            );
+            assert!(
+                !loc.excerpt.trim().is_empty(),
+                "clause {} has an empty excerpt",
+                u.id
+            );
+        }
+    }
+}
+
+#[test]
+fn the_inventory_covers_a_substantial_normative_surface() {
+    // SC-001: the prose surface is large; assert a healthy floor so a regression that
+    // silently drops most clauses is caught (well below the current ~250).
+    assert!(
+        units().len() >= 150,
+        "the pinned prose inventory should carry a substantial number of clauses, got {}",
+        units().len()
+    );
+}

--- a/crates/conformance/tests/clause_classification_join.rs
+++ b/crates/conformance/tests/clause_classification_join.rs
@@ -1,0 +1,249 @@
+//! Acceptance tests for the clause classification join and violation classes V11–V15
+//! (US2, T021; FR-016/FR-024/FR-025, research Decisions 5/7/8). Builds an in-memory
+//! registry (varying only the clause-classification records) pointed at the fixture
+//! prose + committed fixture clause inventory, and asserts each class fires exactly when
+//! it should. Hermetic — no Docker, no network, no model.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use deacon_conformance::clause::generate_clauses;
+use deacon_conformance::load::Registry;
+use deacon_conformance::model::{
+    BehaviorUnit, ClauseClassification, Decision, Disposition, ReferenceStatus, RevisionKind,
+    SourceRevision, SpecStatus,
+};
+use deacon_conformance::validate::{ClauseInputs, Violation, check_clause_inventory};
+use deacon_conformance::workspace_root;
+
+fn spec_dir() -> PathBuf {
+    workspace_root().join("fixtures/conformance/prose")
+}
+fn clauses_file() -> PathBuf {
+    spec_dir().join("clauses.json")
+}
+
+/// The canonical ids of the committed fixture clauses, keyed by an excerpt substring.
+fn clause_id(needle: &str) -> String {
+    generate_clauses(&spec_dir(), &clauses_file())
+        .expect("fixture clauses canonicalize")
+        .units
+        .into_iter()
+        .find(|u| u.locations.iter().any(|l| l.excerpt.contains(needle)))
+        .unwrap_or_else(|| panic!("no fixture clause with excerpt {needle:?}"))
+        .id
+}
+
+fn behavior(id: &str) -> BehaviorUnit {
+    BehaviorUnit {
+        id: id.to_string(),
+        area: "fixture".to_string(),
+        statement: "s".to_string(),
+        applicability: vec![],
+        spec: SpecStatus::Conformant,
+        reference: ReferenceStatus::Aligned,
+        decision: Decision::FollowSpec,
+        notes: None,
+    }
+}
+
+fn per_clause(
+    clause: &str,
+    disposition: Disposition,
+    behaviors: Vec<&str>,
+) -> ClauseClassification {
+    let tail = clause.strip_prefix("clu-").unwrap();
+    ClauseClassification {
+        id: format!("clc-{tail}"),
+        clause: Some(clause.to_string()),
+        document: None,
+        disposition,
+        behaviors: behaviors.into_iter().map(String::from).collect(),
+        rationale: matches!(
+            disposition,
+            Disposition::NonTestable | Disposition::NotApplicable
+        )
+        .then(|| "rationale".to_string()),
+        notes: None,
+    }
+}
+
+fn doc_default(document: &str) -> ClauseClassification {
+    ClauseClassification {
+        id: format!("clc-doc-{document}"),
+        clause: None,
+        document: Some(document.to_string()),
+        disposition: Disposition::NotApplicable,
+        behaviors: vec![],
+        rationale: Some("authoring document; consumer-only scope".to_string()),
+        notes: None,
+    }
+}
+
+/// Run the clause join over an in-memory registry carrying `classifications`.
+fn run(classifications: Vec<ClauseClassification>) -> Vec<Violation> {
+    let registry = Registry {
+        revisions: vec![SourceRevision {
+            id: "rev-spec-113500f4".to_string(),
+            kind: RevisionKind::Spec,
+            pin: "113500f4".to_string(),
+            url: "u".to_string(),
+            verified_against: None,
+        }],
+        behaviors: vec![behavior("bhv-x")],
+        clause_classifications: classifications,
+        ..Default::default()
+    };
+    let spec = spec_dir();
+    let clauses = clauses_file();
+    check_clause_inventory(
+        &registry,
+        &ClauseInputs {
+            spec_dir: &spec,
+            clauses_file: &clauses,
+        },
+    )
+}
+
+/// A fully-classified registry: every consumer clause per-clause, the authoring document
+/// covered by a document-scope default. This must be violation-free.
+fn fully_classified() -> Vec<ClauseClassification> {
+    vec![
+        per_clause(
+            &clause_id("run onCreateCommand exactly once"),
+            Disposition::BehaviorMapped,
+            vec!["bhv-x"],
+        ),
+        per_clause(
+            &clause_id("MUST NOT run it again"),
+            Disposition::BehaviorMapped,
+            vec!["bhv-x"],
+        ),
+        per_clause(
+            &clause_id("should generally complete quickly"),
+            Disposition::NonTestable,
+            vec![],
+        ),
+        per_clause(
+            &clause_id("\"outcome\": \"success\""),
+            Disposition::BehaviorMapped,
+            vec!["bhv-x"],
+        ),
+        per_clause(
+            &clause_id("purely descriptive"),
+            Disposition::NonTestable,
+            vec![],
+        ),
+        // The consumer install clause inside the authoring doc needs a per-clause override.
+        per_clause(
+            &clause_id("invoke the feature install script"),
+            Disposition::BehaviorMapped,
+            vec!["bhv-x"],
+        ),
+        doc_default("authoring-sample"),
+    ]
+}
+
+fn codes(v: &[Violation]) -> HashSet<&str> {
+    v.iter().map(|x| x.code.as_str()).collect()
+}
+
+#[test]
+fn fully_classified_registry_is_clean() {
+    let v = run(fully_classified());
+    assert!(
+        v.is_empty(),
+        "fully-classified fixture must be clean, got: {v:?}"
+    );
+}
+
+#[test]
+fn ambiguous_clause_without_per_clause_record_blocks_as_v12() {
+    // Drop the classification for the ambiguous clause → it is unclassified (V12).
+    let mut cls = fully_classified();
+    let amb = clause_id("should generally complete quickly");
+    cls.retain(|c| c.clause.as_deref() != Some(amb.as_str()));
+    let v = run(cls);
+    assert!(
+        v.iter().any(|x| x.code == "V12" && x.record == amb),
+        "an unresolved ambiguous clause must block as V12, got: {v:?}"
+    );
+}
+
+#[test]
+fn unclassified_consumer_clause_blocks_as_v12() {
+    let mut cls = fully_classified();
+    let target = clause_id("run onCreateCommand exactly once");
+    cls.retain(|c| c.clause.as_deref() != Some(target.as_str()));
+    let v = run(cls);
+    assert!(v.iter().any(|x| x.code == "V12" && x.record == target));
+}
+
+#[test]
+fn stale_classification_blocks_as_v11() {
+    let mut cls = fully_classified();
+    let ghost = "clu-sample-ghost-must-00000000";
+    cls.push(per_clause(ghost, Disposition::NonTestable, vec![]));
+    let v = run(cls);
+    assert!(
+        v.iter().any(|x| x.code == "V11"
+            && x.record == format!("clc-{}", ghost.strip_prefix("clu-").unwrap())),
+        "a classification for a missing clause is V11-stale, got: {v:?}"
+    );
+}
+
+#[test]
+fn document_scope_default_on_a_consumer_document_is_v13() {
+    let mut cls = fully_classified();
+    cls.push(doc_default("sample")); // `sample` is consumer scope.
+    let v = run(cls);
+    assert!(
+        codes(&v).contains("V13"),
+        "a document-scope default on a consumer document must be V13, got: {v:?}"
+    );
+}
+
+#[test]
+fn behavior_mapped_with_empty_behaviors_is_v13() {
+    let mut cls = fully_classified();
+    let target = clause_id("run onCreateCommand exactly once");
+    // Replace the good record with a behavior-mapped one that has no behaviors.
+    for c in &mut cls {
+        if c.clause.as_deref() == Some(target.as_str()) {
+            c.disposition = Disposition::BehaviorMapped;
+            c.behaviors.clear();
+        }
+    }
+    let v = run(cls);
+    assert!(
+        codes(&v).contains("V13"),
+        "empty behaviors on behavior-mapped is V13: {v:?}"
+    );
+}
+
+#[test]
+fn id_tail_mismatch_is_v13() {
+    let mut cls = fully_classified();
+    let target = clause_id("run onCreateCommand exactly once");
+    for c in &mut cls {
+        if c.clause.as_deref() == Some(target.as_str()) {
+            c.id = "clc-wrong-tail".to_string();
+        }
+    }
+    let v = run(cls);
+    assert!(codes(&v).contains("V13"), "id-tail mismatch is V13: {v:?}");
+}
+
+#[test]
+fn authoring_document_scope_default_is_non_blocking() {
+    // The document-scope default covers every non-ambiguous authoring clause without a
+    // per-clause record. Remove the install override → the doc default covers it, clean.
+    let mut cls = fully_classified();
+    let install = clause_id("invoke the feature install script");
+    cls.retain(|c| c.clause.as_deref() != Some(install.as_str()));
+    let v = run(cls);
+    assert!(
+        v.is_empty(),
+        "the authoring doc-scope default covers its non-ambiguous clauses, got: {v:?}"
+    );
+}

--- a/crates/conformance/tests/clause_determinism.rs
+++ b/crates/conformance/tests/clause_determinism.rs
@@ -1,0 +1,123 @@
+//! Determinism acceptance tests for the clause inventory (US1, T012; FR-011/FR-023,
+//! SC-002). Canonicalization is byte-identical across runs, the committed inventory
+//! byte-matches a fresh regeneration, IDs are stable, and no vendored/fixture prose
+//! carries a CR byte. Hermetic — no Docker, no network, no model.
+
+use deacon_conformance::clause::{generate_clauses, render};
+use deacon_conformance::{default_clauses_file, default_pinned_spec_dir, workspace_root};
+
+#[test]
+fn committed_pinned_inventory_byte_matches_regeneration() {
+    let spec = default_pinned_spec_dir();
+    let clauses = default_clauses_file();
+    let regenerated = generate_clauses(&spec, &clauses).expect("pinned clauses canonicalize");
+    let committed = std::fs::read_to_string(&clauses).expect("committed clauses.json is readable");
+    assert_eq!(
+        committed,
+        render(&regenerated),
+        "committed clauses.json must byte-match a fresh `clause generate`"
+    );
+}
+
+#[test]
+fn two_regenerations_are_byte_identical() {
+    let spec = default_pinned_spec_dir();
+    let clauses = default_clauses_file();
+    let a = render(&generate_clauses(&spec, &clauses).unwrap());
+    let b = render(&generate_clauses(&spec, &clauses).unwrap());
+    assert_eq!(a, b, "two in-memory regenerations must be byte-identical");
+    assert!(a.ends_with('\n'), "canonical output is newline-terminated");
+}
+
+#[test]
+fn ids_are_stable_across_runs() {
+    let spec = default_pinned_spec_dir();
+    let clauses = default_clauses_file();
+    let ids1: Vec<String> = generate_clauses(&spec, &clauses)
+        .unwrap()
+        .units
+        .into_iter()
+        .map(|u| u.id)
+        .collect();
+    let ids2: Vec<String> = generate_clauses(&spec, &clauses)
+        .unwrap()
+        .units
+        .into_iter()
+        .map(|u| u.id)
+        .collect();
+    assert_eq!(
+        ids1, ids2,
+        "clause ids must be stable and in the same order"
+    );
+}
+
+#[test]
+fn fixture_inventory_regenerates_byte_identically() {
+    let base = workspace_root().join("fixtures/conformance/prose");
+    let clauses = base.join("clauses.json");
+    let regenerated = generate_clauses(&base, &clauses).unwrap();
+    let committed = std::fs::read_to_string(&clauses).unwrap();
+    assert_eq!(committed, render(&regenerated));
+}
+
+#[test]
+fn vendored_and_fixture_prose_have_no_cr_bytes() {
+    // CR bytes would make cross-platform output non-byte-identical; the loader rejects
+    // them, but assert it here directly over every vendored + fixture Markdown file.
+    let roots = [
+        default_pinned_spec_dir(),
+        workspace_root().join("fixtures/conformance/prose"),
+    ];
+    for root in roots {
+        for entry in std::fs::read_dir(&root)
+            .expect("prose dir readable")
+            .flatten()
+        {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                let bytes = std::fs::read(&path).unwrap();
+                assert!(
+                    !bytes.contains(&b'\r'),
+                    "{path:?} contains a CR byte; vendored/fixture prose must be LF-only"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn crate_has_no_network_or_llm_dependency_so_ci_paths_are_offline() {
+    // SC-004 / T037: `generate`/`check`/`validate`/`diff`/`certify` read ONLY committed +
+    // vendored inputs — no command can perform network IO or invoke a model, because the
+    // dev-only `deacon-conformance` crate declares no HTTP client / model dependency at
+    // all. Assert that structurally over its manifest (the strongest offline guarantee:
+    // the capability is absent, not merely unused).
+    let manifest = std::fs::read_to_string(workspace_root().join("crates/conformance/Cargo.toml"))
+        .expect("conformance Cargo.toml is readable");
+    // Inspect only dependency-declaration lines (`name = …`), so a word like "surface"
+    // in a comment never trips the check — the guarantee is about actual dependencies.
+    let dep_names: Vec<String> = manifest
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#'))
+        .filter_map(|l| l.split_once('=').map(|(name, _)| name.trim().to_string()))
+        .collect();
+    for forbidden in [
+        "reqwest",
+        "hyper",
+        "ureq",
+        "curl",
+        "surf",
+        "isahc",
+        "tokio",
+        "openai",
+        "async-openai",
+        "llm",
+    ] {
+        assert!(
+            !dep_names.iter().any(|d| d == forbidden),
+            "deacon-conformance must not depend on {forbidden:?}: its CI-facing clause \
+             commands must be offline and LLM-free (SC-004)"
+        );
+    }
+}

--- a/crates/conformance/tests/clause_diff.rs
+++ b/crates/conformance/tests/clause_diff.rs
@@ -1,0 +1,102 @@
+//! Acceptance tests for the deterministic, move-aware clause diff (US3, T030;
+//! FR-019/FR-020/FR-021, SC-005/SC-007). Diffs the two fixture revisions under
+//! `fixtures/conformance/clause-drift/{old,new}` and asserts every change lands in the
+//! correct bucket, moves keep their id, reworded clauses mint a new id, and immaterial
+//! reflow is non-material. Hermetic — no Docker, no network, no model.
+
+use deacon_conformance::clause_diff::{diff, render_json, render_md};
+use deacon_conformance::model::ClauseInventory;
+use deacon_conformance::workspace_root;
+
+fn load(rel: &str) -> ClauseInventory {
+    let path = workspace_root()
+        .join("fixtures/conformance/clause-drift")
+        .join(rel);
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {path:?}: {e}"))
+}
+
+#[test]
+fn buckets_are_exactly_as_expected() {
+    let d = diff(&load("old/clauses.json"), &load("new/clauses.json"));
+    assert_eq!(
+        d.new_clauses
+            .iter()
+            .map(|e| e.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["clu-doc-added-must-66666666"],
+        "exactly one added clause"
+    );
+    assert_eq!(
+        d.removed.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+        vec!["clu-doc-removed-must-22222222"],
+        "exactly one removed clause"
+    );
+    assert_eq!(
+        d.moved.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+        vec!["clu-doc-moved-must-11111111"],
+        "exactly one moved clause"
+    );
+    assert_eq!(d.changed.len(), 1, "exactly one materially changed clause");
+    assert_eq!(
+        d.non_material
+            .iter()
+            .map(|e| e.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["clu-doc-nm-must-55555555"],
+        "exactly one immaterial reflow"
+    );
+}
+
+#[test]
+fn a_move_keeps_its_id_and_shows_both_locations() {
+    let d = diff(&load("old/clauses.json"), &load("new/clauses.json"));
+    let m = &d.moved[0];
+    assert_eq!(m.id, "clu-doc-moved-must-11111111");
+    assert_eq!(m.old_locations[0].anchor, "old-location");
+    assert_eq!(m.new_locations[0].anchor, "new-location");
+}
+
+#[test]
+fn a_reword_yields_a_new_id_and_a_stale_old_id() {
+    let d = diff(&load("old/clauses.json"), &load("new/clauses.json"));
+    let c = &d.changed[0];
+    assert_eq!(c.old_id, "clu-doc-old-must-33333333");
+    assert_eq!(c.new_id, "clu-doc-new-must-44444444");
+    assert_ne!(
+        c.old_id, c.new_id,
+        "a material change must carry distinct ids"
+    );
+    // No disposition is inherited by wording similarity: the old id is simply gone.
+    assert!(!d.removed.iter().any(|e| e.id == c.new_id));
+}
+
+#[test]
+fn immaterial_reflow_is_not_reported_as_material() {
+    let d = diff(&load("old/clauses.json"), &load("new/clauses.json"));
+    assert!(
+        d.changed
+            .iter()
+            .all(|c| c.new_id != "clu-doc-nm-must-55555555"),
+        "a reflow must never appear as a material change"
+    );
+}
+
+#[test]
+fn output_is_deterministic_in_both_forms() {
+    let old = load("old/clauses.json");
+    let new = load("new/clauses.json");
+    assert_eq!(
+        render_json(&diff(&old, &new)),
+        render_json(&diff(&old, &new))
+    );
+    let md = render_md(&diff(&old, &new));
+    assert_eq!(md, render_md(&diff(&old, &new)));
+    assert!(md.contains("# Clause Inventory Diff"));
+}
+
+#[test]
+fn identical_inventories_diff_to_nothing() {
+    let old = load("old/clauses.json");
+    assert!(diff(&old, &old).is_empty());
+}

--- a/crates/conformance/tests/clause_extraction.rs
+++ b/crates/conformance/tests/clause_extraction.rs
@@ -1,0 +1,85 @@
+//! Acceptance tests for clause extraction/canonicalization (US1, T011; FR-004/FR-005/
+//! FR-006). Drives `generate_clauses` over the purpose-built fixture prose under
+//! `fixtures/conformance/prose/` and asserts the atomicity, strength-detection, and
+//! ambiguity properties the spec mandates. Hermetic — no Docker, no network, no model.
+
+use deacon_conformance::clause::generate_clauses;
+use deacon_conformance::model::{ClauseUnit, Strength, Testability};
+use deacon_conformance::workspace_root;
+
+fn fixture_units() -> Vec<ClauseUnit> {
+    let base = workspace_root().join("fixtures/conformance/prose");
+    generate_clauses(&base, &base.join("clauses.json"))
+        .expect("fixture clauses canonicalize")
+        .units
+}
+
+fn find<'a>(units: &'a [ClauseUnit], needle: &str) -> &'a ClauseUnit {
+    units
+        .iter()
+        .find(|u| u.locations.iter().any(|l| l.excerpt.contains(needle)))
+        .unwrap_or_else(|| panic!("no clause with excerpt containing {needle:?}"))
+}
+
+#[test]
+fn multi_requirement_paragraph_splits_into_distinct_clauses() {
+    let units = fixture_units();
+    // The single Lifecycle paragraph states two independent MUST obligations; each is its
+    // own atomic clause with a distinct id.
+    let once = find(&units, "run onCreateCommand exactly once");
+    let not_again = find(&units, "MUST NOT run it again");
+    assert_ne!(once.id, not_again.id, "two obligations → two clauses");
+    assert_eq!(once.strength, Strength::Must);
+    assert_eq!(not_again.strength, Strength::Must);
+}
+
+#[test]
+fn strength_families_are_detected_and_recorded() {
+    let units = fixture_units();
+    assert_eq!(
+        find(&units, "run onCreateCommand exactly once").strength,
+        Strength::Must
+    );
+    // The fenced I/O contract is recorded as an io-contract clause.
+    let io = find(&units, "\"outcome\": \"success\"");
+    assert_eq!(io.strength, Strength::IoContract);
+    assert_eq!(
+        io.context.as_ref().and_then(|c| c.get("inCodeFence")),
+        Some(&serde_json::Value::Bool(true)),
+        "the I/O contract is flagged as living in a code fence"
+    );
+}
+
+#[test]
+fn hedged_language_is_surfaced_as_ambiguous_not_promoted_to_must() {
+    let units = fixture_units();
+    let hedged = find(&units, "should generally complete quickly");
+    assert_eq!(
+        hedged.testability,
+        Testability::Ambiguous,
+        "hedged language must surface as ambiguous"
+    );
+    assert_ne!(
+        hedged.strength,
+        Strength::Must,
+        "ambiguous language must NEVER be auto-promoted to a strict MUST"
+    );
+}
+
+#[test]
+fn descriptive_text_is_recorded_as_informative_not_a_requirement() {
+    let units = fixture_units();
+    let descriptive = find(&units, "purely descriptive and");
+    assert_eq!(descriptive.strength, Strength::Descriptive);
+    assert_eq!(descriptive.testability, Testability::Informative);
+}
+
+#[test]
+fn every_fixture_document_is_represented() {
+    let units = fixture_units();
+    assert!(units.iter().any(|u| u.document == "sample"));
+    assert!(
+        units.iter().any(|u| u.document == "authoring-sample"),
+        "authoring-scope documents are inventoried in full, not skipped"
+    );
+}

--- a/crates/conformance/tests/gap_certification.rs
+++ b/crates/conformance/tests/gap_certification.rs
@@ -27,7 +27,7 @@ use deacon_conformance::certify::{BlockingKind, certify};
 use deacon_conformance::inventory::{generate_inventory, write_inventory};
 use deacon_conformance::load::Registry;
 use deacon_conformance::model::ConstraintUnit;
-use deacon_conformance::validate::InventoryInputs;
+use deacon_conformance::validate::{ClauseInputs, InventoryInputs};
 use deacon_conformance::workspace_root;
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -325,7 +325,16 @@ fn certify_fixture(
     registry_dir: &Path,
 ) -> deacon_conformance::certify::Certification {
     let reg = Registry::load(registry_dir).expect("fixture registry loads");
-    certify(&reg, &fx.inputs())
+    certify(&reg, &fx.inputs(), &no_clause_inputs())
+}
+
+/// Clause inputs pointing at absent paths, so the clause join scopes itself out (these
+/// constraint-inventory fixtures ship no committed clause inventory / vendored prose).
+fn no_clause_inputs() -> ClauseInputs<'static> {
+    ClauseInputs {
+        spec_dir: Path::new("/nonexistent-conformance/spec"),
+        clauses_file: Path::new("/nonexistent-conformance/inventory/clauses.json"),
+    }
 }
 
 /// Assert a `constraint` blocker of `code` naming `record` is present.
@@ -497,5 +506,150 @@ fn real_registry_certifies_clean_now_that_the_gate_is_wired() {
             .is_empty(),
         "the real registry has zero blocking items, got: {:?}",
         doc["blocking"]
+    );
+}
+
+// ===========================================================================
+// Normative-clause-inventory certification wiring (021, T033; FR-018/FR-022,
+// SC-008). Proves an unclassified/stale clause blocks `certify`, and well-formed
+// not-applicable/non-testable clause dispositions never do — over the fixture prose
+// (`fixtures/conformance/prose`, seven committed clauses) via the library `certify`.
+// ===========================================================================
+
+use deacon_conformance::model::{ClauseClassification, Disposition, RevisionKind, SourceRevision};
+
+fn prose_spec_dir() -> PathBuf {
+    workspace_root().join("fixtures/conformance/prose")
+}
+
+/// The canonical ids of the committed fixture clauses.
+fn fixture_clause_ids() -> Vec<String> {
+    deacon_conformance::clause::generate_clauses(
+        &prose_spec_dir(),
+        &prose_spec_dir().join("clauses.json"),
+    )
+    .expect("fixture clauses canonicalize")
+    .units
+    .into_iter()
+    .map(|u| u.id)
+    .collect()
+}
+
+/// A registry carrying only a `spec`-kind revision (so V14's revision-pin check passes)
+/// plus the given clause classifications.
+fn clause_registry(classifications: Vec<ClauseClassification>) -> Registry {
+    Registry {
+        revisions: vec![SourceRevision {
+            id: "rev-spec-113500f4".to_string(),
+            kind: RevisionKind::Spec,
+            pin: "113500f4".to_string(),
+            url: "u".to_string(),
+            verified_against: None,
+        }],
+        clause_classifications: classifications,
+        ..Default::default()
+    }
+}
+
+fn certify_clauses(registry: &Registry) -> deacon_conformance::certify::Certification {
+    let spec = prose_spec_dir();
+    let clauses = spec.join("clauses.json");
+    // No constraint inventory here — scope that join out; exercise ONLY the clause gate.
+    certify(
+        registry,
+        &InventoryInputs {
+            schemas_dir: Path::new("/nonexistent-conformance/schemas"),
+            inventory_file: Path::new("/nonexistent-conformance/inventory/constraints.json"),
+        },
+        &ClauseInputs {
+            spec_dir: &spec,
+            clauses_file: &clauses,
+        },
+    )
+}
+
+#[test]
+fn unclassified_clause_blocks_certify() {
+    // No clause classifications at all → every fixture clause is unclassified (V12).
+    let cert = certify_clauses(&clause_registry(vec![]));
+    assert!(!cert.certified, "unclassified clauses must block certify");
+    assert!(
+        cert.blocking
+            .iter()
+            .any(|b| b.kind == BlockingKind::Clause && b.code.as_deref() == Some("V12")),
+        "an unclassified clause must appear as a Clause V12 blocker, got: {:#?}",
+        cert.blocking
+    );
+}
+
+#[test]
+fn not_applicable_and_non_testable_clause_dispositions_never_block() {
+    // Classify every fixture clause with a well-formed non-blocking disposition.
+    let classifications: Vec<ClauseClassification> = fixture_clause_ids()
+        .into_iter()
+        .enumerate()
+        .map(|(i, clause)| {
+            let tail = clause.strip_prefix("clu-").unwrap().to_string();
+            ClauseClassification {
+                id: format!("clc-{tail}"),
+                clause: Some(clause),
+                document: None,
+                disposition: if i % 2 == 0 {
+                    Disposition::NotApplicable
+                } else {
+                    Disposition::NonTestable
+                },
+                behaviors: vec![],
+                rationale: Some(
+                    "outside consumer runtime scope / no testable behavior".to_string(),
+                ),
+                notes: None,
+            }
+        })
+        .collect();
+    let cert = certify_clauses(&clause_registry(classifications));
+    assert!(
+        !cert.blocking.iter().any(|b| b.kind == BlockingKind::Clause),
+        "well-formed not-applicable/non-testable clauses must never block, got: {:#?}",
+        cert.blocking
+    );
+    assert!(cert.certified, "a fully-classified fixture must certify");
+}
+
+#[test]
+fn stale_clause_classification_blocks_certify() {
+    // A classification pointing at a clause that does not exist → V11 stale.
+    let ghost = "clu-sample-ghost-must-00000000";
+    let mut classifications: Vec<ClauseClassification> = fixture_clause_ids()
+        .into_iter()
+        .map(|clause| {
+            let tail = clause.strip_prefix("clu-").unwrap().to_string();
+            ClauseClassification {
+                id: format!("clc-{tail}"),
+                clause: Some(clause),
+                document: None,
+                disposition: Disposition::NotApplicable,
+                behaviors: vec![],
+                rationale: Some("r".to_string()),
+                notes: None,
+            }
+        })
+        .collect();
+    classifications.push(ClauseClassification {
+        id: format!("clc-{}", ghost.strip_prefix("clu-").unwrap()),
+        clause: Some(ghost.to_string()),
+        document: None,
+        disposition: Disposition::NotApplicable,
+        behaviors: vec![],
+        rationale: Some("points at a removed clause".to_string()),
+        notes: None,
+    });
+    let cert = certify_clauses(&clause_registry(classifications));
+    assert!(
+        cert.blocking
+            .iter()
+            .any(|b| b.kind == BlockingKind::Clause && b.code.as_deref() == Some("V11")),
+        "a stale clause classification must block as Clause V11, got: {:#?}",
+        cert.blocking
     );
 }

--- a/crates/conformance/tests/traceability.rs
+++ b/crates/conformance/tests/traceability.rs
@@ -294,3 +294,72 @@ fn section<'a>(md: &'a str, start: &str, end: &str) -> &'a str {
         .unwrap_or_else(|| panic!("report.md missing section {end:?} after {start:?}"));
     &rest[..to]
 }
+
+// ===========================================================================
+// Clause → behavior traceability (021, T034; FR-026, SC-006). Over the REAL
+// committed registry + clause inventory, checked deterministically and offline:
+// every behavior-mapped clause classification resolves forward to an existing
+// behavior, and every such behavior is reachable back from its clause(s). No
+// network, no model — pure functions of committed data.
+// ===========================================================================
+
+use deacon_conformance::model::Disposition;
+use deacon_conformance::{clause_paths_for, default_registry_dir};
+
+#[test]
+fn every_consumer_clause_maps_forward_and_back_to_a_real_behavior() {
+    let registry = Registry::load(&default_registry_dir()).expect("real registry loads");
+    let (_spec, clauses_file) = clause_paths_for(&default_registry_dir());
+    let inventory =
+        deacon_conformance::load::load_clause_inventory(&clauses_file).expect("clauses load");
+
+    let behavior_ids: HashSet<&str> = registry.behaviors.iter().map(|b| b.id.as_str()).collect();
+    let clause_ids: HashSet<&str> = inventory
+        .as_ref()
+        .map(|inv| inv.units.iter().map(|u| u.id.as_str()).collect())
+        .unwrap_or_default();
+
+    // Forward: every behavior-mapped clause classification points at a real clause AND
+    // real behaviors.
+    let mut behavior_to_clauses: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for clc in &registry.clause_classifications {
+        if clc.disposition != Disposition::BehaviorMapped {
+            continue;
+        }
+        let clause = clc
+            .clause
+            .as_deref()
+            .expect("a behavior-mapped clause classification is per-clause, not document-scope");
+        assert!(
+            clause_ids.contains(clause),
+            "clc {:?} references clause {clause:?} absent from the committed inventory",
+            clc.id
+        );
+        assert!(
+            !clc.behaviors.is_empty(),
+            "behavior-mapped clc {:?} must name ≥1 behavior",
+            clc.id
+        );
+        for behavior in &clc.behaviors {
+            assert!(
+                behavior_ids.contains(behavior.as_str()),
+                "clc {:?} maps to behavior {behavior:?}, which is not an existing bhv- record",
+                clc.id
+            );
+            behavior_to_clauses
+                .entry(behavior.clone())
+                .or_default()
+                .push(clause.to_string());
+        }
+    }
+
+    // Backward: each behavior reached from a clause is reachable back to ≥1 clause
+    // (the inverse index is total by construction — assert it is navigable and stable).
+    for (behavior, clauses) in &behavior_to_clauses {
+        assert!(
+            !clauses.is_empty(),
+            "behavior {behavior:?} must back-trace to ≥1 clause"
+        );
+    }
+}

--- a/fixtures/conformance/clause-drift/new/clauses.json
+++ b/fixtures/conformance/clause-drift/new/clauses.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-abcdef12",
+  "units": [
+    { "id": "clu-doc-moved-must-11111111", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "11",
+      "locations": [ { "heading": "New Location", "anchor": "new-location", "ordinal": 1, "excerpt": "The tool MUST relocate." } ], "context": null },
+    { "id": "clu-doc-new-must-44444444", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "44",
+      "locations": [ { "heading": "Shared", "anchor": "shared", "ordinal": 1, "excerpt": "The tool MUST do the new thing." } ], "context": null },
+    { "id": "clu-doc-nm-must-55555555", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "55",
+      "locations": [ { "heading": "Reflow", "anchor": "reflow", "ordinal": 1, "excerpt": "The tool  MUST   stay." } ], "context": null },
+    { "id": "clu-doc-added-must-66666666", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "66",
+      "locations": [ { "heading": "Fresh", "anchor": "fresh", "ordinal": 1, "excerpt": "The tool MUST appear." } ], "context": null }
+  ]
+}

--- a/fixtures/conformance/clause-drift/old/clauses.json
+++ b/fixtures/conformance/clause-drift/old/clauses.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "units": [
+    { "id": "clu-doc-moved-must-11111111", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "11",
+      "locations": [ { "heading": "Old Location", "anchor": "old-location", "ordinal": 1, "excerpt": "The tool MUST relocate." } ], "context": null },
+    { "id": "clu-doc-removed-must-22222222", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "22",
+      "locations": [ { "heading": "Gone", "anchor": "gone", "ordinal": 1, "excerpt": "The tool MUST vanish." } ], "context": null },
+    { "id": "clu-doc-old-must-33333333", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "33",
+      "locations": [ { "heading": "Shared", "anchor": "shared", "ordinal": 1, "excerpt": "The tool MUST do the old thing." } ], "context": null },
+    { "id": "clu-doc-nm-must-55555555", "document": "doc", "strength": "must",
+      "testability": "directly-testable", "fingerprint": "55",
+      "locations": [ { "heading": "Reflow", "anchor": "reflow", "ordinal": 1, "excerpt": "The tool MUST stay." } ], "context": null }
+  ]
+}

--- a/fixtures/conformance/prose/authoring-sample.md
+++ b/fixtures/conformance/prose/authoring-sample.md
@@ -1,0 +1,10 @@
+# Sample Authoring Document
+
+## Publishing
+
+A feature author MUST publish the feature to an OCI registry before it can be
+consumed.
+
+## Install contract
+
+The consuming tool MUST invoke the feature install script as root.

--- a/fixtures/conformance/prose/clauses.json
+++ b/fixtures/conformance/prose/clauses.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "units": [
+    {
+      "id": "clu-authoring-sample-a-feature-author-must-publish-the-feature-to-an-must-62f0091e",
+      "document": "authoring-sample",
+      "strength": "must",
+      "testability": "not-applicable",
+      "fingerprint": "dccd4a441ee9ea24cd492f80e98c9cda74d42930c2858982f922407028a4239b",
+      "locations": [
+        {
+          "heading": "Publishing",
+          "anchor": "publishing",
+          "ordinal": 1,
+          "excerpt": "A feature author MUST publish the feature to an OCI registry before it can be\nconsumed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-authoring-sample-the-consuming-tool-must-invoke-the-feature-insta-must-823ab0b5",
+      "document": "authoring-sample",
+      "strength": "must",
+      "testability": "directly-testable",
+      "fingerprint": "ef1bb2a3c4200f994124878bd2d5b6e0213756c60117e6eeec72309593489fb9",
+      "locations": [
+        {
+          "heading": "Install contract",
+          "anchor": "install-contract",
+          "ordinal": 1,
+          "excerpt": "The consuming tool MUST invoke the feature install script as root."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-sample-outcome-success-io-6882cb22",
+      "document": "sample",
+      "strength": "io-contract",
+      "testability": "directly-testable",
+      "fingerprint": "91196b7d70409d007baabe55aac41bc15786cd1a74b369a95f32deb0051432ed",
+      "locations": [
+        {
+          "heading": "Lifecycle > Output contract",
+          "anchor": "output-contract",
+          "ordinal": 1,
+          "excerpt": "\"outcome\": \"success\""
+        }
+      ],
+      "context": {
+        "inCodeFence": true
+      }
+    },
+    {
+      "id": "clu-sample-the-command-should-generally-complete-quickly-bu-desc-ab743426",
+      "document": "sample",
+      "strength": "descriptive",
+      "testability": "ambiguous",
+      "fingerprint": "1c2bc097094540e499340353de36da12c31570f4b6f0d2b0b75b667a40d59674",
+      "locations": [
+        {
+          "heading": "Lifecycle",
+          "anchor": "lifecycle",
+          "ordinal": 3,
+          "excerpt": "The command should generally complete quickly, but timing is not guaranteed."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-sample-the-tool-must-not-run-it-again-on-a-subsequent-s-must-dc0377df",
+      "document": "sample",
+      "strength": "must",
+      "testability": "directly-testable",
+      "fingerprint": "ea376f7d0acdb1c5831a40233dc73680e402eee20f55ea5a816e296e8b5ac322",
+      "locations": [
+        {
+          "heading": "Lifecycle",
+          "anchor": "lifecycle",
+          "ordinal": 2,
+          "excerpt": "The tool MUST NOT run it again\non a subsequent start."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-sample-the-tool-must-run-oncreatecommand-exactly-once-must-303235b2",
+      "document": "sample",
+      "strength": "must",
+      "testability": "directly-testable",
+      "fingerprint": "c0cedc27015d464891dd3c593eca54e5fd5ac1cebfb937cb3e330fc87cdc6715",
+      "locations": [
+        {
+          "heading": "Lifecycle",
+          "anchor": "lifecycle",
+          "ordinal": 1,
+          "excerpt": "The tool MUST run onCreateCommand exactly once."
+        }
+      ],
+      "context": null
+    },
+    {
+      "id": "clu-sample-this-paragraph-is-purely-descriptive-and-carries-desc-94cc2600",
+      "document": "sample",
+      "strength": "descriptive",
+      "testability": "informative",
+      "fingerprint": "61aad94f8046d8f37a160b528d2ba1eafb3825101ef6cafdd33ae3db4e4f7f55",
+      "locations": [
+        {
+          "heading": "Sample Consumer Document",
+          "anchor": "sample-consumer-document",
+          "ordinal": 1,
+          "excerpt": "This paragraph is purely descriptive and\ncarries no obligation."
+        }
+      ],
+      "context": null
+    }
+  ]
+}

--- a/fixtures/conformance/prose/manifest.json
+++ b/fixtures/conformance/prose/manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "documents": [
+    {
+      "key": "sample",
+      "file": "sample.md",
+      "upstreamUrl": "https://example.invalid/sample.md",
+      "sha256": "14b9ed39c3f87bc1786ffbac6e88aca7343efa66ee0eea2a2e494c806b22aa3f",
+      "scope": "consumer"
+    },
+    {
+      "key": "authoring-sample",
+      "file": "authoring-sample.md",
+      "upstreamUrl": "https://example.invalid/authoring-sample.md",
+      "sha256": "eca7030a9638e31ac5041ef03ac9adec3d0df467d8708f98da9d8c949ca032a7",
+      "scope": "authoring"
+    }
+  ]
+}

--- a/fixtures/conformance/prose/sample.md
+++ b/fixtures/conformance/prose/sample.md
@@ -1,0 +1,26 @@
+# Sample Consumer Document
+
+Intro prose describing the sample. This paragraph is purely descriptive and
+carries no obligation.
+
+## Lifecycle
+
+The tool MUST run onCreateCommand exactly once. The tool MUST NOT run it again
+on a subsequent start.
+
+The command should generally complete quickly, but timing is not guaranteed.
+
+### Output contract
+
+The resolver emits a single JSON document:
+
+```
+{
+  "outcome": "success",
+  "containerId": "abc123"
+}
+```
+
+## Notes
+
+This section is explanatory background and does not define a requirement.

--- a/specs/021-normative-clause-inventory/checklists/requirements.md
+++ b/specs/021-normative-clause-inventory/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Normative Clause Inventory
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Validation performed 2026-07-24: all items pass. The spec is grounded in the existing
+  conformance-registry (019) and schema-constraint-inventory (020) machinery, deliberately
+  mirroring 020's classification/drift/certify patterns for the prose surface.
+- Zero `[NEEDS CLARIFICATION]` markers: all reasonable defaults (clause identity model,
+  move-detection semantics, LLM-proposal-vs-committed-artifact boundary, ambiguity-blocks
+  policy) are documented in the Assumptions section rather than raised as questions, since a
+  well-founded default exists for each by analogy to feature 020.
+- `/speckit.clarify` session 2026-07-24 resolved 3 questions (see spec `## Clarifications`):
+  document scope (all ratified `docs/specs/`, authoring marked not-applicable, proposals
+  out), fail-closed certification triage (any unclassified/ambiguous clause blocks), and
+  dual clause representation (verbatim excerpt + normalized substance fingerprint). Spec
+  edits reconciled across FR-001/008/016/018/019/022, SC-003/008, and the entity/assumption
+  sections; no residual `consumer-relevant`/`relevant to deacon` qualifiers remain.

--- a/specs/021-normative-clause-inventory/contracts/clause-classification-schema.md
+++ b/specs/021-normative-clause-inventory/contracts/clause-classification-schema.md
@@ -1,0 +1,73 @@
+# Contract: Clause Classification + Violation Classes V11–V15
+
+Hand-authored registry records under
+`conformance/registry/clause-classifications/<doc>.json`, one collection file per document
+key (consumer docs) plus an `authoring.json` holding the document-scope defaults. Strict
+JSON, `deny_unknown_fields`, `camelCase`, ID-sorted like every registry collection.
+`clause generate` NEVER touches these files.
+
+## Record — `ClauseClassification`
+
+Closed model; exactly one of `clause` / `document` present.
+
+```json
+// Per-clause (required for every consumer-doc clause and every `ambiguous` clause)
+{
+  "id": "clc-reference-oncreatecommand-run-once-must-a1b2c3d4",
+  "clause": "clu-reference-oncreatecommand-run-once-must-a1b2c3d4",
+  "disposition": "behavior-mapped",
+  "behaviors": ["bhv-up-lifecycle-oncreate-once"],
+  "rationale": null,
+  "notes": null
+}
+
+// Document-scope default (permitted ONLY for `authoring`-scope documents)
+{
+  "id": "clc-doc-features",
+  "document": "features",
+  "disposition": "not-applicable",
+  "rationale": "Feature-authoring document; deacon consumes published features but never authors or validates them (constitution II)."
+}
+```
+
+| Field | Rules |
+|---|---|
+| `id` | Per-clause: `clc-` + the exact tail of the `clu-` id (structural mirror; V13 if broken). Document-scope: `clc-doc-<key>`. |
+| `clause` XOR `document` | Exactly one present (V13). `clause` MUST exist in the committed inventory (V11 if stale). `document` MUST be an `authoring`-scope manifest key (V13 / `DocumentScopeOnConsumerDoc`). |
+| `disposition` | `behavior-mapped` \| `non-testable` \| `not-applicable` (reuses 020's `Disposition`; `non-testable` is prose "informative"). |
+| `behaviors` | Non-empty, all existing behavior IDs iff `behavior-mapped`; absent/empty otherwise (V13). Many clauses → one behavior is allowed (FR-010). |
+| `rationale` | REQUIRED non-empty for `non-testable`/`not-applicable`; optional for `behavior-mapped`. |
+| `notes` | Optional free text (e.g. supersession of a retired prose source unit). |
+
+**Effective disposition of a clause** (research Decision 7):
+1. A per-clause record → that disposition.
+2. Else, if the clause's document `scope` is `authoring` AND `testability` ≠ `ambiguous`
+   → the document-scope default.
+3. Else → **unclassified** (V12, blocking).
+
+Exactly one effective disposition; zero or two per-clause records → V12.
+
+## Violation classes
+
+V11–V14 are the **generalized** inventory-unit classes (the same `join_inventory` engine
+serves 020's constraints and 021's clauses). V15 is new (prose source integrity).
+
+| Class | Trigger | Where |
+|---|---|---|
+| **V11** stale | `clc` references a `clu` id absent from `clauses.json` (delete/re-point in the same change — waiver-style self-invalidation) | `validate` + `certify` |
+| **V12** unclassified | clause with no effective disposition (incl. an unresolved `ambiguous` clause; incl. a clause whose only cover would be an *invalid* document-scope default), or classified more than once | `validate` + `certify` |
+| **V13** malformed | `behaviors`/`rationale` arity vs disposition, `clc-` id-tail ≠ `clu-` tail, `clause`-XOR-`document` broken, or document-scope default on a `consumer` document | `validate` + `certify` |
+| **V14** provenance | spec manifest fingerprint mismatch, inventory `revision` ≠ the `rev-spec-*` pin, or committed `clauses.json` ≠ canonicalized regeneration (byte-identity) | `validate` + `certify` |
+| **V15** clause↔source | `strength` label contradicts excerpt RFC-2119 keywords, a `descriptive` clause hides a mandatory keyword, or an `excerpt` is absent from the pinned document under its `anchor` | `validate` + `certify` |
+
+**Certification semantics** (wired last — research Decision 10): `certify` exits 1 iff any
+gap OR any uncovered in-profile behavior OR any V11–V15 (constraint OR clause). Waivers are
+listed but non-blocking; `not-applicable`/`non-testable` dispositions never block. No flag
+bypasses this; no path invokes a model or the network.
+
+**Drift = unclassified/stale by construction**: a revision bump re-canonicalizes the
+inventory; changed substance yields new IDs (V12) and orphans old classifications (V11);
+moves keep IDs (no new work). There is no separate "drift item" record type — V11+V12
+mechanically enumerate the exact review queue (research Decision 8/9). `clause scaffold`
+emits `UNREVIEWED`-sentinel skeletons (loader-rejected) so the queue is tractable without
+ever auto-deciding a disposition.

--- a/specs/021-normative-clause-inventory/contracts/clause-inventory-schema.md
+++ b/specs/021-normative-clause-inventory/contracts/clause-inventory-schema.md
@@ -1,0 +1,84 @@
+# Contract: Clause Inventory + Spec Manifest
+
+Two committed artifacts. Both strict-JSON, `deny_unknown_fields`, `camelCase`, canonical
+serialization (`to_string_pretty`, 2-space indent, LF, trailing newline). Vendored prose is
+byte-exact upstream Markdown, never edited in place.
+
+## Spec manifest — `conformance/spec/<pin>/manifest.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "documents": [
+    { "key": "reference",       "file": "devcontainer-reference.md",              "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-reference.md",              "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "json-reference",  "file": "devcontainerjson-reference.md",          "upstreamUrl": "…/devcontainerjson-reference.md",          "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "supporting-tools","file": "supporting-tools.md",                    "upstreamUrl": "…/supporting-tools.md",                    "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "image-metadata",  "file": "image-metadata.md",                      "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "lockfile",        "file": "devcontainer-lockfile.md",               "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "devcontainer-id-variable", "file": "devcontainer-id-variable.md",   "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "parallel-lifecycle", "file": "parallel-lifecycle-script-execution.md", "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "features-lifecycle-scripts", "file": "features-contribute-lifecycle-scripts.md", "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "features-user-env", "file": "features-user-env-variables.md",        "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "feature-dependencies", "file": "feature-dependencies.md",           "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "gpu-host-requirement", "file": "gpu-host-requirement.md",           "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "declarative-secrets", "file": "declarative-secrets.md",             "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "secrets-support", "file": "secrets-support.md",                     "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "features-legacy-ids", "file": "features-legacyIds-deprecated-properties.md", "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "consumer" },
+    { "key": "features",        "file": "devcontainer-features.md",               "upstreamUrl": "…/devcontainer-features.md",               "sha256": "<64 hex>", "scope": "authoring" },
+    { "key": "features-distribution",  "file": "devcontainer-features-distribution.md",  "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "authoring" },
+    { "key": "templates",       "file": "devcontainer-templates.md",              "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "authoring" },
+    { "key": "templates-distribution", "file": "devcontainer-templates-distribution.md", "upstreamUrl": "…", "sha256": "<64 hex>", "scope": "authoring" }
+  ]
+}
+```
+
+All **18** ratified `docs/specs/` documents at `113500f4` are mandatory (14 consumer, 4
+authoring). The `features`/`templates` authoring docs are mixed and carry per-clause
+`behavior-mapped` overrides for their consumer install/apply clauses (research Decision 7).
+
+**Rules**
+- `revision` MUST name an existing `rev-spec-*` record in `registry/revisions.json`
+  (V14 / provenance on mismatch).
+- Each `file` MUST exist in the same directory and its bytes MUST hash to `sha256`
+  (verified before every parse; mismatch → `SpecFingerprintMismatch`, V14). Hashing reuses
+  020's `sha256_hex`/`hex_lower`.
+- `key` unique, lowercase `[a-z0-9-]+`.
+- `scope` ∈ {`consumer`, `authoring`}. Only `authoring` documents may carry a document-scope
+  disposition default (V13 otherwise).
+- `upstreamUrl` is provenance only — no command fetches it. Exact filenames and `sha256`
+  values are captured by the human vendoring task (quickstart.md); the 18 ratified
+  `docs/specs/` documents above are the mandatory set (research Decision 6). The final
+  document list is confirmed at vendoring; the manifest is the source of truth.
+
+## Clause inventory — `conformance/inventory/clauses.json`
+
+Envelope `{ schemaVersion, revision, units[] }`. Unit shape and field rules per
+**data-model §2**. Contract highlights:
+
+- `id` = `clu-<doc>-<substance-slug>-<strength>-<hash8>`; `hash8` over
+  `document ‖ normalize_substance(excerpt)` — **location excluded** (Decision 2), so pure
+  moves keep the ID.
+- `fingerprint` = full SHA-256 of the normalized substance (the distinct fingerprint field;
+  drift reads it).
+- `locations[]` non-empty; each `{ heading, anchor, ordinal, excerpt }`. `excerpt` MUST be a
+  verbatim substring of the vendored document under `anchor` (else `ExcerptNotFoundAtAnchor`,
+  V15). Multiple locations = the same normalized obligation stated in multiple places (they
+  merge into one unit).
+- `strength` ∈ {`must`, `should`, `may`, `algorithm`, `io-contract`, `descriptive`}. For
+  `must`/`should`/`may`, the excerpt MUST contain the corresponding RFC-2119 keyword family
+  (else `StrengthKeywordMismatch`, V15). A `descriptive` unit MUST NOT contain an unqualified
+  mandatory keyword.
+- `testability` ∈ {`directly-testable`, `indirectly-testable`, `informative`, `ambiguous`,
+  `not-applicable`}. `ambiguous` requires a per-clause classification (no document-scope cover)
+  before `certify` passes.
+- `units` sorted by `id`; byte-identical regeneration is the contract (V14). Generation is
+  canonicalization of authored records against the pinned prose — no model, no network.
+
+## Determinism guarantees
+
+- No environment input (timestamp, hostname, absolute path, locale) enters either artifact.
+- Markdown is read as bytes with explicit `\n` handling; CR bytes are rejected in vendored
+  files at fingerprint time so cross-platform output stays byte-identical.
+- `normalize_substance` and `detect_strength` are pure functions with exhaustive unit tests;
+  they are the sole sources of identity, materiality, and strength verification.

--- a/specs/021-normative-clause-inventory/contracts/cli-clause.md
+++ b/specs/021-normative-clause-inventory/contracts/cli-clause.md
@@ -1,0 +1,74 @@
+# CLI Contract: `conformance clause …`
+
+Dev-only subcommands on the existing `conformance` bin
+(`cargo run -p deacon-conformance -- clause <cmd>`). NOT part of the `deacon` consumer
+CLI. Shared conventions with `validate`/`report`/`certify`/`inventory`: results to stdout
+or `--out` files; diagnostics via `tracing` to stderr; deterministic outputs (no
+timestamps, no absolute paths); `--registry <dir>`, `--spec <dir>`, and `--clauses <file>`
+overrides exist so tests run against fixtures. **No subcommand performs network IO, and no
+subcommand invokes an LLM — ever.** These are pure functions of the committed records and
+the vendored pinned prose.
+
+## `clause generate [--spec <dir>] [--clauses <file>]`
+
+**Canonicalizes** the committed clause records (it does NOT invent clauses — segmentation
+is out-of-band authoring work, research Decision 1). Reads the committed clause records +
+the spec manifest + vendored prose, verifies SHA-256 fingerprints, then for each authored
+record: recomputes `normalize_substance(excerpt)` → `fingerprint`, recomputes the
+substance-anchored `id`, verifies the excerpt is present in the pinned document under its
+recorded heading, merges records that share a normalized substance into one unit with
+combined `locations`, sorts canonically, and writes the byte-stable inventory (default
+`conformance/inventory/clauses.json`).
+
+- Exit 0: inventory written (byte-stable; rewriting identical content is fine).
+- Exit 1: any integrity error — `SpecFingerprintMismatch`, `ExcerptNotFoundAtAnchor`
+  (names the clause + heading), `StrengthKeywordMismatch` (names labeled vs detected),
+  malformed record. Never writes a partial file (temp-file + `fs::rename`, matching
+  `inventory::write_inventory` / `cache/disk.rs::save_index` discipline).
+
+## `clause check [--spec <dir>] [--clauses <file>]`
+
+Regenerates in memory and byte-compares against the committed inventory.
+
+- Exit 0: identical.
+- Exit 1: differs (`ClauseInventoryOutOfDate`, with a compact unit-level summary of
+  new/removed/moved/changed IDs) or any generate-class error.
+- This is the CLI face of the hermetic determinism/provenance test; CI runs the test,
+  humans run `check`.
+
+## `clause diff <old.json> <new.json> [--format json|md] [--out <file>]`
+
+Deterministic revision diff per data-model §4 (match key: normalized-substance
+fingerprint). Reports `new_clauses`, `removed`, `moved`, `changed`, and `nonMaterial`.
+
+- Exit 0: diff produced (including an empty diff).
+- Exit 1: either input unreadable/malformed.
+- Output sorted by `(document, heading, id)`; `--format md` renders the human review
+  document. Moves are first-class and non-blocking; material changes surface as
+  removed-old-id + new-new-id sharing a heading.
+
+## `clause scaffold [--clauses <file>] [--registry <dir>]`
+
+Emits skeleton `clc-` records (to stdout) for every currently unclassified clause, with
+`disposition` set to the sentinel `"UNREVIEWED"` — a value the loader REJECTS (closed
+`Disposition` enum, no such variant) — so scaffolded output cannot be committed unedited.
+For clauses in an `authoring`-scope document it emits a single per-document skeleton where
+one does not yet exist; for consumer-doc and `ambiguous` clauses it emits per-clause
+skeletons. Never writes into the registry itself.
+
+- Exit 0: skeletons emitted (possibly zero).
+- Exit 1: inventory/registry/manifest unreadable.
+
+## Interactions with existing commands
+
+- `validate`: additionally loads the spec manifest + clause inventory + clause
+  classifications and enforces V11–V15 (see clause-classification-schema.md). V11–V14 are
+  the *generalized* classes (already run for 020's constraints); V15 is clause-specific.
+  All violations reported in one run, consistent with existing behavior.
+- `report`: gains a clause-inventory section (unit counts by strength/testability/document,
+  disposition tallies, unclassified list, ambiguous-pending list). Byte-stable as before.
+- `certify`: (final phase only) fails when any V11/V12/V13/V14/V15 exists for the clause
+  inventory — i.e. exit 1 iff gap OR uncovered in-profile behavior OR unclassified/stale
+  clause OR provenance/source-integrity breakage. `not-applicable`/`non-testable`
+  dispositions never block. No flag can bypass this (no silent weakening); no path invokes
+  a model.

--- a/specs/021-normative-clause-inventory/data-model.md
+++ b/specs/021-normative-clause-inventory/data-model.md
@@ -1,0 +1,221 @@
+# Data Model: Normative Clause Inventory
+
+All new data is strict JSON (`deny_unknown_fields`, `camelCase`, matching every
+`deacon-conformance` record). Four artifact families, paralleling feature 020:
+**vendored prose** (third-party, byte-exact Markdown), **generated clause inventory**
+(canonicalized from authored records, committed), **clause classifications**
+(hand-authored registry records), and command-only **diff** output. New enums/structs
+land in `crates/conformance/src/model.rs`; new prefixes join the closed ID grammar in
+`RecordType`/`parse_id`.
+
+## 1. Spec manifest — `conformance/spec/<rev-pin>/manifest.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "documents": [
+    {
+      "key": "reference",
+      "file": "devcontainer-reference.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-reference.md",
+      "sha256": "<64-hex captured at vendoring>",
+      "scope": "consumer"
+    },
+    {
+      "key": "features",
+      "file": "devcontainer-features.md",
+      "upstreamUrl": "https://raw.githubusercontent.com/devcontainers/spec/113500f4/docs/specs/devcontainer-features.md",
+      "sha256": "<64-hex>",
+      "scope": "authoring"
+    }
+  ]
+}
+```
+
+| Field | Rules |
+|---|---|
+| `revision` | MUST name an existing `rev-` record of kind `spec` in `registry/revisions.json` (V14 on mismatch). |
+| `documents[].key` | Document key used in clause IDs, classification files, and diff sort order. Lowercase `[a-z0-9-]+`, unique. |
+| `documents[].sha256` | Verified against the vendored file bytes before every parse; mismatch → hard error (V14 / `SpecFingerprintMismatch`). |
+| `documents[].upstreamUrl` | Provenance only — never fetched by any command. |
+| `documents[].scope` | Closed enum `consumer` \| `authoring`. Gates the document-scope disposition default (§3): a document-scope `not-applicable` record is permitted only for `authoring` documents (V13 otherwise). |
+
+All **18** ratified `docs/specs/` documents at `113500f4` are mandatory (14 consumer, 4
+authoring — the full set enumerated in research Decision 6). The two rows above are
+illustrative; the manifest lists every document. Adding a future ratified doc at a new pin =
+a manifest entry + vendored file.
+
+## 2. Clause unit — element of `conformance/inventory/clauses.json`
+
+```json
+{
+  "schemaVersion": 1,
+  "revision": "rev-spec-113500f4",
+  "units": [
+    {
+      "id": "clu-reference-oncreatecommand-run-once-must-a1b2c3d4",
+      "document": "reference",
+      "strength": "must",
+      "testability": "directly-testable",
+      "fingerprint": "9f2a…<64 hex sha256 of normalized substance>",
+      "locations": [
+        {
+          "heading": "Lifecycle scripts > onCreateCommand",
+          "anchor": "oncreatecommand",
+          "ordinal": 1,
+          "excerpt": "`onCreateCommand` - This command is the first of three commands ... and MUST be run only once."
+        }
+      ],
+      "context": null
+    }
+  ]
+}
+```
+
+| Field | Rules |
+|---|---|
+| `id` | `clu-<doc>-<substance-slug>-<strength>-<hash8>` (research Decision 2). Grammar-valid per `parse_id` with new `clu` prefix. Unique; identical normalized substance in one document ⇒ the **same** unit (its locations merge), so there is no collision case for genuine duplicates. |
+| `document` | Manifest document key. |
+| `strength` | Closed enum: `must`, `should`, `may`, `algorithm`, `io-contract`, `descriptive`. |
+| `testability` | Closed enum: `directly-testable`, `indirectly-testable`, `informative`, `ambiguous`, `not-applicable`. |
+| `fingerprint` | Full lowercase-hex SHA-256 of `normalize_substance(excerpt)` (Decision 3). The **distinct fingerprint field** the clarification requires; drift's material-vs-immaterial decision reads this. |
+| `locations` | Non-empty array; one entry per place the same normalized substance appears. Each: `heading` (human path), `anchor` (GitHub-style slug of the owning heading), `ordinal` (1-based position within that heading — provenance/order only, never an identity input), `excerpt` (verbatim source substring; the human-readable field). Sorted by `(anchor, ordinal)`. |
+| `context` | Nullable. Optional structural note, e.g. `{ "inCodeFence": true }` for an I/O contract shown in a fenced block, or `{ "listContext": "onCreateCommand bullet" }`. |
+
+**Identity** (Decision 2): `hash8` = first 8 chars of the lowercase-hex SHA-256 of
+`document ‖ normalize_substance(excerpt)` (`‖` = separator byte `0x1f`, reusing 020's
+`HASH_SEPARATOR`). **Location is excluded from the hash**, so a pure move preserves the ID
+(and its disposition); a material change (obligation or strength reworded ⇒ different
+normalized substance) mints a new ID (drift-forcing). `strength` appears in the ID string
+and, because a strength change always co-occurs with an excerpt change, is covered by the
+fingerprint too. `<substance-slug>` is a bounded (≤ 48-char) slug of the normalized
+substance's leading tokens — readability only; identity lives in the hash.
+
+**Normalized substance** (Decision 3): `normalize_substance(excerpt)` = lowercase, strip
+Markdown formatting (emphasis, inline-code backticks, link syntax, list bullets, block-quote
+markers), collapse whitespace runs to one space, trim; preserve RFC-2119 keywords, code-span
+contents, identifiers, and meaningful punctuation. Pure, deterministic, unit-tested in
+isolation. Two excerpts differing only in whitespace/markdown reflow normalize equal ⇒ same
+fingerprint ⇒ immaterial (SC-005).
+
+**Ordering**: `units` sorted by `id`; file is canonical JSON (`to_string_pretty`, 2-space
+indent, LF, trailing newline — 020's `render` discipline). Byte-identical regeneration is the
+contract (V14).
+
+**State transitions** (clause lifecycle across a revision bump):
+
+```
+(absent) ──author+generate──▶ unclassified (V12 blocking) ──human clc record──▶ classified
+classified ──pure move upstream──▶ same id, locations[] change (reported "moved", NON-blocking, disposition kept)
+classified ──substance/strength change──▶ old id absent (clc goes V11-stale)
+                                          + new id unclassified (V12) ── review ──▶ classified
+authored ambiguous ──▶ testability="ambiguous", no doc-scope cover allowed ──▶ V12 until human resolves
+```
+
+## 3. Clause classification — `conformance/registry/clause-classifications/<doc>.json`
+
+Collection envelope identical to other registry files. Two record shapes in one closed
+model (`ClauseClassification`), exactly one of `clause` / `document` present:
+
+**Per-clause** (required for every consumer-document clause and every `ambiguous` clause):
+
+```json
+{
+  "id": "clc-reference-oncreatecommand-run-once-must-a1b2c3d4",
+  "clause": "clu-reference-oncreatecommand-run-once-must-a1b2c3d4",
+  "disposition": "behavior-mapped",
+  "behaviors": ["bhv-up-lifecycle-oncreate-once"],
+  "rationale": null,
+  "notes": "Supersedes retired src-spec-lifecycle-up prose link."
+}
+```
+
+**Document-scope default** (permitted only for `authoring`-scope documents):
+
+```json
+{
+  "id": "clc-doc-features",
+  "document": "features",
+  "disposition": "not-applicable",
+  "rationale": "Feature-authoring document; deacon consumes published features but never authors or validates them (constitution II)."
+}
+```
+
+| Field | Rules |
+|---|---|
+| `id` | Per-clause: `clc-` + the exact tail of the referenced `clu-` id (structural mirror; V13 if mismatched). Document-scope: `clc-doc-<document key>`. |
+| `clause` XOR `document` | Exactly one present (V13 otherwise). `clause` MUST exist in the committed inventory (V11 when stale). `document` MUST be an `authoring`-scope manifest key (V13 otherwise). |
+| `disposition` | Closed enum, reusing 020's `Disposition`: `behavior-mapped`, `non-testable` (the "informative" flavor for prose), `not-applicable`. |
+| `behaviors` | Non-empty and every ID an existing behavior iff `behavior-mapped`; absent/empty otherwise (V13). Several clauses MAY map to one behavior (FR-010). |
+| `rationale` | REQUIRED non-empty for `non-testable` and `not-applicable`; optional for `behavior-mapped`. |
+
+**Resolution order for a clause** (research Decision 7): a per-clause record wins; else, if
+the clause's document is `authoring`-scope AND its `testability` ≠ `ambiguous`, a
+document-scope default applies; else the clause is unclassified (V12, blocking). Exactly one
+effective disposition per clause; zero or two per-clause records is V12.
+
+**Certification semantics** (wired last — Decision 10): any V11/V12/V13/V14/V15 is blocking
+in `validate`; `certify` additionally fails while any clause is unclassified or any
+classification is stale — the prose analogue of "a gap always blocks."
+`not-applicable`/`non-testable` never block.
+
+## 4. Revision diff (command output, not committed)
+
+Match key **normalized-substance fingerprint** over two clause-inventory files
+(Decision 9 — deliberately NOT 020's `(document, pointer, kind)` key, so moves are visible):
+
+```json
+{
+  "schemaVersion": 1,
+  "old": { "revision": "rev-spec-113500f4" },
+  "new": { "revision": "rev-spec-abcdef12" },
+  "new_clauses": [ { "id": "clu-…", "document": "…", "strength": "…", "locations": [ … ] } ],
+  "removed": [ … ],
+  "moved":   [ { "id": "clu-…", "oldLocations": [ … ], "newLocations": [ … ] } ],
+  "changed": [ { "document": "…", "heading": "…", "oldId": "clu-…", "newId": "clu-…", "oldExcerpt": "…", "newExcerpt": "…" } ],
+  "nonMaterial": [ { "id": "clu-…", "oldExcerpt": "…", "newExcerpt": "…" } ]
+}
+```
+
+- **new**: fingerprint present only on the right.
+- **removed**: fingerprint present only on the left.
+- **moved**: same id (fingerprint) both sides, `locations` differ → old/new locations shown;
+  **non-blocking**, disposition preserved.
+- **changed**: a removed old-id and a new new-id share a heading (a material rewrite reads as
+  changed for the reviewer, though mechanically it is remove-old + add-new).
+- **nonMaterial**: same id both sides, excerpt bytes differ but fingerprint equal
+  (whitespace/reflow) — never reported as material (SC-005).
+
+Deterministically sorted by `(document, heading, id)`. Markdown twin for human review. The
+diff is advisory; the *enforcement* of drift is V11/V12 against the regenerated committed
+inventory.
+
+## 5. Model extensions in `crates/conformance/src/model.rs`
+
+- `RecordType` gains `ClauseUnit` (`clu`) and `ClauseClassification` (`clc`); `parse_id`
+  grammar regex extends its prefix alternation to `…|cst|cls|clu|clc`. Existing V2
+  duplicate/sort/prefix checks (`all_ids`) extend to the new collections automatically via
+  the loader.
+- New structs: `SpecManifest`, `SpecDocument` (with `DocumentScope` enum), `ClauseInventory`,
+  `ClauseUnit`, `Strength` enum, `Testability` enum, `ClauseLocation`, `ClauseClassification`
+  (with a `clause`-XOR-`document` invariant), plus `clause_diff` output types. All
+  `deny_unknown_fields`, `camelCase`, kebab-case wire values for enums.
+- New error variants (thiserror, cause-specific per FR-003/FR-008/FR-014): `SpecFingerprintMismatch`,
+  `ExcerptNotFoundAtAnchor { clause, heading }`, `StrengthKeywordMismatch { clause, labeled,
+  detected }`, `AmbiguousClauseUnclassified { clause }`, `ClauseInventoryOutOfDate`,
+  `DocumentScopeOnConsumerDoc { document }`.
+
+## 6. Violation classes (documented in conformance/RULES.md in lockstep)
+
+V11–V14 are **generalized** from "constraint unit" to "inventory unit (schema constraint OR
+prose clause)" — the same `join_inventory`/`InventoryJoin` engine runs for both inventories.
+V15 is new (prose-only source integrity).
+
+| Class | Meaning | Blocking |
+|---|---|---|
+| V11 | Stale classification — a `cls`/`clc` record references a unit ID (`cst`/`clu`) absent from its committed inventory | validate + certify |
+| V12 | Unclassified — an inventory unit with no effective disposition (no per-unit record, and, for a clause, no permitted document-scope cover), or classified more than once; an unresolved `ambiguous` clause is V12 by construction | validate + certify |
+| V13 | Malformed classification — behavior missing/arity, id-tail mismatch, `clause`-XOR-`document` broken, or a document-scope default applied to a non-`authoring` document | validate + certify |
+| V14 | Provenance — spec/schema manifest fingerprint mismatch, inventory `revision` ≠ registry pin of the matching kind, or committed inventory ≠ canonicalized regeneration (byte-identity) | validate + certify |
+| V15 (new) | Clause↔source integrity — `strength` label contradicts excerpt keywords (Decision 4), a `descriptive` clause hides a mandatory RFC-2119 keyword, or a clause `excerpt` is absent from the pinned document under its recorded heading | validate + certify |

--- a/specs/021-normative-clause-inventory/plan.md
+++ b/specs/021-normative-clause-inventory/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Normative Clause Inventory
+
+**Branch**: `021-normative-clause-inventory` | **Date**: 2026-07-24 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/021-normative-clause-inventory/spec.md`
+
+## Summary
+
+Extend the dev-only `deacon-conformance` crate with a **prose-clause inventory** —
+the companion to feature 020's schema-constraint inventory — covering the ratified
+`docs/specs/` documents of the containers.dev specification pinned at `rev-spec-113500f4`.
+The ratified prose documents are **vendored** under `conformance/spec/113500f4/` with
+SHA-256 fingerprints and a `consumer` / `authoring` scope marker per document. The
+committed artifact `conformance/inventory/clauses.json` is a **human-reviewed** list of
+atomic clause records (an LLM-assisted proposal step MAY draft them, but is never invoked
+by CI). A new `clause generate` command **canonicalizes** that committed list against the
+vendored prose — recomputing each clause's substance-anchored stable ID and
+normalized-substance fingerprint, verifying the excerpt is present in the pinned document
+under its recorded heading, sorting canonically — and a hermetic test regenerates it and
+requires byte-identical output. Hand-authored clause-classification records
+(`conformance/registry/clause-classifications/<doc>.json`) join to clauses by stable ID —
+per-clause for consumer documents, with a document-scope not-applicable default permitted
+only for authoring documents. The registry's violation classes V11–V14 are **generalized
+from "constraint unit" to "inventory unit (constraint OR clause)"**, plus a new **V15**
+for clause↔source integrity (strength-label ↔ keyword agreement; excerpt-present-at-anchor);
+`certify` blocks on any unclassified or stale clause — wired only in the final phase, after
+the full initial classification lands. A deterministic `clause diff` matches on the
+substance fingerprint so **moves are first-class** (distinct from new/removed/changed),
+which is how upstream prose drift surfaces as unclassified (blocking) work.
+
+## Technical Context
+
+**Language/Version**: Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide)
+**Primary Dependencies**: existing crate deps only — `serde`/`serde_json` (record
+parsing + canonical serialization; `preserve_order` already on), `indexmap` (ordered
+collections), `clap` (new `clause` subcommands on the existing `conformance` bin),
+`sha2` (fingerprints + stable-ID hashes; already a `deacon-conformance` dep), `thiserror`
+(domain errors), `tracing`. A small deterministic Markdown-heading/section reader is
+written in-crate (ATX headings only) rather than adding a Markdown crate — the parse
+surface needed (heading tree + section text spans + code-fence awareness) is small,
+must be byte-deterministic across platforms, and a new dependency would be
+disproportionate. **No new external crates.**
+**Storage**: strict-JSON + vendored Markdown — vendored prose under
+`conformance/spec/<rev>/` (with `manifest.json` fingerprints + per-document `scope`),
+generated committed inventory at `conformance/inventory/clauses.json` (sibling of 020's
+`constraints.json`), hand-authored clause-classification records under
+`conformance/registry/clause-classifications/`. All version-controlled; no network at
+generate/check/validate/diff/certify time, and no LLM ever in those paths.
+**Testing**: `cargo nextest` via the existing hermetic conformance test-binary pattern
+(`crates/conformance/tests/`); fixture prose under `fixtures/conformance/prose/` plus
+assertions against the vendored pinned baseline. No Docker, no network, no model.
+**Target Platform**: contributor tooling on Linux/macOS/Windows (must stay green in the
+`dev-fast` Windows CI lane; byte-identical output across platforms — LF endings, no
+path-dependent content; Markdown read as bytes with explicit `\n` handling).
+**Project Type**: extension of the existing dev-only `deacon-conformance` library + CLI
+crate (`publish = false`; NOT part of the `deacon` consumer CLI).
+**Performance Goals**: not a driver — canonicalizing/verifying a few thousand clauses over
+the eighteen vendored Markdown documents must simply feel instant (< 1 s); determinism
+matters, speed does not.
+**Constraints**: byte-identical regeneration across runs and platforms; offline-only and
+LLM-free in every CI-facing command; fail-loud on fingerprint mismatch, missing excerpt at
+anchor, strength/keyword contradiction, and stale/unclassified clauses (no partial or
+silently-strict inventories); regeneration must never mutate hand-authored classification
+records; `certify` on main never goes red during rollout (gate wired last).
+**Scale/Scope**: 18 pinned prose documents (14 consumer, 4 authoring — the full ratified
+`docs/specs/` set at `113500f4`) → an estimated ~1,500–3,500 clause units; one new module
+family (`prose/`, `clause`, `clause_diff`) in one crate; two new record prefixes (`clu`,
+`clc`); V11–V14 generalized + one new class (V15).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Assessment |
+|---|-----------|------------|
+| I | Spec-Parity as Source of Truth | **Pass.** The feature *strengthens* spec-parity: it turns the pinned prose (part of the upstream spec repo at `113500f4`) into an enumerated, evidence-tracked surface. No deacon runtime behavior changes. |
+| II | Consumer-Only Scope | **Pass.** Everything lands in the dev-only `deacon-conformance` crate; the consumer CLI is untouched. Authoring-document clauses are *inventoried* but classified `not-applicable` (per-document default) — inventorying them is bookkeeping, not authoring tooling. |
+| III | Keep the Build Green | **Pass.** All new tests are hermetic and register in `.config/nextest.toml` following the existing conformance test binaries. The byte-identical regeneration check is itself a green-build gate. Gate wiring is sequenced last so `certify` never goes red on main (SC-008). |
+| IV | No Silent Fallbacks — Fail Fast | **Pass — this feature is an application of the principle.** Fingerprint mismatch, missing excerpt at anchor, strength/keyword contradiction, unresolved ambiguity, stale/unclassified clauses → cause-specific hard errors / blocking violations; no partial inventory and no silently-strict promotion of ambiguous language (FR-014). |
+| V | Idiomatic, Safe Rust | **Pass.** `thiserror` domain errors in the library, `anyhow` only at the bin boundary; no `unwrap` in runtime paths; pure synchronous file IO in a dev tool (no async); new focused modules (`prose/{mod,normalize,strength}`, `clause`, `clause_diff`) rather than growing `validate.rs`. |
+| VI | Observability & Output Contracts | **Pass.** `clause` subcommands follow the existing `conformance` bin contract: results to stdout/files, diagnostics via `tracing` to stderr; deterministic byte-stable artifacts (no timestamps/absolute paths), reusing `inventory.rs`'s `render`/atomic-write discipline. |
+| VII | Testing Completeness | **Pass.** Spec FR-027/FR-028 enumerate the mandatory acceptance tests (stable identities, multi-requirement splitting, strength detection, moved headings, changed text, ambiguous clauses, authoring-scope exclusions, determinism, traceability) — all planned as fixture-driven hermetic tests plus pinned-baseline assertions. |
+| VIII | Subcommand Consistency & Shared Abstractions | **Pass.** Reuses the crate's loader/validation/report/certify plumbing, the ID grammar (`parse_id` extended with two prefixes), the `join_inventory`/`InventoryJoin` engine, the `write_inventory` atomic pattern, `render`/`canonicalize`, and the `inventory_paths_for` sibling-resolution convention. No duplicated bespoke loaders. |
+| IX | Executable & Self-Verifying Examples | **N/A.** Dev-only tooling; `examples/` is consumer-facing and untouched. |
+
+**Post-Phase-1 re-check**: the design artifacts below introduce no new violations. The two
+new record prefixes (`clu`, `clc`) extend the existing closed ID grammar rather than
+inventing a parallel identity scheme; V11–V14 are *generalized* (not duplicated) and V15 is
+the one genuinely new class (prose has a source-text-integrity dimension schema constraints
+lack). The one spec refinement (identity is substance-anchored, not location-based — research
+Decision 2) is reflected back into the spec Assumptions in lockstep. No Complexity Tracking
+entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-normative-clause-inventory/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (decisions 1–11)
+├── data-model.md        # Phase 1 output (entities, ID scheme, violation classes)
+├── quickstart.md        # Phase 1 output (developer walkthrough)
+├── contracts/
+│   ├── clause-inventory-schema.md        # clauses.json + spec manifest contract
+│   ├── clause-classification-schema.md   # clause-classification record + V11–V15
+│   └── cli-clause.md                     # `conformance clause …` CLI contract
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+conformance/
+├── spec/
+│   └── 113500f4/
+│       ├── manifest.json                     # NEW: doc key + file + upstreamUrl + sha256 + scope + revision id
+│       ├── *.md                              # NEW: all 18 ratified docs/specs Markdown files vendored byte-exact @113500f4
+│       │                                     #   14 consumer (reference, devcontainerjson-reference, supporting-tools,
+│       │                                     #   image-metadata, devcontainer-lockfile, devcontainer-id-variable,
+│       │                                     #   parallel-lifecycle-script-execution, features-contribute-lifecycle-scripts,
+│       │                                     #   features-user-env-variables, feature-dependencies, gpu-host-requirement,
+│       │                                     #   declarative-secrets, secrets-support, features-legacyIds-deprecated-properties)
+│       │                                     #   4 authoring (devcontainer-features{,-distribution}, devcontainer-templates{,-distribution})
+├── inventory/
+│   ├── constraints.json                      # EXISTING (020) — untouched
+│   └── clauses.json                          # NEW: generated (canonicalized), committed, byte-stable
+└── registry/
+    ├── clause-classifications/               # NEW: hand-authored disposition records
+    │   ├── <consumer-doc-key>.json            #   one per-clause file per consumer document (14 files)
+    │   └── authoring.json                     #   document-scope not-applicable defaults for the 4 authoring docs
+    └── sources/spec.json                     # MODIFIED (final phase): hand-written prose units superseded (FR-026)
+
+crates/conformance/
+├── src/
+│   ├── lib.rs                                # MODIFIED: new module decls + CURRENT_SPEC_PIN + clause paths
+│   ├── model.rs                              # MODIFIED: RecordType + Clu/Clc prefixes; ClauseInventory, ClauseUnit,
+│   │                                         #   Strength, Testability, ClauseLocation, ClauseClassification, SpecManifest
+│   ├── load.rs                               # MODIFIED: load clause classifications + clauses.json + spec manifest
+│   ├── validate.rs                           # MODIFIED: V11–V14 generalized to inventory units; V15 clause↔source
+│   ├── certify.rs                            # MODIFIED (last phase): block on unclassified/stale clauses
+│   ├── report.rs                             # MODIFIED: clause inventory coverage section in report.{json,md}
+│   ├── prose/
+│   │   ├── mod.rs                            # NEW: ATX heading tree + section text spans + code-fence awareness
+│   │   ├── normalize.rs                      # NEW: normalize_substance() + fingerprint (Decision 3)
+│   │   └── strength.rs                       # NEW: detect_strength() RFC-2119 keyword map (Decision 4)
+│   ├── clause.rs                             # NEW: clause unit model, substance-anchored IDs, canonicalize/write/compare
+│   └── clause_diff.rs                        # NEW: fingerprint-keyed diff (new/removed/moved/changed) (Decision 9)
+├── src/bin/conformance.rs                    # MODIFIED: `clause generate|check|diff|scaffold`; clause_paths_for()
+└── tests/
+    ├── clause_extraction.rs                  # NEW: fixture-driven segmentation/strength/ambiguity acceptance tests
+    ├── clause_determinism.rs                 # NEW: byte-identical regeneration (pinned + fixtures)
+    ├── clause_baseline.rs                    # NEW: pinned-baseline assertions (FR-028)
+    ├── clause_diff.rs                        # NEW: new/removed/moved/changed + immaterial acceptance tests
+    └── clause_classification_join.rs         # NEW: V11–V15 join validation tests
+
+fixtures/conformance/
+├── prose/                                    # NEW: fixture Markdown (multi-req paragraphs, moved headings, ambiguity, authoring)
+└── clause-drift/                             # NEW: old/new fixture inventories for diff tests
+
+.config/nextest.toml                          # MODIFIED: group overrides for the five new test binaries (all fast lanes)
+conformance/RULES.md                          # MODIFIED: V11–V14 generalized wording + V15; inventory section
+```
+
+**Structure Decision**: extend the existing `deacon-conformance` crate in place — the
+registry loader, ID grammar, `join_inventory`/`InventoryJoin` engine, violation-class
+driver (`check_inventory`), `certify` gate, and deterministic `render`/atomic
+`write_inventory` it already owns are exactly the substrate FR-023/FR-024/FR-026 require.
+New logic is split into focused modules (`prose/{mod,normalize,strength}`, `clause`,
+`clause_diff`) per constitution V rather than growing `validate.rs`. Generated data
+(`conformance/inventory/clauses.json`) sits beside 020's `constraints.json`; vendored prose
+(`conformance/spec/`) is a sibling of vendored schemas (`conformance/schemas/`), keeping the
+hand-edited registry directory free of vendored third-party artifacts. Clause classifications
+get their own `clause-classifications/` directory (not mixed with 020's `classifications/`)
+because their record shape adds the document-scope variant.
+
+## Complexity Tracking
+
+No constitution violations to justify — table intentionally empty.

--- a/specs/021-normative-clause-inventory/quickstart.md
+++ b/specs/021-normative-clause-inventory/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: Normative Clause Inventory
+
+Developer walkthrough for the prose-clause machinery this feature adds to the dev-only
+`deacon-conformance` crate (the companion to 020's schema-constraint inventory).
+Everything below is offline and LLM-free except the two out-of-band human steps
+(vendoring a revision; optionally LLM-assisted clause proposal), which never run in CI.
+
+## Everyday commands
+
+```bash
+# Canonicalize the committed clause inventory from the vendored pinned prose
+# (recomputes ids/fingerprints, verifies each excerpt is present at its heading)
+cargo run -p deacon-conformance -- clause generate
+
+# Verify the committed inventory is exactly what canonicalization produces (CI does this too)
+cargo run -p deacon-conformance -- clause check
+
+# Full registry validation — now includes the clause/classification join (V11–V15)
+cargo run -p deacon-conformance -- validate
+
+# Emit skeleton classification records for anything unclassified
+cargo run -p deacon-conformance -- clause scaffold > /tmp/clc-skeletons.json
+
+# Compare two inventory revisions (drift review — moves are first-class)
+cargo run -p deacon-conformance -- clause diff old-clauses.json conformance/inventory/clauses.json --format md
+```
+
+Hermetic tests: `cargo nextest run -E 'binary(=clause_extraction) + binary(=clause_determinism) + binary(=clause_baseline) + binary(=clause_diff) + binary(=clause_classification_join)'`
+(all in the fast lanes; no Docker, no network, no model).
+
+## Authoring / proposing clauses (out-of-band; never in CI)
+
+1. An LLM-assisted or manual pass reads a vendored document and drafts clause records
+   (excerpt + strength + testability + locations) into `conformance/inventory/clauses.json`.
+   A multi-requirement paragraph becomes several records; descriptive text is labeled
+   `descriptive`/`informative`; unclear language is labeled `ambiguous` — **never** promoted
+   to `must`.
+2. `clause generate` canonicalizes: it fills/recomputes `id` + `fingerprint`, merges
+   same-substance records, and **fails loudly** if an excerpt is not present under its
+   heading or a strength label contradicts the source keywords. Fix the draft until it
+   passes.
+3. Review the plain JSON diff in the PR. The proposal tool is an authoring aid — it is never
+   a dependency of `generate`/`check`/`validate`/`diff`/`certify`.
+
+## Classifying a clause
+
+1. Find the clause in `conformance/inventory/clauses.json` (or via a V12 violation from
+   `validate`).
+2. Add ONE record to `conformance/registry/clause-classifications/<doc>.json`:
+   - Consumer clause, tested → `behavior-mapped` + the `bhv-` id(s) (several clauses MAY
+     share one behavior).
+   - Consumer clause, no behavior yet → create/extend the behavior first (or, honestly,
+     leave it unclassified — it blocks, which is the point; research Decision 11).
+   - Descriptive/informative → `non-testable` + rationale.
+   - Whole authoring document → ONE document-scope `not-applicable` record in `authoring.json`
+     (covers every non-`ambiguous` clause of that document).
+   - `ambiguous` clause → resolve it: a per-clause record is REQUIRED (a document-scope
+     default never covers ambiguity).
+3. `validate` until clean. Never delete a clause to go green — units are machine-canonicalized.
+
+## Re-vendoring on an upstream pin bump (the drift workflow)
+
+1. **(network, one-time, human)** Download the ratified `docs/specs/` Markdown at the new
+   commit into `conformance/spec/<newpin>/`; compute `sha256sum` per file; write the new
+   `manifest.json` (with `scope` per document); add the `rev-spec-<newpin>` revision record.
+2. Re-author/adjust affected clause excerpts, then `clause generate` → the committed
+   inventory re-canonicalizes under the new revision.
+3. `clause diff` old vs new → human-readable review document (new / removed / **moved** /
+   changed / non-material).
+4. `validate` now enumerates the exact review queue: V11 = stale classifications to
+   delete/re-point, V12 = new/changed clauses to classify. **Moves carry their disposition
+   over — no re-review.** Nothing inherits a disposition by wording similarity; `certify`
+   blocks until the queue is empty.
+5. Classify, delete stale records, commit everything in one PR.
+
+## Guard rails to remember
+
+- `conformance/inventory/clauses.json` is canonicalized — hand edits that change substance
+  without valid provenance are detected (V14/V15) and rejected in CI.
+- Clause-classification files are hand-authored — `clause generate` never touches them.
+- No command fetches the network or invokes an LLM. Ambiguity is surfaced (V12), never
+  silently made strict.
+- Fixture prose for the acceptance paths (multi-requirement paragraphs, moved headings,
+  ambiguity, authoring-scope) lives under `fixtures/conformance/prose/` — extend those, not
+  the vendored pinned copies, which are byte-exact upstream artifacts and never edited.
+- Identity is substance-anchored: a moved heading keeps the clause id (and disposition); a
+  reworded obligation mints a new id and forces review.

--- a/specs/021-normative-clause-inventory/research.md
+++ b/specs/021-normative-clause-inventory/research.md
@@ -1,0 +1,300 @@
+# Research: Normative Clause Inventory
+
+All Technical Context unknowns resolved. This feature is the **prose companion** to
+feature 020 (schema constraint inventory) and reuses its machinery, ID grammar, and
+violation-class engine in the dev-only `deacon-conformance` crate. The central new
+problem — absent from 020 — is that prose clauses cannot be extracted by a deterministic
+parser the way JSON-Schema constraints can. Decisions 1–2 resolve that tension; the rest
+mirror 020 with prose-specific adaptations (moves, strength detection, ambiguity).
+
+The pinned source is `devcontainers/spec` @ `113500f4` (the registry's
+`rev-spec-113500f4`). Per the `/speckit.clarify` session, the inventoried surface is the
+ratified `docs/specs/` document set — consumer AND authoring — with authoring documents
+inventoried in full and classified not-applicable; draft `proposals/` are out of scope.
+
+## Decision 1 — The committed clause inventory is authored; the LLM is never in the CI path
+
+**Decision**: The committed artifact `conformance/inventory/clauses.json` is a
+**human-reviewed** list of clause records. An automated (LLM-assisted) proposal step MAY
+draft clause boundaries, strength, and testability, but that step is **out-of-band
+authoring tooling** — it is *never* invoked by `generate`, `check`, `validate`, `diff`,
+`report`, or `certify`. What those CI-facing commands do is **deterministic
+normalization + verification over the committed records and the vendored prose**, with no
+model and no network. Concretely:
+
+- `clause generate` (misnomer inherited from 020's verb — here it **canonicalizes**, it
+  does not invent clauses): reads the committed clause records + the vendored pinned
+  prose, recomputes each clause's normalized-substance fingerprint and stable ID from its
+  recorded excerpt, verifies the excerpt is present in the pinned document under its
+  recorded heading, sorts canonically, and writes the byte-stable artifact. Given an
+  already-canonical committed file, output is byte-identical (the determinism contract).
+- `clause check` = assert `committed == canonicalize(committed, pinned prose)` — the CLI
+  face of the hermetic determinism/provenance test.
+
+**Rationale**: This is the only arrangement that satisfies all of FR-012 (proposal MAY be
+automated), FR-013 + SC-004 (no LLM/network in any CI check), FR-023 (hermetic
+byte-identical regeneration "operates on the committed, reviewed data, never by
+re-invoking a model"), and FR-008/SC-006 (provenance is verifiable offline). The hard,
+non-deterministic work (segmenting prose into atomic clauses, judging testability) is
+done once by a human (optionally LLM-assisted) and frozen into reviewable data; the
+deterministic machine then *guards* that data forever without a model.
+
+**Alternatives considered**: (a) a purely rule-based deterministic prose extractor (RFC
+2119 keyword scan + paragraph segmentation) as the `generate` path — rejected: robust
+atomic-clause segmentation of real spec prose (multi-requirement paragraphs, algorithm
+blocks, I/O contracts in code fences, ambiguity) is exactly what the user input says MAY
+need automated/LLM proposal; a naive rule-based splitter would silently mis-segment and
+mis-strength, defeating the inventory's purpose. (b) LLM in CI with a fixed seed —
+rejected outright by FR-013/SC-004.
+
+## Decision 2 — Identity is substance-anchored (location excluded) so pure moves preserve disposition
+
+**Decision**: A clause's **stable identity** derives from `(document, normalized
+substance)` — **not** its heading/location. ID form:
+`clu-<doc>-<substance-slug>-<strength>-<hash8>`, where `hash8` = first 8 hex chars of
+SHA-256 over `document ‖ normalizedSubstance` (`‖` = fixed separator), `<substance-slug>`
+is a bounded slug of the normalized substance's leading tokens (readability only), and
+`<strength>` is the strength code. Location (heading/anchor/ordinal) is recorded as
+**provenance inside each clause**, never as an ID input.
+
+Consequences, all deterministic:
+- **Pure move** (same normalized substance, new heading): ID unchanged → the
+  hand-authored classification stays attached → reported as `moved` (location metadata
+  changed) and **does not** require re-review or block certification. This is what makes
+  FR-020's "report moved headings distinctly" *useful* rather than busywork.
+- **Material change** (obligation or strength changes → normalized substance changes):
+  new ID → old ID's classification goes V11-stale, new ID unclassified (V12) → blocking
+  drift item (FR-021). Strength is folded into the ID via `<strength>` and into the hash
+  indirectly (a MUST→SHOULD reword changes the excerpt and thus the substance), so a
+  strength change is always a material change.
+- **Immaterial change** (whitespace, markdown reflow, description-wording that leaves the
+  normalized substance equal): same fingerprint → same ID → not reported as material
+  (SC-005).
+- **Same obligation stated in several places**: identical normalized substance ⇒ one
+  clause unit carrying multiple `locations[]` (natural de-duplication); this is also how
+  "several clauses describe one behavior" is represented without collisions.
+
+This **refines** the spec's Assumption wording ("substance-and-location based"): location
+is provenance, not an identity input — the refinement is what lets a pure move keep its
+disposition (the spec's own goal in FR-020). The spec Assumption is updated in lockstep.
+
+**Rationale**: 020's schema IDs *include* location (`pointer`) and therefore report moves
+as remove+add; 021 explicitly requires moves as a distinct, non-destructive category
+(FR-020), which is only coherent if identity survives a move. Excluding location from the
+hash is the minimal change that achieves it while preserving 020's drift-forcing property
+(material change ⇒ new ID).
+
+**Alternatives considered**: (a) location-in-ID like 020 (moves = remove+add) — rejected:
+contradicts FR-020's distinct move reporting and forces needless reclassification of
+unchanged obligations. (b) fuzzy move-matching by text similarity — rejected:
+non-deterministic; identity-by-exact-normalized-substance gives moves for free and stays
+byte-stable.
+
+## Decision 3 — Normalized substance: the deterministic core of identity, drift, and immateriality
+
+**Decision**: `normalize_substance(excerpt) -> String` is a fixed, pure function:
+lowercase; strip Markdown formatting (emphasis/inline-code/link syntax, list bullets,
+block-quote markers); collapse all whitespace runs to a single space; trim; **preserve**
+RFC-2119 keywords, identifiers, code-span *contents*, and punctuation that carries meaning
+(`/`, `.`, `:`). The clause's `fingerprint` is SHA-256 over this normalized string; the ID
+`hash8` is its first 8 hex chars. Material change ⇔ fingerprint change; the diff's
+immaterial bucket is exactly "excerpt bytes differ but fingerprint equal."
+
+**Rationale**: Concentrating identity, material-change detection, and
+immaterial-change tolerance (SC-005) in one small pure function makes all three
+deterministic and unit-testable in isolation, and makes "two humans wrote the excerpt with
+different whitespace" a non-event. Mirrors 020's canonical-substance idea, adapted from
+JSON values to prose.
+
+**Alternatives considered**: hashing raw excerpt bytes — rejected: whitespace/markdown
+reflow would read as material change, violating SC-005. Semantic/embedding similarity —
+rejected: non-deterministic, model-dependent.
+
+## Decision 4 — Deterministic strength detection cross-checks the authored label
+
+**Decision**: A pure `detect_strength(excerpt) -> Option<Strength>` maps RFC-2119 keyword
+presence to a strength: `MUST`/`MUST NOT`/`REQUIRED`/`SHALL`/`SHALL NOT` → `must`;
+`SHOULD`/`SHOULD NOT`/`RECOMMENDED` → `should`; `MAY`/`OPTIONAL` → `may`; none present →
+`None`. Strengths `algorithm`, `io-contract`, and `descriptive` are authored labels not
+derivable from a single keyword. Validation (V15, Decision 8) cross-checks: a clause
+labeled `must`/`should`/`may` MUST contain the corresponding keyword family in its
+excerpt; a `descriptive` clause MUST NOT contain an unqualified RFC-2119 mandatory keyword
+(that would be a mis-label hiding a requirement, FR-005). `detect_strength` returning
+`None` on a clause the author labeled `must` is a V15 violation surfacing a mismatch.
+
+**Rationale**: This turns "normative-strength detection" (FR-006, an FR-027 mandatory
+test) into a deterministic, LLM-free property that both the out-of-band proposal aid and
+the CI validator share — the label is never taken on faith. Ambiguity (Decision 5) is the
+honest `None` outcome that must be resolved by a human.
+
+## Decision 5 — Ambiguity is a testability value that blocks until a human resolves it
+
+**Decision**: `testability` ∈ {`directly-testable`, `indirectly-testable`, `informative`,
+`ambiguous`, `not-applicable`}. `ambiguous` means the strength or meaning could not be
+confidently determined (hedged language, undefined term, conflated requirement). An
+`ambiguous` clause MUST carry a per-clause classification before `certify` passes — a
+document-scope default (Decision 7) does **not** clear ambiguity; the validator treats an
+unresolved `ambiguous` clause as unclassified (blocking). The proposal aid is forbidden
+from promoting `ambiguous` to `must`; only a human edit changes it.
+
+**Rationale**: Implements FR-014 + the fail-closed clarification (any unclassified/ambiguous
+clause blocks). Ambiguity is fail-loud, never silently strict, mirroring the registry's
+gap semantics.
+
+## Decision 6 — Vendor the pinned prose under `conformance/spec/<pin>/` with a fingerprinted manifest
+
+**Decision**: Commit byte-exact copies of the ratified `docs/specs/` Markdown documents at
+`conformance/spec/113500f4/`, with a `manifest.json` recording per document: logical key,
+filename, upstream URL at the pinned commit, SHA-256, and a `scope` marker
+(`consumer` | `authoring`). The manifest references `rev-spec-113500f4`, keeping
+`revisions.json` the single pin authority. Every command verifies each file's SHA-256
+before parsing and hard-fails on mismatch (FR-003, V14).
+
+Document set — **all 18 ratified `docs/specs/` documents at `113500f4`** (verified against
+the upstream tree; keys derived from filenames, exact fingerprints captured at the vendoring
+task). 14 are consumer-scope (per-clause classification) and 4 are authoring-scope
+(document-scope not-applicable default permitted):
+
+| key | scope | upstream `docs/specs/…` file |
+|---|---|---|
+| `reference` | consumer | `devcontainer-reference.md` (lifecycle, resolution, merging, substitution) |
+| `json-reference` | consumer | `devcontainerjson-reference.md` (properties reference) |
+| `supporting-tools` | consumer | `supporting-tools.md` (CLI behavior reference) |
+| `image-metadata` | consumer | `image-metadata.md` (the `devcontainer.metadata` label deacon reads) |
+| `lockfile` | consumer | `devcontainer-lockfile.md` (feature lockfile deacon consumes) |
+| `devcontainer-id-variable` | consumer | `devcontainer-id-variable.md` (`${devcontainerId}` substitution) |
+| `parallel-lifecycle` | consumer | `parallel-lifecycle-script-execution.md` |
+| `features-lifecycle-scripts` | consumer | `features-contribute-lifecycle-scripts.md` |
+| `features-user-env` | consumer | `features-user-env-variables.md` |
+| `feature-dependencies` | consumer | `feature-dependencies.md` (installer dependency resolution) |
+| `gpu-host-requirement` | consumer | `gpu-host-requirement.md` (`hostRequirements.gpu`) |
+| `declarative-secrets` | consumer | `declarative-secrets.md` |
+| `secrets-support` | consumer | `secrets-support.md` |
+| `features-legacy-ids` | consumer | `features-legacyIds-deprecated-properties.md` |
+| `features` | authoring | `devcontainer-features.md` (Features authoring; consumer install clauses handled per-clause via override, Decision 7) |
+| `features-distribution` | authoring | `devcontainer-features-distribution.md` (publishing) |
+| `templates` | authoring | `devcontainer-templates.md` (Templates authoring) |
+| `templates-distribution` | authoring | `devcontainer-templates-distribution.md` (publishing) |
+
+The `features`/`templates` authoring docs are mixed (authoring model + a consumer
+install/apply contract, both in deacon's consumer scope per constitution II). They keep an
+`authoring` document-scope default for the bulk, with per-clause `behavior-mapped` overrides
+for the consumer install/apply clauses (resolution order, Decision 7); a consumer clause is
+never left silently covered by the blanket default — the classifier must override it.
+
+**Rationale**: FR-002/SC-004 require fully offline PR/release testing; vendoring is the
+only arrangement where CI never fetches. Fingerprints make "vendored copy ≠ claimed
+revision" a blocking error. The `scope` marker drives the document-scope disposition
+default (Decision 7). Mirrors 020 Decision 1 exactly, in a sibling directory
+(`conformance/spec/` next to `conformance/schemas/`). Network is used once, by the human
+vendoring a revision (quickstart.md).
+
+**Alternatives considered**: submodule / fetch-at-test — rejected for the same reasons as
+020 Decision 1 (breaks offline clone-and-test). Vendoring only consumer docs — rejected:
+FR-001/FR-015 require the full ratified surface, with authoring marked not-applicable, so
+that an upstream requirement moving from an authoring doc into consumer scope surfaces as
+drift rather than being invisible.
+
+## Decision 7 — Document-scope disposition default keeps the authoring surface tractable
+
+**Decision**: A classification record MAY be **document-scoped** — one record dispositioning
+every clause of an `authoring`-scope document as `not-applicable` with a shared rationale
+(consumer-only scope, constitution II) — in addition to per-clause records. Resolution
+order for a clause: a per-clause record wins; else the document-scope default applies; else
+the clause is unclassified (V12, blocking). Two guard rails: (a) a document-scope default is
+permitted **only** for documents the manifest marks `authoring` (a consumer document must be
+classified clause-by-clause); (b) a clause whose `testability` is `ambiguous` is **never**
+covered by a document-scope default — it needs an explicit per-clause decision.
+
+**Rationale**: Fail-closed (Q2) requires *every* clause to carry a disposition before the
+gate goes live, including the hundreds of authoring-doc clauses. Per-clause not-applicable
+records for entire authoring documents would be pure bookkeeping churn with no reviewer
+value. The document-scope default records the honest, uniform decision once while keeping
+consumer docs strictly per-clause and never letting ambiguity hide behind a blanket default.
+
+**Alternatives considered**: per-clause not-applicable for authoring docs (020's exactly-one
+rule) — rejected: intractable and low-value for whole-document exclusions. Dropping authoring
+docs from the inventory — rejected: violates FR-015 and blinds the drift workflow to
+authoring→consumer migrations.
+
+## Decision 8 — Reuse V11–V14 generalized to inventory units; add V15 for clause↔source integrity
+
+**Decision**: Generalize 020's violation classes from "constraint unit" to "inventory unit
+(schema constraint OR prose clause)" and run the join for both inventories:
+- **V11** stale classification — references a unit ID (`cst-`/`clu-`) absent from its
+  committed inventory.
+- **V12** unclassified — a unit with neither a per-unit classification nor (clauses only)
+  a covering document-scope default; or classified more than once. An unresolved
+  `ambiguous` clause is V12 by construction (Decision 7).
+- **V13** malformed classification — behavior missing / arity rules / id-tail mismatch /
+  document-scope default applied to a non-authoring document.
+- **V14** provenance — manifest fingerprint mismatch, inventory `revision` ≠ registry pin,
+  or committed inventory ≠ canonicalized regeneration (byte-identity).
+- **V15 (new)** clause↔source integrity — a clause's `strength` label contradicts its
+  excerpt keywords (Decision 4), a `descriptive` clause hides a mandatory keyword, or a
+  clause's `excerpt` is not present in the pinned document under its recorded heading
+  (provenance-in-source failure).
+
+All are blocking in `validate`; `certify` additionally fails while any unit is unclassified
+or any classification is stale — the clause-level analogue of "a gap always blocks."
+`not-applicable`/`informative` never block. RULES.md and `validate.rs` stay in lockstep.
+
+**Rationale**: Generalizing the existing classes (rather than minting V16–V19 for clauses)
+keeps one enforcement vocabulary across both inventories and one certify gate. V15 is genuinely
+new because prose clauses have a source-text-integrity dimension that schema constraints (whose
+substance IS the parsed JSON) do not.
+
+## Decision 9 — Diff semantics: match on fingerprint; moves are first-class
+
+**Decision**: `clause diff <old.json> <new.json>` matches units on **normalized-substance
+fingerprint** (⇔ the substance-anchored ID). Present-right-only → **new**;
+present-left-only → **removed**; ID present in both but its `locations` differ → **moved**
+(old and new heading shown); a fingerprint present on neither side that supersedes a removed
+one at the same heading is reported as the removal + a new item (a material change is a
+remove-of-old-ID + add-of-new-ID, which the review reads as "changed" because they share a
+heading). Immaterial differences (excerpt bytes differ, fingerprint equal) are reported in a
+separate non-material section. Output is deterministic (sorted by document, then heading, then
+ID) in JSON and Markdown, mirroring `report`.
+
+**Rationale**: A fingerprint match key makes moves detectable and deterministic (FR-019/FR-020)
+— the key difference from 020's `(document, pointer, kind)` key, which cannot express a move.
+Material change surfaces as new/stale IDs, which is exactly what V11+V12 enforce against the
+regenerated committed inventory (the diff is advisory; the enforcement is the join).
+
+## Decision 10 — Rollout inside the feature: certify wiring is the last phase (SC-008)
+
+**Decision**: Sequence as 020 did: (1) vendor prose + author the committed clause inventory +
+deterministic `generate`/`check` + `diff`, with inventory self-validation (V14/V15) active;
+(2) classification records (per-clause for consumer docs, document-scope for authoring docs)
+land for 100% of clauses, with V11–V13 active in `validate`; (3) only then does `certify` gain
+the "unclassified/stale clause blocks" rule (FR-018/FR-022), the report sections, and any
+supersession of hand-written prose source units in `sources/spec.json` whose behavior links
+move onto the corresponding `clu-` classifications (FR-026 traceability / no dual bookkeeping). The feature merges as
+one CI-gated PR with all three phases complete, so `certify` on main is never red and never
+weakened.
+
+**Rationale**: Implements SC-008 and mirrors 020 Decision 10 / feature 019's single-PR delivery
+shape; every intermediate commit stays green for bisectability.
+
+## Decision 11 — Behavior-mapping evidence rule (inherited from 020 Decision 11)
+
+**Decision**: A consumer clause is disposed, in order: (1) an existing behavior covers it →
+`behavior-mapped` (prefer extending a behavior over minting near-duplicates; several clauses
+MAY map to one behavior per FR-010); (2) no behavior but deacon has a hermetic/integration test
+exercising it → create the behavior with honest three-axis values AND a `case-` record naming
+that test, then map; (3) no evidence at all → write the small hermetic test in-feature, or the
+honest state is a **gap** (blocks certify, blocks merge). Minting an uncovered behavior or a
+decorative waiver to go green is forbidden.
+
+**Rationale**: Keeps SC-008 achievable honestly and preserves the registry's evidence-backed
+semantics. Prose clauses map to the SAME behavior records 020's schema constraints do where they
+describe one behavior (e.g., a `forwardPorts` typing constraint and the prose sentence defining
+`forwardPorts` both map to `bhv-readconfig-…`), realizing "several clauses → one behavior."
+
+## Resolved unknowns summary
+
+No NEEDS CLARIFICATION markers remain. The three `/speckit.clarify` answers (document scope →
+Decision 6; fail-closed triage → Decisions 5/7/8/10; excerpt + fingerprint as distinct fields →
+Decisions 2/3) are fully absorbed. The only spec refinement is the identity wording (Decision 2),
+updated in the spec Assumptions in lockstep. No deferrals are created; there is no "## Deferred
+Work" carried into tasks.md from this research.

--- a/specs/021-normative-clause-inventory/spec.md
+++ b/specs/021-normative-clause-inventory/spec.md
@@ -1,0 +1,506 @@
+# Feature Specification: Normative Clause Inventory
+
+**Feature Branch**: `021-normative-clause-inventory`
+**Created**: 2026-07-24
+**Status**: Draft
+**Input**: User description: "Create a feature specification for maintaining a complete, reviewable inventory of normative and behaviorally relevant clauses from the containers.dev specification pinned by the conformance registry. Cover the full pinned specification rather than only sections known to be implemented. Authoring-only material must be recorded and explicitly marked not applicable under Deacon's consumer-only scope. Break source material into atomic assertions that can be mapped to normalized conformance behaviors. Record stable provenance including source revision, document path, heading or anchor, clause identity, normative strength, scope, and whether the assertion is directly testable, indirectly testable, informative, ambiguous, or not applicable. Distinguish MUST, SHOULD, MAY, algorithm definitions, input/output contracts, and descriptive guidance. Do not infer that every paragraph is a requirement. When one paragraph contains several independent requirements, represent them separately. When several clauses describe one behavior, permit them to map to the same behavior. The workflow may propose extracted clauses automatically, but the committed normative inventory must be human-reviewable and must not require an LLM during CI. Ambiguous source language must be surfaced for classification rather than silently converted into a strict requirement. Provide deterministic drift detection between specification revisions. Report new, removed, moved, and materially changed clauses. New or changed clauses remain unclassified until reviewed and must block strict certification when applicable to Deacon. Acceptance tests are mandatory for stable identities, multi-requirement paragraphs, normative-strength detection, moved headings, changed source text, ambiguous clauses, explicit authoring-scope exclusions, deterministic output, and traceability into the conformance registry."
+
+## Overview
+
+The conformance registry records deacon's conformance against the upstream
+containers.dev specification, pinned at a specific revision (`rev-spec-113500f4`).
+Feature 020 already produced a complete, machine-extracted inventory of the pinned JSON
+**schemas**. But the specification is more than its schemas: the bulk of the normative
+surface — lifecycle ordering, configuration-resolution algorithms, merge rules, variable
+substitution, feature installation semantics, input/output contracts — lives in the
+specification's **prose** documents. Today those prose requirements enter the registry
+only as a handful of hand-written source units, written from memory of the sections
+deacon happens to implement. There is no systematic record of which normative clauses of
+the pinned prose exist, which deacon covers, which are consciously out of scope, and
+which have simply never been read — nor any way to detect when an upstream prose revision
+adds, removes, moves, or rewords a requirement.
+
+This feature closes that blind spot for the prose surface, mirroring what 020 did for
+schemas. It maintains a **complete, reviewable, clause-level inventory** of the pinned
+specification prose — the *whole* pinned specification, not only implemented sections —
+breaking each document into atomic normative assertions with stable provenance and an
+explicit classification. Authoring-only material (feature authoring, template authoring,
+publishing, editor integration) is inventoried in full and explicitly marked
+not-applicable under deacon's consumer-only scope rather than dropped. The workflow may
+use automated (including LLM-assisted) extraction to *propose* clauses, but the committed
+inventory is a human-reviewed, version-controlled artifact, and every CI check that
+consumes it runs deterministically and offline with no LLM in the loop. Ambiguous source
+language is surfaced for a human to classify rather than silently promoted into a strict
+requirement. A deterministic drift report between revisions surfaces new, removed, moved,
+and materially changed clauses as reviewable items instead of letting old dispositions
+silently carry forward.
+
+## Clarifications
+
+### Session 2026-07-24
+
+- Q: Which document set constitutes "the full pinned specification" to inventory? → A:
+  All ratified `docs/specs/` documents — consumer-facing AND authoring
+  (features/templates/distribution) — with authoring documents inventoried in full but
+  classified not-applicable under consumer-only scope. Draft `proposals/` documents are
+  out of scope (they churn and would generate perpetual drift noise); if a proposal is
+  later ratified into `docs/specs/` at a new pin, it enters scope through the normal
+  drift workflow.
+- Q: How does a brand-new, untriaged clause behave at the certification gate before
+  anyone has judged its consumer-relevance? → A: Fail-closed — ANY unclassified or
+  ambiguous clause blocks certification until a human assigns it an explicit disposition,
+  even one that later proves not-applicable. Consumer-relevance is never guessed by the
+  extractor; the not-applicable classification is a human decision, and only that human
+  decision (or an informative/behavior-mapped one) clears the block.
+- Q: How is each clause's source text represented in the committed inventory? → A: Both —
+  a verbatim excerpt of the clause text (so the committed artifact and its PR diffs are
+  human-readable) AND a normalized substance fingerprint (so material-vs-immaterial change
+  is detected deterministically, independent of whitespace/reflow). The excerpt serves
+  reviewability; the fingerprint serves drift detection; they are distinct fields.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build the complete clause inventory from the pinned prose (Priority: P1)
+
+A maintainer runs clause extraction across the full pinned containers.dev specification
+prose and receives a complete, stably ordered list of **atomic normative assertions** —
+one per independent requirement, algorithm step, or input/output contract the prose
+expresses. A paragraph that states several independent requirements yields several
+clauses; several sentences describing one behavior may be grouped or cross-referenced to
+one behavior. Each clause carries provenance (source revision, document path, heading or
+anchor, and a stable clause identity), a detected **normative strength** (MUST / SHOULD /
+MAY / algorithm-definition / input-output-contract / descriptive-guidance), and a
+proposed **testability class** (directly testable, indirectly testable, informative,
+ambiguous, or not-applicable). Automated proposal is permitted, but the emitted artifact
+is plain, reviewable, and free of any runtime LLM dependency.
+
+**Why this priority**: Everything else (classification, drift, certification) operates on
+the inventory. Without a complete and trustworthy clause list there is nothing to classify
+or diff. This story alone delivers value: for the first time the true size and shape of
+the pinned *prose* requirement surface is visible and reviewable.
+
+**Independent Test**: Run extraction on the pinned prose and on purpose-built fixture
+documents; verify every independent requirement expressed by a fixture appears exactly
+once as an atomic clause with correct provenance and detected strength, that a
+multi-requirement paragraph splits into the expected clauses, and that two consecutive
+runs produce byte-identical output.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pinned specification prose, **When** the maintainer builds the inventory,
+   **Then** the output contains one atomic clause for every independent normative
+   assertion across the *full* pinned specification (not only implemented sections), each
+   tagged with source revision, document path, heading/anchor, a stable clause identity,
+   its normative strength, and a proposed testability class.
+2. **Given** a paragraph containing several independent requirements, **When** extraction
+   runs, **Then** each requirement becomes its own clause; and **Given** several sentences
+   describing a single behavior, **Then** they may be grouped or cross-linked to the same
+   behavior rather than being force-split.
+3. **Given** prose containing MUST, SHOULD, and MAY statements, an algorithm definition,
+   an input/output contract, and purely descriptive guidance, **When** extraction runs,
+   **Then** each clause's normative strength is detected and recorded, and descriptive
+   guidance is NOT recorded as a requirement.
+4. **Given** the same pinned inputs, **When** extraction runs twice (or on different
+   machines), **Then** the outputs are identical byte-for-byte, including ordering and
+   clause identifiers.
+5. **Given** normal PR or release testing, **When** the inventory is built or checked,
+   **Then** no network access occurs and no LLM is invoked; only pinned local artifacts
+   are read by deterministic code.
+
+---
+
+### User Story 2 - Classify every clause under the consumer-only scope (Priority: P2)
+
+A maintainer reviews the inventory and ensures every clause carries exactly one explicit
+disposition: mapped to one or more conformance behaviors (a clause may share a behavior
+with other clauses, and a behavior may cover several clauses); informative / non-testable
+(descriptive guidance, with rationale); not-applicable under deacon's consumer-only scope
+(feature authoring, template authoring, publishing, or editor-only material, with
+rationale); or **ambiguous — pending human resolution**. An ambiguous or unclassified
+clause is never silently treated as a strict requirement; it is surfaced as a review item.
+Consumer-runtime requirements enter the certification scope; not-applicable, informative,
+and (once resolved) ambiguous clauses remain visible in the inventory rather than
+disappearing.
+
+**Why this priority**: The inventory only prevents blind spots if unclassified and
+ambiguous clauses are impossible to ignore. This story turns the raw extraction into an
+auditable coverage claim the release certification gate can consume, and guarantees that
+soft or unclear source language is decided by a human, not by the extractor.
+
+**Independent Test**: Take a generated inventory, classify a subset, leave one clause
+ambiguous and one consumer-runtime clause unclassified, and verify validation reports
+precisely those two as blocking; verify a clause explicitly classified not-applicable
+(authoring scope) does not block and remains listed with its rationale.
+
+**Acceptance Scenarios**:
+
+1. **Given** a generated inventory, **When** validation runs, **Then** every clause is
+   either mapped to at least one conformance behavior, classified informative /
+   non-testable, or classified not-applicable — and any clause with none of these
+   (including any clause marked ambiguous) is reported as a blocking review item.
+2. **Given** a clause drawn from an authoring-only document (feature authoring, template
+   authoring, publishing, or editor integration), **When** it is classified not-applicable
+   under consumer-only scope, **Then** it remains present in the inventory and reports with
+   its classification and rationale — it does not disappear, and it does not block
+   certification.
+3. **Given** a clause whose source language is ambiguous (e.g., soft "should generally",
+   an undefined term, or a conflated requirement), **When** extraction proposes it,
+   **Then** it is surfaced as ambiguous and MUST be resolved by a human into a concrete
+   disposition — it is never auto-promoted into a strict MUST.
+4. **Given** several clauses that describe one behavior and a consumer-runtime clause
+   mapped to a conformance behavior, **When** the certification gate evaluates coverage,
+   **Then** the mapped clauses count toward the certified surface exactly as other
+   registry-covered behaviors do, and a clause can be traced to its behavior and back.
+
+---
+
+### User Story 3 - Detect and review upstream prose drift (Priority: P3)
+
+When the pinned specification revision is updated, a maintainer generates a deterministic
+diff between the old and new revisions that reports every **new, removed, moved, and
+materially changed** clause. A heading that moves (reordered or re-nested) is reported as a
+move; source text that changes materially (a requirement's substance or strength) is
+reported as changed; formatting-only or immaterial wording changes are not reported as
+material. Every new or materially changed clause appears as an **unclassified drift item**
+requiring review, and no clause inherits a disposition merely because a similarly worded
+clause existed before.
+
+**Why this priority**: Drift handling is only exercised when the pin moves, which is
+infrequent — but when it happens, this is what prevents silent conformance rot as the
+upstream prose evolves.
+
+**Independent Test**: Prepare two fixture revisions differing by one added clause, one
+removed clause, one clause under a moved heading, and one materially reworded clause;
+verify the diff reports exactly those with the correct change kinds (new / removed / moved
+/ changed), that a formatting-only edit is reported as immaterial, and that the
+added/changed clauses surface as unclassified drift items that block certification until
+reviewed.
+
+**Acceptance Scenarios**:
+
+1. **Given** two specification revisions, **When** the diff is generated, **Then** it
+   deterministically lists every new, removed, moved, and materially changed clause with
+   the correct change kind — and immaterial changes (whitespace, reflowing, description
+   wording that does not change substance) are not reported as material.
+2. **Given** an upstream revision that moves a heading or re-nests a section, **When** the
+   diff is reviewed, **Then** clauses whose substance is unchanged but whose location
+   moved are reported as **moved** (with old and new location), distinct from new and
+   changed clauses.
+3. **Given** an upstream revision that reshapes or rewords a requirement, **When** the diff
+   is reviewed, **Then** the changed clause appears unclassified — it never inherits the
+   prior clause's disposition based on wording or heading similarity alone.
+4. **Given** unreviewed drift items applicable to deacon, **When** the release
+   certification gate runs, **Then** it blocks until every such drift item has been
+   reviewed and classified.
+
+---
+
+### User Story 4 - Trust the committed inventory offline, without an LLM (Priority: P4)
+
+A reviewer inspects the committed clause inventory and classification records directly in a
+pull request. Automated (possibly LLM-assisted) proposal may have produced the initial
+draft, but nothing in CI — validation, drift detection, coverage, or certification —
+invokes an LLM or the network; all of it runs deterministically from the committed, pinned,
+human-reviewed artifacts. A reviewer can read a clause, follow its provenance to the exact
+document and heading in the pinned revision, and trace it into the conformance registry's
+behaviors.
+
+**Why this priority**: The base machinery (P1–P3) is only trustworthy if its CI-facing
+consumption is reproducible and human-auditable. This story makes the "reviewable, LLM-free,
+offline" guarantee explicit and testable, but it rides on the artifacts the earlier stories
+produce.
+
+**Independent Test**: Run the full validate/diff/certify path in a network-isolated
+environment with no model available and confirm it completes deterministically; pick any
+committed clause and confirm its provenance resolves to a real location in the pinned prose
+and to a registry behavior (or an explicit not-applicable/informative rationale).
+
+**Acceptance Scenarios**:
+
+1. **Given** the committed inventory and classifications, **When** CI validation, drift
+   detection, and certification run, **Then** they complete deterministically with zero
+   network requests and zero LLM invocations.
+2. **Given** any clause in the committed inventory, **When** a reviewer follows its
+   recorded provenance, **Then** it resolves to the exact pinned source revision, document
+   path, and heading/anchor, and (for consumer-runtime clauses) to the conformance
+   behavior(s) it maps to.
+3. **Given** an automatically proposed extraction, **When** it is committed, **Then** the
+   committed artifact is plain, diff-reviewable data — a human's review and sign-off is a
+   precondition of committing, and the proposal tooling is never a runtime dependency of
+   any CI check.
+
+---
+
+### Edge Cases
+
+- A single sentence that states two independent obligations (e.g., "the tool MUST do X and
+  MUST NOT do Y") must yield two clauses, not one conflated clause.
+- A requirement expressed across multiple sentences or a bulleted list (one lead-in plus
+  several sub-items) must be represented so that each independently testable obligation is
+  its own clause while the shared context is preserved.
+- Soft or hedged language ("should generally", "is expected to", "typically") must be
+  surfaced as ambiguous for human classification, never auto-detected as a strict MUST.
+- A clause that mixes a normative obligation with descriptive rationale in the same
+  paragraph must separate the obligation (recorded with its strength) from the rationale
+  (recorded as informative), not fold the rationale into the requirement.
+- Requirements that appear only inside a code block, table, or example (e.g., an
+  input/output contract shown as a sample) must still be inventoried where they express a
+  testable contract.
+- A heading that both moves AND has its clause text materially changed between revisions
+  must be represented unambiguously (see Assumptions) rather than being reported only as a
+  move or only as a change.
+- Authoring-only documents (feature/template authoring, publishing/distribution, editor
+  integration) must be inventoried in full and marked not-applicable — they must not be
+  skipped at extraction time on scope grounds.
+- A pinned prose document that is missing, unreadable, or fails integrity verification at
+  generation time must produce an explicit error, never a partial inventory.
+- A clause whose normative strength cannot be confidently detected must be surfaced as
+  ambiguous rather than defaulted to a specific strength.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Inputs and pinning**
+
+- **FR-001**: The inventory MUST be built exclusively from specification prose pinned by
+  the conformance registry's revision records (`rev-spec-113500f4`), and MUST cover **all
+  ratified `docs/specs/` documents** — every consumer-facing AND authoring document
+  (feature authoring, template authoring, distribution) — not only the sections deacon
+  currently implements. Draft `proposals/` documents are out of scope at a given pin; a
+  proposal that is ratified into `docs/specs/` at a later pin enters scope via the drift
+  workflow (FR-019).
+- **FR-002**: Pinned prose documents MUST be stored locally under version control so that
+  normal PR and release testing operates without any network access. The system MUST never
+  silently follow a live URL to obtain source text.
+- **FR-003**: The correspondence between each pinned local prose document and its upstream
+  revision MUST be verifiable (e.g., via a recorded content fingerprint checked at
+  generation time), and a mismatch MUST fail generation explicitly.
+
+**Extraction and atomicity**
+
+- **FR-004**: Extraction MUST produce **atomic clauses**: when a paragraph, sentence, or
+  list expresses several independent requirements, each MUST become its own clause; the
+  system MUST NOT infer that every paragraph is a single requirement.
+- **FR-005**: Extraction MUST NOT treat descriptive guidance as a requirement. Purely
+  descriptive, explanatory, or rationale text MUST be recorded as informative rather than
+  normative.
+- **FR-006**: Each clause MUST record a detected **normative strength**, distinguishing at
+  least: MUST (mandatory), SHOULD (recommended), MAY (optional), algorithm definition,
+  input/output contract, and descriptive guidance. When strength cannot be confidently
+  detected, the clause MUST be surfaced as ambiguous rather than defaulted.
+- **FR-007**: Each clause MUST record a **testability class**: directly testable,
+  indirectly testable, informative, ambiguous, or not-applicable.
+- **FR-008**: Each clause MUST record provenance sufficient for a reviewer to locate it
+  without external systems: source revision, document path, heading or anchor, and a stable
+  clause identity. Each clause MUST carry BOTH a verbatim excerpt of its source text (so the
+  committed artifact and its PR diffs are human-readable) AND a normalized substance
+  fingerprint (so change detection is deterministic and whitespace/reflow-independent) as
+  distinct fields. Reports MUST NOT embed large copies of whole source documents; the
+  per-clause excerpt plus fingerprint and provenance is sufficient to identify change.
+- **FR-009**: Each clause MUST have a **stable identifier** that survives regeneration from
+  unchanged inputs, so that classifications attach durably to clauses.
+- **FR-010**: Several clauses that describe one behavior MAY map to the same conformance
+  behavior; the model MUST permit many-clauses-to-one-behavior as well as
+  one-clause-to-one-behavior.
+- **FR-011**: Inventory generation MUST be deterministic: identical pinned inputs produce
+  identical output (content, identifiers, ordering) across repeated runs and platforms.
+
+**Automated proposal vs. committed artifact**
+
+- **FR-012**: The extraction workflow MAY use automated (including LLM-assisted) means to
+  *propose* clauses and their initial strength/testability classification.
+- **FR-013**: The committed normative inventory MUST be a human-reviewable,
+  version-controlled artifact. No CI check that consumes the inventory (validation, drift
+  detection, coverage, certification) may require an LLM or network access; all such checks
+  MUST run deterministically from the committed, pinned artifacts.
+- **FR-014**: Ambiguous source language MUST be surfaced for human classification and MUST
+  NOT be silently converted into a strict requirement. A clause marked ambiguous is treated
+  as unresolved until a human assigns it a concrete disposition.
+
+**Scope and classification**
+
+- **FR-015**: The entire pinned prose surface MUST be inventoried — including clauses that
+  apply only to feature authoring, template authoring, publishing/distribution, or editor
+  integration. No clause may be dropped at extraction time on scope grounds.
+- **FR-016**: Every clause MUST carry exactly one explicit disposition: (a) mapped to one or
+  more conformance behaviors, (b) informative / non-testable (with rationale), or (c)
+  not-applicable under deacon's consumer-only scope (with rationale). A clause left
+  unclassified or marked ambiguous is not a disposition and MUST be reported by validation
+  as a blocking review item — regardless of its (as-yet-unjudged) consumer-relevance.
+  Consumer-relevance is decided by the human classifier, never guessed by the extractor.
+- **FR-017**: Clauses classified not-applicable or informative MUST remain present in the
+  inventory and in generated reports with their classification and rationale visible — they
+  must not disappear from any output.
+- **FR-018**: The release certification gate MUST be fail-closed on triage: it MUST treat
+  ANY unclassified, ambiguous, or unreviewed clause the same way it treats an open gap
+  (blocking) until a human assigns an explicit disposition — even a disposition that later
+  proves not-applicable. Once assigned, not-applicable and informative classifications MUST
+  NOT block; behavior-mapped consumer-runtime clauses enter the certified surface.
+
+**Drift and diffing**
+
+- **FR-019**: The system MUST produce a deterministic diff between any two pinned
+  specification revisions, classifying each difference as **new, removed, moved, or
+  materially changed**. Material change MUST be defined over clause substance — compared via
+  the normalized substance fingerprint (FR-008) — not over formatting, whitespace, or
+  reflowed prose; a change to the verbatim excerpt that leaves the fingerprint unchanged is
+  immaterial.
+- **FR-020**: A heading or section that moves (reordered or re-nested) while its clause
+  substance is unchanged MUST be reported as **moved** — distinct from new, removed, and
+  changed — with both its prior and current location.
+- **FR-021**: A clause that is new or materially changed in an upstream revision MUST appear
+  as an **unclassified drift item** until a human reviews and classifies it. A disposition
+  MUST NOT be inherited by a clause on the basis of wording or heading similarity to a prior
+  clause.
+- **FR-022**: Any unreviewed drift item MUST block release certification until a human
+  reviews and classifies it, consistent with FR-018's fail-closed-on-triage rule —
+  relevance is not assumed away before review.
+
+**Storage, lifecycle, and traceability**
+
+- **FR-023**: The generated inventory MUST be a committed, version-controlled artifact. A
+  hermetic CI check MUST regenerate it from the pinned artifacts and fail on any byte-level
+  difference, so the committed inventory can never drift from what the pinned prose
+  expresses. (Where extraction depends on an automated proposal step, the committed artifact
+  is the reviewed output; the hermetic check operates on the committed, reviewed data, never
+  by re-invoking a model.)
+- **FR-024**: Classifications MUST be hand-authored records stored separately from the
+  generated inventory, referencing clauses by their stable identifiers. Regenerating the
+  inventory MUST NOT modify, move, or delete any classification record; validation joins the
+  two sets and reports mismatches.
+- **FR-025**: A classification record referencing a clause that no longer exists in the
+  current inventory MUST fail validation as stale and MUST be deleted (or re-pointed) in the
+  same change that updates the inventory — mirroring the registry's self-invalidating waiver
+  semantics.
+- **FR-026**: Every consumer-runtime clause MUST be traceable into the conformance registry:
+  from a clause to the behavior(s) it maps to, and from a behavior back to the clauses that
+  motivate it. This traceability MUST be checkable deterministically and offline.
+
+**Verification**
+
+- **FR-027**: Acceptance tests MUST cover, at minimum: stable clause identities across
+  regeneration, multi-requirement paragraph splitting, normative-strength detection
+  (MUST/SHOULD/MAY/algorithm/io-contract/descriptive), moved headings, changed source text,
+  ambiguous-clause surfacing, explicit authoring-scope not-applicable exclusions,
+  deterministic (byte-identical) output, and traceability into the conformance registry —
+  using purpose-built fixture documents AND assertions against the pinned baseline prose.
+- **FR-028**: The baseline assertions MUST pin observable facts about the real extracted
+  inventory (e.g., that specific well-known normative clauses of the pinned specification
+  are present with the expected strength and provenance), so regressions in extraction logic
+  surface against real inputs, not only fixtures.
+
+### Key Entities
+
+- **Pinned Prose Source**: A specification document included in the inventory — identified by
+  its registry revision record, its upstream document path, and a verifiable content
+  fingerprint of the local pinned copy. The full pinned specification is in scope; no
+  document is excluded on implementation-status grounds.
+- **Clause**: The atomic record of one normative or behaviorally relevant assertion —
+  carrying a stable identifier, its normative strength (MUST / SHOULD / MAY / algorithm /
+  input-output-contract / descriptive), its testability class (directly testable /
+  indirectly testable / informative / ambiguous / not-applicable), BOTH a verbatim excerpt
+  of its source text (for review) AND a normalized substance fingerprint (for deterministic
+  drift), and full provenance (source revision, document path, heading/anchor). A
+  multi-requirement paragraph yields several clauses; several clauses may map to one behavior.
+- **Disposition**: The explicit classification attached to a clause — mapped to conformance
+  behavior(s), informative / non-testable (with rationale), or not-applicable under
+  consumer-only scope (with rationale). Exactly one per clause; an unclassified or ambiguous
+  clause is a blocking review item (fail-closed on triage). Dispositions are hand-authored records
+  stored separately from the generated inventory and joined to it by stable clause
+  identifiers, so regeneration can never alter a human decision; a disposition whose clause
+  no longer exists is a blocking stale-record violation.
+- **Ambiguous Clause**: A clause whose normative strength or meaning could not be confidently
+  determined — surfaced for human resolution and never auto-promoted into a strict
+  requirement. Treated as unresolved (blocking, fail-closed on triage) until classified.
+- **Drift Item**: A clause that is new or materially changed relative to the previously
+  reviewed revision and has not yet been classified. Blocks certification until reviewed.
+- **Revision Diff**: The deterministic comparison of two pinned prose revisions — the sets of
+  new, removed, moved, and materially changed clauses, with the substance and old/new
+  location of each change.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of the pinned specification's documents are represented in the inventory
+  (including authoring-only documents marked not-applicable); an independent spot-audit of at
+  least 25 randomly sampled normative clauses finds zero missing or mis-attributed clauses and
+  zero descriptive paragraphs mis-recorded as requirements.
+- **SC-002**: Regenerating the inventory from unchanged pinned inputs produces byte-identical
+  output on every run and on every supported platform (zero nondeterministic differences
+  observed across repeated CI runs).
+- **SC-003**: After classification, zero clauses exist without an explicit disposition, and
+  validation demonstrably reports any artificially introduced unclassified or ambiguous
+  clause as a blocking review item — regardless of its judged consumer-relevance.
+- **SC-004**: Every CI check that consumes the inventory (validation, drift, coverage,
+  certification) performs zero network requests and zero LLM invocations, verifiable by running
+  in a network-isolated environment with no model available.
+- **SC-005**: In drift fixtures, 100% of new, removed, moved, and materially changed clauses are
+  reported with the correct change kind, and zero immaterial changes (formatting, whitespace,
+  reflowed or reworded-but-equivalent prose) are reported as material.
+- **SC-006**: A reviewer can trace any inventory entry to its exact source revision, document
+  path, and heading/anchor — and any consumer-runtime clause to its conformance behavior(s) and
+  back — using only committed data, without opening external systems or following live URLs.
+- **SC-007**: A new or materially changed upstream clause introduced by a revision bump surfaces
+  as an unclassified drift item in 100% of drift-fixture cases, and never appears with an
+  inherited disposition.
+- **SC-008**: The release certification gate remains passing on the main branch at every point
+  during the feature's rollout — the gate is wired to consume the prose inventory only after
+  every clause carries an explicit disposition (authoring/editor clauses marked
+  not-applicable, informative clauses marked as such, consumer clauses behavior-mapped), and
+  is never loosened to achieve this.
+
+## Assumptions
+
+- **Pinned prose is vendored**: The pinned specification documents will be committed to the
+  repository (as the registry's other pinned data already is), which is what makes offline,
+  LLM-free PR/release testing possible. The existing revision record (`rev-spec-113500f4`)
+  remains the single authority for which revision is pinned.
+- **Automated proposal is an authoring aid, not a runtime dependency**: An LLM-assisted or
+  otherwise automated step MAY draft the clause extraction and initial classification, but its
+  output is committed only after human review. No CI-facing check re-invokes it; the hermetic
+  regeneration check operates on committed, reviewed data. This is how "the workflow may propose
+  clauses automatically" coexists with "CI must not require an LLM".
+- **Clause identity is substance-anchored; location is recorded provenance, not an identity
+  input**: A stable identifier derives from what the clause obliges (its normalized substance)
+  plus the document — deliberately excluding the heading/location — so that a materially changed
+  clause receives a new identity (and surfaces as drift) while a clause that merely moves keeps
+  its identity, and therefore its disposition, without re-review. The clause still records its
+  location for provenance; that location just does not participate in the identity hash. (This
+  refines an earlier "substance-and-location" phrasing; see research Decision 2.)
+- **Moves preserve identity and disposition; they are reported for visibility, not re-review**:
+  When a clause's substance is unchanged but its heading/location moves, the diff reports it as
+  **moved** (old and new location) and its existing disposition carries over unchanged — a move is
+  never a blocking drift item. A clause that both moves and materially changes is reported as a
+  **change** (old identity removed/stale, new identity unclassified and blocking), because its
+  substance — the basis for identity — changed. Movement of unchanged substance is the only case
+  reported as a move. This keeps the diff deterministic while honoring the explicit requirement to
+  report moved headings distinctly.
+- **Ambiguity defaults to blocking, not to strictness**: Consistent with the registry's rule that
+  admissions of missing knowledge (gaps) block release certification, any ambiguous or unclassified
+  clause blocks until a human resolves it (fail-closed on triage) — the extractor never resolves
+  ambiguity by promoting a clause to a strict MUST, nor by guessing it is not-applicable.
+- **Not-applicable means recorded, not invisible**: Authoring-only and editor-only clauses are
+  inventoried and classified not-applicable under consumer-only scope; they stay visible in the
+  inventory and reports and never enter the certification scope.
+- **This feature extends existing machinery**: Classification lives in the existing conformance
+  registry model (behaviors, coverage, the validate/report/certify commands), extended to consume
+  the prose clause inventory alongside feature 020's schema constraint inventory — it does not
+  create a parallel conformance system.
+- **Full initial classification is in scope; the gate goes live last**: This feature is not
+  complete until every clause of the pinned prose carries a disposition (fail-closed on triage
+  means authoring/editor clauses must be explicitly marked not-applicable, not merely left out). The
+  certification-gate wiring (FR-018/FR-022) is enabled only after that initial classification is
+  complete, so the release gate on the main branch never turns red during build-out and is never
+  weakened to compensate.
+
+## Dependencies
+
+- The conformance registry (feature 019) — revision records, behavior records, validation,
+  reporting, and the certification gate — is the substrate this feature extends.
+- The schema constraint inventory (feature 020) — this feature is its prose companion and reuses
+  the same disposition/classification/drift patterns and the same certify gate, covering the prose
+  surface the schemas do not express.
+- The upstream specification revision currently pinned (`rev-spec-113500f4`); updating the pin is
+  the event that exercises the drift workflow.

--- a/specs/021-normative-clause-inventory/tasks.md
+++ b/specs/021-normative-clause-inventory/tasks.md
@@ -1,0 +1,242 @@
+---
+description: "Task list for Normative Clause Inventory (feature 021)"
+---
+
+# Tasks: Normative Clause Inventory
+
+**Input**: Design documents from `/workspaces/deacon/specs/021-normative-clause-inventory/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — spec FR-027/FR-028 mandate acceptance tests and constitution VII
+requires all spec-mandated tests before a feature is complete. Test tasks are written to
+fail first, then made green by the implementation tasks in the same story.
+
+**Organization**: Tasks are grouped by the four user stories (US1–US4) so each is an
+independently testable increment. Per research Decision 10 the `certify` gate is wired in
+the final story (US4), so the gate on `main` never goes red mid-rollout; the feature merges
+as one CI-gated PR with all phases complete.
+
+**Crate**: everything lands in the dev-only `deacon-conformance` crate
+(`crates/conformance/`) and the version-controlled `conformance/` data tree. No consumer
+CLI, Docker, network, or LLM in any test.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US4; Setup/Foundational/Polish tasks carry no story label
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Vendor the pinned prose and stand up test scaffolding.
+
+- [X] T001 Vendor **all 18** ratified `docs/specs/` Markdown files at `113500f4` into `conformance/spec/113500f4/` (network, one-time) and write `conformance/spec/113500f4/manifest.json` with per-document `key`, `file`, `upstreamUrl`, `sha256`, and `scope` — 14 `consumer` (`reference`, `json-reference`, `supporting-tools`, `image-metadata`, `lockfile`, `devcontainer-id-variable`, `parallel-lifecycle`, `features-lifecycle-scripts`, `features-user-env`, `feature-dependencies`, `gpu-host-requirement`, `declarative-secrets`, `secrets-support`, `features-legacy-ids`) and 4 `authoring` (`features`, `features-distribution`, `templates`, `templates-distribution`) — per research Decision 6, referencing the existing `rev-spec-113500f4` record. Reject any CR bytes.
+- [X] T002 [P] Create fixture prose under `fixtures/conformance/prose/` exercising: a multi-requirement paragraph, a moved-heading old/new pair, an ambiguous/hedged clause, an authoring-scope document, an I/O contract inside a code fence, and a whitespace-only (immaterial) reflow; plus `fixtures/conformance/clause-drift/{old,new}` clause-inventory files for diff tests.
+- [X] T003 [P] Register the five new test binaries (`clause_extraction`, `clause_determinism`, `clause_baseline`, `clause_diff`, `clause_classification_join`) in `.config/nextest.toml` in ALL profiles (the `[profile.default]` override, the `[profile.dev-fast]` `default-filter` inclusion, and the `full`/`ci` profiles) as fast, non-docker binaries.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Records, loaders, and the deterministic prose primitives every story needs.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Extend `RecordType`, `prefix()`, `from_prefix()`, and the `parse_id` grammar regex in `crates/conformance/src/model.rs` with the `clu` (ClauseUnit) and `clc` (ClauseClassification) prefixes.
+- [X] T005 Add the serde model structs/enums in `crates/conformance/src/model.rs` (`deny_unknown_fields`, camelCase, kebab-case enum wire values): `SpecManifest`, `SpecDocument`, `DocumentScope`, `ClauseInventory`, `ClauseUnit`, `Strength`, `Testability`, `ClauseLocation`, and `ClauseClassification` (with the `clause`-XOR-`document` invariant).
+- [X] T006 Add the new `LoadError` variants (`SpecFingerprintMismatch`, `ExcerptNotFoundAtAnchor`, `StrengthKeywordMismatch`, `AmbiguousClauseUnclassified`, `ClauseInventoryOutOfDate`, `DocumentScopeOnConsumerDoc`) and the loaders in `crates/conformance/src/load.rs`: `load_spec_manifest` (SHA-256 fingerprint verification), `load_clause_inventory` (absent → `Ok(None)`), and the `clause-classifications/` collection loader.
+- [X] T007 [P] Implement `crates/conformance/src/prose/mod.rs`: a byte-deterministic ATX-heading tree with per-heading text spans and code-fence awareness (anchor = GitHub-style slug of the heading), exposing section lookup used for excerpt-present-at-anchor checks.
+- [X] T008 [P] Implement `crates/conformance/src/prose/normalize.rs`: the pure `normalize_substance(excerpt) -> String` and its SHA-256 `fingerprint` (research Decision 3), with exhaustive unit tests for whitespace/markdown immateriality.
+- [X] T009 [P] Implement `crates/conformance/src/prose/strength.rs`: the pure `detect_strength(excerpt) -> Option<Strength>` RFC-2119 keyword map (research Decision 4), with unit tests for MUST/SHOULD/MAY families and the `None` (ambiguous) case.
+- [X] T010 Wire module declarations, the `CURRENT_SPEC_PIN` constant, and the `clause_paths_for(registry_dir)` sibling-path helper (`<registry>/../spec/<pin>` + `<registry>/../inventory/clauses.json`) in `crates/conformance/src/lib.rs`, mirroring `inventory_paths_for`.
+
+**Checkpoint**: records, loaders, and prose primitives compile and unit-test green.
+
+---
+
+## Phase 3: User Story 1 - Build the complete clause inventory (Priority: P1) 🎯 MVP
+
+**Goal**: A complete, byte-stable committed `conformance/inventory/clauses.json` produced by
+deterministic canonicalization of authored (optionally LLM-proposed) clause records against
+the vendored prose — no LLM/network in the path.
+
+**Independent Test**: Run `clause generate` then `clause check` on the pinned inputs and on
+fixtures; every fixture requirement appears once with correct provenance/strength, a
+multi-requirement paragraph splits, and two runs are byte-identical.
+
+### Tests for User Story 1 ⚠️ (write first, ensure they FAIL)
+
+- [X] T011 [P] [US1] `crates/conformance/tests/clause_extraction.rs`: multi-requirement paragraph splits into distinct clauses, strength detection (MUST/SHOULD/MAY/algorithm/io-contract/descriptive), ambiguity surfaced (not auto-promoted to MUST), I/O contract in a code fence captured, descriptive text NOT recorded as a requirement — over `fixtures/conformance/prose/`.
+- [X] T012 [P] [US1] `crates/conformance/tests/clause_determinism.rs`: regeneration byte-identical to the committed inventory, two in-memory regenerations identical, IDs stable across runs, no CR bytes (pinned + fixtures).
+- [X] T013 [P] [US1] `crates/conformance/tests/clause_baseline.rs`: pinned-baseline assertions (FR-028) — specific well-known clauses of the pinned prose present with expected strength and provenance; per-document clause counts.
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Implement `crates/conformance/src/clause.rs`: `ClauseUnit` canonicalization, `derive_clause_id` (substance-anchored `hash8` over `document ‖ normalize_substance`, location excluded — research Decision 2), same-substance location merge, canonical `render`, and atomic `write_clauses` (temp-file + `fs::rename`, reusing `inventory.rs` discipline).
+- [X] T015 [US1] Add the fail-loud integrity checks used by `generate` in `crates/conformance/src/clause.rs` (with `crates/conformance/src/prose/`): excerpt-present-at-anchor (`ExcerptNotFoundAtAnchor`) and strength-label ↔ excerpt-keyword cross-check (`StrengthKeywordMismatch`); descriptive clauses must not hide a mandatory keyword.
+- [X] T016 [US1] Add the `Clause { command: ClauseCommand }` subcommand and the `clause generate` handler in `crates/conformance/src/bin/conformance.rs`: verify spec fingerprints, canonicalize committed records against vendored prose, write byte-stable `conformance/inventory/clauses.json` (exit 1 on any integrity error, never a partial file).
+- [X] T017 [US1] Implement the `clause check` handler in `crates/conformance/src/bin/conformance.rs`: regenerate in memory and byte-compare against the committed inventory (`ClauseInventoryOutOfDate` with a compact new/removed/moved/changed summary).
+- [X] T018 [US1] Author the clause records for the **14 consumer documents** (`reference`, `json-reference`, `supporting-tools`, `image-metadata`, `lockfile`, `devcontainer-id-variable`, `parallel-lifecycle`, `features-lifecycle-scripts`, `features-user-env`, `feature-dependencies`, `gpu-host-requirement`, `declarative-secrets`, `secrets-support`, `features-legacy-ids`) into `conformance/inventory/clauses.json` (LLM-proposed + human-reviewed; multi-requirement paragraphs split; ambiguous language labeled `ambiguous`, never `must`).
+- [X] T019 [US1] Author the clause records for the **4 authoring documents** (`features`, `features-distribution`, `templates`, `templates-distribution`) into `conformance/inventory/clauses.json` (same file as T018 — sequential; full coverage per FR-015, including the consumer install/apply clauses inside `features`/`templates`).
+- [X] T020 [US1] Run `clause generate` to canonicalize the committed inventory; make T011–T013 pass (green MVP: the inventory exists, is complete, and regenerates byte-identically).
+
+**Checkpoint**: `clause generate`/`clause check` work; `clauses.json` is committed, complete, and byte-stable — independently demoable.
+
+---
+
+## Phase 4: User Story 2 - Classify every clause under consumer-only scope (Priority: P2)
+
+**Goal**: Every clause carries exactly one effective disposition (per-clause for consumer
+docs; document-scope not-applicable for authoring docs); ambiguous/unclassified clauses are
+blocking review items; the join is machine-enforced (V11–V15).
+
+**Independent Test**: Classify a subset, leave one clause ambiguous and one consumer clause
+unclassified → `validate` reports exactly those two as blocking; an authoring document-scope
+not-applicable does not block and stays listed with rationale.
+
+### Tests for User Story 2 ⚠️ (write first, ensure they FAIL)
+
+- [X] T021 [P] [US2] `crates/conformance/tests/clause_classification_join.rs`: V11 stale, V12 unclassified/duplicate AND unresolved-`ambiguous`-blocks, V13 malformed (id-tail mismatch, behaviors/rationale arity, `clause`-XOR-`document`, document-scope on a `consumer` doc), V15 (strength/keyword mismatch, excerpt-not-found-at-anchor, descriptive-hides-keyword), the `UNREVIEWED` sentinel load rejection, document-scope resolution order, and authoring-scope not-applicable non-blocking.
+
+### Implementation for User Story 2
+
+- [X] T022 [US2] Generalize V11–V14 in `crates/conformance/src/validate.rs` from "constraint unit" to "inventory unit": run `join_inventory`/`InventoryJoin` for the clause inventory + clause classifications, and extend `check_classification_shape` for the `clc` id-tail mirror, `clause`-XOR-`document`, and document-scope-only-on-authoring rules.
+- [X] T023 [US2] Add V14 provenance for clauses in `crates/conformance/src/validate.rs`: spec-manifest fingerprint verification, `clauses.json` `revision` = the `rev-spec-*` pin, and committed-inventory byte-identity vs canonicalized regeneration.
+- [X] T024 [US2] Add the new **V15** clause↔source-integrity class to `crates/conformance/src/validate.rs` (strength/keyword agreement, descriptive-hides-keyword, excerpt-present-at-anchor), reported in one pass with all other violations.
+- [X] T025 [US2] Implement the `clause scaffold` handler in `crates/conformance/src/bin/conformance.rs`: emit `UNREVIEWED`-sentinel `clc` skeletons for unclassified clauses (per-clause for consumer/ambiguous; one per-document skeleton for authoring docs); never write the registry.
+- [X] T026 [US2] Add the clause-inventory section to `crates/conformance/src/report.rs` (`report.{json,md}`): counts by strength/testability/document, disposition tallies, unclassified + ambiguous-pending lists; byte-stable (no timestamps/paths).
+- [X] T027 [P] [US2] Author per-clause `clc` classifications for the **14 consumer documents** — one `conformance/registry/clause-classifications/<doc-key>.json` file per document (behavior-mapped with existing/extended `bhv-` ids per research Decision 11; `non-testable`/`not-applicable` with rationale). Several clauses MAY share one behavior (FR-010).
+- [X] T028 [P] [US2] Author the document-scope `not-applicable` defaults for the four authoring documents in `conformance/registry/clause-classifications/authoring.json` (one `clc-doc-<key>` record each, with consumer-only-scope rationale), PLUS per-clause `behavior-mapped` overrides for the consumer install/apply clauses inside `features`/`templates` and per-clause records for any authoring clause labeled `ambiguous` (a blanket default never covers a consumer or ambiguous clause — research Decision 7).
+- [X] T029 [US2] Update `conformance/RULES.md` in lockstep: generalize V11–V14 wording to "inventory unit (constraint or clause)", add V15, and describe the clause inventory + document-scope resolution rule (keep RULES.md ↔ `validate.rs` in sync).
+
+**Checkpoint**: `validate` enforces V11–V15 over clauses; 100% of clauses classified; ambiguous/unclassified are blocking.
+
+---
+
+## Phase 5: User Story 3 - Detect and review upstream prose drift (Priority: P3)
+
+**Goal**: A deterministic `clause diff` that reports new, removed, **moved**, and materially
+changed clauses (moves first-class and non-blocking; immaterial reflow excluded).
+
+**Independent Test**: Diff two fixture revisions differing by one added, one removed, one
+moved-heading, and one reworded clause → exactly those with correct kinds; a formatting-only
+edit is immaterial; added/changed surface as blocking drift, moved keeps its disposition.
+
+### Tests for User Story 3 ⚠️ (write first, ensure they FAIL)
+
+- [X] T030 [P] [US3] `crates/conformance/tests/clause_diff.rs`: new/removed/moved/changed/nonMaterial buckets over `fixtures/conformance/clause-drift/{old,new}`; a moved clause keeps its id (and disposition); a reworded clause yields new id + stale old id; immaterial reflow reported non-material; deterministic ordering; no disposition inherited by wording similarity.
+
+### Implementation for User Story 3
+
+- [X] T031 [US3] Implement `crates/conformance/src/clause_diff.rs`: fingerprint-keyed match (research Decision 9) producing `new_clauses`/`removed`/`moved`/`changed`/`nonMaterial`, deterministically sorted by `(document, heading, id)`, with `render_json` and `render_md` mirroring `diff.rs`.
+- [X] T032 [US3] Implement the `clause diff <old> <new> [--format json|md] [--out <file>]` handler in `crates/conformance/src/bin/conformance.rs` (exit 1 on unreadable input; empty diff is exit 0).
+
+**Checkpoint**: drift review is deterministic and move-aware; independently demoable on fixtures.
+
+---
+
+## Phase 6: User Story 4 - Trust the committed inventory offline, without an LLM (Priority: P4)
+
+**Goal**: Wire the `certify` gate to block on clause V11–V15 (last, per Decision 10), prove
+the whole CI-facing path is offline + LLM-free, and establish clause↔behavior traceability.
+
+**Independent Test**: Run `validate`/`clause diff`/`certify` with no network and no model →
+deterministic completion; any clause resolves from provenance to a real pinned location and
+(for consumer clauses) to a behavior and back; an artificial unclassified clause blocks
+`certify`.
+
+### Tests for User Story 4 ⚠️ (write first, ensure they FAIL)
+
+- [X] T033 [P] [US4] Extend the existing (already-registered) `crates/conformance/tests/gap_certification.rs`: an unclassified/stale clause blocks `certify`; `not-applicable`/`non-testable` clause dispositions do not; the real registry certifies clean once the gate is wired. (Extends an existing 020 binary — no new test binary, so no nextest change.)
+- [X] T034 [P] [US4] Add a traceability test (`crates/conformance/tests/traceability.rs` extension): every consumer clause maps to an existing behavior and each mapped behavior is reachable back from its clauses (FR-026), checked deterministically and offline.
+
+### Implementation for User Story 4
+
+- [X] T035 [US4] Wire the clause blockers into `crates/conformance/src/certify.rs`: `certify` exits 1 iff any gap OR uncovered in-profile behavior OR any clause V11–V15 (in addition to 020's constraint blockers); waivers listed non-blocking; no flag bypass, no model/network.
+- [X] T036 [US4] Supersede the hand-written prose source units in `conformance/registry/sources/spec.json` (FR-026 traceability / no dual bookkeeping): move their behavior links onto the corresponding `clc` classifications and retire the superseded records in the same change, so each behavior back-traces to clauses through exactly one path.
+- [X] T037 [US4] Add the offline/LLM-free assertion coverage: confirm (in-test and in `contracts/cli-clause.md`) that `generate`/`check`/`validate`/`diff`/`certify` read only committed + vendored inputs — the hermetic harness already runs with no network/Docker/model, and this task makes the guarantee explicit (SC-004).
+
+**Checkpoint**: `certify` blocks on clause gaps and is green on the real registry; the full path is provably offline and LLM-free.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T038 [P] Update the "Conformance Registry" section of `CLAUDE.md` and `AGENTS.md` to document the prose clause inventory (`conformance/spec/`, `conformance/inventory/clauses.json`, `clause` subcommands, V15, document-scope defaults) alongside 020's schema inventory.
+- [X] T039 [P] Confirm `conformance/RULES.md`'s "Constraint inventory" section reflects the generalized V11–V14 + V15 and the clause/document-scope semantics (final consistency pass with `validate.rs`).
+- [X] T040 Run `quickstart.md` end-to-end (`clause generate`/`check`/`validate`/`scaffold`/`diff`) and the full gate (`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `make test-nextest`), fixing any drift; confirm `registry_valid` and `certify` are green.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: T001 (vendoring) blocks the loaders/baseline; T002/T003 [P] can start immediately.
+- **Foundational (Phase 2)**: depends on Setup. T004→T005→T006 are sequential (`model.rs`/`load.rs`); T007/T008/T009 are [P] (separate files); T010 depends on T007–T009. **BLOCKS all user stories.**
+- **US1 (Phase 3)**: depends on Foundational. MVP.
+- **US2 (Phase 4)**: depends on US1 (needs `clauses.json` + `generate`).
+- **US3 (Phase 5)**: depends on US1 (diffs clause inventories); independent of US2.
+- **US4 (Phase 6)**: depends on US2 (classifications) and US1; wires the gate last (Decision 10).
+- **Polish (Phase 7)**: depends on all desired stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after Foundational. No dependency on other stories.
+- **US2 (P2)**: after US1 (classifies the generated clauses).
+- **US3 (P3)**: after US1 (operates on clause inventories); parallelizable with US2.
+- **US4 (P4)**: after US2 (gate consumes classifications) + US1.
+
+### Parallel Opportunities
+
+- Setup: T002, T003 in parallel.
+- Foundational: T007, T008, T009 in parallel (prose primitives).
+- US1 tests T011, T012, T013 in parallel; then implementation.
+- US2 classification authoring T027, T028 in parallel (different files); US3 can proceed in parallel with US2 once US1 is done.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write the three US1 test binaries together (they must fail first):
+Task: "clause_extraction.rs in crates/conformance/tests/"
+Task: "clause_determinism.rs in crates/conformance/tests/"
+Task: "clause_baseline.rs in crates/conformance/tests/"
+```
+
+```bash
+# Foundational prose primitives in parallel:
+Task: "prose/mod.rs heading tree in crates/conformance/src/prose/"
+Task: "prose/normalize.rs normalize_substance in crates/conformance/src/prose/"
+Task: "prose/strength.rs detect_strength in crates/conformance/src/prose/"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Setup (Phase 1) + Foundational (Phase 2).
+2. US1 (Phase 3) → committed `clauses.json` that regenerates byte-identically.
+3. **STOP and VALIDATE**: `clause generate` + `clause check` + the three US1 test binaries green.
+
+### Incremental Delivery (single CI-gated PR)
+
+1. Foundation → US1 (inventory exists) → US2 (fully classified, V11–V15 enforced) → US3 (drift review) → US4 (certify gate wired last, offline/LLM-free proven).
+2. Because the `certify` gate is wired only in US4 after 100% classification (research Decision 10), every intermediate commit keeps `validate`/`certify` green for bisectability, and the branch merges as one PR (SC-008) with no red gate on `main`.
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task. Tasks editing the same file
+  (`model.rs` T004/T005; `clauses.json` T018/T019; `validate.rs` T022–T024;
+  `bin/conformance.rs` T016/T017/T025/T032) are sequential.
+- Tests are written first and must fail before the implementing task closes them.
+- No `## Deferred Work`: research resolves every unknown; no deferrals are carried into this
+  feature (a specification is not complete while deferrals remain — none exist here).
+- Never delete a clause or weaken `certify` to go green; units are machine-canonicalized and
+  ambiguity/unclassified/stale are blocking by design.


### PR DESCRIPTION
## Summary

Adds the **normative clause inventory** (feature 021) — the prose companion to the schema constraint inventory (020). A machine-canonicalized inventory of every normative clause in the 18 ratified upstream `devcontainers/spec` prose documents (pinned at `113500f4`), classified under deacon's consumer-only scope, with move-aware drift detection and a `certify` gate. No LLM or network in any CI-facing command.

## What's included

- **Vendored pinned prose** under `conformance/spec/113500f4/` (14 consumer + 4 authoring docs) with a SHA-256-fingerprinted `manifest.json`; re-vendored only on a pin bump.
- **Machine-owned `conformance/inventory/clauses.json`** (`clu-` units, substance-anchored ids: `hash8` over `document ‖ normalize_substance`, location excluded so a pure move keeps its id/disposition).
- **Hand-authored `clc-` classifications**: per-clause for consumer docs, document-scope `not-applicable` defaults for authoring docs, plus per-clause `behavior-mapped` overrides for the consumer install/apply clauses inside `features`/`templates`.
- **New prose model**: deterministic ATX heading reader, substance normalizer, RFC-2119 strength detection.
- **New CLI subcommands** (dev-only `deacon-conformance`): `clause generate` / `check` / `diff` / `scaffold`.
- **Validation**: V11–V14 generalized from constraint units to inventory units; new **V15** clause↔source integrity. Clause join wired into `validate`, `certify`, and `report`.
- **Source retirement**: three redundant `src-spec-*` prose source units retired now that their behaviors back-trace through `behavior-mapped` clause classifications.

## Notes

- Includes a fix to `clause diff`'s `pair_changed`: a removed + added clause under a shared heading are paired into a `changed` entry only on an **unambiguous 1:1 match**; multi-clause headings are left as distinct `removed`/`new` entries rather than mispaired (which would fabricate a spurious rewrite and hide genuine add/removes). Regression test added.

## Verification (local, hermetic)

- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features -D warnings` clean.
- `deacon-conformance` suite: **261/261 passing**.
- `clause check` byte-identical regeneration; `validate` clean; `certify` clean (0 blocking, 10 waived).

The `parity / live-certification` lane is not in scope here (dev-only-crate change; needs Docker + the pinned oracle, which don't run in the authoring workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT
