### PR TITLE
fix(conformance): force LF for vendored clause prose on Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,19 @@ conformance/inventory/constraints.json -text
 # Fixture schemas and inventories carrying their own fingerprints/expected bytes.
 fixtures/conformance/schemas/** -text
 fixtures/conformance/inventory-drift/** -text
+
+# The normative clause inventory (021-normative-clause-inventory) applies the same
+# discipline to prose: `clause generate`/`check` fingerprint-verify the vendored spec
+# Markdown against `manifest.json`, byte-compare the committed inventory against a fresh
+# regeneration, and explicitly reject any CR byte in the vendored/fixture prose. A Windows
+# CRLF checkout would break every one of those checks, so these paths must stay byte-exact.
+
+# Vendored upstream spec prose + their fingerprint manifests (never edited in place).
+conformance/spec/** -text
+
+# The machine-owned canonical clause inventory (byte-compared by `clause check` / V14).
+conformance/inventory/clauses.json -text
+
+# Fixture prose and clause inventories carrying their own fingerprints/expected bytes.
+fixtures/conformance/prose/** -text
+fixtures/conformance/clause-drift/** -text


### PR DESCRIPTION
## Summary

Follow-up to #360 (normative clause inventory, 021). That PR auto-merged at its first commit before the Windows CRLF fix landed, so `main`'s `Test (MVP fast) (windows)` lane is currently broken.

On a Windows checkout, git's `autocrlf` rewrites the vendored spec prose LF→CRLF, which changes the bytes and breaks the 021 machinery: SHA-256 fingerprint verification against `manifest.json`, the committed-inventory byte-comparison (`clause check` / V14), and the explicit no-CR guard — cascading into **27** clause integration-test failures (all other lanes, including the `live-certification` parity lane, passed).

## Fix

Extend `.gitattributes` with `-text` for the new byte-exact 021 paths, mirroring the existing 020 schema-inventory entries:
- `conformance/spec/**` (vendored prose + fingerprint manifest)
- `conformance/inventory/clauses.json` (machine-owned, byte-compared)
- `fixtures/conformance/prose/**`, `fixtures/conformance/clause-drift/**`

Committed blobs are already LF, so this only pins the working-tree bytes on every platform — no file content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT