### PR TITLE
feat(conformance): add declarative conformance runner (022)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -41,13 +41,19 @@ parity = { max-threads = 2 }
 parity-cli = { max-threads = 8 }
 
 # Dev-only `deacon-conformance` hermetic test binaries — `registry_valid`,
-# `classification_join`, `inventory_*`, `gap_certification`, `traceability`, and the
+# `classification_join`, `inventory_*`, `gap_certification`, `traceability`, the
 # 021-normative-clause-inventory binaries `clause_extraction` / `clause_determinism` /
-# `clause_baseline` / `clause_diff` / `clause_classification_join` — carry NO override:
-# they are fast, non-docker, non-network, no-model tests that run in EVERY profile
-# (default / dev-fast / full / ci) by default (they are neither in any `default-filter`
-# exclusion nor a docker/smoke group). This is the standing convention for conformance
-# tests; the five clause binaries follow it (T003).
+# `clause_baseline` / `clause_diff` / `clause_classification_join`, and the
+# 022-conformance-runner binaries `case_schema_valid` / `snapshot_staleness` /
+# `allowed_difference_scoping` / `normalization_semantics` (conformance crate) plus
+# `runner_record_replay` (parity-harness crate) — carry NO override: they are fast,
+# non-docker, non-network, no-model tests that run in EVERY profile (default / dev-fast /
+# full / ci) by default (they are neither in any `default-filter` exclusion nor a
+# docker/smoke group; `runner_record_replay` does not match `binary(#parity_*)`, so it is
+# NOT captured by the live-parity exclusions). This is the standing convention for
+# conformance tests; the four new hermetic conformance binaries + `runner_record_replay`
+# follow it (T004). The live differential binary `parity_conformance_runner` (US1, T026)
+# is the ONLY 022 binary that gets per-profile overrides, added in US1 (T027).
 
 # Default profile: Balanced parallelization for local development
 [profile.default]
@@ -56,7 +62,7 @@ slow-timeout = "60s"
 status-level = "pass"
 # Live parity scenario binaries run ONLY under `--profile parity` (018-harden-parity-harness).
 # Exclude them here so the default lane is truthful by non-selection (FR-014).
-default-filter = 'not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors))'
+default-filter = 'not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner))'
 
 [[profile.default.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -154,7 +160,7 @@ test-group = 'docker-slow-shared'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=docker_channels)'
 test-group = 'docker-shared'
 
 [[profile.default.overrides]]
@@ -192,7 +198,7 @@ priority = 100
 retries = 0
 slow-timeout = "30s"
 # Exclude: smoke, parity, Docker-dependent tests, testcontainers-based tests
-default-filter = 'not (binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_registry_check))) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build))'
+default-filter = 'not (binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_registry_check))) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build) | binary(=docker_channels))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -277,7 +283,7 @@ filter = 'binary(=integration_build) | binary(=integration_build_output) | binar
 test-group = 'docker-slow-shared'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=docker_channels)'
 test-group = 'docker-shared'
 
 [[profile.dev-fast.overrides]]
@@ -315,7 +321,7 @@ slow-timeout = { period = "90s", terminate-after = 1 }
 status-level = "none"
 # Live parity scenario binaries run ONLY under `--profile parity` (018-harden-parity-harness).
 # Exclude them here so even the "full" lane is truthful by non-selection (FR-014).
-default-filter = 'not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors))'
+default-filter = 'not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner))'
 
 # Profile for long-running integration tests (heavy end-to-end builds)
 [profile.long-running]
@@ -340,7 +346,7 @@ slow-timeout = { period = "30m", terminate-after = 1 }
 retries = 0
 slow-timeout = { period = "10m", terminate-after = 1 }
 status-level = "pass"
-default-filter = 'binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors))) | binary(#integration_*) | binary(=build_consistency) | binary(=up_dotfiles)'
+default-filter = 'binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner))) | binary(#integration_*) | binary(=build_consistency) | binary(=up_dotfiles)'
 
 [[profile.docker.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -419,7 +425,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.docker.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=docker_channels)'
 test-group = 'docker-shared'
 
 [[profile.docker.overrides]]
@@ -512,7 +518,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.full.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=docker_channels)'
 test-group = 'docker-shared'
 
 [[profile.full.overrides]]
@@ -552,7 +558,7 @@ fail-fast = false
 global-timeout = "1h"
 # Live parity scenario binaries run ONLY under `--profile parity` (018); exclude
 # them from ci alongside smoke so this lane is truthful by non-selection (FR-014).
-default-filter = 'not (binary(#smoke_*) | binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors))'
+default-filter = 'not (binary(#smoke_*) | binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner))'
 
 # Throttle smoke and parity tests while allowing more overlap
 [[profile.ci.overrides]]
@@ -619,7 +625,7 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "30m", terminate-after = 1 }
 
 [[profile.ci.overrides]]
-filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts)'
+filter = 'binary(=integration_host_requirements) | binary(=integration_port_forwarding) | binary(=integration_feature_security) | binary(=integration_feature_lifecycle) | binary(=integration_feature_mounts) | binary(=integration_feature_entrypoints) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=docker_channels)'
 test-group = 'docker-shared'
 threads-required = 1
 
@@ -659,7 +665,7 @@ slow-timeout = { period = "5m", terminate-after = 1 }
 status-level = "pass"
 fail-fast = false
 # MVP integration tests: smoke, parity, and core integration tests for up/exec/down/read-configuration
-default-filter = 'binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors))) | binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(=integration_up_exec_identity) | binary(=integration_down) | binary(=integration_runtime_selection) | binary(=integration_read_configuration) | binary(=integration_read_configuration_output) | binary(=integration_config) | binary(=integration_custom_container_name) | binary(=integration_exec) | binary(=integration_exec_env) | binary(=integration_exec_pty) | binary(=integration_e2e) | binary(#integration_env_probe_*) | binary(=aggregator) | binary(=normalize_consistency) | binary(=raw_outputs)'
+default-filter = 'binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner))) | binary(=integration_exec_selection) | binary(=integration_exec_id_label) | binary(=integration_up_exec_identity) | binary(=integration_down) | binary(=integration_runtime_selection) | binary(=integration_read_configuration) | binary(=integration_read_configuration_output) | binary(=integration_config) | binary(=integration_custom_container_name) | binary(=integration_exec) | binary(=integration_exec_env) | binary(=integration_exec_pty) | binary(=integration_e2e) | binary(#integration_env_probe_*) | binary(=aggregator) | binary(=normalize_consistency) | binary(=raw_outputs)'
 
 # Smoke test grouping
 [[profile.mvp-integration.overrides]]
@@ -728,11 +734,13 @@ test-group = 'fs-heavy'
 retries = 0
 slow-timeout = { period = "15m", terminate-after = 1 }
 status-level = "pass"
-default-filter = 'binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors)'
+default-filter = 'binary(=parity_read_configuration) | binary(=parity_exec) | binary(=parity_build) | binary(=parity_up_exec) | binary(=parity_observable_state) | binary(=parity_state_diff) | binary(=parity_corpus_tier1) | binary(=parity_corpus_merged) | binary(=parity_corpus_errors) | binary(=parity_conformance_runner)'
 
-# Config-only parity runner → parity-cli group.
+# Config-only parity runners → parity-cli group. `parity_conformance_runner` (022,
+# US1) drives the declarative runner over config-only read-configuration cases, so it
+# is CLI-throttled like `parity_read_configuration`.
 [[profile.parity.overrides]]
-filter = 'binary(=parity_read_configuration)'
+filter = 'binary(=parity_read_configuration) | binary(=parity_conformance_runner)'
 test-group = 'parity-cli'
 
 # Container-scenario parity runners → parity group (throttled, daemon-friendly).

--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,15 @@ conformance/inventory/clauses.json -text
 # Fixture prose and clause inventories carrying their own fingerprints/expected bytes.
 fixtures/conformance/prose/** -text
 fixtures/conformance/clause-drift/** -text
+
+# The declarative conformance runner (022-conformance-runner) hashes fixture bytes into
+# `fixtureHash` → `caseHash` and commits provenance-stamped snapshots. The hermetic
+# `snapshot_staleness` tests recompute those hashes from the fixture bytes and byte-compare
+# them to the recorded provenance. On a Windows checkout git's autocrlf would rewrite LF to
+# CRLF, changing the fixture bytes and failing the hash match. Pin these byte-exact paths.
+
+# Fixtures whose raw bytes feed fixtureHash / caseHash (never CRLF-translated).
+conformance/fixtures/** -text
+
+# Committed provenance/raw/normalized snapshot evidence (byte-exact committed artifacts).
+conformance/snapshots/** -text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,18 +368,24 @@ waiver + registry loaders (`waiver`, `registry`), run-report fragments
 `crates/deacon/tests/parity_*.rs` are thin shells over these helpers.
 
 **Selection is profile-based, never an env-var opt-in.** The legacy
-`DEACON_PARITY=1` gate and the `cargo test` side-channel are retired. The nine
-live binaries run **only** under `cargo nextest run --profile parity` (whose
-`default-filter` is an explicit `binary(=…)` allow-list of exactly those nine —
-NOT a `parity_*` glob, which would wrongly capture the hermetic guards
-`parity_harness_faults` / `parity_registry_check`). Every other profile
-(`default`/`full`/`ci`/`dev-fast`/`mvp-integration`) excludes the nine, so those
+`DEACON_PARITY=1` gate and the `cargo test` side-channel are retired. The **ten**
+live binaries (the nine original scenario/corpus binaries plus
+`parity_conformance_runner`, the 022 declarative-runner driver) run **only** under
+`cargo nextest run --profile parity` (whose `default-filter` is an explicit
+`binary(=…)` allow-list of exactly those ten — NOT a `parity_*` glob, which would
+wrongly capture the hermetic guards `parity_harness_faults` /
+`parity_registry_check`). Every other profile
+(`default`/`full`/`ci`/`dev-fast`/`mvp-integration`) excludes the ten, so those
 lanes are truthful by **non-selection**: a green fast/CI run never implies live
 parity ran. There is no silent skip — a missing/mismatched oracle, missing
 Docker, or a normalization failure **fails** the run with a cause-specific
 `HarnessError`. `make test-parity` is a thin alias:
 `cargo nextest run --profile parity` then `cargo run -p parity-harness --bin
-parity-report`.
+parity-report`. (The 022 declarative runner extends this crate along the same
+seams — `exec`/`normalize`/`oracle`/`report`/`waiver` — adding `runner`,
+`oracle_type`, `compare`, `evidence`, `observe/`, `workspace`, and the
+`conformance-snapshot` refresh bin; see the "Declarative conformance runner"
+subsection under Conformance Registry.)
 
 **Registry + waiver model.** `fixtures/parity-corpus/registry.json` enumerates
 the live binaries, the internal-consistency binaries, and the corpora (with
@@ -496,6 +502,78 @@ until `certify` unblocks; disposition is never inherited by name.
 axes, link its source unit, cover it with a case/waiver/gap, then `validate`). Statuses
 are **evidence-backed** claims — no test case or waiver yet means `reference: unknown` →
 `decision: unresolved-gap` → a `gap-*` record.
+
+**Declarative conformance runner** (022-conformance-runner) — cases are DATA a shared
+runner executes, not pointers to hand-written Rust tests. A `cases.json` record is either
+**legacy** (`executable.binary` → a `parity_*` Rust test) or **declarative**
+(`operations` + `oracleType` + `expected`); never both, never neither (exactly-one-of
+enforced fail-loud at load). Adding a case/assertion/fixture is a pure data edit — NO new
+Rust function (SC-001). The hermetic data/validation/staleness logic lives in
+`deacon-conformance`; the live execution/observation/record logic in `parity-harness`.
+- **Declarative case shape** (data-model.md §1): ordered `operations[]` (consumer
+  subcommand + argv, `${WORKSPACE}` token, `fixtures`, optional `relationship` for
+  metamorphic); `oracleType`; per-channel `expected[]` (`assertion` shapes per
+  contract observer-channel.md); scoped `allowedDifferences[]`; `fsAllowlist`; `cleanup`;
+  `resourceGroup` (nextest group for Docker cases). Excluded from `caseHash`: `notes`,
+  `allowedDifferences`, `behaviors` — annotating never re-records a snapshot (D3).
+- **Four oracle types** (one explicit dispatch in `oracle_type.rs`, re-pointed by changing
+  ONLY `oracleType`): `spec-expectation` (compare to the declared `assertion`, deacon
+  only), `live-differential` (deacon vs the verified pinned oracle), `snapshot` (deacon vs
+  a committed provenance-checked snapshot), `invariant-metamorphic` (evaluate a declared
+  RELATIONSHIP — idempotence / first-create-vs-restart / resume — across ≥2 operations,
+  not a fixed output).
+- **Observable channels + observers** (`observe/`, one module per channel): CLI-process
+  (`chan-exit-code`/`chan-stdout`/`chan-stderr`/`chan-structured-output`), `chan-filesystem`/
+  `chan-file-content` (allowlist-scoped, NEVER full-tree), and the four Docker channels
+  `chan-image`/`chan-process-graph`/`chan-injected-process`/`chan-temporal`. Evidence is
+  captured RAW then normalized by the **single** `normalize.rs` — named, field-specific
+  rules (`path_token`/`label_semantic`/`mount_source_canonical`/`path_env_segmented`/
+  `null_preserving`); nothing blanket-removed (FR-029); raw + normalized persisted SEPARATELY.
+  `NORMALIZER_VERSION` (single source of truth in `deacon-conformance::snapshot`,
+  re-exported by `parity-harness::normalize`) participates in snapshot staleness.
+- **Docker cases** run in an ISOLATED external temp workspace (`workspace.rs`) with
+  collision-resistant names (unique workspace path → unique `devcontainer.local_folder`
+  label) and an RAII cleanup guard that reclaims container/network/volume/temp-dir on
+  success AND unwind. Image inputs MUST be pinned (`@sha256:`/concrete tag, never `latest`
+  — V18).
+- **Committed snapshots** live under `conformance/snapshots/<os-arch>/<case-id>/` as three
+  files — `provenance.json` (the FR-017 identity/env fields: oracle/source/node/docker/
+  compose versions, case/fixture hashes, imageDigests, normalizerVersion, argv, platform/
+  arch, `capturedAt`), `raw.json`, `normalized.json` (raw + normalized SEPARATE, FR-016).
+  Replay fails as **stale** naming the FIRST drifted EVIDENCE-DETERMINING input
+  (caseHash/fixtureHash/oracle/source/imageDigests/normalizerVersion — NOT
+  capturedAt/platform/arch, which are selectors, and NOT the host tool versions
+  node/docker/compose, which are informational: gating staleness on them would make every
+  snapshot stale on every machine but the recorder's, breaking cross-machine CI replay —
+  a genuine host-version effect on evidence shows up as a divergence instead); a missing
+  snapshot for the current `os-arch` is **no-reference-for-platform** (a coverage gap,
+  distinct from stale and from a silent skip).
+- **Runner/refresh/check split** (all dev-only, Principle II — NEVER a shipped `deacon`
+  subcommand): `conformance snapshot check|diff` (hermetic, `deacon-conformance` bin,
+  read-only — recompute hashes + probe env vs committed provenance; NEVER writes);
+  `conformance-snapshot refresh` (`parity-harness` bin — the REVIEWED record path: requires
+  the verified oracle + Docker + Node fail-loud, runs the reference, writes the three files
+  ATOMICALLY, prints a review diff — the git diff is the review surface); and the live test
+  binary `parity_conformance_runner` (`crates/deacon/tests/`, `--profile parity` only) that
+  drives the runner over every declarative case. Ordinary `cargo nextest run` NEVER rewrites
+  a committed snapshot (`only_the_refresh_bin_writes_committed_snapshots` guards this).
+- **Scoped allowed differences** (US4) — a tolerated divergence is `(behavior, context,
+  observablePath)` + exactly one resolvable `waiverId` (a real `wvr-`) or `divergenceId`
+  (an `ext-`/intentional-divergence behavior). NO global ignore lists (a bare-channel
+  `observablePath` is rejected fail-loud at load, FR-032); duplicates conflict at load
+  (FR-035); dangling ids are V19. A covered divergence verdicts `allowed-difference` (with
+  the backing id in the detail); an uncovered path stays `diverge`; an unconsumed tolerance
+  (its difference stopped reproducing) is reported STALE — the SAME self-invalidating
+  pattern as `waiver.rs`, not a fork (FR-043/034).
+- **New validation classes** (`validate.rs`, all block a PR via `registry_valid`): **V16**
+  declarative-case well-formedness (shape, `oracleType` present, consumer-surface
+  subcommand, spec-expectation ⇒ assertions, `fsAllowlist` iff a filesystem channel);
+  **V17** committed-snapshot integrity (orphan/malformed, in `validate_path_with_inventory`);
+  **V18** Docker-case pinned image inputs; **V19** allowed-difference identity resolution;
+  **V20** invariant-metamorphic arity (≥2 ops + a `relationship` referencing a sibling op).
+  `certify` surfaces committed-snapshot coverage + `no-reference-for-platform` as
+  NON-BLOCKING info (a snapshot is a reviewed artifact, not a release gate); it still blocks
+  ONLY on gaps/uncovered/inventory/clause. See `specs/022-conformance-runner/quickstart.md`.
 
 ## Parity & Conformance: Vocabulary, Gates, and the Build-Out Loop
 
@@ -921,6 +999,8 @@ RUST_LOG=debug cargo run -- up --container-data-folder /tmp/cache
 - strict-JSON files — vendored schemas under `conformance/schemas/<rev>/` (020-schema-constraint-inventory)
 - Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide) + existing crate deps only — `serde`/`serde_json` (record (021-normative-clause-inventory)
 - strict-JSON + vendored Markdown — vendored prose under (021-normative-clause-inventory)
+- Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide) + existing workspace deps only — `serde`/`serde_json`, `indexmap` (declaration order), `sha2` (already used in `deacon-conformance` for `hash8`/fingerprints → case/fixture hashing), `tokio` (bounded async exec + streamed capture, already in `parity-harness`), `thiserror` (`HarnessError`/domain errors), `tracing`, `toml` (nextest-profile drift check, already a `parity-harness` dep), `tempfile` (isolated external workspaces, dev-dep); no new runtime crates (022-conformance-runner)
+- strict-JSON, version-controlled — extend `conformance/registry/cases.json` (declarative case shape) + `channels.json` (new channels); new committed evidence tree `conformance/snapshots/<os>-<arch>/<case-id>/{provenance,raw,normalized}.json` (atomic temp-file + `fs::rename` writes) (022-conformance-runner)
 
 ## Recent Changes
 - 018-harden-parity-harness: Added the dev-only `crates/parity-harness/` crate (oracle resolution + exact-version verify, bounded exec with raw capture, the single `normalize` module, waiver/registry loaders, report fragments + `parity-report` aggregator bin); moved live parity onto the dedicated `[profile.parity]` nextest profile; retired the `DEACON_PARITY=1` gate and the three Python corpus runners; added the `parity / live-certification` CI lane. See the "Parity Test Harness" section.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "console",
+ "deacon-conformance",
  "deacon-core",
  "flate2",
  "futures",
@@ -2127,6 +2128,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "deacon-conformance",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/conformance/RULES.md
+++ b/conformance/RULES.md
@@ -122,6 +122,27 @@ distort the coverage denominator). If a purported differentiator has no external
 observable effect on stdout, stderr, exit code, container state, or the filesystem, it is
 out of scope for the registry.
 
+## The declarative conformance runner is DEV-ONLY (Principle II)
+
+The declarative conformance runner (022-conformance-runner) — the shared machinery that
+executes a `cases.json` record against deacon / the pinned reference / a committed
+snapshot, capturing and normalizing observable channels — is **contributor test tooling,
+never a shipped consumer command**. It adds NO `deacon` subcommand. Concretely:
+
+- `conformance snapshot check|diff` is a subcommand of the dev-only `deacon-conformance`
+  bin (`cargo run -p deacon-conformance -- …`), not of the `deacon` CLI.
+- `conformance-snapshot refresh` (the reviewed record path) is a `parity-harness` bin
+  (`cargo run -p parity-harness --bin conformance-snapshot -- …`), not `deacon`.
+- The live differential run is a **test binary** (`parity_conformance_runner`, `--profile
+  parity` only), not a runtime command.
+
+The consumer surface stays exactly `up`/`down`/`exec`/`build`/`read-configuration`/
+`run-user-commands`/`templates apply`/`doctor` (Constitution II). A declarative
+`operations[].subcommand` is validated to be in that surface (V16); the runner exercises
+only consumer commands, never authoring ones. Do NOT add a `deacon conformance` /
+`deacon snapshot` command — that would drag test tooling into the shipped binary and
+violate the consumer-only scope.
+
 ## Inventory join (V11 – V15) — constraints AND clauses
 
 This section is the human-readable companion to the two inventory joins enforced in

--- a/conformance/fixtures/fx-config-with-unknown-field/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-config-with-unknown-field/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "conformance-unknown-field-echo",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "customUnknownKey": "preserved"
+}

--- a/conformance/fixtures/fx-up-basic/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-up-basic/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "ConformanceUpBasic",
+  "image": "alpine:3.19",
+  "containerEnv": { "CONF_TOKEN": "us5" }
+}

--- a/conformance/registry/cases.json
+++ b/conformance/registry/cases.json
@@ -236,6 +236,159 @@
       "outcomes": [
         { "channel": "chan-exit-code", "expectation": "the selected profile's flags/config are applied to the invocation" }
       ]
+    },
+    {
+      "id": "case-readconfig-unknown-field-echo",
+      "behaviors": ["bhv-readconfig-unknown-field-preserved"],
+      "context": [],
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-config-with-unknown-field"]
+        }
+      ],
+      "expected": [
+        { "channel": "chan-exit-code", "operation": "op-read", "assertion": { "equals": 0 } },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": { "jsonSubset": { "configuration": { "customUnknownKey": "preserved" } } }
+        }
+      ],
+      "cleanup": { "tempdir": true },
+      "notes": "Declarative spec-expectation case (022-conformance-runner MVP): unknown top-level keys round-trip through read-configuration (Constitution IV faithful-on-unmodeled). No new Rust function — the shared runner verdicts it from this data."
+    },
+    {
+      "id": "case-readconfig-parity-exit",
+      "behaviors": ["bhv-readconfig-basic-parse"],
+      "context": [],
+      "oracleType": "live-differential",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-config-with-unknown-field"]
+        }
+      ],
+      "expected": [
+        { "channel": "chan-exit-code", "operation": "op-read" }
+      ],
+      "cleanup": { "tempdir": true },
+      "notes": "Declarative live-differential case (022-conformance-runner MVP): deacon and the pinned reference both exit 0 for a well-formed configuration. Runs in the parity lane only; the exit-code channel is compared without US3 normalization."
+    },
+    {
+      "id": "case-readconfig-workspace-file-present",
+      "behaviors": ["bhv-readconfig-basic-parse"],
+      "context": [],
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-config-with-unknown-field"]
+        }
+      ],
+      "expected": [
+        { "channel": "chan-exit-code", "operation": "op-read", "assertion": { "equals": 0 } },
+        {
+          "channel": "chan-filesystem",
+          "operation": "op-read",
+          "assertion": { "exists": ".devcontainer/devcontainer.json" }
+        }
+      ],
+      "fsAllowlist": [".devcontainer/devcontainer.json"],
+      "cleanup": { "tempdir": true },
+      "notes": "Declarative spec-expectation case (022-conformance-runner US3): exercises the allowlist-scoped filesystem observer — the workspace's .devcontainer/devcontainer.json is present after read-configuration. path_token normalization applies; no full-tree diff (clarify Q1)."
+    },
+    {
+      "id": "case-readconfig-snapshot",
+      "behaviors": ["bhv-readconfig-basic-parse"],
+      "context": [],
+      "oracleType": "snapshot",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-config-with-unknown-field"]
+        }
+      ],
+      "expected": [
+        { "channel": "chan-exit-code", "operation": "op-read" }
+      ],
+      "cleanup": { "tempdir": true },
+      "notes": "Declarative snapshot-oracle case (022-conformance-runner US2): deacon's exit-code is compared against the committed, provenance-checked reference snapshot recorded via `conformance-snapshot refresh`. Replay fails as stale on caseHash/fixtureHash/oracleVersion/sourceRevision/node|docker|compose|imageDigests/normalizerVersion drift; a missing snapshot for the current os-arch is no-reference-for-platform."
+    },
+    {
+      "id": "case-up-docker-channels",
+      "behaviors": ["bhv-up-exec-parity"],
+      "context": [],
+      "oracleType": "spec-expectation",
+      "resourceGroup": "docker-shared",
+      "operations": [
+        {
+          "id": "op-up",
+          "subcommand": "up",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-up-basic"]
+        }
+      ],
+      "expected": [
+        { "channel": "chan-exit-code", "operation": "op-up", "assertion": { "equals": 0 } },
+        {
+          "channel": "chan-image",
+          "operation": "op-up",
+          "assertion": { "jsonSubset": { "labels": { "devcontainer.source": "deacon" } } }
+        },
+        {
+          "channel": "chan-injected-process",
+          "operation": "op-up",
+          "assertion": { "jsonSubset": { "env": { "CONF_TOKEN": "us5" } } }
+        },
+        {
+          "channel": "chan-process-graph",
+          "operation": "op-up",
+          "assertion": { "jsonSubset": {} }
+        },
+        {
+          "channel": "chan-temporal",
+          "operation": "op-up",
+          "assertion": { "jsonSubset": { "status": "running" } }
+        }
+      ],
+      "cleanup": { "containers": true, "images": false, "networks": true, "volumes": true, "tempdir": true },
+      "notes": "Declarative Docker-backed spec-expectation case (022-conformance-runner US5): `deacon up` in an ISOLATED external temp workspace (collision-resistant, guaranteed cleanup) exercises all four Docker channels — chan-image (deacon stamps devcontainer.source), chan-injected-process (containerEnv CONF_TOKEN injected), chan-process-graph (mount/network/volume graph captured), chan-temporal (container running). Image pinned to alpine:3.19 (V18)."
+    },
+    {
+      "id": "case-up-idempotent",
+      "behaviors": ["bhv-up-exec-parity"],
+      "context": [],
+      "oracleType": "invariant-metamorphic",
+      "resourceGroup": "docker-shared",
+      "operations": [
+        {
+          "id": "op-up-1",
+          "subcommand": "up",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "fixtures": ["fx-up-basic"]
+        },
+        {
+          "id": "op-up-2",
+          "subcommand": "up",
+          "argv": ["--workspace-folder", "${WORKSPACE}"],
+          "relationship": { "kind": "idempotence", "againstOp": "op-up-1" }
+        }
+      ],
+      "expected": [
+        { "channel": "chan-temporal", "operation": "op-up-2" }
+      ],
+      "cleanup": { "containers": true, "images": false, "networks": true, "volumes": true, "tempdir": true },
+      "notes": "Declarative invariant-metamorphic case (022-conformance-runner US6): a second `deacon up` on the same isolated workspace must be IDEMPOTENT — it reuses the running container created by the first up (same container id, still running) rather than recreating it. The oracle verdicts on the DECLARED RELATIONSHIP between op-up-2 and op-up-1's chan-temporal state, not a fixed output (FR-008). Image pinned to alpine:3.19 (V18)."
     }
   ]
 }

--- a/conformance/registry/channels.json
+++ b/conformance/registry/channels.json
@@ -18,12 +18,32 @@
       "description": "Presence, absence, or attributes of files and directories on the workspace or container filesystem."
     },
     {
+      "id": "chan-image",
+      "description": "Built-image configuration and metadata (labels parsed semantically, environment, entrypoint)."
+    },
+    {
+      "id": "chan-injected-process",
+      "description": "Injected process context: environment, user, cwd, PATH resolution, signals, TTY, and exit propagation."
+    },
+    {
+      "id": "chan-process-graph",
+      "description": "Container, network, volume, and mount graph produced by a run."
+    },
+    {
       "id": "chan-stderr",
       "description": "Bytes written to standard error (diagnostics, logs, progress)."
     },
     {
       "id": "chan-stdout",
       "description": "Bytes written to standard output (the command result document)."
+    },
+    {
+      "id": "chan-structured-output",
+      "description": "Parsed structured (JSON) result document, distinct from the raw stdout bytes."
+    },
+    {
+      "id": "chan-temporal",
+      "description": "Lifecycle ordering, first-create versus restart, resume, and cleanup transitions across a run."
     }
   ]
 }

--- a/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/normalized.json
+++ b/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/normalized.json
@@ -1,0 +1,8 @@
+[
+  {
+    "channel": "chan-exit-code",
+    "operation": "op-read",
+    "present": true,
+    "value": 0
+  }
+]

--- a/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/provenance.json
+++ b/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/provenance.json
@@ -1,0 +1,19 @@
+{
+  "oracleVersion": "0.87.0",
+  "sourceRevision": "113500f4",
+  "caseHash": "42d69e9b0dd1e614d98e4fe0caacb26eaff7345833003eecffeb721c5d66bf1e",
+  "fixtureHash": "854692bcaf0627df3643ce4bb0fd8126ad7b5d32390d92986d445a88386f1be6",
+  "argv": [
+    "read-configuration",
+    "--workspace-folder",
+    "<WORKSPACE>"
+  ],
+  "platform": "linux",
+  "arch": "x86_64",
+  "nodeVersion": "22.23.1",
+  "dockerVersion": "29.6.2-1",
+  "composeVersion": "2.40.3",
+  "imageDigests": {},
+  "normalizerVersion": "2",
+  "capturedAt": "2026-07-24T14:46:23Z"
+}

--- a/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/raw.json
+++ b/conformance/snapshots/linux-x86_64/case-readconfig-snapshot/raw.json
@@ -1,0 +1,8 @@
+[
+  {
+    "channel": "chan-exit-code",
+    "operation": "op-read",
+    "present": true,
+    "value": 0
+  }
+]

--- a/crates/conformance/src/bin/conformance.rs
+++ b/crates/conformance/src/bin/conformance.rs
@@ -17,6 +17,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
 
+use deacon_conformance::case_hash::hashes_for_case;
 use deacon_conformance::certify::certify;
 use deacon_conformance::clause::{generate_clauses, render as render_clauses, write_clauses};
 use deacon_conformance::clause_diff::{
@@ -33,12 +34,14 @@ use deacon_conformance::load::{
 };
 use deacon_conformance::model::{ClauseInventory, ConstraintInventory, DocumentScope};
 use deacon_conformance::report::write_reports;
+use deacon_conformance::snapshot;
 use deacon_conformance::validate::{
     ClauseInputs, InventoryInputs, Violation, validate_path, validate_path_with_inventory,
 };
 use deacon_conformance::{
-    CURRENT_SCHEMA_PIN, clause_paths_for, default_clauses_file, default_inventory_file,
-    default_pinned_schemas_dir, default_pinned_spec_dir, default_registry_dir, workspace_root,
+    CURRENT_SCHEMA_PIN, CURRENT_SPEC_PIN, clause_paths_for, default_clauses_file,
+    default_inventory_file, default_pinned_schemas_dir, default_pinned_spec_dir,
+    default_registry_dir, workspace_root,
 };
 
 /// Structural conformance-registry tooling (dev-only).
@@ -96,6 +99,43 @@ enum Command {
     Clause {
         #[command(subcommand)]
         command: ClauseCommand,
+    },
+    /// Committed snapshot staleness/diff tooling (022-conformance-runner). Hermetic,
+    /// read-only (never writes; the reviewed refresh is the `parity-harness`
+    /// `conformance-snapshot` bin). Handlers land in User Story 2 (T031–T033).
+    Snapshot {
+        #[command(subcommand)]
+        command: SnapshotCommand,
+    },
+}
+
+/// `snapshot <check|diff>` — hermetic, read-only staleness + drift operations over the
+/// committed `conformance/snapshots/<os>-<arch>/<case-id>/` trees (contract
+/// runner-cli.md §1). NEVER writes evidence — ordinary runs only read/compare (FR-021).
+#[derive(Debug, Subcommand)]
+enum SnapshotCommand {
+    /// Recompute case/fixture hashes + probe the environment and compare to the
+    /// committed provenance; report `stale` (naming the mismatched field) or
+    /// `no-reference-for-platform`. Exit `0` pass, `1` stale/violation, `2` malformed.
+    Check {
+        /// Restrict the check to a single case id (default: all cases).
+        #[arg(long, value_name = "ID")]
+        case: Option<String>,
+        /// Restrict the check to a single `os-arch` platform (default: the current one).
+        #[arg(long, value_name = "OS-ARCH")]
+        platform: Option<String>,
+    },
+    /// Deterministic drift between two snapshot trees.
+    Diff {
+        /// The old (left) snapshot directory.
+        #[arg(value_name = "OLD-DIR")]
+        old: PathBuf,
+        /// The new (right) snapshot directory.
+        #[arg(value_name = "NEW-DIR")]
+        new: PathBuf,
+        /// Output format. Defaults to `json`; `md` renders the human review document.
+        #[arg(long, value_name = "FORMAT", default_value = "json")]
+        format: DiffFormat,
     },
 }
 
@@ -267,7 +307,188 @@ fn run(cli: Cli) -> i32 {
                 clause_scaffold(&registry_dir, clauses, spec)
             }
         },
+        Command::Snapshot { command } => match command {
+            SnapshotCommand::Check { case, platform } => {
+                snapshot_check(&registry_dir, case.as_deref(), platform.as_deref())
+            }
+            SnapshotCommand::Diff { old, new, format } => snapshot_diff(&old, &new, format),
+        },
     }
+}
+
+/// `snapshot check` (contract runner-cli.md §1): recompute the case/fixture hashes +
+/// probe the host environment, compare to the committed provenance, and report `stale`
+/// (naming the first drifted field) or `no-reference-for-platform`. Hermetic (never
+/// writes). Exit `0` all fresh / no-reference (informational), `1` any stale, `2`
+/// malformed input / dangling reference.
+///
+/// The evidence-determining inputs (case/fixture hashes, oracle + source pins, normalizer
+/// version) are recomputed and compared. Host tool versions (Node/Docker/Compose) are
+/// informational, NOT staleness signals (see `snapshot::compare_staleness`), so they are
+/// neither probed nor compared — a snapshot stays fresh across machines regardless of the
+/// host toolchain (SC-003). `imageDigests` is not recomputed hermetically (it needs image
+/// inspection) — carried from the recorded provenance.
+fn snapshot_check(registry_dir: &Path, case_filter: Option<&str>, platform: Option<&str>) -> i32 {
+    let registry = match Registry::load(registry_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: cannot load registry: {e}");
+            return 2;
+        }
+    };
+    let os_arch = platform
+        .map(str::to_string)
+        .unwrap_or_else(snapshot::current_os_arch);
+    // Snapshots are a sibling of the registry dir (mirrors the certify/validate
+    // sibling-resolution), so `snapshot check --registry <dir>` inspects that tree's
+    // snapshots rather than always the real committed ones. Fixtures stay
+    // workspace-rooted, matching how the runner/refresh/validate resolve them.
+    let snapshots_root = registry_dir
+        .parent()
+        .map(|p| p.join("snapshots"))
+        .unwrap_or_else(snapshot::default_snapshots_dir);
+    let fixtures_root = workspace_root().join("conformance").join("fixtures");
+
+    // Which declarative cases to check: the named one, or every declarative case.
+    let cases: Vec<&deacon_conformance::model::TestCase> = registry
+        .cases
+        .iter()
+        .filter(|c| {
+            matches!(
+                c.classify(),
+                Ok(deacon_conformance::model::CaseKind::Declarative)
+            )
+        })
+        // A default sweep (no --case) checks only `snapshot`-oracle cases — the ones a
+        // committed snapshot is expected for. An explicit --case is checked regardless of
+        // its oracle type (the user asked for it by id).
+        .filter(|c| {
+            case_filter.map_or(
+                c.oracle_type == Some(deacon_conformance::model::OracleType::Snapshot),
+                |id| c.id == id,
+            )
+        })
+        .collect();
+
+    if let Some(id) = case_filter {
+        if cases.is_empty() {
+            eprintln!("error: no declarative case with id {id:?}");
+            return 2;
+        }
+    }
+
+    let oracle_pin = snapshot::current_oracle_version_pin();
+    let mut stale = Vec::new();
+    let mut no_reference = Vec::new();
+    let mut fresh = 0usize;
+
+    for case in cases {
+        let resolution = match snapshot::resolve(&snapshots_root, &os_arch, &case.id) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 2;
+            }
+        };
+        let recorded = match resolution {
+            snapshot::Resolution::NoReferenceForPlatform { os_arch } => {
+                no_reference.push((case.id.clone(), os_arch));
+                continue;
+            }
+            snapshot::Resolution::Found(s) => s.provenance,
+        };
+        let (case_hash, fixture_hash) = match hashes_for_case(case, &fixtures_root) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("error: cannot recompute hashes for {}: {e}", case.id);
+                return 2;
+            }
+        };
+        // Build the `current` provenance: recompute the evidence-determining inputs and
+        // carry recorded values for the rest (host tool versions are not staleness signals,
+        // so they are not probed here; never fabricated).
+        let mut current = recorded.clone();
+        current.case_hash = case_hash;
+        current.fixture_hash = fixture_hash;
+        current.source_revision = CURRENT_SPEC_PIN.to_string();
+        current.normalizer_version = snapshot::NORMALIZER_VERSION.to_string();
+        if let Some(v) = &oracle_pin {
+            current.oracle_version = v.clone();
+        }
+
+        match snapshot::compare_staleness(&recorded, &current) {
+            snapshot::Staleness::Fresh => {
+                println!("fresh {}", case.id);
+                fresh += 1;
+            }
+            snapshot::Staleness::Stale {
+                field,
+                recorded,
+                current,
+            } => {
+                println!(
+                    "stale {} {field}: recorded {recorded:?} != current {current:?}",
+                    case.id
+                );
+                stale.push(case.id.clone());
+            }
+        }
+    }
+
+    for (id, os_arch) in &no_reference {
+        println!("no-reference-for-platform {id} ({os_arch})");
+    }
+    eprintln!(
+        "snapshot check ({os_arch}): {fresh} fresh, {} stale, {} no-reference",
+        stale.len(),
+        no_reference.len()
+    );
+    if stale.is_empty() { 0 } else { 1 }
+}
+
+/// `snapshot diff <old-dir> <new-dir>` (contract runner-cli.md §1): deterministic drift
+/// between two committed snapshot trees (a single case directory each). Exit `0` on
+/// success (whether or not differences exist — the diff IS the output), `2` on IO error.
+fn snapshot_diff(old: &Path, new: &Path, format: DiffFormat) -> i32 {
+    let old_snap = match snapshot::load_snapshot(old) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: cannot load old snapshot: {e}");
+            return 2;
+        }
+    };
+    let new_snap = match snapshot::load_snapshot(new) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: cannot load new snapshot: {e}");
+            return 2;
+        }
+    };
+    let entries = snapshot::diff(&old_snap, &new_snap);
+    match format {
+        DiffFormat::Json => match serde_json::to_string_pretty(&entries) {
+            Ok(doc) => println!("{doc}"),
+            Err(e) => {
+                eprintln!("error: could not serialize diff: {e}");
+                return 2;
+            }
+        },
+        DiffFormat::Md => {
+            if entries.is_empty() {
+                println!("No snapshot differences.");
+            } else {
+                println!("| Artifact | Path | Old | New |");
+                println!("|----------|------|-----|-----|");
+                for e in &entries {
+                    println!(
+                        "| {} | `{}` | `{}` | `{}` |",
+                        e.artifact, e.path, e.old, e.new
+                    );
+                }
+            }
+        }
+    }
+    0
 }
 
 /// `clause generate` (contracts/cli-clause.md): fingerprint-verify the spec manifest,
@@ -1082,7 +1303,13 @@ fn certify_cmd(registry_dir: &Path, today: &str, json: bool) -> i32 {
         spec_dir: &spec_dir,
         clauses_file: &clauses_file,
     };
-    let result = certify(&registry, &inputs, &clause_inputs);
+    // Committed snapshots are a sibling of the registry dir (mirrors the inventory/clause
+    // sibling resolution); snapshot coverage is NON-BLOCKING info (T073).
+    let snapshots_dir = registry_dir
+        .parent()
+        .map(|p| p.join("snapshots"))
+        .unwrap_or_else(|| registry_dir.join("snapshots"));
+    let result = certify(&registry, &inputs, &clause_inputs, &snapshots_dir);
 
     if json {
         match serde_json::to_string_pretty(&result) {
@@ -1109,6 +1336,17 @@ fn certify_cmd(registry_dir: &Path, today: &str, json: bool) -> i32 {
                     item.id
                 ),
             }
+        }
+        // NON-BLOCKING snapshot coverage info (T073, FR-042).
+        for cov in &result.snapshot_coverage {
+            println!(
+                "info snapshot-coverage: {} [{}]",
+                cov.case_id,
+                cov.platforms.join(", ")
+            );
+        }
+        for id in &result.no_reference {
+            println!("info no-reference-for-platform: {id} (no committed snapshot yet)");
         }
         if result.certified {
             println!("certified: {}", result.profile);

--- a/crates/conformance/src/case_hash.rs
+++ b/crates/conformance/src/case_hash.rs
@@ -1,0 +1,290 @@
+//! Case + fixture hashing (research D3, FR-020, 022-conformance-runner).
+//!
+//! [`case_hash`] is SHA-256 over the **canonicalized behavior-affecting inputs** of a
+//! declarative case — `operations`, `oracleType`, `expected`, `fsAllowlist`, and the
+//! referenced fixture hashes — and NOTHING else. `notes`, `allowedDifferences`, and
+//! any other human prose are excluded, so annotating a case never invalidates its
+//! committed snapshot (clarify Q4). [`fixture_hash`] is SHA-256 over the fixture
+//! bytes. Both reuse the `sha2::{Digest, Sha256}` pattern already proven in
+//! [`crate::clause`] (research D3).
+//!
+//! Canonicalization sorts JSON **object keys** recursively (object key order is
+//! insignificant) while preserving **array order** (`operations`, `argv`, `expected`
+//! are ordered and their order IS significant). This makes the hash independent of how
+//! the author happened to order keys in an assertion object, so a cosmetic re-order
+//! never re-records a snapshot.
+
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::model::TestCase;
+
+/// The lowercase-hex SHA-256 of `bytes`, rendered in full (64 hex chars).
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::new().chain_update(bytes).finalize();
+    let mut hex = String::with_capacity(64);
+    for b in digest.iter() {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    hex
+}
+
+/// Recursively canonicalize a JSON value: sort every object's keys (insignificant
+/// order → deterministic) and recurse into arrays element-wise (significant order →
+/// preserved). Scalars pass through unchanged.
+fn canonicalize(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = Map::with_capacity(map.len());
+            for k in keys {
+                out.insert(k.clone(), canonicalize(&map[k]));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonicalize).collect()),
+        other => other.clone(),
+    }
+}
+
+/// The canonical byte serialization used as hash input: a canonicalized value rendered
+/// with `serde_json::to_vec` (compact, no whitespace). Because [`canonicalize`] sorts
+/// object keys, this is stable regardless of the `preserve_order` insertion order.
+fn canonical_bytes(value: &Value) -> Vec<u8> {
+    // `serde_json::to_vec` on a fully-canonicalized value cannot fail (no non-string
+    // map keys, no NaN/Inf — the value came from parsed JSON), but we surface any
+    // error defensively rather than unwrap (constitution V — panic-free).
+    serde_json::to_vec(&canonicalize(value)).unwrap_or_default()
+}
+
+/// Compute `fixtureHash`: the full lowercase-hex SHA-256 of a fixture's bytes
+/// (data-model §3, FR-020). Path-relative, byte-exact.
+pub fn fixture_hash(bytes: &[u8]) -> String {
+    sha256_hex(bytes)
+}
+
+/// Compute a fixture directory's hash: SHA-256 over every file's `(relative-path,
+/// bytes)` in sorted relative-path order (data-model §3). Deterministic and portable —
+/// a rename or content change alters the hash; iteration order does not. A missing
+/// directory hashes as empty (the caller decides whether that is an error).
+pub fn fixture_hash_dir(dir: &std::path::Path) -> std::io::Result<String> {
+    let mut files: Vec<(String, Vec<u8>)> = Vec::new();
+    collect_files(dir, dir, &mut files)?;
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    for (rel, bytes) in &files {
+        hasher.update(rel.as_bytes());
+        hasher.update([0u8]); // separator so (`a`,`bc`) ≠ (`ab`,`c`)
+        hasher.update(bytes);
+        hasher.update([0u8]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in digest.iter() {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    Ok(hex)
+}
+
+/// The combined fixture hash over several fixture directories, in the given order — the
+/// `fixtureHash` recorded in snapshot provenance (data-model §7). Each directory's
+/// [`fixture_hash_dir`] is folded in with its id so a reordering or an added fixture
+/// changes the result.
+pub fn combined_fixture_hash(fixtures: &[(String, std::path::PathBuf)]) -> std::io::Result<String> {
+    let mut hasher = Sha256::new();
+    for (id, dir) in fixtures {
+        let dir_hash = fixture_hash_dir(dir)?;
+        hasher.update(id.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(dir_hash.as_bytes());
+        hasher.update([0u8]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for b in digest.iter() {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{b:02x}");
+    }
+    Ok(hex)
+}
+
+/// Recursively collect `(relative-path, bytes)` for every file under `dir`, relative to
+/// `base`. Symlinks are followed as ordinary files (fixtures are trusted, committed
+/// inputs); directories recurse. Relative paths use `/` separators for portability.
+fn collect_files(
+    base: &std::path::Path,
+    dir: &std::path::Path,
+    out: &mut Vec<(String, Vec<u8>)>,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_files(base, &path, out)?;
+        } else {
+            let rel = path
+                .strip_prefix(base)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            out.push((rel, std::fs::read(&path)?));
+        }
+    }
+    Ok(())
+}
+
+/// Compute `caseHash`: SHA-256 over the canonical JSON of the behavior-affecting
+/// inputs `{ operations, oracleType, expected, fsAllowlist, fixtureHashes }` — and
+/// nothing else (research D3, data-model §1). `fixture_hashes` is the list of
+/// [`fixture_hash`] values for every fixture the case's operations reference, in a
+/// caller-fixed order.
+///
+/// Excluded by construction: `id`, `behaviors`, `context`, `notes`,
+/// `allowedDifferences`, `cleanup`, `resourceGroup`, and the legacy `executable` /
+/// `outcomes` — none affect what the runner observes.
+pub fn case_hash(case: &TestCase, fixture_hashes: &[String]) -> String {
+    // Build the canonical input document explicitly so the field set is a deliberate,
+    // reviewable allow-list rather than "whatever the record happens to carry".
+    let input = serde_json::json!({
+        "operations": case.operations,
+        "oracleType": case.oracle_type,
+        "expected": case.expected,
+        "fsAllowlist": case.fs_allowlist,
+        "fixtureHashes": fixture_hashes,
+    });
+    sha256_hex(&canonical_bytes(&input))
+}
+
+/// Compute the `(caseHash, fixtureHash)` pair for a case, rooting its fixtures under
+/// `fixtures_root` (data-model §7). BOTH the reviewed refresh (`parity-harness`) and the
+/// hermetic `snapshot check` (`deacon-conformance`) call this so the two never disagree
+/// about a snapshot's freshness. Fixture ids are de-duplicated and sorted for a
+/// deterministic result; a fixture directory that does not exist is a fail-loud IO error.
+pub fn hashes_for_case(
+    case: &TestCase,
+    fixtures_root: &std::path::Path,
+) -> std::io::Result<(String, String)> {
+    let mut ids: Vec<String> = case
+        .operations
+        .iter()
+        .flat_map(|op| op.fixtures.iter().cloned())
+        .collect();
+    ids.sort();
+    ids.dedup();
+
+    let mut fixtures: Vec<(String, std::path::PathBuf)> = Vec::with_capacity(ids.len());
+    let mut per_fixture_hashes: Vec<String> = Vec::with_capacity(ids.len());
+    for id in ids {
+        let dir = fixtures_root.join(&id);
+        let dir_hash = fixture_hash_dir(&dir)?;
+        per_fixture_hashes.push(dir_hash);
+        fixtures.push((id, dir));
+    }
+    let case_hash = case_hash(case, &per_fixture_hashes);
+    let fixture_hash = combined_fixture_hash(&fixtures)?;
+    Ok((case_hash, fixture_hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ExpectedObservable, Operation, OracleType};
+
+    fn declarative_case() -> TestCase {
+        TestCase {
+            id: "case-hash-fixture".to_string(),
+            behaviors: vec!["bhv-x".to_string()],
+            operations: vec![Operation {
+                id: "op-1".to_string(),
+                subcommand: "read-configuration".to_string(),
+                argv: vec!["--workspace-folder".to_string(), "${WORKSPACE}".to_string()],
+                ..Operation::default()
+            }],
+            oracle_type: Some(OracleType::SpecExpectation),
+            expected: vec![ExpectedObservable {
+                channel: "chan-exit-code".to_string(),
+                operation: Some("op-1".to_string()),
+                assertion: Some(serde_json::json!({ "equals": 0 })),
+            }],
+            ..TestCase::default()
+        }
+    }
+
+    #[test]
+    fn fixture_hash_is_stable_hex_sha256() {
+        let h = fixture_hash(b"hello");
+        // Known SHA-256 of "hello".
+        assert_eq!(
+            h,
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        assert_eq!(h.len(), 64);
+    }
+
+    #[test]
+    fn case_hash_is_deterministic() {
+        let case = declarative_case();
+        let a = case_hash(&case, &["deadbeef".to_string()]);
+        let b = case_hash(&case, &["deadbeef".to_string()]);
+        assert_eq!(a, b, "same inputs → same hash");
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn case_hash_ignores_prose_fields() {
+        let mut annotated = declarative_case();
+        annotated.notes = Some("a reviewer annotation".to_string());
+        annotated.allowed_differences = vec![crate::model::AllowedDifference {
+            behavior: "bhv-x".to_string(),
+            context: vec![],
+            observable_path: "chan-exit-code.value".to_string(),
+            rationale: "characterized".to_string(),
+            waiver_id: Some("wvr-x".to_string()),
+            divergence_id: None,
+        }];
+        let base = declarative_case();
+        assert_eq!(
+            case_hash(&base, &[]),
+            case_hash(&annotated, &[]),
+            "notes / allowedDifferences must NOT affect caseHash (D3)"
+        );
+    }
+
+    #[test]
+    fn case_hash_tracks_behavior_affecting_inputs() {
+        let base = declarative_case();
+        let mut changed = declarative_case();
+        changed.operations[0].argv.push("--extra".to_string());
+        assert_ne!(
+            case_hash(&base, &[]),
+            case_hash(&changed, &[]),
+            "changing argv must change caseHash"
+        );
+        assert_ne!(
+            case_hash(&base, &[]),
+            case_hash(&base, &["fixturehash".to_string()]),
+            "changing referenced fixture hashes must change caseHash"
+        );
+    }
+
+    #[test]
+    fn canonicalize_sorts_object_keys_not_arrays() {
+        let a = serde_json::json!({ "b": 1, "a": [3, 1, 2] });
+        let b = serde_json::json!({ "a": [3, 1, 2], "b": 1 });
+        assert_eq!(
+            canonical_bytes(&a),
+            canonical_bytes(&b),
+            "object key order is insignificant"
+        );
+        let c = serde_json::json!({ "a": [1, 2, 3], "b": 1 });
+        assert_ne!(
+            canonical_bytes(&a),
+            canonical_bytes(&c),
+            "array order IS significant"
+        );
+    }
+}

--- a/crates/conformance/src/certify.rs
+++ b/crates/conformance/src/certify.rs
@@ -24,10 +24,13 @@
 //! ONE join implementation — there is no parallel check. Reading the pinned schemas
 //! + committed inventory is the only IO; the registry is already in memory.
 
+use std::path::Path;
+
 use serde::Serialize;
 
 use crate::coverage::Coverage;
 use crate::load::Registry;
+use crate::model::{CaseKind, OracleType};
 use crate::validate::{ClauseInputs, InventoryInputs, check_clause_inventory, check_inventory};
 
 /// Why a certification is blocked: an unresolved gap record, an in-profile behavior
@@ -65,6 +68,17 @@ pub struct Blocking {
     pub code: Option<String>,
 }
 
+/// Committed-snapshot coverage for one snapshot-oracle case (022-conformance-runner US2;
+/// NON-BLOCKING info surfaced in `certify`, FR-042).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotCoverage {
+    /// The snapshot-oracle case id.
+    pub case_id: String,
+    /// The `os-arch` platform keys that have a committed snapshot, sorted.
+    pub platforms: Vec<String>,
+}
+
 /// The certification verdict for the active profile (contracts/cli.md `certify`).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Certification {
@@ -77,6 +91,16 @@ pub struct Certification {
     pub blocking: Vec<Blocking>,
     /// All waiver IDs — enumerated, non-blocking (FR-025), ID-sorted.
     pub waived: Vec<String>,
+    /// NON-BLOCKING info (022-conformance-runner US2, T073): committed-snapshot coverage
+    /// per snapshot-oracle case — surfaced so a reviewer sees which platforms are pinned,
+    /// but never a blocker (a snapshot is a reviewed artifact, not a release gate; FR-042).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub snapshot_coverage: Vec<SnapshotCoverage>,
+    /// NON-BLOCKING info: snapshot-oracle case ids with NO committed snapshot on ANY
+    /// platform — a `no-reference-for-platform` coverage gap, surfaced but never blocking
+    /// (FR-016a/042), ID-sorted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub no_reference: Vec<String>,
 }
 
 /// Evaluate strict certification over a VALIDATED registry plus its committed
@@ -96,6 +120,7 @@ pub fn certify(
     registry: &Registry,
     inventory: &InventoryInputs,
     clauses: &ClauseInputs,
+    snapshots_dir: &Path,
 ) -> Certification {
     let coverage = Coverage::evaluate(registry);
 
@@ -150,12 +175,69 @@ pub fn certify(
     let mut waived: Vec<String> = registry.waivers.iter().map(|w| w.id.clone()).collect();
     waived.sort();
 
+    let (snapshot_coverage, no_reference) = snapshot_coverage(registry, snapshots_dir);
+
     Certification {
+        // Snapshot coverage / no-reference are NON-BLOCKING info — `certified` depends
+        // ONLY on `blocking` (gaps/uncovered/inventory/clause), unchanged.
         certified: blocking.is_empty(),
         profile,
         blocking,
         waived,
+        snapshot_coverage,
+        no_reference,
     }
+}
+
+/// Compute the NON-BLOCKING committed-snapshot coverage (T073): for every declarative
+/// `snapshot`-oracle case, the `os-arch` platforms with a committed snapshot under
+/// `snapshots_dir` (`<os-arch>/<case-id>/`). Cases with a snapshot go into
+/// `SnapshotCoverage`; cases with none go into the `no_reference` list. A missing
+/// snapshots directory yields empty coverage and every snapshot-oracle case as
+/// no-reference (all deterministically ID/key-sorted).
+fn snapshot_coverage(
+    registry: &Registry,
+    snapshots_dir: &Path,
+) -> (Vec<SnapshotCoverage>, Vec<String>) {
+    let mut snapshot_cases: Vec<&str> = registry
+        .cases
+        .iter()
+        .filter(|c| matches!(c.classify(), Ok(CaseKind::Declarative)))
+        .filter(|c| c.oracle_type == Some(OracleType::Snapshot))
+        .map(|c| c.id.as_str())
+        .collect();
+    snapshot_cases.sort_unstable();
+
+    let mut coverage = Vec::new();
+    let mut no_reference = Vec::new();
+    for case_id in snapshot_cases {
+        let mut platforms = platforms_with_snapshot(snapshots_dir, case_id);
+        platforms.sort();
+        if platforms.is_empty() {
+            no_reference.push(case_id.to_string());
+        } else {
+            coverage.push(SnapshotCoverage {
+                case_id: case_id.to_string(),
+                platforms,
+            });
+        }
+    }
+    (coverage, no_reference)
+}
+
+/// The `os-arch` keys under `snapshots_dir/<os-arch>/<case-id>/` that hold a committed
+/// snapshot for `case_id`.
+fn platforms_with_snapshot(snapshots_dir: &Path, case_id: &str) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(snapshots_dir) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for os_arch in entries.flatten() {
+        if os_arch.path().join(case_id).is_dir() {
+            out.push(os_arch.file_name().to_string_lossy().into_owned());
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -189,12 +271,18 @@ mod tests {
         }
     }
 
+    /// A snapshots dir pointing at an absent path (these fixtures ship no snapshots); the
+    /// real-registry snapshot coverage is exercised by `gap_certification.rs`.
+    fn no_snapshots() -> &'static Path {
+        Path::new("/nonexistent-conformance/snapshots")
+    }
+
     #[test]
     fn valid_fixture_with_a_gap_is_not_certified() {
         // The valid fixture carries `gap-readconfig-remote-user`, so it is structurally
         // valid yet NOT certified — a gap always blocks (FR-020, FR-025).
         let registry = valid_registry();
-        let result = certify(&registry, &no_inventory(), &no_clauses());
+        let result = certify(&registry, &no_inventory(), &no_clauses(), no_snapshots());
         assert!(!result.certified, "a registry with a gap must not certify");
         assert!(
             result
@@ -217,9 +305,42 @@ mod tests {
     fn empty_registry_certifies_cleanly() {
         // Nothing in-profile, no gaps → certified (mirrors the real seed registry).
         let registry = Registry::default();
-        let result = certify(&registry, &no_inventory(), &no_clauses());
+        let result = certify(&registry, &no_inventory(), &no_clauses(), no_snapshots());
         assert!(result.certified, "empty registry must certify");
         assert!(result.blocking.is_empty());
         assert!(result.waived.is_empty());
+    }
+
+    #[test]
+    fn snapshot_coverage_is_info_only_and_never_blocks() {
+        use crate::model::{OracleType, TestCase};
+        // A snapshot-oracle case with a committed snapshot on one platform, and one with
+        // none. Neither affects `certified` (T073, FR-042).
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("linux-x86_64/case-has-snap")).unwrap();
+
+        let mut registry = Registry::default();
+        for id in ["case-has-snap", "case-no-snap"] {
+            registry.cases.push(TestCase {
+                id: id.to_string(),
+                oracle_type: Some(OracleType::Snapshot),
+                operations: vec![crate::model::Operation {
+                    id: "op".to_string(),
+                    subcommand: "read-configuration".to_string(),
+                    ..Default::default()
+                }],
+                ..TestCase::default()
+            });
+        }
+
+        let result = certify(&registry, &no_inventory(), &no_clauses(), dir.path());
+        assert!(
+            result.certified,
+            "snapshot coverage must NOT block certification"
+        );
+        assert_eq!(result.snapshot_coverage.len(), 1);
+        assert_eq!(result.snapshot_coverage[0].case_id, "case-has-snap");
+        assert_eq!(result.snapshot_coverage[0].platforms, vec!["linux-x86_64"]);
+        assert_eq!(result.no_reference, vec!["case-no-snap".to_string()]);
     }
 }

--- a/crates/conformance/src/coverage.rs
+++ b/crates/conformance/src/coverage.rs
@@ -316,16 +316,17 @@ mod tests {
             id: id.to_string(),
             behaviors: behaviors.iter().map(|b| b.to_string()).collect(),
             context: vec![],
-            executable: Executable {
+            executable: Some(Executable {
                 binary: "some_binary".to_string(),
                 test: None,
                 corpus: None,
                 case: None,
-            },
+            }),
             outcomes: vec![ExpectedOutcome {
                 channel: "chan-exit-code".to_string(),
                 expectation: "exits 0".to_string(),
             }],
+            ..TestCase::default()
         }
     }
 

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [`diff`] — deterministic revision diff between two constraint inventories
 //!   (US3, T030–T031).
 
+pub mod case_hash;
 pub mod certify;
 pub mod clause;
 pub mod clause_diff;
@@ -28,6 +29,7 @@ pub mod model;
 pub mod prose;
 pub mod report;
 pub mod schema;
+pub mod snapshot;
 pub mod validate;
 
 /// Absolute path to the workspace root, derived from this crate's

--- a/crates/conformance/src/load.rs
+++ b/crates/conformance/src/load.rs
@@ -263,10 +263,84 @@ impl Registry {
             ),
         };
 
+        // 022-conformance-runner (T007, FR-003): every case record MUST be exactly one
+        // of legacy (binary-backed) or declarative (data-driven). A mixed/neither record
+        // is a structural malformation — reject it fail-loud at load, as a located
+        // schema error naming the offending case id, so it never reaches validation as a
+        // half-interpreted record. (Semantic well-formedness of a correctly-shaped
+        // declarative case is a V-series validation concern; see `validate.rs`.)
+        check_case_shapes(&root.join("cases.json"), &registry.cases, &mut errors);
+        // 022-conformance-runner (T062, FR-032/035): each allowed-difference must be
+        // exactly-one-of waiverId/divergenceId, target a dotted path within a channel
+        // (never a bare-channel/global-ignore), and be unique per (behavior, path) within
+        // its case — all fail-loud at load.
+        check_allowed_differences(&root.join("cases.json"), &registry.cases, &mut errors);
+
         if errors.is_empty() {
             Ok(registry)
         } else {
             Err(LoadError::Schema(errors))
+        }
+    }
+}
+
+/// Push a located [`SchemaError`] for every case record that is neither cleanly legacy
+/// nor cleanly declarative (both shapes present, or neither). The `location` names the
+/// offending case id (or its index when the id is empty) so the diagnosis is precise
+/// (022-conformance-runner, FR-003).
+fn check_case_shapes(cases_file: &Path, cases: &[TestCase], errors: &mut Vec<SchemaError>) {
+    for (idx, case) in cases.iter().enumerate() {
+        if let Err(shape) = case.classify() {
+            let location = if case.id.is_empty() {
+                format!("records[{idx}]")
+            } else {
+                format!("records[{idx}] ({})", case.id)
+            };
+            errors.push(SchemaError {
+                file: cases_file.to_path_buf(),
+                location: Some(location),
+                message: shape.message().to_string(),
+            });
+        }
+    }
+}
+
+/// Push a located [`SchemaError`] for every malformed allowed-difference: both/neither
+/// of `waiverId`/`divergenceId`, a bare-channel/global-ignore `observablePath`, or a
+/// duplicate `(behavior, observablePath)` within the same case (a conflicting duplicate).
+/// These are structural, per-case defects rejected fail-loud at load (FR-032/035).
+fn check_allowed_differences(cases_file: &Path, cases: &[TestCase], errors: &mut Vec<SchemaError>) {
+    for (idx, case) in cases.iter().enumerate() {
+        let mut seen: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        for (adx, ad) in case.allowed_differences.iter().enumerate() {
+            let where_at = format!("records[{idx}] ({}).allowedDifferences[{adx}]", case.id);
+            let mut push = |message: String| {
+                errors.push(SchemaError {
+                    file: cases_file.to_path_buf(),
+                    location: Some(where_at.clone()),
+                    message,
+                });
+            };
+            if let Err(id_err) = ad.resolved_id() {
+                push(id_err.message().to_string());
+            }
+            if ad.is_global_ignore() {
+                push(format!(
+                    "observablePath {:?} is a bare channel / global-ignore construct; scope it to \
+                     a dotted path within a channel (e.g. `chan-x.field.sub`), never a whole \
+                     channel (FR-032)",
+                    ad.observable_path
+                ));
+            }
+            let key = (ad.behavior.clone(), ad.observable_path.clone());
+            if !seen.insert(key) {
+                push(format!(
+                    "duplicate allowed difference for (behavior {:?}, observablePath {:?}); a \
+                     conflicting duplicate is rejected (FR-035)",
+                    ad.behavior, ad.observable_path
+                ));
+            }
         }
     }
 }

--- a/crates/conformance/src/model.rs
+++ b/crates/conformance/src/model.rs
@@ -364,8 +364,16 @@ pub struct ExpectedOutcome {
     pub expectation: String,
 }
 
-/// An executable-test reference record (`case-`) — `cases.json`.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// A conformance case record (`case-`) — `cases.json`.
+///
+/// A record is either **legacy** (binary-backed, with [`executable`](Self::executable)
+/// and [`outcomes`](Self::outcomes), pointing at a hand-written Rust test) or
+/// **declarative** (data-driven, with [`operations`](Self::operations), `oracleType`,
+/// and `expected`, run by the shared conformance runner). Never both, never neither;
+/// see [`TestCase::classify`] (research D2, 022-conformance-runner). The legacy and
+/// declarative field blocks below are mutually exclusive, and both the loader
+/// (`load.rs`) and the validator (`validate.rs`) enforce that fail-loud (FR-003).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TestCase {
     pub id: String,
@@ -375,10 +383,384 @@ pub struct TestCase {
     /// Declared context; must intersect every linked behavior's applicability (V10).
     #[serde(default)]
     pub context: Vec<Condition>,
-    pub executable: Executable,
-    /// Expected outcomes; ≥1 required.
-    #[serde(default)]
+
+    // ---- Legacy (binary-backed) fields — present iff this is a legacy case ----
+    /// The Rust test binary that exercises this case (legacy path only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executable: Option<Executable>,
+    /// Expected outcomes on observable channels; ≥1 required for a legacy case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub outcomes: Vec<ExpectedOutcome>,
+
+    // ---- Declarative fields (022-conformance-runner) — present iff declarative ----
+    /// The ordered actions the runner performs (declarative path only); ≥1 required.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub operations: Vec<Operation>,
+    /// Which oracle this case is evaluated against (declarative path only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oracle_type: Option<OracleType>,
+    /// Per-channel expectations captured after running the operations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub expected: Vec<ExpectedObservable>,
+    /// Scoped tolerances for characterized divergences ([`AllowedDifference`], US4).
+    /// Excluded from `caseHash` (research D3) so annotating a tolerance never re-records.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowed_differences: Vec<AllowedDifference>,
+    /// Path/glob allowlist for the filesystem channel; required iff a filesystem-channel
+    /// expectation exists (keeps capture scoped, clarify Q1).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fs_allowlist: Vec<String>,
+    /// Resources to reclaim after the run (success or failure).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup: Option<Cleanup>,
+    /// The nextest resource group for a Docker-backed case (default `none`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_group: Option<ResourceGroup>,
+    /// Human prose; **excluded from `caseHash`** so annotating never re-records (D3).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+/// The shape of a [`TestCase`] record: legacy (binary-backed) or declarative
+/// (data-driven), per research D2 (022-conformance-runner).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaseKind {
+    /// Binary-backed: `executable` present, no `operations`.
+    Legacy,
+    /// Data-driven: `operations` present, no `executable`.
+    Declarative,
+}
+
+/// Why a [`TestCase`] record is malformed with respect to the legacy/declarative
+/// either-or (FR-003). Rendered by [`CaseShapeError::message`] for located loader and
+/// validator diagnostics (constitution IV — fail-loud).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CaseShapeError {
+    /// Both `executable` (legacy) and `operations` (declarative) are present.
+    Mixed,
+    /// Neither `executable` nor `operations` is present.
+    Neither,
+}
+
+impl CaseShapeError {
+    /// A precise, human-readable diagnosis naming the mistake and the remedy.
+    pub fn message(self) -> &'static str {
+        match self {
+            CaseShapeError::Mixed => {
+                "case declares BOTH a legacy `executable` and declarative `operations`; a \
+                 record must be exactly one shape (remove one)"
+            }
+            CaseShapeError::Neither => {
+                "case declares NEITHER a legacy `executable` nor declarative `operations`; a \
+                 record must be exactly one shape (add one)"
+            }
+        }
+    }
+}
+
+impl TestCase {
+    /// Classify this case as [`CaseKind::Legacy`] or [`CaseKind::Declarative`], or a
+    /// [`CaseShapeError`] if it is a mixed/neither malformed record (research D2,
+    /// FR-003). Legacy ⇔ has `executable`; declarative ⇔ has `operations`.
+    pub fn classify(&self) -> Result<CaseKind, CaseShapeError> {
+        match (self.executable.is_some(), !self.operations.is_empty()) {
+            (true, true) => Err(CaseShapeError::Mixed),
+            (false, false) => Err(CaseShapeError::Neither),
+            (true, false) => Ok(CaseKind::Legacy),
+            (false, true) => Ok(CaseKind::Declarative),
+        }
+    }
+}
+
+/// The consumer subcommand surface an [`Operation`] may invoke (Principle II).
+///
+/// A closed vocabulary, kept as a named constant so a Principle-II audit can grep it
+/// and the validator (`validate.rs`) can emit a located, human-readable message for a
+/// non-consumer subcommand rather than a cryptic enum-variant error (contract
+/// case-schema.md: "each `operations[].subcommand` ∈ consumer surface | new V-series").
+pub const CONSUMER_SUBCOMMANDS: &[&str] = &[
+    "up",
+    "down",
+    "exec",
+    "build",
+    "read-configuration",
+    "run-user-commands",
+    "templates-apply",
+    "doctor",
+];
+
+/// The observable-channel ids whose expectations require an `fsAllowlist` (data-model
+/// §1 / contract observer-channel.md). Filesystem capture is allowlist-scoped, never a
+/// full-tree diff (clarify Q1).
+pub const FILESYSTEM_CHANNELS: &[&str] = &[CHAN_FILESYSTEM, CHAN_FILE_CONTENT];
+
+// -- Channel id constants (data-model §4) -----------------------------------------
+// Stable ids matching `conformance/registry/channels.json`. The first six are the
+// pre-existing channels; the last five are added by 022-conformance-runner (T002).
+/// Process exit status.
+pub const CHAN_EXIT_CODE: &str = "chan-exit-code";
+/// Raw stdout bytes.
+pub const CHAN_STDOUT: &str = "chan-stdout";
+/// Raw stderr bytes.
+pub const CHAN_STDERR: &str = "chan-stderr";
+/// Presence/attributes of allowlisted paths (NOT full tree).
+pub const CHAN_FILESYSTEM: &str = "chan-filesystem";
+/// Contents of an allowlisted file.
+pub const CHAN_FILE_CONTENT: &str = "chan-file-content";
+/// Container lifecycle state (retained for legacy cases).
+pub const CHAN_CONTAINER_STATE: &str = "chan-container-state";
+/// Parsed structured (JSON) result document, distinct from raw stdout.
+pub const CHAN_STRUCTURED_OUTPUT: &str = "chan-structured-output";
+/// Built-image configuration + metadata (labels parsed semantically).
+pub const CHAN_IMAGE: &str = "chan-image";
+/// Container + network + volume + mount graph.
+pub const CHAN_PROCESS_GRAPH: &str = "chan-process-graph";
+/// Env, user, cwd, PATH resolution, signals, TTY, exit propagation.
+pub const CHAN_INJECTED_PROCESS: &str = "chan-injected-process";
+/// Lifecycle ordering, first-create vs restart, resume, cleanup transitions.
+pub const CHAN_TEMPORAL: &str = "chan-temporal";
+
+/// Which oracle a declarative [`TestCase`] is evaluated against (data-model §1,
+/// research D8). The four are semantically distinct verdicts; re-pointing a case at a
+/// different target changes only this field (FR-007).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OracleType {
+    /// Compare normalized observables to the declared `expected`; no reference run.
+    SpecExpectation,
+    /// Compare to a committed, provenance-checked snapshot.
+    Snapshot,
+    /// Run deacon + the pinned reference and compare normalized observables.
+    LiveDifferential,
+    /// Evaluate a declared relationship across ≥2 operations (idempotence,
+    /// first-create-vs-restart, resume) rather than a fixed output.
+    InvariantMetamorphic,
+}
+
+/// A single action the runner performs, ordered within a [`TestCase`] (data-model §2).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Operation {
+    /// Unique within the case (referenced by a metamorphic [`Relationship`]).
+    pub id: String,
+    /// Consumer subcommand to invoke; validated against [`CONSUMER_SUBCOMMANDS`].
+    pub subcommand: String,
+    /// Arguments after the subcommand; part of `caseHash`.
+    #[serde(default)]
+    pub argv: Vec<String>,
+    /// Fixture ids this op materializes into the workspace.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fixtures: Vec<String>,
+    /// Optional stdin payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdin: Option<String>,
+    /// For negative cases: the failure phase the op is expected to fail in.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expect_failure_phase: Option<FailurePhase>,
+    /// Invariant/metamorphic only: the relationship this op asserts against a sibling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relationship: Option<Relationship>,
+}
+
+/// A metamorphic/invariant relationship asserted across operations (data-model §2).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Relationship {
+    /// The kind of relationship being asserted.
+    pub kind: RelationshipKind,
+    /// The sibling operation id this relationship is evaluated against.
+    pub against_op: String,
+}
+
+/// The closed set of metamorphic relationship kinds (data-model §2, FR-008).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RelationshipKind {
+    /// Re-running the operation produces the same observable state.
+    Idempotence,
+    /// First create differs from a subsequent restart in the declared way.
+    FirstCreateVsRestart,
+    /// A resumed run reattaches to existing state rather than recreating it.
+    Resume,
+}
+
+/// A fixture the runner materializes into the workspace (data-model §3). Inputs are
+/// pinned (images by digest/tag, never `latest`); `fixtureHash` is derived from the
+/// fixture bytes and feeds `caseHash` + provenance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Fixture {
+    /// Referenced by [`Operation::fixtures`].
+    pub id: String,
+    /// Repo-relative source path (pinned input).
+    pub path: String,
+    /// SHA-256 of the fixture bytes; derived, so optional on the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixture_hash: Option<String>,
+}
+
+/// A per-channel expectation on a declarative [`TestCase`] (data-model §5).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExpectedObservable {
+    /// A declared channel (`chan-…`); checked against `channels.json` (V9).
+    pub channel: String,
+    /// Which operation produced it (default: the last operation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+    /// Channel-specific expectation shape (contract observer-channel.md). Required for
+    /// `spec-expectation`; MAY be omitted for `live-differential`/`snapshot` (the
+    /// reference/snapshot supplies the expectation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assertion: Option<Value>,
+}
+
+/// Resources the runner reclaims after a case runs, on success AND failure (data-model
+/// §1, contract case-schema.md). `images` is `false` | `true` | `"case-built"`; typed
+/// precisely in US5 (T052), stored as raw JSON here.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Cleanup {
+    #[serde(default)]
+    pub containers: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub images: Option<Value>,
+    #[serde(default)]
+    pub networks: bool,
+    #[serde(default)]
+    pub volumes: bool,
+    #[serde(default)]
+    pub tempdir: bool,
+}
+
+/// The nextest resource group for a Docker-backed case (data-model §1). Absence means
+/// the default `none` (a hermetic case needs no Docker group).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResourceGroup {
+    /// Safe concurrent Docker usage (unique resource names).
+    DockerShared,
+    /// Exclusive Docker daemon access (shared state).
+    DockerExclusive,
+    /// Significant filesystem operations, no Docker.
+    FsHeavy,
+    /// No special group.
+    None,
+}
+
+/// A scoped tolerance for a characterized divergence (data-model §6, research D9, US4).
+///
+/// A tolerated divergence is scoped to `(behavior, observablePath, context)` and backed
+/// by a resolvable registry identity — exactly one of `waiverId`
+/// (`conformance/registry/waivers/wvr-*`) or `divergenceId` (a `bhv-`/`ext-` intentional
+/// divergence record). It applies ONLY to its `(behavior, observablePath)` (FR-033);
+/// there are NO global ignore lists (FR-032). Excluded from `caseHash` (research D3).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AllowedDifference {
+    /// A `bhv-…` linked by the case; the tolerance is scoped to this behavior.
+    pub behavior: String,
+    /// Context tags the tolerance applies under (documents where it is valid).
+    #[serde(default)]
+    pub context: Vec<String>,
+    /// A dotted path WITHIN a channel (e.g. `chan-injected-process.env.TZ`), never a
+    /// bare channel (that would be a global ignore, FR-032).
+    pub observable_path: String,
+    /// Why this difference is acceptable.
+    pub rationale: String,
+    /// Backing registry waiver id (`wvr-…`); exactly one of `waiverId`/`divergenceId`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiver_id: Option<String>,
+    /// Backing intentional-divergence record id (`bhv-…`/`ext-…`); exactly one of
+    /// `waiverId`/`divergenceId`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub divergence_id: Option<String>,
+}
+
+/// Why an [`AllowedDifference`]'s backing identity is malformed (exactly-one-of
+/// `waiverId`/`divergenceId`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllowedDifferenceIdError {
+    /// Both `waiverId` and `divergenceId` are present.
+    Both,
+    /// Neither is present.
+    Neither,
+}
+
+impl AllowedDifferenceIdError {
+    /// A precise, human-readable diagnosis (constitution IV — fail-loud).
+    pub fn message(self) -> &'static str {
+        match self {
+            AllowedDifferenceIdError::Both => {
+                "allowed difference declares BOTH `waiverId` and `divergenceId`; exactly one \
+                 backing identity is required"
+            }
+            AllowedDifferenceIdError::Neither => {
+                "allowed difference declares NEITHER `waiverId` nor `divergenceId`; a backing \
+                 waiver/divergence identity is required (no unbacked tolerances)"
+            }
+        }
+    }
+}
+
+impl AllowedDifference {
+    /// The single backing identity (waiver or divergence id), or an
+    /// [`AllowedDifferenceIdError`] when both/neither is present.
+    pub fn resolved_id(&self) -> Result<&str, AllowedDifferenceIdError> {
+        match (&self.waiver_id, &self.divergence_id) {
+            (Some(_), Some(_)) => Err(AllowedDifferenceIdError::Both),
+            (None, None) => Err(AllowedDifferenceIdError::Neither),
+            (Some(w), None) => Ok(w),
+            (None, Some(d)) => Ok(d),
+        }
+    }
+
+    /// Whether the `observablePath` is a BARE channel (a `chan-…` id with no dotted
+    /// sub-path) or an empty/`*` wildcard — a global-ignore construct rejected by FR-032.
+    /// A well-formed path is `chan-<name>.<sub.path>` (at least one dotted segment after
+    /// the channel id).
+    pub fn is_global_ignore(&self) -> bool {
+        let p = self.observable_path.trim();
+        if p.is_empty() || p == "*" {
+            return true;
+        }
+        // Must start with a channel id and have a dotted sub-path after it.
+        match p.split_once('.') {
+            Some((chan, rest)) => !chan.starts_with("chan-") || rest.trim().is_empty(),
+            None => true, // no dot → bare channel (or a bare token)
+        }
+    }
+}
+
+/// The closed set of failure phases (data-model §8, clarify Q5). Reuses deacon's
+/// lifecycle/execution vocabulary — never an open string. Ordered as the run
+/// progresses: config-resolution → build → container-create → lifecycle:* → exec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FailurePhase {
+    /// Resolving/merging the devcontainer configuration.
+    ConfigResolution,
+    /// Building the image.
+    Build,
+    /// Creating the container.
+    ContainerCreate,
+    /// `onCreateCommand`.
+    #[serde(rename = "lifecycle:onCreate")]
+    LifecycleOnCreate,
+    /// `updateContentCommand`.
+    #[serde(rename = "lifecycle:updateContent")]
+    LifecycleUpdateContent,
+    /// `postCreateCommand`.
+    #[serde(rename = "lifecycle:postCreate")]
+    LifecyclePostCreate,
+    /// `postStartCommand`.
+    #[serde(rename = "lifecycle:postStart")]
+    LifecyclePostStart,
+    /// `postAttachCommand`.
+    #[serde(rename = "lifecycle:postAttach")]
+    LifecyclePostAttach,
+    /// Executing a command in the container.
+    Exec,
 }
 
 /// A known gap (`gap-`) — `gaps.json`. Gaps satisfy structural coverage (V5) but

--- a/crates/conformance/src/report.rs
+++ b/crates/conformance/src/report.rs
@@ -66,6 +66,61 @@ pub struct ReportJson {
     /// unclassified + ambiguous-pending review queues. Present-but-zeroed when the
     /// registry ships no sibling clause inventory.
     pub clauses: ClauseSection,
+    /// Per-channel normalized-evidence coverage from declarative cases
+    /// (022-conformance-runner US3, T048): for every declared observable channel, how
+    /// many declarative cases exercise it and how many expectations carry an assertion
+    /// (spec-expectation coverage). One entry per declared channel, channel-id-sorted, so
+    /// the shape is stable (all channels present, zero when unused).
+    pub channel_coverage: Vec<ChannelCoverageEntry>,
+}
+
+/// One channel's declarative-case coverage row (022-conformance-runner, T048).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelCoverageEntry {
+    /// The `chan-…` id (declared in `channels.json`).
+    pub channel: String,
+    /// Number of declarative cases that declare an `expected` observable on this channel.
+    pub declarative_cases: usize,
+    /// Number of those expectations that carry an `assertion` (spec-expectation
+    /// normalized-evidence coverage; live-differential/snapshot expectations may omit it).
+    pub asserted_expectations: usize,
+}
+
+/// Build the per-channel declarative-evidence coverage (T048): one row per declared
+/// channel, channel-id-sorted, counting declarative cases that exercise it and the
+/// expectations carrying an assertion. Deterministic (all declared channels present).
+fn build_channel_coverage(registry: &Registry) -> Vec<ChannelCoverageEntry> {
+    let mut channels: Vec<&str> = registry.channels.iter().map(|c| c.id.as_str()).collect();
+    channels.sort_unstable();
+    channels
+        .into_iter()
+        .map(|channel| {
+            let mut declarative_cases = 0usize;
+            let mut asserted_expectations = 0usize;
+            for case in &registry.cases {
+                if !matches!(case.classify(), Ok(crate::model::CaseKind::Declarative)) {
+                    continue;
+                }
+                let on_channel: Vec<_> = case
+                    .expected
+                    .iter()
+                    .filter(|e| e.channel == channel)
+                    .collect();
+                if on_channel.is_empty() {
+                    continue;
+                }
+                declarative_cases += 1;
+                asserted_expectations +=
+                    on_channel.iter().filter(|e| e.assertion.is_some()).count();
+            }
+            ChannelCoverageEntry {
+                channel: channel.to_string(),
+                declarative_cases,
+                asserted_expectations,
+            }
+        })
+        .collect()
 }
 
 /// The normative-clause-inventory section of `report.json`
@@ -426,6 +481,7 @@ fn build_report_from_coverage(
         unclassified_source_units,
         inventory: inventory_section,
         clauses: clause_section,
+        channel_coverage: build_channel_coverage(registry),
     }
 }
 
@@ -803,7 +859,34 @@ fn render_md(report: &ReportJson) -> String {
     // 9. Normative clause inventory — committed clauses joined against classifications.
     render_clause_md(&mut md, &report.clauses);
 
+    // 10. Declarative channel coverage — normalized-evidence coverage per channel.
+    render_channel_coverage_md(&mut md, &report.channel_coverage);
+
     md
+}
+
+/// Render the per-channel declarative-evidence coverage section of `report.md`
+/// (022-conformance-runner, T048). Deterministic (channel-id-sorted); "none" when no
+/// declarative case exercises any channel yet.
+fn render_channel_coverage_md(md: &mut String, coverage: &[ChannelCoverageEntry]) {
+    md.push_str("\n## Declarative channel coverage\n\n");
+    let exercised: Vec<&ChannelCoverageEntry> = coverage
+        .iter()
+        .filter(|c| c.declarative_cases > 0)
+        .collect();
+    if exercised.is_empty() {
+        md.push_str("No declarative case exercises any channel yet.\n");
+        return;
+    }
+    md.push_str("| Channel | Declarative cases | Asserted expectations |\n");
+    md.push_str("|---------|-------------------|-----------------------|\n");
+    for entry in exercised {
+        let _ = writeln!(
+            md,
+            "| `{}` | {} | {} |",
+            entry.channel, entry.declarative_cases, entry.asserted_expectations
+        );
+    }
 }
 
 /// Render the normative-clause-inventory section of `report.md`

--- a/crates/conformance/src/snapshot.rs
+++ b/crates/conformance/src/snapshot.rs
@@ -1,0 +1,500 @@
+//! Committed, provenance-tracked snapshots + staleness comparison (data-model §7,
+//! contract snapshot-provenance.md, 022-conformance-runner, US2).
+//!
+//! Snapshots live under `conformance/snapshots/<os>-<arch>/<case-id>/` as three files —
+//! `provenance.json` (the FR-017 identity/environment elements), `raw.json` (verbatim
+//! per-channel evidence), and `normalized.json` (rule-normalized evidence, kept separate
+//! per FR-016). The **pure** staleness comparison ([`compare_staleness`]) is hermetic and
+//! lives here; the live re-record path is `parity-harness`'s `conformance-snapshot` bin
+//! (research D5). `platform`/`arch` are SELECTORS (they pick a snapshot), never staleness
+//! signals; a missing snapshot for the current `os-arch` is a distinct
+//! `no-reference-for-platform` outcome (FR-016a).
+
+use std::path::{Path, PathBuf};
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The single source of truth for the normalizer version, recorded in snapshot
+/// provenance and participating in staleness (FR-030). `parity-harness`'s
+/// `normalize::NORMALIZER_VERSION` re-exports THIS constant so the two never drift
+/// (`parity-harness` depends on `deacon-conformance`, not the reverse). Bumped in
+/// lockstep with any named-normalization-rule change (US3 set it to `"2"`).
+pub const NORMALIZER_VERSION: &str = "2";
+
+/// The `provenance.json` record — the FR-017 identity/environment elements (data-model
+/// §7, contract snapshot-provenance.md). Thirteen fields: twelve identity/environment
+/// elements plus the informational `capturedAt`. The captured observables (the
+/// thirteenth FR-017 element) live in the sibling `raw.json`/`normalized.json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Provenance {
+    /// Pinned `@devcontainers/cli` version (verified via `oracle.rs` at record time).
+    pub oracle_version: String,
+    /// Pinned spec/source revision (e.g. `113500f4`).
+    pub source_revision: String,
+    /// The case hash over behavior-affecting inputs (`case_hash`).
+    pub case_hash: String,
+    /// The combined fixture hash.
+    pub fixture_hash: String,
+    /// The complete argv actually executed, with temp paths tokenized (`<WORKSPACE>`).
+    pub argv: Vec<String>,
+    /// OS selector (e.g. `linux`, `macos`). NOT a staleness field.
+    pub platform: String,
+    /// Architecture selector (e.g. `x86_64`, `aarch64`). NOT a staleness field.
+    pub arch: String,
+    /// Node version the oracle ran under (informational; NOT a staleness field — see
+    /// [`Provenance::staleness_fields`]).
+    pub node_version: String,
+    /// Docker engine version (informational; NOT a staleness field).
+    pub docker_version: String,
+    /// Compose version (informational; NOT a staleness field).
+    pub compose_version: String,
+    /// image ref → digest for every pinned image the operations used.
+    pub image_digests: IndexMap<String, String>,
+    /// The `NORMALIZER_VERSION` the evidence was normalized under.
+    pub normalizer_version: String,
+    /// Provenance timestamp — informational; NOT one of the FR-017 thirteen and NOT a
+    /// staleness field (contract snapshot-provenance.md).
+    pub captured_at: String,
+}
+
+impl Provenance {
+    /// The staleness fields, in comparison order, as `(name, recorded)` pairs — the ONLY
+    /// fields [`compare_staleness`] compares. These are the *inputs* that determine the
+    /// recorded evidence: the case/fixture hashes, the reference (`oracleVersion`) and spec
+    /// (`sourceRevision`) pins, the pinned `imageDigests`, and the `normalizerVersion`.
+    ///
+    /// `nodeVersion`/`dockerVersion`/`composeVersion` are recorded in provenance for
+    /// reproducibility but are DELIBERATELY NOT staleness signals. The reference CLI's
+    /// output is independent of the host Node runtime, and any Docker/Compose-version
+    /// effect on recorded evidence surfaces as a real evidence *divergence* on replay — not
+    /// a false stale. Gating staleness on host tool versions would make every committed
+    /// snapshot stale on every machine but the recorder's, defeating cross-machine CI
+    /// replay (SC-003) — e.g. a snapshot recorded under Node 22 would falsely fail the
+    /// parity lane's Node 20. Like `argv`/`platform`/`arch`/`capturedAt`, they are
+    /// informational selectors, not staleness signals.
+    fn staleness_fields(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("caseHash", self.case_hash.clone()),
+            ("fixtureHash", self.fixture_hash.clone()),
+            ("oracleVersion", self.oracle_version.clone()),
+            ("sourceRevision", self.source_revision.clone()),
+            ("imageDigests", canonical_digests(&self.image_digests)),
+            ("normalizerVersion", self.normalizer_version.clone()),
+        ]
+    }
+}
+
+/// A deterministic string form of the image-digest map for staleness comparison
+/// (key-sorted so ordering never falsely triggers staleness).
+fn canonical_digests(digests: &IndexMap<String, String>) -> String {
+    let mut pairs: Vec<(&String, &String)> = digests.iter().collect();
+    pairs.sort_by(|a, b| a.0.cmp(b.0));
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// The result of a staleness comparison (FR-020).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Staleness {
+    /// Every staleness field matches — the snapshot is fresh.
+    Fresh,
+    /// A staleness field drifted; `field` names the FIRST mismatch (recorded vs current).
+    Stale {
+        /// The camelCase name of the first drifted field.
+        field: String,
+        /// The recorded value.
+        recorded: String,
+        /// The current (recomputed/probed) value.
+        current: String,
+    },
+}
+
+/// Pure staleness comparison (FR-020, D5): compare `recorded` provenance to a `current`
+/// provenance (recomputed input-derived fields), returning [`Staleness::Fresh`] or the
+/// FIRST drifted field. Only the input-derived staleness fields are compared (see
+/// [`Provenance::staleness_fields`]) — `argv`/`platform`/`arch`/`capturedAt` and the host
+/// tool versions (`nodeVersion`/`dockerVersion`/`composeVersion`) never trigger staleness.
+/// Total and hermetic.
+pub fn compare_staleness(recorded: &Provenance, current: &Provenance) -> Staleness {
+    let recorded_fields = recorded.staleness_fields();
+    let current_fields = current.staleness_fields();
+    for ((name, rec), (_, cur)) in recorded_fields.into_iter().zip(current_fields) {
+        if rec != cur {
+            return Staleness::Stale {
+                field: name.to_string(),
+                recorded: rec,
+                current: cur,
+            };
+        }
+    }
+    Staleness::Fresh
+}
+
+/// A committed snapshot: provenance + the raw and normalized evidence (kept SEPARATE,
+/// FR-016). `raw`/`normalized` are opaque JSON arrays here (the conformance crate does
+/// not interpret channel-evidence semantics — that is `parity-harness`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Snapshot {
+    /// The 13-field provenance.
+    pub provenance: Provenance,
+    /// The verbatim per-channel evidence (`raw.json`).
+    pub raw: Value,
+    /// The rule-normalized per-channel evidence (`normalized.json`).
+    pub normalized: Value,
+}
+
+/// An error loading a committed snapshot (fail-loud, constitution IV).
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    /// A snapshot file was unreadable.
+    #[error("could not read snapshot file {path:?}: {cause}")]
+    Read { path: PathBuf, cause: String },
+    /// A snapshot file was malformed JSON / schema-invalid.
+    #[error("malformed snapshot file {path:?}: {cause}")]
+    Malformed { path: PathBuf, cause: String },
+}
+
+/// The outcome of resolving a snapshot for a case + platform (FR-016a).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Resolution {
+    /// A snapshot exists for this `os-arch` and loaded. Boxed — the [`Snapshot`] payload
+    /// is far larger than the sibling variant.
+    Found(Box<Snapshot>),
+    /// No snapshot directory exists for the current `os-arch` — a coverage gap, distinct
+    /// from stale and from a silent skip.
+    NoReferenceForPlatform {
+        /// The `os-arch` selector that had no committed snapshot.
+        os_arch: String,
+    },
+}
+
+/// The current platform selector, `"<os>-<arch>"` (e.g. `linux-x86_64`), from the build
+/// target. Both the record key and the recorded `platform`/`arch` derive from this.
+pub fn current_os_arch() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+/// The default committed-snapshots root: `<workspace>/conformance/snapshots`.
+pub fn default_snapshots_dir() -> PathBuf {
+    crate::workspace_root()
+        .join("conformance")
+        .join("snapshots")
+}
+
+/// The probed host environment versions used to build a `current` provenance for
+/// staleness (and recorded verbatim at refresh). Each is `None` when its tool is absent
+/// — the caller must NOT invent a value (constitution IV: no fabricated provenance).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EnvProbe {
+    /// `node --version`, `v`-stripped (e.g. `22.23.1`).
+    pub node_version: Option<String>,
+    /// `docker version` server version (e.g. `29.6.2`).
+    pub docker_version: Option<String>,
+    /// `docker compose version --short` (e.g. `2.40.3`).
+    pub compose_version: Option<String>,
+}
+
+/// Probe the host for Node / Docker / Compose versions via subprocesses. Best-effort:
+/// an absent or failing tool yields `None` for that field (never a fabricated value).
+/// The SINGLE probe implementation, shared by `snapshot check` (comparison) and the
+/// reviewed refresh (recording) so the two record/compare identical formats.
+pub fn probe_environment() -> EnvProbe {
+    EnvProbe {
+        node_version: run_version(&["node", "--version"])
+            .map(|s| s.strip_prefix('v').unwrap_or(&s).to_string()),
+        docker_version: run_version(&["docker", "version", "--format", "{{.Server.Version}}"]),
+        compose_version: run_version(&["docker", "compose", "version", "--short"]),
+    }
+}
+
+/// Run `argv` and return the trimmed first non-empty stdout line, or `None` on any
+/// failure (missing binary, non-zero exit, empty output).
+fn run_version(argv: &[&str]) -> Option<String> {
+    let (program, args) = argv.split_first()?;
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// The currently pinned oracle version, read from `fixtures/parity-corpus/oracle.json`
+/// (the source of truth for the `oracleVersion` staleness field). `None` if the pin file
+/// is absent/malformed.
+pub fn current_oracle_version_pin() -> Option<String> {
+    let path = crate::workspace_root()
+        .join("fixtures")
+        .join("parity-corpus")
+        .join("oracle.json");
+    let raw = std::fs::read_to_string(path).ok()?;
+    let doc: Value = serde_json::from_str(&raw).ok()?;
+    doc.get("version")?.as_str().map(str::to_string)
+}
+
+/// The directory a case's snapshot for `os_arch` lives in:
+/// `<snapshots>/<os-arch>/<case-id>/`.
+pub fn snapshot_case_dir(snapshots_root: &Path, os_arch: &str, case_id: &str) -> PathBuf {
+    snapshots_root.join(os_arch).join(case_id)
+}
+
+/// Resolve the snapshot for `case_id` at `os_arch` under `snapshots_root`. A missing
+/// `os-arch`/`case` directory is [`Resolution::NoReferenceForPlatform`] (not an error);
+/// a present-but-malformed snapshot is a fail-loud [`SnapshotError`].
+pub fn resolve(
+    snapshots_root: &Path,
+    os_arch: &str,
+    case_id: &str,
+) -> Result<Resolution, SnapshotError> {
+    let dir = snapshot_case_dir(snapshots_root, os_arch, case_id);
+    if !dir.is_dir() {
+        return Ok(Resolution::NoReferenceForPlatform {
+            os_arch: os_arch.to_string(),
+        });
+    }
+    Ok(Resolution::Found(Box::new(load_snapshot(&dir)?)))
+}
+
+/// Load the three snapshot files from a case's snapshot directory.
+pub fn load_snapshot(dir: &Path) -> Result<Snapshot, SnapshotError> {
+    let provenance: Provenance = load_json(&dir.join("provenance.json"))?;
+    let raw: Value = load_json(&dir.join("raw.json"))?;
+    let normalized: Value = load_json(&dir.join("normalized.json"))?;
+    Ok(Snapshot {
+        provenance,
+        raw,
+        normalized,
+    })
+}
+
+/// Load just the provenance (the staleness gate needs nothing else).
+pub fn load_provenance(dir: &Path) -> Result<Provenance, SnapshotError> {
+    load_json(&dir.join("provenance.json"))
+}
+
+fn load_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, SnapshotError> {
+    let raw = std::fs::read_to_string(path).map_err(|e| SnapshotError::Read {
+        path: path.to_path_buf(),
+        cause: e.to_string(),
+    })?;
+    serde_json::from_str(&raw).map_err(|e| SnapshotError::Malformed {
+        path: path.to_path_buf(),
+        cause: e.to_string(),
+    })
+}
+
+/// A single field-level difference between two snapshot trees (`snapshot diff`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotDiffEntry {
+    /// Which artifact differs: `provenance` / `raw` / `normalized`.
+    pub artifact: String,
+    /// A dotted path within that artifact (empty = the whole artifact).
+    pub path: String,
+    /// The old (left) value.
+    pub old: Value,
+    /// The new (right) value.
+    pub new: Value,
+}
+
+/// Deterministic drift between two loaded snapshots (`snapshot diff`), artifact then
+/// path ordered. Compares provenance field-by-field and raw/normalized structurally.
+pub fn diff(old: &Snapshot, new: &Snapshot) -> Vec<SnapshotDiffEntry> {
+    let mut out = Vec::new();
+    let old_prov = serde_json::to_value(&old.provenance).unwrap_or(Value::Null);
+    let new_prov = serde_json::to_value(&new.provenance).unwrap_or(Value::Null);
+    diff_value("provenance", "", &old_prov, &new_prov, &mut out);
+    diff_value("raw", "", &old.raw, &new.raw, &mut out);
+    diff_value("normalized", "", &old.normalized, &new.normalized, &mut out);
+    out.sort_by(|a, b| a.artifact.cmp(&b.artifact).then(a.path.cmp(&b.path)));
+    out
+}
+
+/// Recursively record differences between two values under `artifact`/`path`.
+fn diff_value(
+    artifact: &str,
+    path: &str,
+    old: &Value,
+    new: &Value,
+    out: &mut Vec<SnapshotDiffEntry>,
+) {
+    match (old, new) {
+        (Value::Object(o), Value::Object(n)) => {
+            let mut keys: Vec<&String> = o.keys().chain(n.keys()).collect();
+            keys.sort();
+            keys.dedup();
+            for k in keys {
+                let child = if path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{path}.{k}")
+                };
+                diff_value(
+                    artifact,
+                    &child,
+                    o.get(k).unwrap_or(&Value::Null),
+                    n.get(k).unwrap_or(&Value::Null),
+                    out,
+                );
+            }
+        }
+        _ if old != new => out.push(SnapshotDiffEntry {
+            artifact: artifact.to_string(),
+            path: path.to_string(),
+            old: old.clone(),
+            new: new.clone(),
+        }),
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provenance() -> Provenance {
+        Provenance {
+            oracle_version: "0.87.0".to_string(),
+            source_revision: "113500f4".to_string(),
+            case_hash: "aaaa".to_string(),
+            fixture_hash: "bbbb".to_string(),
+            argv: vec!["read-configuration".to_string()],
+            platform: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            node_version: "22.23.1".to_string(),
+            docker_version: "29.6.2".to_string(),
+            compose_version: "2.40.3".to_string(),
+            image_digests: IndexMap::new(),
+            normalizer_version: NORMALIZER_VERSION.to_string(),
+            captured_at: "2026-07-24T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn fresh_when_all_staleness_fields_match() {
+        assert_eq!(
+            compare_staleness(&provenance(), &provenance()),
+            Staleness::Fresh
+        );
+    }
+
+    #[test]
+    fn each_staleness_field_drift_is_named() {
+        type Mutate = fn(&mut Provenance);
+        let cases: &[(&str, Mutate)] = &[
+            ("caseHash", |p| p.case_hash = "x".to_string()),
+            ("fixtureHash", |p| p.fixture_hash = "x".to_string()),
+            ("oracleVersion", |p| p.oracle_version = "9.9.9".to_string()),
+            ("sourceRevision", |p| {
+                p.source_revision = "deadbeef".to_string()
+            }),
+            ("imageDigests", |p| {
+                p.image_digests
+                    .insert("img".to_string(), "sha256:x".to_string());
+            }),
+            ("normalizerVersion", |p| {
+                p.normalizer_version = "99".to_string()
+            }),
+        ];
+        for (field, mutate) in cases {
+            let recorded = provenance();
+            let mut current = provenance();
+            mutate(&mut current);
+            match compare_staleness(&recorded, &current) {
+                Staleness::Stale { field: got, .. } => {
+                    assert_eq!(&got, field, "drift in {field} must be named")
+                }
+                Staleness::Fresh => panic!("drift in {field} must be stale"),
+            }
+        }
+    }
+
+    #[test]
+    fn selectors_and_host_versions_do_not_trigger_staleness() {
+        // capturedAt/platform/arch/argv are selectors/informational; the host tool
+        // versions (node/docker/compose) are informational too (a snapshot recorded under
+        // Node 22 must NOT be stale on a Node 20 replay — cross-machine CI replay, SC-003).
+        for mutate in [
+            (|p: &mut Provenance| p.captured_at = "2099-01-01T00:00:00Z".to_string())
+                as fn(&mut Provenance),
+            |p: &mut Provenance| p.platform = "macos".to_string(),
+            |p: &mut Provenance| p.arch = "aarch64".to_string(),
+            |p: &mut Provenance| p.argv = vec!["different".to_string()],
+            |p: &mut Provenance| p.node_version = "20.0.0".to_string(),
+            |p: &mut Provenance| p.docker_version = "27.0.0".to_string(),
+            |p: &mut Provenance| p.compose_version = "2.29.0".to_string(),
+        ] {
+            let recorded = provenance();
+            let mut current = provenance();
+            mutate(&mut current);
+            assert_eq!(
+                compare_staleness(&recorded, &current),
+                Staleness::Fresh,
+                "capturedAt/platform/arch/argv/node/docker/compose are not staleness signals"
+            );
+        }
+    }
+
+    #[test]
+    fn first_mismatch_wins() {
+        let recorded = provenance();
+        let mut current = provenance();
+        current.fixture_hash = "x".to_string(); // 2nd staleness field
+        current.normalizer_version = "9".to_string(); // later staleness field
+        match compare_staleness(&recorded, &current) {
+            Staleness::Stale { field, .. } => assert_eq!(field, "fixtureHash", "first mismatch"),
+            Staleness::Fresh => panic!("must be stale"),
+        }
+    }
+
+    #[test]
+    fn image_digest_order_does_not_trigger_staleness() {
+        let mut recorded = provenance();
+        recorded
+            .image_digests
+            .insert("a".to_string(), "1".to_string());
+        recorded
+            .image_digests
+            .insert("b".to_string(), "2".to_string());
+        let mut current = provenance();
+        current
+            .image_digests
+            .insert("b".to_string(), "2".to_string());
+        current
+            .image_digests
+            .insert("a".to_string(), "1".to_string());
+        assert_eq!(compare_staleness(&recorded, &current), Staleness::Fresh);
+    }
+
+    #[test]
+    fn diff_reports_provenance_and_evidence_changes() {
+        let a = Snapshot {
+            provenance: provenance(),
+            raw: serde_json::json!([{ "channel": "chan-exit-code", "value": 0 }]),
+            normalized: serde_json::json!([{ "channel": "chan-exit-code", "value": 0 }]),
+        };
+        let mut b = a.clone();
+        b.provenance.case_hash = "zzzz".to_string();
+        b.raw = serde_json::json!([{ "channel": "chan-exit-code", "value": 1 }]);
+        let d = diff(&a, &b);
+        assert!(
+            d.iter()
+                .any(|e| e.artifact == "provenance" && e.path == "caseHash")
+        );
+        assert!(d.iter().any(|e| e.artifact == "raw"));
+        // Identical snapshots diff empty.
+        assert!(diff(&a, &a).is_empty());
+    }
+}

--- a/crates/conformance/src/validate.rs
+++ b/crates/conformance/src/validate.rs
@@ -1,8 +1,13 @@
-//! Structural validation engine (violation classes V1–V14 + SCHEMA), FR-019.
+//! Structural validation engine (violation classes V1–V20 + SCHEMA), FR-019.
 //!
-//! [`run`] evaluates the registry-only violation classes (V1–V10) over a loaded
-//! [`Registry`] and returns ALL violations found in a single pass (never
-//! first-failure), sorted by code then record ID (contracts/cli.md).
+//! [`run`] evaluates the registry-only violation classes (V1–V10, plus **V16**
+//! declarative-case well-formedness, **V18** Docker-case pinned-input enforcement, **V19**
+//! allowed-difference identity resolution, and **V20** invariant-metamorphic arity —
+//! 022-conformance-runner) over a loaded [`Registry`] and returns ALL violations found in
+//! a single pass (never first-failure),
+//! sorted by code then record ID (contracts/cli.md). **V17** (committed-snapshot
+//! integrity) runs in [`validate_path_with_inventory`], scoped to the snapshots sibling
+//! of the registry.
 //! [`check_inventory`] adds the schema-constraint-inventory join classes (V11–V14),
 //! which need the committed inventory + vendored schemas alongside the registry
 //! (020-schema-constraint-inventory). [`validate_path`] is the registry-only
@@ -55,10 +60,11 @@ use crate::load::{
     LoadError, Registry, SchemaError, load_clause_inventory, load_inventory, load_spec_manifest,
 };
 use crate::model::{
-    BehaviorUnit, CertificationProfile, Classification, ClauseClassification, ClauseInventory,
-    ClauseUnit, Condition, ConstraintInventory, ConstraintUnit, Decision, Disposition,
-    DocumentScope, RecordType, ReferenceStatus, RevisionKind, SpecManifest, SpecStatus, Strength,
-    Testability, parse_id,
+    BehaviorUnit, CONSUMER_SUBCOMMANDS, CaseKind, CertificationProfile, Classification,
+    ClauseClassification, ClauseInventory, ClauseUnit, Condition, ConstraintInventory,
+    ConstraintUnit, Decision, Disposition, DocumentScope, FILESYSTEM_CHANNELS, OracleType,
+    RecordType, ReferenceStatus, RevisionKind, SpecManifest, SpecStatus, Strength, Testability,
+    parse_id,
 };
 use crate::prose::Document;
 use crate::prose::strength::{has_family, hides_mandatory_keyword};
@@ -173,12 +179,92 @@ pub fn validate_path_with_inventory(
             let mut violations = run(&registry, today, repo_root);
             violations.extend(check_inventory(&registry, inputs));
             violations.extend(check_clause_inventory(&registry, clause_inputs));
+            // V17: committed snapshots are a sibling of the registry dir (mirrors the
+            // inventory/clause sibling resolution) — absent for fixture registries.
+            let snapshots_dir = root
+                .parent()
+                .map(|p| p.join("snapshots"))
+                .unwrap_or_else(|| root.join("snapshots"));
+            violations.extend(check_snapshots(&registry, &snapshots_dir));
             sort_violations(&mut violations);
             Ok(violations)
         }
         Err(LoadError::Schema(errors)) => Ok(schema_violations(&errors)),
         Err(other) => Err(other),
     }
+}
+
+/// **V17 — committed-snapshot provenance integrity** (022-conformance-runner, US2).
+/// Scans `snapshots_dir` (`<os-arch>/<case-id>/`) and flags: a snapshot whose `case-id`
+/// is not a declarative case in the registry (an orphan snapshot for a
+/// deleted/renamed/legacy case), and a snapshot whose `provenance.json` is missing or
+/// malformed. A missing snapshots directory yields no violations (fixture registries
+/// ship none). Staleness of a well-formed snapshot is NOT a validate concern — it is the
+/// `snapshot check` gate (a snapshot may be legitimately stale pending a reviewed
+/// refresh).
+pub fn check_snapshots(registry: &Registry, snapshots_dir: &Path) -> Vec<Violation> {
+    let mut out = Vec::new();
+    if !snapshots_dir.is_dir() {
+        return out;
+    }
+    let declarative: HashSet<&str> = registry
+        .cases
+        .iter()
+        .filter(|c| matches!(c.classify(), Ok(CaseKind::Declarative)))
+        .map(|c| c.id.as_str())
+        .collect();
+
+    // <snapshots>/<os-arch>/<case-id>/
+    let os_arch_dirs = match std::fs::read_dir(snapshots_dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            out.push(Violation::new(
+                "V17",
+                snapshots_dir.display().to_string(),
+                format!("cannot read snapshots directory: {e}"),
+            ));
+            return out;
+        }
+    };
+    let mut entries: Vec<(String, std::path::PathBuf)> = Vec::new();
+    for os_arch in os_arch_dirs.flatten() {
+        if !os_arch.path().is_dir() {
+            continue;
+        }
+        let os_arch_name = os_arch.file_name().to_string_lossy().into_owned();
+        if let Ok(cases) = std::fs::read_dir(os_arch.path()) {
+            for case_dir in cases.flatten() {
+                if case_dir.path().is_dir() {
+                    let case_id = case_dir.file_name().to_string_lossy().into_owned();
+                    entries.push((format!("{os_arch_name}/{case_id}"), case_dir.path()));
+                }
+            }
+        }
+    }
+    // Deterministic order.
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (key, dir) in entries {
+        let case_id = key.rsplit('/').next().unwrap_or(&key);
+        if !declarative.contains(case_id) {
+            out.push(Violation::new(
+                "V17",
+                key.clone(),
+                format!(
+                    "committed snapshot for {case_id:?} has no matching declarative case in the \
+                     registry (orphan snapshot — delete it or restore the case)"
+                ),
+            ));
+        }
+        if let Err(e) = crate::snapshot::load_provenance(&dir) {
+            out.push(Violation::new(
+                "V17",
+                key,
+                format!("committed snapshot provenance is unreadable/malformed: {e}"),
+            ));
+        }
+    }
+    out
 }
 
 /// The join of the committed inventory against the hand-authored classification
@@ -1055,6 +1141,10 @@ pub fn run(registry: &Registry, today: &str, repo_root: &Path) -> Vec<Violation>
     checker.check_contradictions(); // V8
     checker.check_channels(); // V9
     checker.check_context_intersection(); // V10
+    checker.check_declarative_cases(); // V16 (022-conformance-runner)
+    checker.check_docker_pinned_inputs(); // V18 (022-conformance-runner US5)
+    checker.check_allowed_difference_refs(); // V19 (022-conformance-runner US4)
+    checker.check_metamorphic_arity(); // V20 (022-conformance-runner US6)
 
     let mut out = checker.violations;
     sort_violations(&mut out);
@@ -1361,7 +1451,12 @@ impl<'a> Checker<'a> {
 
     fn check_executables(&mut self) {
         for case in &self.reg.cases {
-            let binary = &case.executable.binary;
+            // Declarative cases (022-conformance-runner) carry no `executable`; they
+            // are run by the shared runner, not a bespoke Rust binary.
+            let Some(executable) = &case.executable else {
+                continue;
+            };
+            let binary = &executable.binary;
             if !binary_exists(self.repo_root, binary) {
                 self.push(
                     "V1",
@@ -1652,10 +1747,11 @@ impl<'a> Checker<'a> {
         }
     }
 
-    // -- V9: outcome referencing an undeclared observable channel ------------
+    // -- V9: outcome/expected referencing an undeclared observable channel ---
 
     fn check_channels(&mut self) {
         for case in &self.reg.cases {
+            // Legacy outcomes.
             for outcome in &case.outcomes {
                 if !self.channel_ids.contains(outcome.channel.as_str()) {
                     self.push(
@@ -1664,6 +1760,20 @@ impl<'a> Checker<'a> {
                         format!(
                             "outcome references undeclared observable channel {:?}",
                             outcome.channel
+                        ),
+                    );
+                }
+            }
+            // Declarative expectations (022-conformance-runner): every `expected[].channel`
+            // must be declared in `channels.json` too (contract case-schema.md → V9).
+            for exp in &case.expected {
+                if !self.channel_ids.contains(exp.channel.as_str()) {
+                    self.push(
+                        "V9",
+                        &case.id,
+                        format!(
+                            "expected observable references undeclared observable channel {:?}",
+                            exp.channel
                         ),
                     );
                 }
@@ -1692,6 +1802,326 @@ impl<'a> Checker<'a> {
                 }
             }
         }
+    }
+
+    // -- V16: declarative case well-formedness (022-conformance-runner, T013) -----
+    //
+    // Core well-formedness of a declarative case record (data-model §1, contract
+    // case-schema.md). The exactly-one-of shape is normally caught fail-loud at load
+    // (`load.rs::check_case_shapes`); it is re-checked here so a directly-constructed
+    // `Registry` (e.g. a unit test that bypasses `Registry::load`) still surfaces it
+    // under a stable code. Legacy (binary-backed) cases are governed by V1/V3/V9/V10
+    // and are untouched here.
+    fn check_declarative_cases(&mut self) {
+        for case in &self.reg.cases {
+            match case.classify() {
+                Err(shape) => self.push("V16", &case.id, shape.message().to_string()),
+                Ok(CaseKind::Legacy) => {} // legacy cases: existing V-series apply.
+                Ok(CaseKind::Declarative) => self.check_one_declarative_case(case),
+            }
+        }
+    }
+
+    /// The declarative-only rules, evaluated on a record already classified
+    /// [`CaseKind::Declarative`]: `oracleType` present, every `operations[].subcommand`
+    /// in the consumer surface (Principle II), `spec-expectation` ⇒ every `expected`
+    /// carries an `assertion`, and `fsAllowlist` present **iff** a filesystem-channel
+    /// expectation exists.
+    fn check_one_declarative_case(&mut self, case: &crate::model::TestCase) {
+        // oracleType must be declared (its 4-value membership is enforced at load by
+        // the closed `OracleType` enum; here we require presence).
+        let Some(oracle_type) = case.oracle_type else {
+            self.push(
+                "V16",
+                &case.id,
+                "declarative case must declare an `oracleType` \
+                 (spec-expectation | snapshot | live-differential | invariant-metamorphic)",
+            );
+            // Continue: the remaining rules do not depend on the oracle type except
+            // the spec-expectation assertion rule, which we can skip safely.
+            self.check_case_subcommands(case);
+            self.check_case_fs_allowlist(case);
+            return;
+        };
+
+        self.check_case_subcommands(case);
+
+        // spec-expectation ⇒ every declared expectation carries an assertion (there is
+        // no reference/snapshot to supply it).
+        if oracle_type == OracleType::SpecExpectation {
+            for exp in &case.expected {
+                if exp.assertion.is_none() {
+                    self.push(
+                        "V16",
+                        &case.id,
+                        format!(
+                            "spec-expectation case must carry an `assertion` on every \
+                             expected channel; channel {:?} has none",
+                            exp.channel
+                        ),
+                    );
+                }
+            }
+        }
+
+        self.check_case_fs_allowlist(case);
+    }
+
+    /// Every `operations[].subcommand` must be in the consumer surface (Principle II).
+    fn check_case_subcommands(&mut self, case: &crate::model::TestCase) {
+        for op in &case.operations {
+            if !CONSUMER_SUBCOMMANDS.contains(&op.subcommand.as_str()) {
+                self.push(
+                    "V16",
+                    &case.id,
+                    format!(
+                        "operation {:?} references non-consumer subcommand {:?}; the \
+                         consumer surface is {}",
+                        op.id,
+                        op.subcommand,
+                        CONSUMER_SUBCOMMANDS.join(" | ")
+                    ),
+                );
+            }
+        }
+    }
+
+    // -- V20: invariant-metamorphic arity (022-conformance-runner US6, T070) ----------
+    //
+    // An `invariant-metamorphic` case MUST declare ≥2 operations and at least one
+    // operation with a `relationship` referencing a SIBLING op id (data-model §1, FR-008)
+    // — a relationship needs a second operation to relate to. Conversely, a `relationship`
+    // on a non-metamorphic case is meaningless (only the metamorphic oracle evaluates it).
+    fn check_metamorphic_arity(&mut self) {
+        use crate::model::OracleType;
+        for case in &self.reg.cases {
+            let op_ids: HashSet<&str> = case.operations.iter().map(|o| o.id.as_str()).collect();
+            let is_metamorphic = case.oracle_type == Some(OracleType::InvariantMetamorphic);
+
+            if is_metamorphic {
+                if case.operations.len() < 2 {
+                    self.push(
+                        "V20",
+                        &case.id,
+                        "invariant-metamorphic case must declare at least 2 operations \
+                         (a relationship needs a sibling to relate to)",
+                    );
+                }
+                if !case.operations.iter().any(|o| o.relationship.is_some()) {
+                    self.push(
+                        "V20",
+                        &case.id,
+                        "invariant-metamorphic case must declare a `relationship` on at least \
+                         one operation (the declared relationship IS the oracle)",
+                    );
+                }
+            }
+
+            for op in &case.operations {
+                let Some(rel) = &op.relationship else {
+                    continue;
+                };
+                if !is_metamorphic {
+                    self.push(
+                        "V20",
+                        &case.id,
+                        format!(
+                            "operation {:?} declares a `relationship`, but the case is not \
+                             invariant-metamorphic (only that oracle evaluates relationships)",
+                            op.id
+                        ),
+                    );
+                }
+                if rel.against_op == op.id {
+                    self.push(
+                        "V20",
+                        &case.id,
+                        format!(
+                            "operation {:?} relationship references itself; it must reference a \
+                             SIBLING operation",
+                            op.id
+                        ),
+                    );
+                } else if !op_ids.contains(rel.against_op.as_str()) {
+                    self.push(
+                        "V20",
+                        &case.id,
+                        format!(
+                            "operation {:?} relationship references op {:?}, which is not an \
+                             operation of the case",
+                            op.id, rel.against_op
+                        ),
+                    );
+                }
+            }
+        }
+    }
+
+    // -- V19: allowed-difference identity resolution (022-conformance-runner US4, T063) --
+    //
+    // Each allowed difference must (a) scope to a behavior the case links, and (b) resolve
+    // its backing identity — `waiverId` to an existing `wvr-` record, or `divergenceId` to
+    // an existing `ext-` record or an intentional-divergence behavior (FR-031/043). The
+    // exactly-one-of + bare-channel/duplicate structural checks are enforced fail-loud at
+    // load (`load.rs::check_allowed_differences`); V19 covers cross-record resolution.
+    fn check_allowed_difference_refs(&mut self) {
+        let waiver_ids: HashSet<&str> = self.reg.waivers.iter().map(|w| w.id.as_str()).collect();
+        let ext_ids: HashSet<&str> = self.reg.extensions.iter().map(|e| e.id.as_str()).collect();
+        let intentional_behaviors: HashSet<&str> = self
+            .reg
+            .behaviors
+            .iter()
+            .filter(|b| b.decision == Decision::IntentionalDivergence)
+            .map(|b| b.id.as_str())
+            .collect();
+
+        for case in &self.reg.cases {
+            let linked: HashSet<&str> = case.behaviors.iter().map(String::as_str).collect();
+            for ad in &case.allowed_differences {
+                if !linked.contains(ad.behavior.as_str()) {
+                    self.push(
+                        "V19",
+                        &case.id,
+                        format!(
+                            "allowed difference scopes to behavior {:?}, which the case does not \
+                             link (a tolerance must be scoped to a linked behavior)",
+                            ad.behavior
+                        ),
+                    );
+                }
+                if let Some(w) = &ad.waiver_id {
+                    if !waiver_ids.contains(w.as_str()) {
+                        self.push(
+                            "V19",
+                            &case.id,
+                            format!(
+                                "allowed difference waiverId {w:?} resolves to no \
+                                 `conformance/registry/waivers/wvr-*` record (dangling tolerance)"
+                            ),
+                        );
+                    }
+                }
+                if let Some(d) = &ad.divergence_id {
+                    if !ext_ids.contains(d.as_str()) && !intentional_behaviors.contains(d.as_str())
+                    {
+                        self.push(
+                            "V19",
+                            &case.id,
+                            format!(
+                                "allowed difference divergenceId {d:?} resolves to no `ext-` \
+                                 record or intentional-divergence behavior (dangling tolerance)"
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // -- V18: Docker cases must pin their image inputs (022-conformance-runner, T058) --
+    //
+    // A Docker-backed case (`resourceGroup: docker-*`) must reference fixtures whose
+    // devcontainer image is PINNED — a `@sha256:` digest or a concrete `:tag` other than
+    // `latest` (FR-038). A floating `latest` (or an untagged image) makes a snapshot
+    // non-reproducible. Fixtures whose config declares no `image` (Dockerfile/compose) or
+    // is absent/unreadable are skipped — V18 flags only a declared, unpinned image.
+    fn check_docker_pinned_inputs(&mut self) {
+        let fixtures_root = self.repo_root.join("conformance").join("fixtures");
+        for case in &self.reg.cases {
+            if !is_docker_case(case) {
+                continue;
+            }
+            let mut fixture_ids: Vec<&str> = case
+                .operations
+                .iter()
+                .flat_map(|op| op.fixtures.iter().map(String::as_str))
+                .collect();
+            fixture_ids.sort_unstable();
+            fixture_ids.dedup();
+            for id in fixture_ids {
+                if let Some(image) = fixture_image(&fixtures_root.join(id)) {
+                    if !image_is_pinned(&image) {
+                        self.violations.push(Violation::new(
+                            "V18",
+                            &case.id,
+                            format!(
+                                "Docker case references fixture {id:?} with an unpinned image \
+                                 {image:?}; pin it to a digest (`@sha256:…`) or a concrete tag \
+                                 (never `latest`) for reproducible snapshots (FR-038)"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    /// `fsAllowlist` must be non-empty **iff** an `expected` filesystem-channel exists —
+    /// required so the filesystem observer has a scope, forbidden otherwise so capture
+    /// stays scoped (data-model §1, clarify Q1).
+    fn check_case_fs_allowlist(&mut self, case: &crate::model::TestCase) {
+        let has_fs_expectation = case
+            .expected
+            .iter()
+            .any(|e| FILESYSTEM_CHANNELS.contains(&e.channel.as_str()));
+        match (has_fs_expectation, case.fs_allowlist.is_empty()) {
+            (true, true) => self.push(
+                "V16",
+                &case.id,
+                "case has a filesystem-channel expectation but declares no `fsAllowlist` \
+                 (filesystem capture must be allowlist-scoped)",
+            ),
+            (false, false) => self.push(
+                "V16",
+                &case.id,
+                "case declares an `fsAllowlist` but has no filesystem-channel expectation \
+                 (remove the allowlist to keep capture scoped)",
+            ),
+            _ => {}
+        }
+    }
+}
+
+/// Whether a case is Docker-backed (its `resourceGroup` requests a Docker group).
+fn is_docker_case(case: &crate::model::TestCase) -> bool {
+    use crate::model::ResourceGroup;
+    matches!(
+        case.resource_group,
+        Some(ResourceGroup::DockerShared) | Some(ResourceGroup::DockerExclusive)
+    )
+}
+
+/// The `image` a fixture's devcontainer config declares, if any. Looks in
+/// `<fixture>/.devcontainer/devcontainer.json` then `<fixture>/.devcontainer.json`. A
+/// missing/unreadable/non-JSON config, or one with no `image`, yields `None`.
+fn fixture_image(fixture_dir: &Path) -> Option<String> {
+    for rel in [".devcontainer/devcontainer.json", ".devcontainer.json"] {
+        let path = fixture_dir.join(rel);
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        if let Some(image) = doc.get("image").and_then(|v| v.as_str()) {
+            return Some(image.to_string());
+        }
+    }
+    None
+}
+
+/// Whether an image reference is PINNED (FR-038): a `@sha256:` digest, or a concrete
+/// `:tag` other than `latest`. An untagged image or `:latest` is NOT pinned. The tag is
+/// the segment after the LAST `/` (so a `registry:port/image` host-port colon is not
+/// mistaken for a tag).
+fn image_is_pinned(image: &str) -> bool {
+    if image.contains("@sha256:") {
+        return true;
+    }
+    let last_segment = image.rsplit('/').next().unwrap_or(image);
+    match last_segment.split_once(':') {
+        Some((_, tag)) => !tag.is_empty() && tag != "latest",
+        None => false, // no tag → unpinned
     }
 }
 
@@ -2046,16 +2476,17 @@ mod tests {
             id: "case-x".to_string(),
             behaviors: vec!["bhv-a".to_string()],
             context: vec![],
-            executable: crate::model::Executable {
+            executable: Some(crate::model::Executable {
                 binary: "no_such_binary".to_string(),
                 test: None,
                 corpus: None,
                 case: None,
-            },
+            }),
             outcomes: vec![crate::model::ExpectedOutcome {
                 channel: "chan-ghost".to_string(),
                 expectation: "x".to_string(),
             }],
+            ..TestCase::default()
         });
         let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
         assert!(
@@ -2069,5 +2500,275 @@ mod tests {
         let reg = Registry::default();
         let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
         assert!(out.is_empty(), "empty registry is valid, got {out:?}");
+    }
+
+    #[test]
+    fn image_pinning_classifier() {
+        assert!(image_is_pinned("alpine:3.19"));
+        assert!(image_is_pinned(
+            "mcr.microsoft.com/devcontainers/base:bookworm"
+        ));
+        assert!(image_is_pinned("foo@sha256:abcdef"));
+        assert!(image_is_pinned("registry:5000/foo:1.2"));
+        assert!(!image_is_pinned("alpine:latest"));
+        assert!(!image_is_pinned("alpine"), "untagged is not pinned");
+        assert!(
+            !image_is_pinned("registry:5000/foo"),
+            "a host-port colon is not a tag"
+        );
+    }
+
+    #[test]
+    fn v18_flags_unpinned_docker_fixture_image() {
+        use crate::model::{ExpectedObservable, Operation, OracleType, ResourceGroup};
+        // A temp fixtures tree with an unpinned (`latest`) image under conformance/fixtures.
+        let repo = tempfile::tempdir().expect("tempdir");
+        let fx = repo
+            .path()
+            .join("conformance/fixtures/fx-latest/.devcontainer");
+        std::fs::create_dir_all(&fx).unwrap();
+        std::fs::write(
+            fx.join("devcontainer.json"),
+            r#"{ "image": "alpine:latest" }"#,
+        )
+        .unwrap();
+
+        let mut reg = Registry::default();
+        reg.cases.push(TestCase {
+            id: "case-docker-latest".to_string(),
+            behaviors: vec!["bhv-a".to_string()],
+            oracle_type: Some(OracleType::SpecExpectation),
+            resource_group: Some(ResourceGroup::DockerShared),
+            operations: vec![Operation {
+                id: "op-up".to_string(),
+                subcommand: "up".to_string(),
+                fixtures: vec!["fx-latest".to_string()],
+                ..Operation::default()
+            }],
+            expected: vec![ExpectedObservable {
+                channel: "chan-exit-code".to_string(),
+                operation: Some("op-up".to_string()),
+                assertion: Some(serde_json::json!({ "equals": 0 })),
+            }],
+            ..TestCase::default()
+        });
+        let out = run(&reg, "2026-07-19", repo.path());
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V18" && v.record == "case-docker-latest"),
+            "an unpinned Docker fixture image must be V18, got {out:?}"
+        );
+
+        // Re-pin to a concrete tag → no V18.
+        std::fs::write(
+            fx.join("devcontainer.json"),
+            r#"{ "image": "alpine:3.19" }"#,
+        )
+        .unwrap();
+        let out2 = run(&reg, "2026-07-19", repo.path());
+        assert!(
+            !out2.iter().any(|v| v.code == "V18"),
+            "a pinned image must not trip V18, got {out2:?}"
+        );
+    }
+
+    /// A well-formed declarative case, built directly (bypassing `Registry::load`), so
+    /// the V16 checks in `run` are exercised on the correctly-shaped path.
+    fn declarative_case(id: &str) -> TestCase {
+        use crate::model::{ExpectedObservable, Operation, OracleType};
+        TestCase {
+            id: id.to_string(),
+            behaviors: vec!["bhv-a".to_string()],
+            operations: vec![Operation {
+                id: "op-1".to_string(),
+                subcommand: "read-configuration".to_string(),
+                argv: vec!["--workspace-folder".to_string(), "${WORKSPACE}".to_string()],
+                ..Operation::default()
+            }],
+            oracle_type: Some(OracleType::SpecExpectation),
+            expected: vec![ExpectedObservable {
+                channel: "chan-exit-code".to_string(),
+                operation: Some("op-1".to_string()),
+                assertion: Some(serde_json::json!({ "equals": 0 })),
+            }],
+            ..TestCase::default()
+        }
+    }
+
+    /// A well-formed invariant-metamorphic case: two `up` ops, the second declaring an
+    /// idempotence relationship against the first (a sibling).
+    fn metamorphic_case(id: &str) -> TestCase {
+        use crate::model::{Operation, OracleType, Relationship, RelationshipKind};
+        let mut case = declarative_case(id);
+        case.oracle_type = Some(OracleType::InvariantMetamorphic);
+        case.operations = vec![
+            Operation {
+                id: "op-up-1".to_string(),
+                subcommand: "up".to_string(),
+                ..Operation::default()
+            },
+            Operation {
+                id: "op-up-2".to_string(),
+                subcommand: "up".to_string(),
+                relationship: Some(Relationship {
+                    kind: RelationshipKind::Idempotence,
+                    against_op: "op-up-1".to_string(),
+                }),
+                ..Operation::default()
+            },
+        ];
+        case
+    }
+
+    #[test]
+    fn v20_accepts_well_formed_metamorphic_case() {
+        let mut reg = Registry::default();
+        reg.cases.push(metamorphic_case("case-meta-ok"));
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            !out.iter().any(|v| v.code == "V20"),
+            "a well-formed metamorphic case must not trip V20, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn v20_flags_metamorphic_arity_and_relationship_errors() {
+        use crate::model::{Operation, Relationship, RelationshipKind};
+
+        // < 2 ops.
+        let mut one_op = metamorphic_case("case-meta-one-op");
+        one_op.operations.truncate(1);
+        one_op.operations[0].relationship = None;
+        // no relationship.
+        let mut no_rel = metamorphic_case("case-meta-no-rel");
+        no_rel.operations[1].relationship = None;
+        // relationship to a non-existent op.
+        let mut dangling = metamorphic_case("case-meta-dangling");
+        dangling.operations[1].relationship = Some(Relationship {
+            kind: RelationshipKind::Idempotence,
+            against_op: "op-nope".to_string(),
+        });
+        // relationship on a NON-metamorphic case.
+        let mut spec_with_rel = declarative_case("case-spec-rel");
+        spec_with_rel.operations.push(Operation {
+            id: "op-2".to_string(),
+            subcommand: "up".to_string(),
+            relationship: Some(Relationship {
+                kind: RelationshipKind::Idempotence,
+                against_op: "op-1".to_string(),
+            }),
+            ..Operation::default()
+        });
+
+        for case in [one_op, no_rel, dangling, spec_with_rel] {
+            let id = case.id.clone();
+            let mut reg = Registry::default();
+            reg.cases.push(case);
+            let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+            assert!(
+                out.iter().any(|v| v.code == "V20" && v.record == id),
+                "{id} must trip V20, got {out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn v16_accepts_a_well_formed_declarative_case() {
+        let mut reg = Registry::default();
+        reg.cases.push(declarative_case("case-decl-ok"));
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            !out.iter().any(|v| v.code == "V16"),
+            "a well-formed declarative case must not trip V16, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn v16_flags_non_consumer_subcommand() {
+        let mut reg = Registry::default();
+        let mut case = declarative_case("case-decl-bad-subcommand");
+        case.operations[0].subcommand = "features".to_string(); // out of consumer scope
+        reg.cases.push(case);
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-decl-bad-subcommand"),
+            "a non-consumer subcommand must be V16 (Principle II), got {out:?}"
+        );
+    }
+
+    #[test]
+    fn v16_flags_mixed_and_neither_shapes() {
+        let mut reg = Registry::default();
+        // Mixed: both executable and operations.
+        let mut mixed = declarative_case("case-mixed");
+        mixed.executable = Some(crate::model::Executable {
+            binary: "some_binary".to_string(),
+            test: None,
+            corpus: None,
+            case: None,
+        });
+        reg.cases.push(mixed);
+        // Neither: no executable, no operations.
+        reg.cases.push(TestCase {
+            id: "case-neither".to_string(),
+            behaviors: vec!["bhv-a".to_string()],
+            ..TestCase::default()
+        });
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-mixed"),
+            "a mixed legacy+declarative case must be V16, got {out:?}"
+        );
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-neither"),
+            "a shapeless case must be V16, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn v16_enforces_fs_allowlist_iff_filesystem_channel() {
+        // A filesystem-channel expectation with no allowlist trips V16.
+        let mut reg = Registry::default();
+        let mut needs_allowlist = declarative_case("case-fs-missing-allowlist");
+        needs_allowlist
+            .expected
+            .push(crate::model::ExpectedObservable {
+                channel: "chan-filesystem".to_string(),
+                operation: Some("op-1".to_string()),
+                assertion: Some(serde_json::json!({ "exists": "out.txt" })),
+            });
+        reg.cases.push(needs_allowlist);
+        // An allowlist with no filesystem channel also trips V16 (forbidden otherwise).
+        let mut stray_allowlist = declarative_case("case-fs-stray-allowlist");
+        stray_allowlist.fs_allowlist = vec!["out.txt".to_string()];
+        reg.cases.push(stray_allowlist);
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-fs-missing-allowlist"),
+            "a filesystem expectation with no fsAllowlist must be V16, got {out:?}"
+        );
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-fs-stray-allowlist"),
+            "an fsAllowlist with no filesystem expectation must be V16, got {out:?}"
+        );
+    }
+
+    #[test]
+    fn v16_requires_assertions_for_spec_expectation() {
+        let mut reg = Registry::default();
+        let mut case = declarative_case("case-spec-no-assertion");
+        case.expected[0].assertion = None; // spec-expectation needs it
+        reg.cases.push(case);
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            out.iter()
+                .any(|v| v.code == "V16" && v.record == "case-spec-no-assertion"),
+            "spec-expectation without an assertion must be V16, got {out:?}"
+        );
     }
 }

--- a/crates/conformance/tests/allowed_difference_scoping.rs
+++ b/crates/conformance/tests/allowed_difference_scoping.rs
@@ -1,0 +1,296 @@
+//! Hermetic allowed-difference scoping tests (022-conformance-runner US4, T060,
+//! FR-031/032/033/035, SC-008).
+//!
+//! The conformance crate owns the DATA rules: a conflicting duplicate and a
+//! global-ignore-shaped entry fail loudly at LOAD; a dangling waiver/divergence id and an
+//! unlinked behavior fail at VALIDATE (V19); a well-formed tolerance backed by a real
+//! registry `wvr-` resolves cleanly. The RUNTIME scoping ("path A tolerated, path B still
+//! fails") and self-invalidating STALENESS (FR-034) are verdict-time behavior, unit-tested
+//! in `parity-harness::compare` (`covered_divergence_is_allowed_difference_uncovered_stays_diverge`,
+//! `unconsumed_tolerance_is_stale`) — the conformance crate cannot run the comparison.
+
+use std::fs;
+
+use deacon_conformance::load::{LoadError, Registry};
+use deacon_conformance::model::{
+    AllowedDifference, BehaviorUnit, DeaconExtension, Decision, Expect, ExpectedObservable,
+    ObservableChannel, Operation, OracleType, ReferenceStatus, Scope, SpecStatus, TestCase, Waiver,
+};
+use deacon_conformance::validate::run;
+use deacon_conformance::workspace_root;
+
+const TODAY: &str = "2026-07-24";
+
+fn behavior(id: &str, decision: Decision) -> BehaviorUnit {
+    BehaviorUnit {
+        id: id.to_string(),
+        area: "test".to_string(),
+        statement: "a behavior".to_string(),
+        applicability: vec![],
+        spec: SpecStatus::Conformant,
+        reference: ReferenceStatus::Aligned,
+        decision,
+        notes: None,
+    }
+}
+
+fn waiver(id: &str) -> Waiver {
+    Waiver {
+        id: id.to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        scope: Scope::CorpusCase {
+            corpus: "errors".to_string(),
+            case: "x".to_string(),
+        },
+        expect: Expect::DeaconStricter { signal: None },
+        rationale: "characterized".to_string(),
+        added: "2026-07-19".to_string(),
+        expires: "2027-01-19".to_string(),
+        config: None,
+    }
+}
+
+/// A declarative live-differential case linked to `bhv-x` with the given tolerances.
+fn case_with(allowed: Vec<AllowedDifference>) -> TestCase {
+    TestCase {
+        id: "case-tol".to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        oracle_type: Some(OracleType::LiveDifferential),
+        operations: vec![Operation {
+            id: "op-up".to_string(),
+            subcommand: "up".to_string(),
+            ..Operation::default()
+        }],
+        expected: vec![ExpectedObservable {
+            channel: "chan-injected-process".to_string(),
+            operation: Some("op-up".to_string()),
+            assertion: None,
+        }],
+        allowed_differences: allowed,
+        ..TestCase::default()
+    }
+}
+
+fn registry_with(
+    cases: Vec<TestCase>,
+    waivers: Vec<Waiver>,
+    exts: Vec<DeaconExtension>,
+) -> Registry {
+    Registry {
+        behaviors: vec![
+            behavior("bhv-x", Decision::FollowSpec),
+            behavior("bhv-intentional", Decision::IntentionalDivergence),
+        ],
+        channels: vec![ObservableChannel {
+            id: "chan-injected-process".to_string(),
+            description: "c".to_string(),
+        }],
+        cases,
+        waivers,
+        extensions: exts,
+        ..Registry::default()
+    }
+}
+
+fn tz_allowed(waiver_id: Option<&str>, divergence_id: Option<&str>) -> AllowedDifference {
+    AllowedDifference {
+        behavior: "bhv-x".to_string(),
+        context: vec!["single-container".to_string()],
+        observable_path: "chan-injected-process.env.TZ".to_string(),
+        rationale: "reference leaks host TZ".to_string(),
+        waiver_id: waiver_id.map(str::to_string),
+        divergence_id: divergence_id.map(str::to_string),
+    }
+}
+
+#[test]
+fn well_formed_tolerance_backed_by_real_waiver_validates_cleanly() {
+    let case = case_with(vec![tz_allowed(Some("wvr-x"), None)]);
+    let reg = registry_with(vec![case], vec![waiver("wvr-x")], vec![]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        !out.iter().any(|v| v.code == "V19"),
+        "a tolerance backed by a real wvr- resolves cleanly, got {out:?}"
+    );
+}
+
+#[test]
+fn divergence_id_resolves_to_ext_or_intentional_behavior() {
+    // ext- record backing.
+    let case = case_with(vec![tz_allowed(None, Some("ext-x"))]);
+    let ext = DeaconExtension {
+        id: "ext-x".to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        description: "d".to_string(),
+        docs: None,
+    };
+    let reg = registry_with(vec![case], vec![], vec![ext]);
+    assert!(
+        !run(&reg, TODAY, &workspace_root())
+            .iter()
+            .any(|v| v.code == "V19")
+    );
+
+    // intentional-divergence behavior backing.
+    let mut ad = tz_allowed(None, Some("bhv-intentional"));
+    ad.observable_path = "chan-injected-process.env.LANG".to_string();
+    let case2 = case_with(vec![ad]);
+    let reg2 = registry_with(vec![case2], vec![], vec![]);
+    assert!(
+        !run(&reg2, TODAY, &workspace_root())
+            .iter()
+            .any(|v| v.code == "V19")
+    );
+}
+
+#[test]
+fn dangling_waiver_id_is_v19() {
+    let case = case_with(vec![tz_allowed(Some("wvr-does-not-exist"), None)]);
+    let reg = registry_with(vec![case], vec![], vec![]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter()
+            .any(|v| v.code == "V19" && v.message.contains("wvr-does-not-exist")),
+        "a dangling waiverId must be V19, got {out:?}"
+    );
+}
+
+#[test]
+fn dangling_divergence_id_is_v19() {
+    let case = case_with(vec![tz_allowed(None, Some("ext-nope"))]);
+    let reg = registry_with(vec![case], vec![], vec![]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter()
+            .any(|v| v.code == "V19" && v.message.contains("ext-nope")),
+        "a dangling divergenceId must be V19, got {out:?}"
+    );
+}
+
+#[test]
+fn tolerance_scoped_to_unlinked_behavior_is_v19() {
+    let mut ad = tz_allowed(Some("wvr-x"), None);
+    ad.behavior = "bhv-not-linked".to_string();
+    let case = case_with(vec![ad]);
+    let reg = registry_with(vec![case], vec![waiver("wvr-x")], vec![]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter()
+            .any(|v| v.code == "V19" && v.message.contains("bhv-not-linked")),
+        "a tolerance scoped to a behavior the case does not link must be V19, got {out:?}"
+    );
+}
+
+/// Write a temp registry with just a `cases.json` and load it — the load-time structural
+/// checks fire even with the rest of the registry empty.
+fn load_temp_cases(cases_json: &str) -> Result<Registry, LoadError> {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join("cases.json"), cases_json).expect("write cases.json");
+    // Keep the tempdir alive for the load by leaking it into a thread-local is overkill;
+    // load reads synchronously before this returns, so a local binding suffices.
+    let result = Registry::load(dir.path());
+    drop(dir);
+    result
+}
+
+#[test]
+fn conflicting_duplicate_fails_at_load() {
+    // Two allowed differences with the SAME (behavior, observablePath) — a conflict.
+    let json = r#"{
+      "schemaVersion": 1,
+      "records": [
+        {
+          "id": "case-dup",
+          "behaviors": ["bhv-x"],
+          "context": [],
+          "oracleType": "live-differential",
+          "operations": [ { "id": "op", "subcommand": "up", "argv": [] } ],
+          "expected": [ { "channel": "chan-injected-process", "operation": "op" } ],
+          "allowedDifferences": [
+            { "behavior": "bhv-x", "context": [], "observablePath": "chan-injected-process.env.TZ",
+              "rationale": "a", "waiverId": "wvr-a" },
+            { "behavior": "bhv-x", "context": [], "observablePath": "chan-injected-process.env.TZ",
+              "rationale": "b", "waiverId": "wvr-b" }
+          ]
+        }
+      ]
+    }"#;
+    let err = load_temp_cases(json).expect_err("a conflicting duplicate must fail to load");
+    match err {
+        LoadError::Schema(errors) => assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("duplicate allowed difference")),
+            "the located error must name the conflict, got {errors:?}"
+        ),
+        other => panic!("expected Schema error, got {other:?}"),
+    }
+}
+
+#[test]
+fn global_ignore_construct_fails_at_load() {
+    // A bare-channel observablePath (no dotted sub-path) is a global ignore — rejected.
+    let json = r#"{
+      "schemaVersion": 1,
+      "records": [
+        {
+          "id": "case-global",
+          "behaviors": ["bhv-x"],
+          "context": [],
+          "oracleType": "live-differential",
+          "operations": [ { "id": "op", "subcommand": "up", "argv": [] } ],
+          "expected": [ { "channel": "chan-injected-process", "operation": "op" } ],
+          "allowedDifferences": [
+            { "behavior": "bhv-x", "context": [], "observablePath": "chan-injected-process",
+              "rationale": "ignore the whole channel", "waiverId": "wvr-a" }
+          ]
+        }
+      ]
+    }"#;
+    let err = load_temp_cases(json).expect_err("a bare-channel global ignore must fail to load");
+    match err {
+        LoadError::Schema(errors) => assert!(
+            errors.iter().any(|e| e.message.contains("global-ignore")),
+            "the located error must name the global-ignore rejection, got {errors:?}"
+        ),
+        other => panic!("expected Schema error, got {other:?}"),
+    }
+}
+
+#[test]
+fn both_and_neither_backing_ids_fail_at_load() {
+    let both = r#"{
+      "schemaVersion": 1,
+      "records": [ {
+        "id": "case-both", "behaviors": ["bhv-x"], "context": [],
+        "oracleType": "live-differential",
+        "operations": [ { "id": "op", "subcommand": "up", "argv": [] } ],
+        "expected": [ { "channel": "chan-injected-process", "operation": "op" } ],
+        "allowedDifferences": [ { "behavior": "bhv-x", "context": [],
+          "observablePath": "chan-injected-process.env.TZ", "rationale": "r",
+          "waiverId": "wvr-a", "divergenceId": "ext-a" } ]
+      } ]
+    }"#;
+    let err = load_temp_cases(both).expect_err("both ids must fail");
+    assert!(matches!(err, LoadError::Schema(_)));
+
+    let neither = r#"{
+      "schemaVersion": 1,
+      "records": [ {
+        "id": "case-neither", "behaviors": ["bhv-x"], "context": [],
+        "oracleType": "live-differential",
+        "operations": [ { "id": "op", "subcommand": "up", "argv": [] } ],
+        "expected": [ { "channel": "chan-injected-process", "operation": "op" } ],
+        "allowedDifferences": [ { "behavior": "bhv-x", "context": [],
+          "observablePath": "chan-injected-process.env.TZ", "rationale": "r" } ]
+      } ]
+    }"#;
+    let err = load_temp_cases(neither).expect_err("neither id must fail");
+    match err {
+        LoadError::Schema(errors) => assert!(
+            errors.iter().any(|e| e.message.contains("NEITHER")),
+            "must name the missing backing identity, got {errors:?}"
+        ),
+        other => panic!("expected Schema error, got {other:?}"),
+    }
+}

--- a/crates/conformance/tests/case_schema_valid.rs
+++ b/crates/conformance/tests/case_schema_valid.rs
@@ -1,0 +1,186 @@
+//! Hermetic declarative-case schema tests (022-conformance-runner, US1 T015).
+//!
+//! A well-formed declarative case loads and validates cleanly; an unknown behavior, an
+//! undeclared channel, a legacy+declarative mix, and a non-consumer subcommand each fail
+//! loudly with a located message (FR-001..004, FR-003). No Docker, no network — runs in
+//! every lane including the Windows `dev-fast` lane.
+
+use std::fs;
+
+use deacon_conformance::load::{LoadError, Registry};
+use deacon_conformance::model::{
+    BehaviorUnit, CaseKind, Decision, ExpectedObservable, ObservableChannel, Operation, OracleType,
+    ReferenceStatus, SpecStatus, TestCase,
+};
+use deacon_conformance::validate::run;
+use deacon_conformance::{default_registry_dir, workspace_root};
+
+const TODAY: &str = "2026-07-24";
+
+fn behavior(id: &str) -> BehaviorUnit {
+    BehaviorUnit {
+        id: id.to_string(),
+        area: "test".to_string(),
+        statement: "a behavior".to_string(),
+        applicability: vec![],
+        spec: SpecStatus::Conformant,
+        reference: ReferenceStatus::Aligned,
+        decision: Decision::FollowSpec,
+        notes: None,
+    }
+}
+
+fn channel(id: &str) -> ObservableChannel {
+    ObservableChannel {
+        id: id.to_string(),
+        description: "a channel".to_string(),
+    }
+}
+
+/// A well-formed declarative spec-expectation case linked to `bhv-x`, exit-code only.
+fn well_formed_case() -> TestCase {
+    TestCase {
+        id: "case-decl-ok".to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        oracle_type: Some(OracleType::SpecExpectation),
+        operations: vec![Operation {
+            id: "op-1".to_string(),
+            subcommand: "read-configuration".to_string(),
+            argv: vec!["--workspace-folder".to_string(), "${WORKSPACE}".to_string()],
+            fixtures: vec!["fx-x".to_string()],
+            ..Operation::default()
+        }],
+        expected: vec![ExpectedObservable {
+            channel: "chan-exit-code".to_string(),
+            operation: Some("op-1".to_string()),
+            assertion: Some(serde_json::json!({ "equals": 0 })),
+        }],
+        ..TestCase::default()
+    }
+}
+
+/// A registry carrying `bhv-x` + `chan-exit-code` and the given cases.
+fn registry_with(cases: Vec<TestCase>) -> Registry {
+    Registry {
+        behaviors: vec![behavior("bhv-x")],
+        channels: vec![channel("chan-exit-code")],
+        cases,
+        ..Registry::default()
+    }
+}
+
+#[test]
+fn well_formed_declarative_case_has_no_case_schema_violations() {
+    // A well-formed declarative case trips no case-schema class: no V16 (shape /
+    // subcommand / assertion / fsAllowlist) and no V9 on the case (its channel is
+    // declared). Registry-completeness classes (a behavior needing a source unit, V1)
+    // are orthogonal to case schema and are exercised elsewhere.
+    let reg = registry_with(vec![well_formed_case()]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        !out.iter()
+            .any(|v| v.code == "V16" || (v.code == "V9" && v.record == "case-decl-ok")),
+        "a well-formed declarative case must trip no case-schema violation, got {out:?}"
+    );
+    assert_eq!(reg.cases[0].classify().unwrap(), CaseKind::Declarative);
+}
+
+#[test]
+fn the_real_registry_carries_the_declarative_mvp_cases() {
+    // The two 022 MVP cases live in the authoritative registry and load + validate as
+    // part of it (registry_valid guards the whole set; here we assert their presence and
+    // shape specifically).
+    let reg = Registry::load(&default_registry_dir()).expect("real registry loads");
+    let spec = reg
+        .cases
+        .iter()
+        .find(|c| c.id == "case-readconfig-unknown-field-echo")
+        .expect("spec-expectation MVP case present");
+    assert_eq!(spec.classify().unwrap(), CaseKind::Declarative);
+    assert_eq!(spec.oracle_type, Some(OracleType::SpecExpectation));
+    let diff = reg
+        .cases
+        .iter()
+        .find(|c| c.id == "case-readconfig-parity-exit")
+        .expect("live-differential MVP case present");
+    assert_eq!(diff.oracle_type, Some(OracleType::LiveDifferential));
+}
+
+#[test]
+fn unknown_behavior_fails_loud_and_located() {
+    let mut case = well_formed_case();
+    case.behaviors = vec!["bhv-does-not-exist".to_string()];
+    let reg = registry_with(vec![case]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter()
+            .any(|v| v.code == "V1" && v.record == "case-decl-ok"),
+        "an unknown behavior must be a located V1, got {out:?}"
+    );
+}
+
+#[test]
+fn undeclared_channel_fails_loud() {
+    let mut case = well_formed_case();
+    case.expected[0].channel = "chan-ghost".to_string();
+    let reg = registry_with(vec![case]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter().any(|v| v.code == "V9"
+            && v.record == "case-decl-ok"
+            && v.message.contains("chan-ghost")),
+        "an undeclared expected channel must be a located V9, got {out:?}"
+    );
+}
+
+#[test]
+fn non_consumer_subcommand_fails_loud() {
+    let mut case = well_formed_case();
+    case.operations[0].subcommand = "features".to_string(); // authoring-only, out of scope
+    let reg = registry_with(vec![case]);
+    let out = run(&reg, TODAY, &workspace_root());
+    assert!(
+        out.iter().any(|v| v.code == "V16"
+            && v.record == "case-decl-ok"
+            && v.message.contains("features")),
+        "a non-consumer subcommand must be a located V16 (Principle II), got {out:?}"
+    );
+}
+
+#[test]
+fn legacy_declarative_mix_fails_loud_at_load() {
+    // A record with BOTH `executable` (legacy) and `operations` (declarative) is a
+    // structural malformation the loader rejects fail-loud, naming the offending case.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cases_json = r#"{
+      "schemaVersion": 1,
+      "records": [
+        {
+          "id": "case-mixed",
+          "behaviors": ["bhv-x"],
+          "context": [],
+          "executable": { "binary": "some_binary" },
+          "operations": [
+            { "id": "op", "subcommand": "read-configuration", "argv": [] }
+          ]
+        }
+      ]
+    }"#;
+    fs::write(dir.path().join("cases.json"), cases_json).expect("write cases.json");
+
+    let err = Registry::load(dir.path()).expect_err("a mixed case must fail to load");
+    match err {
+        LoadError::Schema(errors) => {
+            assert!(
+                errors.iter().any(|e| {
+                    e.location
+                        .as_deref()
+                        .is_some_and(|l| l.contains("case-mixed"))
+                        && e.message.contains("BOTH")
+                }),
+                "the located schema error must name `case-mixed` and the mix, got {errors:?}"
+            );
+        }
+        other => panic!("expected a located Schema error, got {other:?}"),
+    }
+}

--- a/crates/conformance/tests/gap_certification.rs
+++ b/crates/conformance/tests/gap_certification.rs
@@ -325,7 +325,12 @@ fn certify_fixture(
     registry_dir: &Path,
 ) -> deacon_conformance::certify::Certification {
     let reg = Registry::load(registry_dir).expect("fixture registry loads");
-    certify(&reg, &fx.inputs(), &no_clause_inputs())
+    certify(
+        &reg,
+        &fx.inputs(),
+        &no_clause_inputs(),
+        Path::new("/nonexistent-conformance/snapshots"),
+    )
 }
 
 /// Clause inputs pointing at absent paths, so the clause join scopes itself out (these
@@ -565,6 +570,7 @@ fn certify_clauses(registry: &Registry) -> deacon_conformance::certify::Certific
             spec_dir: &spec,
             clauses_file: &clauses,
         },
+        Path::new("/nonexistent-conformance/snapshots"),
     )
 }
 

--- a/crates/conformance/tests/load_real.rs
+++ b/crates/conformance/tests/load_real.rs
@@ -19,7 +19,11 @@ fn seed_registry_loads_cleanly() {
     // The four closed collections are seeded exactly (T004).
     assert_eq!(registry.revisions.len(), 4, "four pinned source revisions");
     assert_eq!(registry.dimensions.len(), 4, "os/arch/runtime/oracle");
-    assert_eq!(registry.channels.len(), 6, "six observable channels");
+    assert_eq!(
+        registry.channels.len(),
+        11,
+        "six original observable channels + five added by 022-conformance-runner"
+    );
     assert_eq!(registry.profiles.len(), 1, "one active profile");
     assert!(
         registry.profiles[0].active,

--- a/crates/conformance/tests/normalization_semantics.rs
+++ b/crates/conformance/tests/normalization_semantics.rs
@@ -1,0 +1,112 @@
+//! Conformance-side normalization coverage tests (022-conformance-runner, US3 T048).
+//!
+//! The named normalization RULES (`path_token`, `label_semantic`,
+//! `mount_source_canonical`, `path_env_segmented`, `null_preserving`) live in
+//! `parity-harness::normalize` and are unit-tested there (T039/T040) — the conformance
+//! crate is hermetic and cannot execute them. What the conformance crate owns is the
+//! `report`'s per-channel normalized-evidence coverage: this asserts that surface (T048)
+//! reflects the declarative cases' declared channels.
+
+use deacon_conformance::load::Registry;
+use deacon_conformance::model::{
+    ExpectedObservable, ObservableChannel, Operation, OracleType, TestCase,
+};
+use deacon_conformance::report::build_report;
+use deacon_conformance::{default_registry_dir, model::CaseKind};
+
+fn channel(id: &str) -> ObservableChannel {
+    ObservableChannel {
+        id: id.to_string(),
+        description: "c".to_string(),
+    }
+}
+
+fn declarative_case(id: &str, channels: &[(&str, bool)]) -> TestCase {
+    TestCase {
+        id: id.to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        oracle_type: Some(OracleType::SpecExpectation),
+        operations: vec![Operation {
+            id: "op".to_string(),
+            subcommand: "read-configuration".to_string(),
+            ..Operation::default()
+        }],
+        expected: channels
+            .iter()
+            .map(|(ch, asserted)| ExpectedObservable {
+                channel: ch.to_string(),
+                operation: Some("op".to_string()),
+                assertion: asserted.then(|| serde_json::json!({ "equals": 0 })),
+            })
+            .collect(),
+        ..TestCase::default()
+    }
+}
+
+#[test]
+fn report_surfaces_per_channel_declarative_coverage() {
+    let reg = Registry {
+        channels: vec![channel("chan-exit-code"), channel("chan-filesystem")],
+        cases: vec![
+            declarative_case("case-a", &[("chan-exit-code", true)]),
+            declarative_case(
+                "case-b",
+                &[("chan-exit-code", true), ("chan-filesystem", false)],
+            ),
+        ],
+        ..Registry::default()
+    };
+    let report = build_report(&reg, None);
+
+    let by_channel = |id: &str| {
+        report
+            .channel_coverage
+            .iter()
+            .find(|c| c.channel == id)
+            .unwrap_or_else(|| panic!("channel {id} present in coverage"))
+    };
+    // Every declared channel appears (stable shape), channel-id-sorted.
+    assert_eq!(report.channel_coverage.len(), 2);
+    assert_eq!(report.channel_coverage[0].channel, "chan-exit-code");
+
+    let exit = by_channel("chan-exit-code");
+    assert_eq!(exit.declarative_cases, 2, "both cases exercise exit-code");
+    assert_eq!(exit.asserted_expectations, 2);
+
+    let fs = by_channel("chan-filesystem");
+    assert_eq!(fs.declarative_cases, 1, "only case-b exercises filesystem");
+    assert_eq!(
+        fs.asserted_expectations, 0,
+        "case-b's filesystem expectation carries no assertion"
+    );
+}
+
+#[test]
+fn real_registry_report_covers_the_declarative_mvp_channels() {
+    // The real registry's declarative cases exercise exit-code, structured-output, and
+    // filesystem — the report must surface each with a nonzero declarative-case count.
+    let reg = Registry::load(&default_registry_dir()).expect("real registry loads");
+    let declarative = reg
+        .cases
+        .iter()
+        .filter(|c| matches!(c.classify(), Ok(CaseKind::Declarative)))
+        .count();
+    assert!(declarative >= 3, "US1+US3 add declarative cases");
+
+    let report = build_report(&reg, None);
+    for ch in [
+        "chan-exit-code",
+        "chan-structured-output",
+        "chan-filesystem",
+    ] {
+        let row = report
+            .channel_coverage
+            .iter()
+            .find(|c| c.channel == ch)
+            .unwrap_or_else(|| panic!("{ch} in coverage"));
+        assert!(
+            row.declarative_cases > 0,
+            "{ch} must be exercised by >= 1 declarative case, got {row:?}"
+        );
+    }
+}

--- a/crates/conformance/tests/snapshot_staleness.rs
+++ b/crates/conformance/tests/snapshot_staleness.rs
@@ -1,0 +1,201 @@
+//! Hermetic snapshot-staleness tests (022-conformance-runner, US2 T028/T029, FR-020,
+//! SC-003). Cross-platform: they read the COMMITTED `linux-x86_64` snapshot files
+//! (committed JSON, loadable on any host) and the pure staleness comparison — no Docker,
+//! no oracle, no network.
+
+use std::path::PathBuf;
+
+use deacon_conformance::case_hash::hashes_for_case;
+use deacon_conformance::load::Registry;
+use deacon_conformance::model::TestCase;
+use deacon_conformance::snapshot::{self, Provenance, Resolution, Staleness};
+use deacon_conformance::{default_registry_dir, workspace_root};
+
+const CASE_ID: &str = "case-readconfig-snapshot";
+
+fn committed_snapshot_dir() -> PathBuf {
+    snapshot::default_snapshots_dir()
+        .join("linux-x86_64")
+        .join(CASE_ID)
+}
+
+fn fixtures_root() -> PathBuf {
+    workspace_root().join("conformance").join("fixtures")
+}
+
+fn the_case() -> TestCase {
+    let reg = Registry::load(&default_registry_dir()).expect("registry loads");
+    reg.cases
+        .into_iter()
+        .find(|c| c.id == CASE_ID)
+        .unwrap_or_else(|| panic!("{CASE_ID} must exist in the registry"))
+}
+
+fn recorded_provenance() -> Provenance {
+    snapshot::load_provenance(&committed_snapshot_dir())
+        .expect("the committed snapshot provenance loads")
+}
+
+#[test]
+fn committed_snapshot_carries_all_thirteen_provenance_fields() {
+    // A recorded provenance with every FR-017 field populated — none fabricated: it was
+    // written live by `conformance-snapshot refresh` against the pinned oracle.
+    let p = recorded_provenance();
+    assert_eq!(p.oracle_version, "0.87.0");
+    assert_eq!(p.source_revision, "113500f4");
+    assert!(!p.case_hash.is_empty() && p.case_hash.len() == 64);
+    assert!(!p.fixture_hash.is_empty() && p.fixture_hash.len() == 64);
+    assert!(!p.argv.is_empty());
+    assert_eq!(p.platform, "linux");
+    assert_eq!(p.arch, "x86_64");
+    assert!(!p.node_version.is_empty());
+    assert!(!p.docker_version.is_empty());
+    assert!(!p.compose_version.is_empty());
+    assert_eq!(p.normalizer_version, snapshot::NORMALIZER_VERSION);
+    assert!(!p.captured_at.is_empty());
+    // imageDigests is empty for a config-only read-configuration case (no images).
+    assert!(p.image_digests.is_empty());
+}
+
+#[test]
+fn committed_snapshot_hashes_match_the_committed_case() {
+    // Recompute the case/fixture hashes from the committed case + fixtures; they MUST
+    // equal the recorded provenance — i.e. the committed snapshot is fresh-by-hash and
+    // consistent with the case it belongs to (editing the case without a refresh would
+    // break this, exactly as `snapshot check` fails as stale).
+    let (case_hash, fixture_hash) =
+        hashes_for_case(&the_case(), &fixtures_root()).expect("recompute hashes");
+    let p = recorded_provenance();
+    assert_eq!(
+        case_hash, p.case_hash,
+        "recomputed caseHash matches recorded"
+    );
+    assert_eq!(
+        fixture_hash, p.fixture_hash,
+        "recomputed fixtureHash matches recorded"
+    );
+}
+
+#[test]
+fn each_staleness_field_drift_is_named() {
+    type Mutate = fn(&mut Provenance);
+    let cases: &[(&str, Mutate)] = &[
+        ("caseHash", |p| p.case_hash = "drift".into()),
+        ("fixtureHash", |p| p.fixture_hash = "drift".into()),
+        ("oracleVersion", |p| p.oracle_version = "9.9.9".into()),
+        ("sourceRevision", |p| p.source_revision = "deadbeef".into()),
+        ("imageDigests", |p| {
+            p.image_digests.insert("img".into(), "sha256:x".into());
+        }),
+        ("normalizerVersion", |p| p.normalizer_version = "99".into()),
+    ];
+    let recorded = recorded_provenance();
+    for (field, mutate) in cases {
+        let mut current = recorded.clone();
+        mutate(&mut current);
+        match snapshot::compare_staleness(&recorded, &current) {
+            Staleness::Stale { field: got, .. } => {
+                assert_eq!(&got, field, "drift in {field} must be named as stale")
+            }
+            Staleness::Fresh => panic!("drift in {field} must be stale"),
+        }
+    }
+}
+
+#[test]
+fn selectors_and_host_versions_do_not_trigger_staleness() {
+    // Selectors (platform/arch), informational fields (capturedAt/argv), AND the host
+    // tool versions (node/docker/compose) must NOT trigger staleness: a snapshot recorded
+    // in this dev container (e.g. Node 22) must stay fresh when replayed on the parity
+    // lane (Node 20) — cross-machine CI replay (SC-003). The evidence-determining inputs
+    // (case/fixture hashes, oracle/source pins, imageDigests, normalizer) still gate.
+    let recorded = recorded_provenance();
+    let non_staleness: &[fn(&mut Provenance)] = &[
+        |p| p.captured_at = "2099-01-01T00:00:00Z".into(),
+        |p| p.platform = "macos".into(),
+        |p| p.arch = "aarch64".into(),
+        |p| p.argv = vec!["totally".into(), "different".into()],
+        |p| p.node_version = "20.0.0".into(),
+        |p| p.docker_version = "27.0.0".into(),
+        |p| p.compose_version = "2.29.0".into(),
+    ];
+    for mutate in non_staleness {
+        let mut current = recorded.clone();
+        mutate(&mut current);
+        assert_eq!(
+            snapshot::compare_staleness(&recorded, &current),
+            Staleness::Fresh,
+            "capturedAt/platform/arch/argv/node/docker/compose must NOT trigger staleness"
+        );
+    }
+}
+
+#[test]
+fn missing_snapshot_for_current_os_arch_is_no_reference_for_platform() {
+    // Resolving a platform with no committed snapshot yields `no-reference-for-platform`
+    // — a coverage gap distinct from `stale` (a different Resolution variant entirely, so
+    // no staleness comparison even runs) and from a silent skip.
+    let snapshots_root = snapshot::default_snapshots_dir();
+    let resolution = snapshot::resolve(&snapshots_root, "no-such-osarch", CASE_ID)
+        .expect("resolve is fallible only on malformed files");
+    match resolution {
+        Resolution::NoReferenceForPlatform { os_arch } => assert_eq!(os_arch, "no-such-osarch"),
+        Resolution::Found(_) => panic!("there is no snapshot for a bogus os-arch"),
+    }
+
+    // The committed platform DOES resolve to a snapshot (the two outcomes are distinct).
+    assert!(matches!(
+        snapshot::resolve(&snapshots_root, "linux-x86_64", CASE_ID).unwrap(),
+        Resolution::Found(_)
+    ));
+}
+
+/// T038 (FR-021): ordinary runs NEVER write a committed snapshot — the ONLY snapshot
+/// writer (`evidence::write_snapshot`) is invoked from exactly one place in library/bin
+/// source: the reviewed refresh bin. Any new caller in a runtime path would fail this
+/// structural guard, so a snapshot can never be rewritten by a plain `cargo nextest run`.
+#[test]
+fn only_the_refresh_bin_writes_committed_snapshots() {
+    let mut callers: Vec<String> = Vec::new();
+    for crate_src in ["conformance/src", "parity-harness/src"] {
+        let root = workspace_root().join("crates").join(crate_src);
+        scan_for_writer(&root, &mut callers);
+    }
+    callers.sort();
+    // Sorted: the reviewed refresh bin (only caller) + the writer's definition.
+    assert_eq!(
+        callers,
+        vec![
+            "parity-harness/src/bin/conformance-snapshot.rs".to_string(),
+            "parity-harness/src/evidence.rs".to_string(),
+        ],
+        "`write_snapshot` must appear only in its definition + the refresh bin; a new \
+         caller in a runtime path would let an ordinary run rewrite a committed snapshot"
+    );
+}
+
+/// Recursively collect `crates/<crate>/src/...` files that reference `write_snapshot(`,
+/// as `<crate>/src/<rel>` strings.
+fn scan_for_writer(dir: &std::path::Path, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_for_writer(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                if text.contains("write_snapshot(") {
+                    // Render as `<crate>/src/<rel-to-crates>` for a stable assertion.
+                    let rel = path
+                        .strip_prefix(workspace_root().join("crates"))
+                        .unwrap_or(&path)
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    out.push(rel);
+                }
+            }
+        }
+    }
+}

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -45,3 +45,6 @@ temp-env.workspace = true
 # Dev-only parity harness (publish = false). Consumed by the `parity_*` and
 # `consistency_*` test binaries; never linked into the shipped deacon binary.
 parity-harness = { path = "../parity-harness" }
+# Dev-only conformance registry (publish = false). The `parity_conformance_runner`
+# binary loads declarative cases from it; never linked into the shipped deacon binary.
+deacon-conformance = { path = "../conformance" }

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -1046,7 +1046,24 @@ pub struct Cli {
     ///
     /// When disabled (default), lifecycle commands run without PTY allocation. This is suitable
     /// for non-interactive scripts and automated environments.
-    #[arg(long, global = true, env = "DEACON_FORCE_TTY_IF_JSON")]
+    ///
+    /// Parsing: the documented case-insensitive truthy/falsey vocabulary
+    /// (`true`/`yes`/`on`/`1` vs `false`/`no`/`off`/`0`) is honored for BOTH the env var and
+    /// an explicit `--force-tty-if-json=<value>` via clap's `BoolishValueParser` — clap's
+    /// default `bool` parser accepts only exact lowercase `true`/`false`, which contradicted
+    /// this flag's documented contract (e.g. `DEACON_FORCE_TTY_IF_JSON=False` was rejected).
+    /// A bare `--force-tty-if-json` (no value) means `true` (`default_missing_value`);
+    /// `require_equals` keeps the bare switch from greedily consuming a following subcommand.
+    #[arg(
+        long,
+        global = true,
+        env = "DEACON_FORCE_TTY_IF_JSON",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value_t = false,
+        default_missing_value = "true",
+    )]
     pub force_tty_if_json: bool,
 
     /// Default user env probe mode (none|loginInteractiveShell|interactiveShell|loginShell).

--- a/crates/deacon/tests/parity_conformance_runner.rs
+++ b/crates/deacon/tests/parity_conformance_runner.rs
@@ -1,0 +1,167 @@
+//! Live differential run of the declarative conformance runner over the registry's
+//! declarative cases (022-conformance-runner, US1 T026).
+//!
+//! Runs ONLY under `cargo nextest run --profile parity`. There is no opt-in env gate and
+//! no silent skip: a missing/mismatched oracle, a missing fixture, a CLI failure, or a
+//! normalization failure FAILS the test with a cause-specific message (constitution IV).
+//! It drives the SHARED runner over every declarative `cases.json` record — spec-
+//! expectation cases against deacon, live-differential cases against deacon + the pinned
+//! oracle — so adding a case is a pure data edit (SC-001). The deterministic verdict
+//! report is emitted on stdout; a run-report fragment is written to
+//! `target/parity/report/parity_conformance_runner.json` for the aggregator.
+
+use std::path::Path;
+
+use deacon_conformance::default_registry_dir;
+use deacon_conformance::load::Registry;
+use deacon_conformance::model::CaseKind;
+
+use parity_harness::evidence::{CaseVerdict, Outcome};
+use parity_harness::oracle::Oracle;
+use parity_harness::report::{
+    CaseResult, Cause, OracleInfo, RawPaths, ReportFragment, VerdictReport, now_rfc3339,
+};
+use parity_harness::runner::{RUNNER_BINARY, RunConfig, run_case};
+use parity_harness::{HarnessError, report_root, workspace_root};
+
+/// This binary's name — the fragment key and raw-artifact subdirectory.
+const BINARY: &str = "parity_conformance_runner";
+
+/// Fail the test with the error's cause-specific `Display` message (never `Debug`) so an
+/// oracle/prereq/normalization failure reads as its remedy.
+fn ff<T>(r: Result<T, HarnessError>) -> T {
+    r.unwrap_or_else(|e| panic!("{e}"))
+}
+
+/// The report-relative raw paths for a case's FIRST operation (diagnostic pointers for
+/// the fragment). The runner writes raw capture under
+/// `raw/<RUNNER_BINARY>/<case>__<op>/{deacon,oracle}.{stdout,stderr}`.
+fn raw_paths(case_id: &str, first_op: &str) -> RawPaths {
+    let base = format!("raw/{RUNNER_BINARY}/{case_id}__{first_op}");
+    RawPaths {
+        deacon_stdout: format!("{base}/deacon.stdout"),
+        deacon_stderr: format!("{base}/deacon.stderr"),
+        oracle_stdout: format!("{base}/oracle.stdout"),
+        oracle_stderr: format!("{base}/oracle.stderr"),
+    }
+}
+
+/// Map a case verdict to a report-fragment case result (agree/allowed-difference pass;
+/// anything else fails with a cause).
+fn case_result(verdict: &CaseVerdict, raw: RawPaths) -> CaseResult {
+    match verdict.overall {
+        // `no-reference-for-platform` is a NON-BLOCKING coverage gap (no snapshot recorded
+        // for THIS platform yet), never a divergence — consistent with the runner's
+        // exit-code contract (maps it to 0) and certify (surfaces it as non-blocking info).
+        // It is logged in the main loop; here it passes so it never reddens the lane
+        // (finding #2).
+        Outcome::Agree | Outcome::AllowedDifference | Outcome::NoReferenceForPlatform => {
+            CaseResult::pass(verdict.case_id.clone(), raw)
+        }
+        Outcome::Stale => CaseResult::fail(
+            verdict.case_id.clone(),
+            Cause::Divergence,
+            Some("snapshot stale".to_string()),
+            raw,
+        ),
+        Outcome::Diverge | Outcome::Error => CaseResult::fail(
+            verdict.case_id.clone(),
+            Cause::Divergence,
+            Some(summarize(verdict)),
+            raw,
+        ),
+    }
+}
+
+/// A compact, path-free summary of a case's diverging channels for the fragment.
+fn summarize(verdict: &CaseVerdict) -> String {
+    verdict
+        .channels
+        .iter()
+        .filter(|c| c.outcome != Outcome::Agree && c.outcome != Outcome::AllowedDifference)
+        .map(|c| format!("{}: {:?}", c.channel, c.outcome))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+#[tokio::test]
+async fn parity_conformance_runner() {
+    // Fail fast if the pinned oracle is absent/mismatched — never skip to pass. Every
+    // declarative case may need it (live-differential does; spec-expectation ignores it).
+    let oracle = ff(Oracle::acquire().await);
+    let deacon_bin = Path::new(env!("CARGO_BIN_EXE_deacon"));
+    let root = workspace_root();
+    let fixtures_root = root.join("conformance").join("fixtures");
+    let reports = report_root();
+
+    let registry = Registry::load(&default_registry_dir())
+        .unwrap_or_else(|e| panic!("conformance registry must load: {e}"));
+
+    let declarative: Vec<_> = registry
+        .cases
+        .iter()
+        .filter(|c| matches!(c.classify(), Ok(CaseKind::Declarative)))
+        .collect();
+    assert!(
+        !declarative.is_empty(),
+        "expected at least one declarative case to drive the runner"
+    );
+
+    let snapshots_root = root.join("conformance").join("snapshots");
+    let cfg = RunConfig {
+        deacon_path: deacon_bin,
+        oracle: Some(&oracle),
+        fixtures_root: &fixtures_root,
+        report_root: &reports,
+        snapshots_root: &snapshots_root,
+    };
+
+    let started = now_rfc3339();
+    let mut verdicts = Vec::new();
+    let mut results = Vec::new();
+    let mut failures = Vec::new();
+
+    for case in &declarative {
+        let verdict = ff(run_case(case, &cfg).await);
+        let first_op = case
+            .operations
+            .first()
+            .map(|o| o.id.as_str())
+            .unwrap_or("op");
+        results.push(case_result(&verdict, raw_paths(&case.id, first_op)));
+        match verdict.overall {
+            Outcome::Agree | Outcome::AllowedDifference => {}
+            // Non-blocking coverage gap: surface it (never a silent skip) but do NOT fail
+            // the lane — a snapshot simply has not been recorded for this platform yet
+            // (finding #2; consistent with certify + the runner exit-code contract).
+            Outcome::NoReferenceForPlatform => eprintln!(
+                "note: {} has no committed snapshot for this platform (no-reference-for-platform)",
+                case.id
+            ),
+            _ => failures.push(format!("{}: {}", case.id, summarize(&verdict))),
+        }
+        verdicts.push(verdict);
+    }
+
+    // The deterministic verdict report on stdout (contract runner-cli.md).
+    let report = VerdictReport::new(verdicts);
+    ff(report.emit_stdout());
+
+    // The run-report fragment for the aggregator's completeness gate.
+    let finished = now_rfc3339();
+    let fragment = ReportFragment::new(
+        BINARY,
+        OracleInfo::from(&oracle),
+        started,
+        finished,
+        results,
+        Vec::new(),
+    );
+    ff(fragment.write().await);
+
+    assert!(
+        failures.is_empty(),
+        "declarative conformance divergence(s) vs the runner's expectations:\n{}",
+        failures.join("\n"),
+    );
+}

--- a/crates/parity-harness/Cargo.toml
+++ b/crates/parity-harness/Cargo.toml
@@ -23,9 +23,14 @@ chrono = "0.4"
 # NEW dev-scope dependency: parses `.config/nextest.toml` in the registry check
 # (registry.rs / parity_registry_check) so profile-filter drift fails structurally.
 toml = "0.8"
+# Declarative conformance runner (022): the `matches` stdout/stderr assertion is a
+# regex match; `regex` is already a [workspace.dependencies] entry (used by core).
+regex = { workspace = true }
+# Isolated external temp workspaces for Docker-backed conformance cases (022 US5,
+# workspace.rs). Runtime dep now (not just dev): the RAII cleanup guard owns a TempDir.
+tempfile = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/parity-harness/src/bin/conformance-snapshot.rs
+++ b/crates/parity-harness/src/bin/conformance-snapshot.rs
@@ -1,0 +1,198 @@
+//! `conformance-snapshot` — the reviewed snapshot REFRESH bin (022-conformance-runner
+//! US2, T037; contract runner-cli.md §2).
+//!
+//! `cargo run -p parity-harness --bin conformance-snapshot -- refresh [--case <id>]
+//! [--platform <os-arch>]`
+//!
+//! Runs each `snapshot`-oracle case's operations against the VERIFIED pinned reference,
+//! captures and normalizes the declared channels, records the 13-field provenance, and
+//! writes `provenance.json` / `raw.json` / `normalized.json` ATOMICALLY under
+//! `conformance/snapshots/<os-arch>/<case-id>/`. It requires the verified oracle, Docker,
+//! and Node, and FAILS LOUD if any is absent (constitution IV — never a silent skip,
+//! never a fabricated provenance field). It prints a review diff (old vs new) for the
+//! reviewer; the git diff is the review surface. Ordinary test runs NEVER call this —
+//! they only read/compare (FR-021).
+
+use std::process::ExitCode;
+
+use deacon_conformance::load::Registry;
+use deacon_conformance::model::{CaseKind, OracleType, TestCase};
+use deacon_conformance::{default_registry_dir, snapshot, workspace_root};
+
+use parity_harness::exec::Side;
+use parity_harness::oracle::Oracle;
+use parity_harness::prereq::require_docker;
+use parity_harness::runner::{RunConfig, capture_provenance, collect_evidence_on};
+use parity_harness::{HarnessError, evidence, report_root};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("refresh") => run_refresh(&args[1..]),
+        _ => {
+            eprintln!("usage: conformance-snapshot refresh [--case <id>] [--platform <os-arch>]");
+            ExitCode::from(2)
+        }
+    }
+}
+
+/// Parse `--case`/`--platform` and drive the refresh on a bounded tokio runtime.
+fn run_refresh(args: &[String]) -> ExitCode {
+    let mut case_filter: Option<String> = None;
+    let mut platform: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--case" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => case_filter = Some(v.clone()),
+                    None => return usage("--case requires a value"),
+                }
+            }
+            "--platform" => {
+                i += 1;
+                match args.get(i) {
+                    Some(v) => platform = Some(v.clone()),
+                    None => return usage("--platform requires a value"),
+                }
+            }
+            other => return usage(&format!("unknown argument {other:?}")),
+        }
+        i += 1;
+    }
+
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: could not start async runtime: {e}");
+            return ExitCode::from(4);
+        }
+    };
+    match runtime.block_on(refresh(case_filter.as_deref(), platform.as_deref())) {
+        Ok(count) => {
+            eprintln!("refreshed {count} snapshot(s)");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::from(4)
+        }
+    }
+}
+
+fn usage(msg: &str) -> ExitCode {
+    eprintln!("error: {msg}");
+    eprintln!("usage: conformance-snapshot refresh [--case <id>] [--platform <os-arch>]");
+    ExitCode::from(2)
+}
+
+/// Record snapshots for the selected `snapshot`-oracle cases against the verified
+/// reference. Returns the number of snapshots written.
+async fn refresh(case_filter: Option<&str>, platform: Option<&str>) -> Result<usize, HarnessError> {
+    // Fail-loud prerequisites: verified oracle + Docker + Node — never a silent skip.
+    let oracle = Oracle::acquire().await?;
+    require_docker().await?;
+    let env = snapshot::probe_environment();
+    if env.node_version.is_none() {
+        return Err(HarnessError::NodeUnavailable {
+            cause: "`node --version` did not report a version".to_string(),
+        });
+    }
+
+    let root = workspace_root();
+    let fixtures_root = root.join("conformance").join("fixtures");
+    let snapshots_root = snapshot::default_snapshots_dir();
+    let reports = report_root();
+    let os_arch = platform
+        .map(str::to_string)
+        .unwrap_or_else(snapshot::current_os_arch);
+
+    let registry =
+        Registry::load(&default_registry_dir()).map_err(|e| HarnessError::FixtureMissing {
+            path: default_registry_dir().join(format!("<load failed: {e}>")),
+        })?;
+
+    let cases: Vec<&TestCase> = registry
+        .cases
+        .iter()
+        .filter(|c| matches!(c.classify(), Ok(CaseKind::Declarative)))
+        .filter(|c| c.oracle_type == Some(OracleType::Snapshot))
+        .filter(|c| case_filter.is_none_or(|id| c.id == id))
+        .collect();
+
+    if cases.is_empty() {
+        return Err(HarnessError::FixtureMissing {
+            path: default_registry_dir().join(match case_filter {
+                Some(id) => format!("<no snapshot-oracle case {id:?}>"),
+                None => "<no snapshot-oracle cases>".to_string(),
+            }),
+        });
+    }
+
+    let cfg = RunConfig {
+        // The refresh records the REFERENCE; `deacon_path` is a placeholder (the oracle
+        // path) since only the oracle side is collected here.
+        deacon_path: &oracle.path,
+        oracle: Some(&oracle),
+        fixtures_root: &fixtures_root,
+        report_root: &reports,
+        snapshots_root: &snapshots_root,
+    };
+
+    let mut written = 0usize;
+    for case in cases {
+        let dir = snapshot::snapshot_case_dir(&snapshots_root, &os_arch, &case.id);
+        // The prior snapshot (if any) is the review baseline.
+        let old = snapshot::load_snapshot(&dir).ok();
+
+        // Run the case against the reference and capture raw + normalized evidence.
+        let case_evidence = collect_evidence_on(Side::Oracle, &oracle.path, case, &cfg).await?;
+        let provenance = capture_provenance(case, &cfg, &oracle.version)?;
+
+        // Print the review diff BEFORE writing (old vs new).
+        print_review_diff(case, &old, &provenance, &case_evidence);
+
+        evidence::write_snapshot(&dir, &provenance, &case_evidence).await?;
+        eprintln!("wrote {}", dir.display());
+        written += 1;
+    }
+    Ok(written)
+}
+
+/// Print a human review diff (old vs newly-recorded) for one case.
+fn print_review_diff(
+    case: &TestCase,
+    old: &Option<snapshot::Snapshot>,
+    provenance: &snapshot::Provenance,
+    new_evidence: &evidence::CaseEvidence,
+) {
+    let new_normalized = serde_json::to_value(&new_evidence.normalized).unwrap_or_default();
+    let new_raw = serde_json::to_value(&new_evidence.raw).unwrap_or_default();
+    match old {
+        None => eprintln!("[{}] NEW snapshot (no prior baseline)", case.id),
+        Some(prev) => {
+            let new_snap = snapshot::Snapshot {
+                provenance: provenance.clone(),
+                raw: new_raw,
+                normalized: new_normalized,
+            };
+            let entries = snapshot::diff(prev, &new_snap);
+            let material: Vec<_> = entries
+                .iter()
+                .filter(|e| !(e.artifact == "provenance" && e.path == "capturedAt"))
+                .collect();
+            if material.is_empty() {
+                eprintln!(
+                    "[{}] no material change (only capturedAt refreshed)",
+                    case.id
+                );
+            } else {
+                eprintln!("[{}] review diff:", case.id);
+                for e in material {
+                    eprintln!("  {} {}: {} -> {}", e.artifact, e.path, e.old, e.new);
+                }
+            }
+        }
+    }
+}

--- a/crates/parity-harness/src/compare.rs
+++ b/crates/parity-harness/src/compare.rs
@@ -1,0 +1,730 @@
+//! Per-channel comparison → [`ChannelVerdict`] (T021, 022-conformance-runner).
+//!
+//! Compares NORMALIZED evidence (never raw) for each declared channel and produces a
+//! verdict. Two entry points:
+//! - [`verdict_spec_expectation`] evaluates a declared `assertion` against one side's
+//!   normalized evidence (no reference run);
+//! - [`verdict_differential`] compares deacon's normalized evidence to the reference's
+//!   for the same channel.
+//!
+//! Allowed-difference integration (US4, T064): a divergence whose every diverging
+//! observable path is covered by a scoped [`Tolerances`] entry becomes
+//! `allowed-difference`; an uncovered divergence stays `diverge`. Detail payloads are
+//! path-free and deterministic so the verdict report stays byte-stable (contract
+//! runner-cli.md, T018).
+
+use serde_json::{Value, json};
+
+use deacon_conformance::model::{
+    CHAN_EXIT_CODE, CHAN_FILE_CONTENT, CHAN_FILESYSTEM, CHAN_IMAGE, CHAN_INJECTED_PROCESS,
+    CHAN_PROCESS_GRAPH, CHAN_STDERR, CHAN_STDOUT, CHAN_STRUCTURED_OUTPUT, CHAN_TEMPORAL,
+};
+
+use crate::HarnessError;
+use crate::evidence::{ChannelVerdict, NormalizedChannelEvidence, Outcome};
+
+/// Evaluate a declared `assertion` against one side's normalized `evidence` for
+/// `channel` (spec-expectation oracle). Returns an `agree`/`diverge` verdict, or a
+/// fail-loud [`HarnessError`] when the assertion is malformed or targets a channel this
+/// comparison does not understand (a case-authoring error, constitution IV).
+pub fn verdict_spec_expectation(
+    channel: &str,
+    evidence: &NormalizedChannelEvidence,
+    assertion: &Value,
+) -> Result<ChannelVerdict, HarnessError> {
+    let outcome = evaluate_assertion(channel, evidence, assertion)?;
+    Ok(match outcome {
+        AssertionResult::Pass => agree(channel),
+        AssertionResult::Fail(detail) => diverge(channel, detail),
+    })
+}
+
+/// Compare deacon's normalized evidence to the reference's for `channel`
+/// (live-differential oracle). Equal normalized values agree; otherwise diverge with a
+/// path-free detail. `present:false` on either side is itself part of the comparison
+/// (not-captured must match not-captured — FR-018).
+///
+/// A divergence whose EVERY diverging observable path is covered by a scoped
+/// [`Tolerances`] entry becomes `allowed-difference` (with the backing waiver/divergence
+/// ids in the detail, FR-033); a divergence with any UNCOVERED path stays `diverge`. Each
+/// consumed tolerance's key is recorded in `consumed` so the caller can report the
+/// unconsumed (stale) ones — the same self-invalidating pattern as the registry waiver
+/// check (FR-034, reused, not re-implemented).
+pub fn verdict_differential(
+    channel: &str,
+    deacon: &NormalizedChannelEvidence,
+    reference: &NormalizedChannelEvidence,
+    tolerances: &Tolerances<'_>,
+    consumed: &mut std::collections::HashSet<String>,
+) -> ChannelVerdict {
+    // The diverging observable paths (channel-prefixed dotted paths).
+    let mut diverging: Vec<String> = Vec::new();
+    if deacon.present != reference.present {
+        diverging.push(channel.to_string());
+    } else if deacon.present {
+        diff_paths(channel, &deacon.value, &reference.value, &mut diverging);
+    }
+    if diverging.is_empty() {
+        return agree(channel);
+    }
+
+    let mut uncovered: Vec<String> = Vec::new();
+    let mut covered: Vec<Value> = Vec::new();
+    for path in &diverging {
+        match tolerances.covering(path) {
+            Some(ad) => {
+                let backing = ad.resolved_id().unwrap_or("<unresolved>");
+                covered.push(json!({ "observablePath": path, "backingId": backing }));
+                consumed.insert(tolerance_key(ad));
+            }
+            None => uncovered.push(path.clone()),
+        }
+    }
+
+    if uncovered.is_empty() {
+        ChannelVerdict {
+            channel: channel.to_string(),
+            outcome: Outcome::AllowedDifference,
+            detail: Some(json!({ "allowed": covered })),
+        }
+    } else {
+        diverge(
+            channel,
+            json!({ "kind": "differential", "divergingPaths": uncovered }),
+        )
+    }
+}
+
+/// The scoped tolerances applicable to a case: its allowed differences plus the
+/// behaviors it links (a tolerance applies only under a linked behavior, FR-033).
+pub struct Tolerances<'a> {
+    allowed: &'a [deacon_conformance::model::AllowedDifference],
+    behaviors: &'a [String],
+}
+
+impl<'a> Tolerances<'a> {
+    /// Build the tolerance set for a case.
+    pub fn new(
+        allowed: &'a [deacon_conformance::model::AllowedDifference],
+        behaviors: &'a [String],
+    ) -> Tolerances<'a> {
+        Tolerances { allowed, behaviors }
+    }
+
+    /// Whether there are no tolerances (the common case).
+    pub fn is_empty(&self) -> bool {
+        self.allowed.is_empty()
+    }
+
+    /// The allowed difference covering `observable_path` — matched by a LINKED behavior
+    /// and an `observablePath` that equals `observable_path` or is a segment-prefix of it
+    /// (so `chan-image.labels` covers `chan-image.labels.foo`). `None` if uncovered.
+    fn covering(
+        &self,
+        observable_path: &str,
+    ) -> Option<&'a deacon_conformance::model::AllowedDifference> {
+        self.allowed.iter().find(|ad| {
+            self.behaviors.contains(&ad.behavior)
+                && path_covers(&ad.observable_path, observable_path)
+        })
+    }
+
+    /// The tolerance keys that were NOT consumed by any covered divergence this run — the
+    /// STALE allowed differences (their characterized difference no longer reproduces,
+    /// FR-034). The caller surfaces them in the report.
+    pub fn stale(&self, consumed: &std::collections::HashSet<String>) -> Vec<String> {
+        self.allowed
+            .iter()
+            .filter(|ad| self.behaviors.contains(&ad.behavior))
+            .filter(|ad| !consumed.contains(&tolerance_key(ad)))
+            .map(|ad| {
+                format!(
+                    "{} @ {} ({})",
+                    ad.behavior,
+                    ad.observable_path,
+                    ad.resolved_id().unwrap_or("<unresolved>")
+                )
+            })
+            .collect()
+    }
+}
+
+/// The stable consumption key for a tolerance: `(behavior, observablePath)` (FR-033).
+fn tolerance_key(ad: &deacon_conformance::model::AllowedDifference) -> String {
+    format!("{}\u{0}{}", ad.behavior, ad.observable_path)
+}
+
+/// Whether an allowed `observablePath` covers a diverging `path`: exact match, or the
+/// allowed path is a segment-boundary prefix of the diverging path.
+fn path_covers(allowed: &str, path: &str) -> bool {
+    allowed == path
+        || (path.len() > allowed.len()
+            && path.starts_with(allowed)
+            && path.as_bytes().get(allowed.len()) == Some(&b'.'))
+}
+
+/// Collect the channel-prefixed dotted paths where `a` and `b` differ. Objects recurse
+/// key-wise; arrays/scalars that differ emit their path. `prefix` starts as the channel id.
+fn diff_paths(prefix: &str, a: &Value, b: &Value, out: &mut Vec<String>) {
+    match (a, b) {
+        (Value::Object(oa), Value::Object(ob)) => {
+            let mut keys: Vec<&String> = oa.keys().chain(ob.keys()).collect();
+            keys.sort();
+            keys.dedup();
+            for k in keys {
+                let child = format!("{prefix}.{k}");
+                match (oa.get(k), ob.get(k)) {
+                    (Some(va), Some(vb)) => diff_paths(&child, va, vb, out),
+                    // Present on one side only → a divergence at that key.
+                    _ => out.push(child),
+                }
+            }
+        }
+        _ if a != b => out.push(prefix.to_string()),
+        _ => {}
+    }
+}
+
+/// An `agree` verdict with no detail.
+fn agree(channel: &str) -> ChannelVerdict {
+    ChannelVerdict {
+        channel: channel.to_string(),
+        outcome: Outcome::Agree,
+        detail: None,
+    }
+}
+
+/// A `diverge` verdict carrying a path-free, deterministic `detail`.
+fn diverge(channel: &str, detail: Value) -> ChannelVerdict {
+    ChannelVerdict {
+        channel: channel.to_string(),
+        outcome: Outcome::Diverge,
+        detail: Some(detail),
+    }
+}
+
+/// The outcome of evaluating one assertion.
+enum AssertionResult {
+    Pass,
+    /// Failed with a path-free detail describing the mismatch.
+    Fail(Value),
+}
+
+/// Dispatch an assertion to its channel-appropriate evaluator. Unknown channels /
+/// assertion keys are fail-loud authoring errors.
+fn evaluate_assertion(
+    channel: &str,
+    evidence: &NormalizedChannelEvidence,
+    assertion: &Value,
+) -> Result<AssertionResult, HarnessError> {
+    let obj = assertion
+        .as_object()
+        .ok_or_else(|| malformed(channel, "assertion must be an object"))?;
+    // Exactly one predicate key; take it fallibly so there is no unchecked panic path.
+    let mut entries = obj.iter();
+    let (key, expected) = match (entries.next(), entries.next()) {
+        (Some(entry), None) => entry,
+        _ => {
+            return Err(malformed(
+                channel,
+                "assertion must carry exactly one predicate key",
+            ));
+        }
+    };
+
+    match channel {
+        CHAN_EXIT_CODE => exit_code_assertion(channel, key, expected, evidence),
+        CHAN_STDOUT | CHAN_STDERR => text_assertion(channel, key, expected, evidence),
+        // JSON-object channels (structured output, file content, and the four Docker
+        // channels) share the `jsonEquals`/`jsonSubset` evaluator.
+        CHAN_STRUCTURED_OUTPUT
+        | CHAN_FILE_CONTENT
+        | CHAN_IMAGE
+        | CHAN_PROCESS_GRAPH
+        | CHAN_INJECTED_PROCESS
+        | CHAN_TEMPORAL => structured_assertion(channel, key, expected, evidence),
+        CHAN_FILESYSTEM => filesystem_assertion(channel, key, expected, evidence),
+        other => Err(malformed(
+            other,
+            "no spec-expectation assertion evaluator for this channel",
+        )),
+    }
+}
+
+/// `chan-filesystem`: `{ exists: "<relpath>" } | { absent: "<relpath>" } | { mode: {"<relpath>": "0644"} }`.
+/// Evaluated against the observer's `{ "<relpath>": { exists, mode } }` map (normalized,
+/// so any path in a value is already tokenized).
+fn filesystem_assertion(
+    channel: &str,
+    key: &str,
+    expected: &Value,
+    evidence: &NormalizedChannelEvidence,
+) -> Result<AssertionResult, HarnessError> {
+    let map = evidence
+        .value
+        .as_object()
+        .ok_or_else(|| malformed(channel, "filesystem evidence is not an object"))?;
+    match key {
+        "exists" | "absent" => {
+            let path = expected
+                .as_str()
+                .ok_or_else(|| malformed(channel, &format!("`{key}` must be a path string")))?;
+            let exists = map
+                .get(path)
+                .and_then(|e| e.get("exists"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            let want_exists = key == "exists";
+            Ok(pass_if(
+                exists == want_exists,
+                json!({ "predicate": key, "path": path, "actualExists": exists }),
+            ))
+        }
+        "mode" => {
+            let want = expected
+                .as_object()
+                .ok_or_else(|| malformed(channel, "`mode` must be a { path: mode } object"))?;
+            for (path, mode) in want {
+                let actual = map.get(path).and_then(|e| e.get("mode")).cloned();
+                if actual.as_ref() != Some(mode) {
+                    return Ok(AssertionResult::Fail(
+                        json!({ "predicate": "mode", "path": path, "expectedMode": mode, "actualMode": actual }),
+                    ));
+                }
+            }
+            Ok(AssertionResult::Pass)
+        }
+        other => Err(malformed(
+            channel,
+            &format!("unknown filesystem assertion `{other}` (expected `exists`/`absent`/`mode`)"),
+        )),
+    }
+}
+
+/// `chan-exit-code`: `{ equals: <int> }` | `{ nonZero: true }`.
+fn exit_code_assertion(
+    channel: &str,
+    key: &str,
+    expected: &Value,
+    evidence: &NormalizedChannelEvidence,
+) -> Result<AssertionResult, HarnessError> {
+    let actual = evidence.value.as_i64();
+    match key {
+        "equals" => {
+            let want = expected
+                .as_i64()
+                .ok_or_else(|| malformed(channel, "`equals` must be an integer"))?;
+            Ok(if actual == Some(want) {
+                AssertionResult::Pass
+            } else {
+                AssertionResult::Fail(json!({ "expectedExitCode": want, "actualExitCode": actual }))
+            })
+        }
+        "nonZero" => {
+            let want = expected
+                .as_bool()
+                .ok_or_else(|| malformed(channel, "`nonZero` must be a boolean"))?;
+            let is_non_zero = matches!(actual, Some(code) if code != 0);
+            Ok(if is_non_zero == want {
+                AssertionResult::Pass
+            } else {
+                AssertionResult::Fail(json!({ "expectedNonZero": want, "actualExitCode": actual }))
+            })
+        }
+        other => Err(malformed(
+            channel,
+            &format!("unknown exit-code assertion `{other}` (expected `equals`/`nonZero`)"),
+        )),
+    }
+}
+
+/// `chan-stdout`/`chan-stderr`: `{ equals } | { contains } | { matches }` (regex).
+fn text_assertion(
+    channel: &str,
+    key: &str,
+    expected: &Value,
+    evidence: &NormalizedChannelEvidence,
+) -> Result<AssertionResult, HarnessError> {
+    let actual = evidence
+        .value
+        .as_str()
+        .ok_or_else(|| malformed(channel, "text-channel evidence is not a string"))?;
+    let want = expected
+        .as_str()
+        .ok_or_else(|| malformed(channel, &format!("`{key}` must be a string")))?;
+    match key {
+        "equals" => Ok(pass_if(actual == want, json!({ "predicate": "equals" }))),
+        "contains" => Ok(pass_if(
+            actual.contains(want),
+            json!({ "predicate": "contains", "missingSubstring": want }),
+        )),
+        "matches" => {
+            let re = regex::Regex::new(want)
+                .map_err(|e| malformed(channel, &format!("`matches` is not a valid regex: {e}")))?;
+            Ok(pass_if(
+                re.is_match(actual),
+                json!({ "predicate": "matches", "pattern": want }),
+            ))
+        }
+        other => Err(malformed(
+            channel,
+            &format!("unknown text assertion `{other}` (expected `equals`/`contains`/`matches`)"),
+        )),
+    }
+}
+
+/// `chan-structured-output`/`chan-file-content`: `{ jsonEquals } | { jsonSubset }`.
+/// `present:false` (channel not captured) fails any structured assertion — the runner
+/// declared it and it was not observable (FR-018).
+fn structured_assertion(
+    channel: &str,
+    key: &str,
+    expected: &Value,
+    evidence: &NormalizedChannelEvidence,
+) -> Result<AssertionResult, HarnessError> {
+    if !evidence.present {
+        return Ok(AssertionResult::Fail(
+            json!({ "reason": "structured output not captured (stdout was not valid JSON)" }),
+        ));
+    }
+    match key {
+        "jsonEquals" => Ok(pass_if(
+            &evidence.value == expected,
+            json!({ "predicate": "jsonEquals" }),
+        )),
+        "jsonSubset" => {
+            let mut missing = Vec::new();
+            let ok = is_json_subset(expected, &evidence.value, "", &mut missing);
+            Ok(pass_if(
+                ok,
+                json!({ "predicate": "jsonSubset", "firstMismatchPath": missing.first() }),
+            ))
+        }
+        other => Err(malformed(
+            channel,
+            &format!("unknown structured assertion `{other}` (expected `jsonEquals`/`jsonSubset`)"),
+        )),
+    }
+}
+
+/// Pass/fail helper with a supplied fail-detail.
+fn pass_if(ok: bool, fail_detail: Value) -> AssertionResult {
+    if ok {
+        AssertionResult::Pass
+    } else {
+        AssertionResult::Fail(fail_detail)
+    }
+}
+
+/// Recursive JSON-subset check: every object key in `subset` must be present in `actual`
+/// and recurse; an `subset` ARRAY is order-insensitive "contains" — each subset element
+/// must be a subset of SOME actual element (so `mounts: [{target: "/w"}]` matches a mount
+/// with more fields, in any position); scalars require exact equality. `jsonEquals` is the
+/// assertion for exact equality. On the first mismatch, records the dotted JSON path (NOT
+/// a filesystem path) into `missing` for a path-free, byte-stable detail.
+fn is_json_subset(subset: &Value, actual: &Value, path: &str, missing: &mut Vec<String>) -> bool {
+    match subset {
+        Value::Object(sub_map) => {
+            let Some(act_map) = actual.as_object() else {
+                missing.push(path.to_string());
+                return false;
+            };
+            for (k, v) in sub_map {
+                let child = if path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{path}.{k}")
+                };
+                match act_map.get(k) {
+                    Some(av) => {
+                        if !is_json_subset(v, av, &child, missing) {
+                            return false;
+                        }
+                    }
+                    None => {
+                        missing.push(child);
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+        Value::Array(sub_items) => {
+            let Some(act_items) = actual.as_array() else {
+                missing.push(path.to_string());
+                return false;
+            };
+            for (idx, sub) in sub_items.iter().enumerate() {
+                // Some actual element must contain this subset element (order-insensitive).
+                let found = act_items
+                    .iter()
+                    .any(|act| is_json_subset(sub, act, path, &mut Vec::new()));
+                if !found {
+                    missing.push(format!("{path}[{idx}]"));
+                    return false;
+                }
+            }
+            true
+        }
+        other => {
+            if other == actual {
+                true
+            } else {
+                missing.push(path.to_string());
+                false
+            }
+        }
+    }
+}
+
+/// A malformed-assertion / unsupported-channel authoring error (fail-loud).
+fn malformed(channel: &str, cause: &str) -> HarnessError {
+    HarnessError::NormalizationFailed {
+        channel: channel.to_string(),
+        cause: format!("malformed assertion: {cause}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn norm(channel: &str, value: Value) -> NormalizedChannelEvidence {
+        NormalizedChannelEvidence {
+            channel: channel.to_string(),
+            operation: "op".to_string(),
+            present: true,
+            value,
+        }
+    }
+
+    #[test]
+    fn exit_code_equals_agree_and_diverge() {
+        let ev = norm(CHAN_EXIT_CODE, json!(0));
+        assert_eq!(
+            verdict_spec_expectation(CHAN_EXIT_CODE, &ev, &json!({"equals":0}))
+                .unwrap()
+                .outcome,
+            Outcome::Agree
+        );
+        assert_eq!(
+            verdict_spec_expectation(CHAN_EXIT_CODE, &ev, &json!({"equals":1}))
+                .unwrap()
+                .outcome,
+            Outcome::Diverge
+        );
+    }
+
+    #[test]
+    fn exit_code_non_zero() {
+        let fail = norm(CHAN_EXIT_CODE, json!(3));
+        assert_eq!(
+            verdict_spec_expectation(CHAN_EXIT_CODE, &fail, &json!({"nonZero":true}))
+                .unwrap()
+                .outcome,
+            Outcome::Agree
+        );
+    }
+
+    #[test]
+    fn text_equals_contains_matches() {
+        let ev = norm(CHAN_STDOUT, json!("hello world"));
+        assert_eq!(
+            verdict_spec_expectation(CHAN_STDOUT, &ev, &json!({"contains":"world"}))
+                .unwrap()
+                .outcome,
+            Outcome::Agree
+        );
+        assert_eq!(
+            verdict_spec_expectation(CHAN_STDOUT, &ev, &json!({"matches":"^hello"}))
+                .unwrap()
+                .outcome,
+            Outcome::Agree
+        );
+        assert_eq!(
+            verdict_spec_expectation(CHAN_STDOUT, &ev, &json!({"equals":"nope"}))
+                .unwrap()
+                .outcome,
+            Outcome::Diverge
+        );
+    }
+
+    #[test]
+    fn json_subset_nested() {
+        let ev = norm(
+            CHAN_STRUCTURED_OUTPUT,
+            json!({ "configuration": { "customUnknownKey": "preserved", "name": "x" } }),
+        );
+        let ok = verdict_spec_expectation(
+            CHAN_STRUCTURED_OUTPUT,
+            &ev,
+            &json!({ "jsonSubset": { "configuration": { "customUnknownKey": "preserved" } } }),
+        )
+        .unwrap();
+        assert_eq!(ok.outcome, Outcome::Agree);
+
+        let bad = verdict_spec_expectation(
+            CHAN_STRUCTURED_OUTPUT,
+            &ev,
+            &json!({ "jsonSubset": { "configuration": { "customUnknownKey": "WRONG" } } }),
+        )
+        .unwrap();
+        assert_eq!(bad.outcome, Outcome::Diverge);
+    }
+
+    #[test]
+    fn structured_absent_diverges() {
+        let mut ev = norm(CHAN_STRUCTURED_OUTPUT, Value::Null);
+        ev.present = false;
+        let v = verdict_spec_expectation(
+            CHAN_STRUCTURED_OUTPUT,
+            &ev,
+            &json!({ "jsonSubset": { "a": 1 } }),
+        )
+        .unwrap();
+        assert_eq!(v.outcome, Outcome::Diverge);
+    }
+
+    #[test]
+    fn malformed_assertion_is_fail_loud() {
+        let ev = norm(CHAN_EXIT_CODE, json!(0));
+        assert!(verdict_spec_expectation(CHAN_EXIT_CODE, &ev, &json!({"weird": 1})).is_err());
+        assert!(verdict_spec_expectation(CHAN_EXIT_CODE, &ev, &json!("not-an-object")).is_err());
+    }
+
+    use deacon_conformance::model::AllowedDifference;
+    use std::collections::HashSet;
+
+    fn no_tolerances() -> Tolerances<'static> {
+        Tolerances::new(&[], &[])
+    }
+
+    #[test]
+    fn differential_equal_agree_unequal_diverge() {
+        let a = norm(CHAN_EXIT_CODE, json!(0));
+        let b = norm(CHAN_EXIT_CODE, json!(0));
+        let mut consumed = HashSet::new();
+        assert_eq!(
+            verdict_differential(CHAN_EXIT_CODE, &a, &b, &no_tolerances(), &mut consumed).outcome,
+            Outcome::Agree
+        );
+        let c = norm(CHAN_EXIT_CODE, json!(1));
+        assert_eq!(
+            verdict_differential(CHAN_EXIT_CODE, &a, &c, &no_tolerances(), &mut consumed).outcome,
+            Outcome::Diverge
+        );
+    }
+
+    fn tz_difference() -> AllowedDifference {
+        AllowedDifference {
+            behavior: "bhv-x".to_string(),
+            context: vec![],
+            observable_path: "chan-injected-process.env.TZ".to_string(),
+            rationale: "reference leaks host TZ; deacon does not".to_string(),
+            waiver_id: Some("wvr-tz".to_string()),
+            divergence_id: None,
+        }
+    }
+
+    #[test]
+    fn covered_divergence_is_allowed_difference_uncovered_stays_diverge() {
+        let allowed = vec![tz_difference()];
+        let behaviors = vec!["bhv-x".to_string()];
+        let tol = Tolerances::new(&allowed, &behaviors);
+
+        // A divergence ONLY at the covered path (env.TZ) → allowed-difference, with the
+        // backing waiver id in the detail.
+        let deacon = norm(
+            CHAN_INJECTED_PROCESS,
+            json!({ "env": { "TZ": "UTC" }, "user": "vscode" }),
+        );
+        let reference = norm(
+            CHAN_INJECTED_PROCESS,
+            json!({ "env": { "TZ": "America/NY" }, "user": "vscode" }),
+        );
+        let mut consumed = HashSet::new();
+        let v = verdict_differential(
+            CHAN_INJECTED_PROCESS,
+            &deacon,
+            &reference,
+            &tol,
+            &mut consumed,
+        );
+        assert_eq!(
+            v.outcome,
+            Outcome::AllowedDifference,
+            "TZ path is tolerated: {v:?}"
+        );
+        assert!(
+            v.detail.as_ref().unwrap().to_string().contains("wvr-tz"),
+            "the backing waiver id is in the detail: {v:?}"
+        );
+        assert!(!consumed.is_empty(), "the tolerance was consumed");
+
+        // The SAME difference on a DIFFERENT path (env.LANG) is NOT covered → diverge.
+        let deacon2 = norm(CHAN_INJECTED_PROCESS, json!({ "env": { "LANG": "C" } }));
+        let reference2 = norm(CHAN_INJECTED_PROCESS, json!({ "env": { "LANG": "en_US" } }));
+        let mut consumed2 = HashSet::new();
+        let v2 = verdict_differential(
+            CHAN_INJECTED_PROCESS,
+            &deacon2,
+            &reference2,
+            &tol,
+            &mut consumed2,
+        );
+        assert_eq!(
+            v2.outcome,
+            Outcome::Diverge,
+            "the same difference on path B still fails (FR-033): {v2:?}"
+        );
+    }
+
+    #[test]
+    fn a_mix_of_covered_and_uncovered_paths_stays_diverge() {
+        let allowed = vec![tz_difference()];
+        let behaviors = vec!["bhv-x".to_string()];
+        let tol = Tolerances::new(&allowed, &behaviors);
+        // Divergence at env.TZ (covered) AND user (uncovered) → the whole channel diverges.
+        let deacon = norm(
+            CHAN_INJECTED_PROCESS,
+            json!({ "env": { "TZ": "UTC" }, "user": "root" }),
+        );
+        let reference = norm(
+            CHAN_INJECTED_PROCESS,
+            json!({ "env": { "TZ": "America/NY" }, "user": "vscode" }),
+        );
+        let mut consumed = HashSet::new();
+        let v = verdict_differential(
+            CHAN_INJECTED_PROCESS,
+            &deacon,
+            &reference,
+            &tol,
+            &mut consumed,
+        );
+        assert_eq!(
+            v.outcome,
+            Outcome::Diverge,
+            "an uncovered path makes the whole channel diverge: {v:?}"
+        );
+    }
+
+    #[test]
+    fn unconsumed_tolerance_is_stale() {
+        // The tolerance is declared but its difference does not reproduce (deacon ==
+        // reference) → it is unconsumed → stale (self-invalidating, FR-034).
+        let allowed = vec![tz_difference()];
+        let behaviors = vec!["bhv-x".to_string()];
+        let tol = Tolerances::new(&allowed, &behaviors);
+        let same = norm(CHAN_INJECTED_PROCESS, json!({ "env": { "TZ": "UTC" } }));
+        let mut consumed = HashSet::new();
+        let v = verdict_differential(CHAN_INJECTED_PROCESS, &same, &same, &tol, &mut consumed);
+        assert_eq!(v.outcome, Outcome::Agree, "no divergence when values match");
+        let stale = tol.stale(&consumed);
+        assert_eq!(
+            stale.len(),
+            1,
+            "the unused tolerance is reported stale: {stale:?}"
+        );
+        assert!(stale[0].contains("wvr-tz"));
+    }
+}

--- a/crates/parity-harness/src/evidence.rs
+++ b/crates/parity-harness/src/evidence.rs
@@ -1,0 +1,402 @@
+//! Evidence + verdict base types for the declarative conformance runner (data-model
+//! §9, 022-conformance-runner).
+//!
+//! An observer captures a channel as [`RawChannelEvidence`]; the single normalizer
+//! ([`crate::normalize::normalize_channel`]) maps it to [`NormalizedChannelEvidence`];
+//! [`crate::compare`] turns a pair (or a spec expectation) into a [`ChannelVerdict`];
+//! the runner aggregates those into a [`CaseVerdict`]. Raw and normalized evidence are
+//! persisted **separately** (raw.json / normalized.json, FR-016); the atomic write path
+//! + separate persistence land in US2/US3 (T034/T045).
+//!
+//! `present: bool` is load-bearing: `present:false` means the channel was NOT captured
+//! for this operation, which is distinct from a captured-but-empty value
+//! (`present:true` with `value` `null`/`""`/`[]`) — FR-018. Named normalization rules
+//! keep the null/empty/default distinction intact (FR-025).
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use deacon_conformance::model::OracleType;
+use deacon_conformance::snapshot::Provenance;
+
+use crate::HarnessError;
+
+/// Verbatim per-channel evidence captured by an observer (data-model §9, FR-018).
+///
+/// Temp paths, host values, etc. are preserved as-observed; tokenization happens only
+/// in the normalized copy (FR-024).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawChannelEvidence {
+    /// The channel id (`chan-…`).
+    pub channel: String,
+    /// The operation id this evidence was captured for.
+    pub operation: String,
+    /// `false` ⇒ the channel could not be observed for this op (not captured); distinct
+    /// from a captured-but-empty `value` (FR-018).
+    pub present: bool,
+    /// The captured value (channel-specific shape). `null`/`""`/`[]` are captured-empty
+    /// and remain distinct from `present:false`.
+    pub value: Value,
+}
+
+/// Per-channel evidence after the named normalization rules (data-model §9). Same shape
+/// as [`RawChannelEvidence`], but a distinct type so raw and normalized evidence can
+/// never be accidentally compared or persisted to the wrong file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NormalizedChannelEvidence {
+    /// The channel id (`chan-…`).
+    pub channel: String,
+    /// The operation id this evidence was captured for.
+    pub operation: String,
+    /// `false` ⇒ not captured (preserved from the raw evidence, FR-018).
+    pub present: bool,
+    /// The normalized value; null/empty/default preserved distinctly (FR-025), nothing
+    /// blanket-removed (FR-029).
+    pub value: Value,
+}
+
+/// The verdict outcome on one channel (data-model §9, contract observer-channel.md).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Outcome {
+    /// deacon and the reference/expectation agree after normalization.
+    Agree,
+    /// An uncharacterized divergence.
+    Diverge,
+    /// A divergence fully covered by a scoped `AllowedDifference` (US4).
+    AllowedDifference,
+    /// No committed snapshot exists for the current platform (coverage gap, FR-016a).
+    NoReferenceForPlatform,
+    /// A committed snapshot is stale (a provenance/hash field drifted, FR-020).
+    Stale,
+    /// The channel could not be verdicted (capture/normalization fault).
+    Error,
+}
+
+impl Outcome {
+    /// Severity rank for `CaseVerdict.overall = worst channel outcome` (data-model §9).
+    /// Higher is worse. Ordered to match the runner's exit-code severity (contract
+    /// runner-cli.md): `agree`/`allowed-difference` are clean (exit 0), then
+    /// `no-reference-for-platform` (non-blocking coverage gap) < `diverge` (exit 1) <
+    /// `stale` (exit 3) < `error` (exit 4).
+    pub fn severity(self) -> u8 {
+        match self {
+            Outcome::Agree => 0,
+            Outcome::AllowedDifference => 1,
+            Outcome::NoReferenceForPlatform => 2,
+            Outcome::Diverge => 3,
+            Outcome::Stale => 4,
+            Outcome::Error => 5,
+        }
+    }
+}
+
+/// A per-channel verdict (data-model §9, FR-015).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelVerdict {
+    /// The channel id (`chan-…`).
+    pub channel: String,
+    /// The outcome on this channel.
+    pub outcome: Outcome,
+    /// Cause-specific detail (waiver id, mismatched field, …) or `null`. Always
+    /// serialized (even when `null`) so the report body is byte-deterministic
+    /// (contract runner-cli.md).
+    pub detail: Option<Value>,
+}
+
+/// The whole-case verdict (data-model §9, report shape contract runner-cli.md).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaseVerdict {
+    /// The case id.
+    pub case_id: String,
+    /// The oracle type the case was evaluated under.
+    pub oracle_type: OracleType,
+    /// The behaviors this case is attributable to (FR-042).
+    pub behaviors: Vec<String>,
+    /// Per-channel verdicts, in declaration order (never `BTreeMap`).
+    pub channels: Vec<ChannelVerdict>,
+    /// The worst channel outcome (see [`Outcome::severity`]).
+    pub overall: Outcome,
+    /// Allowed differences declared on this case whose characterized divergence did NOT
+    /// reproduce this run — self-invalidating STALE tolerances to remove or re-characterize
+    /// (FR-034, US4). Empty (and omitted) when every declared tolerance was consumed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stale_allowed_differences: Vec<String>,
+}
+
+impl CaseVerdict {
+    /// The worst channel outcome across `channels` (data-model §9). An empty channel
+    /// list verdicts as [`Outcome::Agree`] (nothing diverged).
+    pub fn compute_overall(channels: &[ChannelVerdict]) -> Outcome {
+        channels
+            .iter()
+            .map(|c| c.outcome)
+            .max_by_key(|o| o.severity())
+            .unwrap_or(Outcome::Agree)
+    }
+}
+
+/// One run's captured evidence, with raw and normalized held **separately** (FR-016,
+/// SC-006). Each is independently retrievable, and the two are never conflated: raw
+/// preserves temp paths verbatim; normalized shows the `<WORKSPACE>` tokens. US2 (T034)
+/// persists these to the sibling `raw.json` / `normalized.json` files atomically; US3
+/// keeps the in-memory separation and threads it through the runner.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaseEvidence {
+    /// Verbatim per-channel evidence (temp paths preserved).
+    pub raw: Vec<RawChannelEvidence>,
+    /// Rule-normalized per-channel evidence (paths tokenized, nulls preserved).
+    pub normalized: Vec<NormalizedChannelEvidence>,
+}
+
+impl CaseEvidence {
+    /// An empty evidence set.
+    pub fn new() -> CaseEvidence {
+        CaseEvidence::default()
+    }
+
+    /// Record a channel's raw + normalized evidence as a matched pair.
+    pub fn push(&mut self, raw: RawChannelEvidence, normalized: NormalizedChannelEvidence) {
+        self.raw.push(raw);
+        self.normalized.push(normalized);
+    }
+
+    /// The raw evidence for `(channel, operation)`, if captured — independently
+    /// retrievable from the normalized copy.
+    pub fn raw_for(&self, channel: &str, operation: &str) -> Option<&RawChannelEvidence> {
+        self.raw
+            .iter()
+            .find(|e| e.channel == channel && e.operation == operation)
+    }
+
+    /// The normalized evidence for `(channel, operation)`, if captured.
+    pub fn normalized_for(
+        &self,
+        channel: &str,
+        operation: &str,
+    ) -> Option<&NormalizedChannelEvidence> {
+        self.normalized
+            .iter()
+            .find(|e| e.channel == channel && e.operation == operation)
+    }
+
+    /// Serialize the raw evidence array to a byte-stable pretty JSON string.
+    fn raw_json(&self) -> Result<String, HarnessError> {
+        render_json(&self.raw)
+    }
+
+    /// Serialize the normalized evidence array to a byte-stable pretty JSON string.
+    fn normalized_json(&self) -> Result<String, HarnessError> {
+        render_json(&self.normalized)
+    }
+}
+
+/// Serialize a value to pretty JSON with a trailing newline (byte-stable), mapping a
+/// serialization failure to a fail-loud [`HarnessError`].
+fn render_json<T: Serialize>(value: &T) -> Result<String, HarnessError> {
+    let mut s = serde_json::to_string_pretty(value).map_err(|e| HarnessError::Report {
+        cause: format!("could not serialize snapshot evidence: {e}"),
+    })?;
+    s.push('\n');
+    Ok(s)
+}
+
+/// Write a committed snapshot's three files — `provenance.json`, `raw.json`,
+/// `normalized.json` — into `dir` ATOMICALLY (temp file + `fs::rename` via
+/// [`crate::atomic_write`], FR-019/D4). Raw and normalized are kept SEPARATE (FR-016).
+/// Because each write renames a fully-written temp file into place, a shorter payload
+/// can never leave trailing bytes from a previous longer file. Used ONLY by the reviewed
+/// refresh bin — ordinary runs never call it (FR-021).
+pub async fn write_snapshot(
+    dir: &Path,
+    provenance: &Provenance,
+    evidence: &CaseEvidence,
+) -> Result<(), HarnessError> {
+    let provenance_json = render_json(provenance)?;
+    crate::atomic_write(&dir.join("provenance.json"), provenance_json.as_bytes()).await?;
+    crate::atomic_write(&dir.join("raw.json"), evidence.raw_json()?.as_bytes()).await?;
+    crate::atomic_write(
+        &dir.join("normalized.json"),
+        evidence.normalized_json()?.as_bytes(),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn present_false_is_distinct_from_empty_value() {
+        let not_captured = RawChannelEvidence {
+            channel: "chan-stdout".to_string(),
+            operation: "op-1".to_string(),
+            present: false,
+            value: Value::Null,
+        };
+        let captured_empty = RawChannelEvidence {
+            channel: "chan-stdout".to_string(),
+            operation: "op-1".to_string(),
+            present: true,
+            value: Value::String(String::new()),
+        };
+        assert_ne!(
+            not_captured, captured_empty,
+            "not-captured must differ from captured-but-empty (FR-018)"
+        );
+    }
+
+    #[test]
+    fn overall_is_worst_channel_outcome() {
+        let mk = |outcome| ChannelVerdict {
+            channel: "chan-exit-code".to_string(),
+            outcome,
+            detail: None,
+        };
+        assert_eq!(
+            CaseVerdict::compute_overall(&[mk(Outcome::Agree), mk(Outcome::Diverge)]),
+            Outcome::Diverge
+        );
+        assert_eq!(
+            CaseVerdict::compute_overall(&[
+                mk(Outcome::AllowedDifference),
+                mk(Outcome::NoReferenceForPlatform)
+            ]),
+            Outcome::NoReferenceForPlatform
+        );
+        assert_eq!(
+            CaseVerdict::compute_overall(&[mk(Outcome::Diverge), mk(Outcome::Stale)]),
+            Outcome::Stale
+        );
+        assert_eq!(CaseVerdict::compute_overall(&[]), Outcome::Agree);
+    }
+
+    #[test]
+    fn case_evidence_keeps_raw_and_normalized_separate_and_retrievable() {
+        let mut ev = CaseEvidence::new();
+        let raw = RawChannelEvidence {
+            channel: "chan-structured-output".to_string(),
+            operation: "op-read".to_string(),
+            present: true,
+            value: serde_json::json!({ "root": "/tmp/ws-abc" }),
+        };
+        let normalized = NormalizedChannelEvidence {
+            channel: "chan-structured-output".to_string(),
+            operation: "op-read".to_string(),
+            present: true,
+            value: serde_json::json!({ "root": "<WORKSPACE>" }),
+        };
+        ev.push(raw.clone(), normalized.clone());
+
+        // Independently retrievable, and NOT conflated (raw keeps the temp path).
+        let got_raw = ev.raw_for("chan-structured-output", "op-read").unwrap();
+        let got_norm = ev
+            .normalized_for("chan-structured-output", "op-read")
+            .unwrap();
+        assert_eq!(got_raw.value["root"], serde_json::json!("/tmp/ws-abc"));
+        assert_eq!(got_norm.value["root"], serde_json::json!("<WORKSPACE>"));
+        assert_ne!(
+            got_raw.value, got_norm.value,
+            "raw and normalized must stay separate (FR-016)"
+        );
+        assert_eq!(ev.raw.len(), 1);
+        assert_eq!(ev.normalized.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn write_snapshot_is_atomic_and_leaves_no_trailing_bytes() {
+        use deacon_conformance::snapshot::Provenance;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut prov = Provenance {
+            oracle_version: "0.87.0".to_string(),
+            source_revision: "113500f4".to_string(),
+            case_hash: "aaaa".to_string(),
+            fixture_hash: "bbbb".to_string(),
+            argv: vec!["read-configuration".to_string()],
+            platform: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            node_version: "22.23.1".to_string(),
+            docker_version: "29.6.2".to_string(),
+            compose_version: "2.40.3".to_string(),
+            image_digests: Default::default(),
+            normalizer_version: "2".to_string(),
+            captured_at: "2026-07-24T00:00:00Z".to_string(),
+        };
+
+        // First write: a LONG raw evidence array.
+        let long_evidence = CaseEvidence {
+            raw: vec![RawChannelEvidence {
+                channel: "chan-stdout".to_string(),
+                operation: "op".to_string(),
+                present: true,
+                value: Value::String("a-very-long-first-payload-".repeat(20)),
+            }],
+            normalized: Vec::new(),
+        };
+        write_snapshot(dir.path(), &prov, &long_evidence)
+            .await
+            .expect("first write");
+
+        // Second write: a SHORTER raw evidence array over the same file.
+        prov.case_hash = "cccc".to_string();
+        let short_evidence = CaseEvidence {
+            raw: vec![RawChannelEvidence {
+                channel: "chan-exit-code".to_string(),
+                operation: "op".to_string(),
+                present: true,
+                value: Value::from(0),
+            }],
+            normalized: Vec::new(),
+        };
+        write_snapshot(dir.path(), &prov, &short_evidence)
+            .await
+            .expect("second write");
+
+        // The shorter payload must be intact — no trailing bytes from the longer one.
+        let raw_back = std::fs::read_to_string(dir.path().join("raw.json")).unwrap();
+        let parsed: Value = serde_json::from_str(&raw_back).expect("raw.json parses clean");
+        assert_eq!(parsed[0]["channel"], "chan-exit-code");
+        assert_eq!(parsed[0]["value"], 0);
+        assert!(
+            !raw_back.contains("a-very-long"),
+            "no trailing bytes remain"
+        );
+
+        // Provenance + normalized files exist and parse.
+        let prov_back = std::fs::read_to_string(dir.path().join("provenance.json")).unwrap();
+        let prov_parsed: Provenance = serde_json::from_str(&prov_back).unwrap();
+        assert_eq!(prov_parsed.case_hash, "cccc");
+        assert!(dir.path().join("normalized.json").is_file());
+
+        // No temp files survive a successful write.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files must be renamed away");
+    }
+
+    #[test]
+    fn channel_verdict_serializes_null_detail() {
+        let v = ChannelVerdict {
+            channel: "chan-exit-code".to_string(),
+            outcome: Outcome::Agree,
+            detail: None,
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        assert!(
+            json.contains("\"detail\":null"),
+            "detail must serialize even when null for byte-determinism, got {json}"
+        );
+        assert!(json.contains("\"outcome\":\"agree\""));
+    }
+}

--- a/crates/parity-harness/src/lib.rs
+++ b/crates/parity-harness/src/lib.rs
@@ -21,13 +21,19 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 pub mod aggregate;
+pub mod compare;
+pub mod evidence;
 pub mod exec;
 pub mod normalize;
+pub mod observe;
 pub mod oracle;
+pub mod oracle_type;
 pub mod prereq;
 pub mod registry;
 pub mod report;
+pub mod runner;
 pub mod waiver;
+pub mod workspace;
 
 /// The one error taxonomy for the whole harness (data-model §9, FR-005).
 ///
@@ -157,6 +163,55 @@ pub enum HarnessError {
         found: usize,
         min: usize,
     },
+
+    // --- Declarative conformance runner (022-conformance-runner, T012) ---------
+    // Cause-specific fail-loud variants for the runner: a declared Docker/Node channel
+    // or normalization step, or a snapshot-oracle comparison, must never be silently
+    // skipped (constitution IV). These are distinct from the legacy
+    // [`DockerMissing`](Self::DockerMissing) pre-check, which the pre-022 `parity_*`
+    // path still uses: `DockerUnavailable`/`NodeUnavailable` are the 022 runner's
+    // environment-probe failures, carrying the specific cause the probe observed.
+    /// The runner requires Docker for a case's declared channels but it is unavailable.
+    #[error(
+        "Docker is unavailable for the conformance runner: {cause}. Remedy: start Docker (or \
+         provide a working `docker`) — a declared Docker channel must never be silently skipped."
+    )]
+    DockerUnavailable { cause: String },
+
+    /// The runner requires Node (for the pinned oracle) but it is unavailable.
+    #[error(
+        "Node is unavailable for the conformance runner: {cause}. Remedy: install the Node \
+         runtime the pinned `@devcontainers/cli` oracle needs — a live-differential case must \
+         never be silently skipped."
+    )]
+    NodeUnavailable { cause: String },
+
+    /// Normalization of a channel's evidence failed; the runner never falls back to raw
+    /// comparison (FR-005 / FR-029).
+    #[error(
+        "normalization failed for channel `{channel}`: {cause}. Remedy: fix the producer or the \
+         named normalization rule — there is no raw-comparison fallback."
+    )]
+    NormalizationFailed { channel: String, cause: String },
+
+    /// A committed snapshot is stale: a provenance/hash field no longer matches the
+    /// recomputed inputs or probed environment (FR-020). `field` names the FIRST
+    /// mismatch so the diagnosis is precise.
+    #[error(
+        "snapshot is stale: `{field}` no longer matches the committed provenance. Remedy: \
+         re-record via the reviewed `conformance-snapshot refresh` — a stale snapshot must fail, \
+         never auto-refresh."
+    )]
+    SnapshotStale { field: String },
+
+    /// No committed snapshot exists for the current platform — a coverage gap, distinct
+    /// from stale and from a silent skip (FR-016a).
+    #[error(
+        "no committed snapshot for platform `{os_arch}` (no-reference-for-platform). Remedy: \
+         record one via the reviewed refresh on this platform, or accept the coverage gap — this \
+         is never a silent skip."
+    )]
+    NoReferenceForPlatform { os_arch: String },
 }
 
 /// Environment override for the report/artifact root (see [`report_root`]).

--- a/crates/parity-harness/src/normalize.rs
+++ b/crates/parity-harness/src/normalize.rs
@@ -36,9 +36,253 @@ use std::path::Path;
 use serde_json::{Map, Value};
 
 use crate::HarnessError;
+use crate::evidence::{NormalizedChannelEvidence, RawChannelEvidence};
 
 /// Keys the reference adds that carry no cross-CLI meaning (pure noise).
 const DROP_KEYS: &[&str] = &["configFilePath"];
+
+// ===========================================================================
+// Declarative conformance runner: THE single channel-normalization entry point
+// and its named, field-specific rules (022-conformance-runner, D6, T042/T043).
+//
+// Named rules — `path_token`, `label_semantic`, `mount_source_canonical`,
+// `path_env_segmented`, `null_preserving` — REPLACE the T011 pass-through. Each rule
+// REWRITES or CANONICALIZES; NONE blanket-removes env vars, labels, mount sources,
+// entrypoints, commands, or networks (FR-029). The null/empty/default distinction is
+// preserved (FR-025). This is the ONLY normalizer (Constitution VIII).
+// ===========================================================================
+
+/// The normalizer version, recorded in snapshot provenance and participating in
+/// staleness (FR-030). It is bumped whenever ANY named normalization rule changes so a
+/// snapshot recorded under an older normalizer replays as stale (data-model §7).
+///
+/// SINGLE SOURCE OF TRUTH: re-exported from [`deacon_conformance::snapshot`] so the
+/// snapshot provenance (conformance, the lower crate) and this normalizer never drift.
+/// `"1"` was the T011 pass-through; `"2"` is the US3 named-rule normalizer. The runner
+/// stamps it into the verdict report (`VerdictReport::new`) and the refresh bin records
+/// it into `Provenance.normalizerVersion`; staleness compares the recorded value
+/// against it (T032).
+pub use deacon_conformance::snapshot::NORMALIZER_VERSION;
+
+/// The `<WORKSPACE>` / `<PROJECT>` path token substitution context for `path_token`
+/// (FR-024). Each `(path, token)` pair rewrites occurrences of an absolute temp path to
+/// a stable token so evidence is portable across machines/recordings. Substitutions are
+/// applied longest-path-first so a nested path tokenizes before its parent.
+#[derive(Debug, Clone, Default)]
+pub struct TokenMap {
+    subs: Vec<(String, String)>,
+}
+
+impl TokenMap {
+    /// An empty token map (no substitutions).
+    pub fn new() -> TokenMap {
+        TokenMap::default()
+    }
+
+    /// A token map that rewrites the workspace path to `<WORKSPACE>`.
+    pub fn workspace(workspace: &Path) -> TokenMap {
+        let mut m = TokenMap::new();
+        m.insert(workspace.to_string_lossy(), "<WORKSPACE>");
+        m
+    }
+
+    /// Add a `(path → token)` substitution. Empty paths are ignored.
+    pub fn insert(&mut self, path: impl Into<String>, token: impl Into<String>) {
+        let path = path.into();
+        if path.is_empty() {
+            return;
+        }
+        self.subs.push((path, token.into()));
+        // Longest path first: a nested path must tokenize before its parent prefix.
+        self.subs.sort_by_key(|(p, _)| std::cmp::Reverse(p.len()));
+    }
+
+    /// Apply every substitution to `s` (rewrite, never delete).
+    fn apply(&self, s: &str) -> String {
+        let mut out = s.to_string();
+        for (path, token) in &self.subs {
+            if out.contains(path.as_str()) {
+                out = out.replace(path.as_str(), token);
+            }
+        }
+        out
+    }
+}
+
+/// **Rule `path_token`** (FR-024): rewrite temp workspace/project paths to stable tokens
+/// in every string within `value`, recursively (object keys AND values, array
+/// elements). Rewrite, NEVER delete; structure, null, and empty are preserved.
+pub fn path_token(value: &Value, tokens: &TokenMap) -> Value {
+    match value {
+        Value::String(s) => Value::String(tokens.apply(s)),
+        Value::Array(items) => Value::Array(items.iter().map(|v| path_token(v, tokens)).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, v)| (tokens.apply(k), path_token(v, tokens)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// **Rule `null_preserving`** (FR-025): the channel normalizer NEVER prunes
+/// null / missing / empty / defaulted fields (unlike the config `prune`). This named
+/// rule is identity on the value — it exists so the preservation guarantee is explicit
+/// and auditable wherever the contract lists it. Only a named rule may ever collapse a
+/// specific field; nothing is dropped implicitly.
+pub fn null_preserving(value: &Value) -> Value {
+    value.clone()
+}
+
+/// **Rule `label_semantic`** (FR-026): parse container labels into a canonical
+/// key/value object so labels compare SEMANTICALLY, not as opaque strings. Accepts an
+/// object (`{k: v}`) or a Docker-style array of `"k=v"` strings and yields an object.
+/// NEVER blanket-removes a label (FR-029) — every label is preserved.
+pub fn label_semantic(labels: &Value) -> Value {
+    match labels {
+        Value::Array(items) => {
+            let mut map = Map::new();
+            for item in items {
+                if let Some(s) = item.as_str() {
+                    let (k, v) = s.split_once('=').unwrap_or((s, ""));
+                    map.insert(k.to_string(), Value::String(v.to_string()));
+                }
+            }
+            Value::Object(map)
+        }
+        other => other.clone(),
+    }
+}
+
+/// **Rule `mount_source_canonical`** (FR-027): path-substitute each mount `source`
+/// before compare, so two mounts that differ ONLY by a temp path compare equal. Given a
+/// mounts array `[{ source, target, ... }]`, rewrites each `source` via the token map.
+/// NEVER removes a mount (FR-029).
+pub fn mount_source_canonical(mounts: &Value, tokens: &TokenMap) -> Value {
+    match mounts {
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|m| match m {
+                    Value::Object(obj) => {
+                        let mut obj = obj.clone();
+                        if let Some(src) = obj.get("source").and_then(Value::as_str) {
+                            obj.insert("source".to_string(), Value::String(tokens.apply(src)));
+                        }
+                        Value::Object(obj)
+                    }
+                    other => path_token(other, tokens),
+                })
+                .collect(),
+        ),
+        other => path_token(other, tokens),
+    }
+}
+
+/// **Rule `path_env_segmented`** (FR-028): compare a PATH-like value SEGMENT-WISE, not as
+/// one string. Accepts a `:`-joined string OR an array of segments and yields an array
+/// of (path-tokenized) segments, so equality compares element-by-element. The optional
+/// executable probe (resolving which segment holds the invoked executable) is a seam for
+/// the injected-process channel (US5, FR-028) — the segmentation itself is the rule's
+/// core and is what US3 needs; no US3 channel requires the probe.
+pub fn path_env_segmented(path_value: &Value, tokens: &TokenMap) -> Value {
+    let segments: Vec<Value> = match path_value {
+        Value::String(s) => s
+            .split(':')
+            .map(|seg| Value::String(tokens.apply(seg)))
+            .collect(),
+        Value::Array(items) => items
+            .iter()
+            .map(|v| match v.as_str() {
+                Some(seg) => Value::String(tokens.apply(seg)),
+                None => path_token(v, tokens),
+            })
+            .collect(),
+        other => return path_token(other, tokens),
+    };
+    Value::Array(segments)
+}
+
+/// THE single channel-normalization entry point for the declarative runner
+/// (Constitution VIII — one normalizer). Applies the per-channel named rules
+/// (contract observer-channel.md) to a channel's [`RawChannelEvidence`], yielding
+/// [`NormalizedChannelEvidence`]. `present` is preserved verbatim — a not-captured
+/// channel (`present:false`) stays distinct from a captured-empty value (FR-018) — and
+/// nothing is blanket-removed (FR-029).
+pub fn normalize_channel(
+    channel: &str,
+    raw: &RawChannelEvidence,
+    tokens: &TokenMap,
+) -> NormalizedChannelEvidence {
+    debug_assert_eq!(
+        channel, raw.channel,
+        "normalize_channel: `channel` must match the evidence's channel"
+    );
+    NormalizedChannelEvidence {
+        channel: raw.channel.clone(),
+        operation: raw.operation.clone(),
+        present: raw.present,
+        value: apply_channel_rules(channel, &raw.value, tokens),
+    }
+}
+
+/// Apply the named rules the contract lists for `channel` (observer-channel.md). An
+/// unknown channel is identity (never blanket-removed).
+fn apply_channel_rules(channel: &str, value: &Value, tokens: &TokenMap) -> Value {
+    use deacon_conformance::model::{
+        CHAN_EXIT_CODE, CHAN_FILE_CONTENT, CHAN_FILESYSTEM, CHAN_IMAGE, CHAN_INJECTED_PROCESS,
+        CHAN_PROCESS_GRAPH, CHAN_STDERR, CHAN_STDOUT, CHAN_STRUCTURED_OUTPUT, CHAN_TEMPORAL,
+    };
+    match channel {
+        // No rule: an exit code carries no path/label/PATH content.
+        CHAN_EXIT_CODE => value.clone(),
+        CHAN_STDOUT | CHAN_STDERR => path_token(value, tokens),
+        CHAN_STRUCTURED_OUTPUT | CHAN_FILE_CONTENT => null_preserving(&path_token(value, tokens)),
+        CHAN_FILESYSTEM => path_token(value, tokens),
+        CHAN_IMAGE => normalize_image(value, tokens),
+        CHAN_PROCESS_GRAPH => normalize_process_graph(value, tokens),
+        CHAN_INJECTED_PROCESS => normalize_injected_process(value, tokens),
+        CHAN_TEMPORAL => null_preserving(value),
+        _ => value.clone(),
+    }
+}
+
+/// `chan-image`: `label_semantic` on the `labels` field, `path_token` elsewhere,
+/// `null_preserving` overall.
+fn normalize_image(value: &Value, tokens: &TokenMap) -> Value {
+    let mut v = path_token(value, tokens);
+    if let Value::Object(obj) = &mut v {
+        if let Some(labels) = obj.get("labels") {
+            let semantic = label_semantic(labels);
+            obj.insert("labels".to_string(), semantic);
+        }
+    }
+    null_preserving(&v)
+}
+
+/// `chan-process-graph`: `mount_source_canonical` on `mounts`, `path_token` elsewhere.
+fn normalize_process_graph(value: &Value, tokens: &TokenMap) -> Value {
+    let mut v = value.clone();
+    if let Value::Object(obj) = &mut v {
+        if let Some(mounts) = obj.get("mounts") {
+            let canonical = mount_source_canonical(mounts, tokens);
+            obj.insert("mounts".to_string(), canonical);
+        }
+    }
+    path_token(&v, tokens)
+}
+
+/// `chan-injected-process`: `path_env_segmented` on `path`, `path_token` + `null_preserving`.
+fn normalize_injected_process(value: &Value, tokens: &TokenMap) -> Value {
+    let mut v = value.clone();
+    if let Value::Object(obj) = &mut v {
+        if let Some(path) = obj.get("path") {
+            let segmented = path_env_segmented(path, tokens);
+            obj.insert("path".to_string(), segmented);
+        }
+    }
+    null_preserving(&path_token(&v, tokens))
+}
 
 // ===========================================================================
 // Configuration normalization (Tier 1 / Tier 1b)
@@ -304,6 +548,30 @@ pub const INTENTIONAL_LABEL_PREFIXES: &[&str] = &[
     "dev.containers.",
 ];
 
+/// **NAMED, SCOPED legacy rule `drop_noise_env` — chan-container-state ONLY** (research
+/// D6, FR-029). Whether `key` is a runtime-injected env var present in every container
+/// with no cross-CLI outcome meaning ([`NOISE_ENV_KEYS`]). This is the ONLY sanctioned
+/// env subtraction, scoped to the legacy observable-state channel and carrying the
+/// rationale above. The NEW per-channel `chan-injected-process` normalization
+/// ([`path_env_segmented`] + [`null_preserving`]) NEVER blanket-removes env — it
+/// preserves every var and characterizes intentional differences via scoped
+/// allowed-differences (US4), never a blanket ignore list.
+pub fn is_noise_env_key(key: &str) -> bool {
+    NOISE_ENV_KEYS.contains(&key)
+}
+
+/// **NAMED, SCOPED legacy rule `strip_intentional_labels` — chan-container-state ONLY**
+/// (research D6, FR-029). Whether `key` is a label both CLIs stamp by design and
+/// differently ([`INTENTIONAL_LABEL_PREFIXES`]). The ONLY sanctioned label subtraction,
+/// scoped to the legacy observable-state channel. The NEW `chan-image` normalization
+/// ([`label_semantic`]) NEVER blanket-removes a label — it parses labels to key/value
+/// and preserves them, deferring intentional differences to scoped allowed-differences.
+pub fn is_intentional_label(key: &str) -> bool {
+    INTENTIONAL_LABEL_PREFIXES
+        .iter()
+        .any(|p| key.starts_with(p))
+}
+
 /// Normalized single-mount state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MountState {
@@ -399,19 +667,24 @@ pub fn container_state(case: &str, raw: &Value) -> Result<StateSnapshot, Harness
         }
     }
 
+    // Legacy chan-container-state env subtraction via the NAMED, SCOPED rule
+    // `drop_noise_env` ([`is_noise_env_key`]) — the only sanctioned env removal (D6).
     let env = str_array(&raw["Config"]["Env"])
         .into_iter()
         .filter(|e| {
             let key = e.split_once('=').map(|(k, _)| k).unwrap_or(e.as_str());
-            !NOISE_ENV_KEYS.contains(&key)
+            !is_noise_env_key(key)
         })
         .collect();
 
+    // Legacy chan-container-state label subtraction via the NAMED, SCOPED rule
+    // `strip_intentional_labels` ([`is_intentional_label`]) — the only sanctioned label
+    // removal (D6).
     let labels = raw["Config"]["Labels"]
         .as_object()
         .map(|o| {
             o.iter()
-                .filter(|(k, _)| !INTENTIONAL_LABEL_PREFIXES.iter().any(|p| k.starts_with(p)))
+                .filter(|(k, _)| !is_intentional_label(k))
                 .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
                 .collect()
         })
@@ -619,6 +892,178 @@ fn diff_kv(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    use deacon_conformance::model::{
+        CHAN_EXIT_CODE, CHAN_IMAGE, CHAN_INJECTED_PROCESS, CHAN_PROCESS_GRAPH, CHAN_STDOUT,
+        CHAN_STRUCTURED_OUTPUT,
+    };
+
+    fn raw(channel: &str, value: Value) -> RawChannelEvidence {
+        RawChannelEvidence {
+            channel: channel.to_string(),
+            operation: "op-1".to_string(),
+            present: true,
+            value,
+        }
+    }
+
+    // -- T039: path_token rewrites (never deletes); null states distinct; no removal ---
+
+    #[test]
+    fn path_token_rewrites_temp_paths_to_a_stable_token_without_deleting() {
+        let tokens = TokenMap::workspace(std::path::Path::new("/tmp/ws-abc"));
+        let value = json!({
+            "rootFolderPath": "/tmp/ws-abc",
+            "mount": "source=/tmp/ws-abc/proj,target=/w",
+            "nested": ["/tmp/ws-abc/x", "/unrelated/y"],
+            "null_val": null, "empty_str": "", "empty_arr": [], "empty_obj": {}
+        });
+        let out = path_token(&value, &tokens);
+        assert_eq!(out["rootFolderPath"], json!("<WORKSPACE>"));
+        assert_eq!(out["mount"], json!("source=<WORKSPACE>/proj,target=/w"));
+        assert_eq!(out["nested"][0], json!("<WORKSPACE>/x"));
+        assert_eq!(out["nested"][1], json!("/unrelated/y"), "rewrite is scoped");
+        // The four null states remain DISTINCT and PRESENT (FR-025) — none deleted.
+        assert_eq!(out["null_val"], Value::Null);
+        assert_eq!(out["empty_str"], json!(""));
+        assert_eq!(out["empty_arr"], json!([]));
+        assert_eq!(out["empty_obj"], json!({}));
+        let obj = out.as_object().unwrap();
+        for k in ["null_val", "empty_str", "empty_arr", "empty_obj"] {
+            assert!(obj.contains_key(k), "field {k} must not be dropped");
+        }
+    }
+
+    #[test]
+    fn normalize_channel_preserves_present_false() {
+        let not_captured = RawChannelEvidence {
+            channel: CHAN_STRUCTURED_OUTPUT.to_string(),
+            operation: "op-1".to_string(),
+            present: false,
+            value: Value::Null,
+        };
+        let out = normalize_channel(CHAN_STRUCTURED_OUTPUT, &not_captured, &TokenMap::new());
+        assert!(
+            !out.present,
+            "present:false (not captured) is preserved (FR-018)"
+        );
+    }
+
+    #[test]
+    fn no_channel_blanket_removes_env_labels_mounts_entrypoint_command_networks() {
+        let tokens = TokenMap::new();
+        // Image: labels + env + entrypoint all survive normalization.
+        let img = raw(
+            CHAN_IMAGE,
+            json!({ "labels": {"a":"1"}, "env": ["A=1"], "entrypoint": ["/bin/sh"] }),
+        );
+        let n = normalize_channel(CHAN_IMAGE, &img, &tokens);
+        assert!(n.value.get("labels").is_some() && n.value.get("env").is_some());
+        assert!(
+            n.value.get("entrypoint").is_some(),
+            "entrypoint not removed"
+        );
+        // Process graph: mounts + networks + volumes survive.
+        let graph = raw(
+            CHAN_PROCESS_GRAPH,
+            json!({ "mounts": [{"source":"/s","target":"/t"}], "networks": ["n"], "volumes": ["v"] }),
+        );
+        let g = normalize_channel(CHAN_PROCESS_GRAPH, &graph, &tokens);
+        assert_eq!(g.value["mounts"].as_array().unwrap().len(), 1);
+        assert!(g.value.get("networks").is_some() && g.value.get("volumes").is_some());
+        // Injected process: env + command survive.
+        let inj = raw(
+            CHAN_INJECTED_PROCESS,
+            json!({ "env": {"A":"1"}, "command": ["run"], "path": "/usr/bin:/bin" }),
+        );
+        let i = normalize_channel(CHAN_INJECTED_PROCESS, &inj, &tokens);
+        assert!(i.value.get("env").is_some() && i.value.get("command").is_some());
+    }
+
+    // -- T040: label_semantic / mount_source_canonical / path_env_segmented ------------
+
+    #[test]
+    fn label_semantic_parses_and_compares_key_value() {
+        let as_array = label_semantic(&json!(["k1=v1", "k2=v2"]));
+        let as_object = json!({ "k1": "v1", "k2": "v2" });
+        assert_eq!(
+            as_array, as_object,
+            "labels compare semantically, not as strings"
+        );
+        // Already-object labels pass through unchanged; nothing removed.
+        assert_eq!(label_semantic(&as_object), as_object);
+    }
+
+    #[test]
+    fn mount_source_canonical_makes_temp_path_mounts_equal() {
+        let mut tokens = TokenMap::new();
+        tokens.insert("/tmp/ws-abc", "<WORKSPACE>");
+        tokens.insert("/tmp/ws-def", "<WORKSPACE>");
+        let a = mount_source_canonical(
+            &json!([{ "source": "/tmp/ws-abc/proj", "target": "/w" }]),
+            &tokens,
+        );
+        let b = mount_source_canonical(
+            &json!([{ "source": "/tmp/ws-def/proj", "target": "/w" }]),
+            &tokens,
+        );
+        assert_eq!(
+            a, b,
+            "two mounts differing only by temp path compare equal (FR-027)"
+        );
+        assert_eq!(a[0]["source"], json!("<WORKSPACE>/proj"));
+    }
+
+    #[test]
+    fn path_env_segmented_compares_segment_wise() {
+        let tokens = TokenMap::new();
+        let out = path_env_segmented(&json!("/usr/local/bin:/usr/bin:/bin"), &tokens);
+        assert_eq!(out, json!(["/usr/local/bin", "/usr/bin", "/bin"]));
+        // An array PATH normalizes to the same segmented form → segment-wise equality.
+        let from_array =
+            path_env_segmented(&json!(["/usr/local/bin", "/usr/bin", "/bin"]), &tokens);
+        assert_eq!(out, from_array);
+    }
+
+    #[test]
+    fn normalize_channel_applies_per_channel_rules() {
+        let tokens = TokenMap::workspace(std::path::Path::new("/tmp/ws"));
+        // structured-output: paths tokenized, structure preserved.
+        let s = normalize_channel(
+            CHAN_STRUCTURED_OUTPUT,
+            &raw(
+                CHAN_STRUCTURED_OUTPUT,
+                json!({ "root": "/tmp/ws", "keep": null }),
+            ),
+            &tokens,
+        );
+        assert_eq!(s.value["root"], json!("<WORKSPACE>"));
+        assert_eq!(s.value["keep"], Value::Null, "null preserved");
+        // exit-code: no rule (a number is untouched).
+        let e = normalize_channel(CHAN_EXIT_CODE, &raw(CHAN_EXIT_CODE, json!(0)), &tokens);
+        assert_eq!(e.value, json!(0));
+        // stdout: path_token on the string.
+        let o = normalize_channel(
+            CHAN_STDOUT,
+            &raw(CHAN_STDOUT, json!("at /tmp/ws/x")),
+            &tokens,
+        );
+        assert_eq!(o.value, json!("at <WORKSPACE>/x"));
+    }
+
+    #[test]
+    fn normalizer_version_is_bumped_for_named_rules() {
+        assert_eq!(NORMALIZER_VERSION, "2", "US3 named-rule normalizer");
+    }
+
+    #[test]
+    fn legacy_noise_rules_are_named_and_scoped() {
+        assert!(is_noise_env_key("PATH") && !is_noise_env_key("MY_VAR"));
+        assert!(
+            is_intentional_label("com.docker.compose.project")
+                && !is_intentional_label("org.opencontainers.image.title")
+        );
+    }
 
     #[test]
     fn prune_drops_nulls_empties_and_configfilepath() {

--- a/crates/parity-harness/src/observe/cli_process.rs
+++ b/crates/parity-harness/src/observe/cli_process.rs
@@ -1,0 +1,215 @@
+//! CLI-process observer (`chan-exit-code` / `chan-stdout` / `chan-stderr` /
+//! `chan-structured-output`): exit code, stdout, stderr, and the parsed structured
+//! result document, plus the [`FailurePhase`] on failure (T019/T020,
+//! 022-conformance-runner).
+//!
+//! The runner runs each operation once (via [`crate::exec`]) and records a
+//! [`ProcessOutcome`] on the [`RunContext`]; this observer reads that outcome and maps
+//! it to per-channel [`RawChannelEvidence`]. It never re-runs the command.
+
+use deacon_conformance::model::{
+    CHAN_EXIT_CODE, CHAN_STDERR, CHAN_STDOUT, CHAN_STRUCTURED_OUTPUT, FailurePhase, Operation,
+};
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{ChannelObserver, ProcessOutcome, RunContext};
+
+/// An observer for one of the four CLI-process channels. One instance per channel (the
+/// channel id it captures is fixed at construction), so the runner can invoke exactly
+/// the channels a case declares.
+#[derive(Debug, Clone, Copy)]
+pub struct CliProcessObserver {
+    channel: &'static str,
+}
+
+impl CliProcessObserver {
+    /// Construct the observer for a CLI-process channel, or `None` when `channel` is not
+    /// one of the four this module owns.
+    pub fn for_channel(channel: &str) -> Option<CliProcessObserver> {
+        let channel = match channel {
+            CHAN_EXIT_CODE => CHAN_EXIT_CODE,
+            CHAN_STDOUT => CHAN_STDOUT,
+            CHAN_STDERR => CHAN_STDERR,
+            CHAN_STRUCTURED_OUTPUT => CHAN_STRUCTURED_OUTPUT,
+            _ => return None,
+        };
+        Some(CliProcessObserver { channel })
+    }
+
+    /// Build this channel's evidence from an already-captured [`ProcessOutcome`]. Kept
+    /// separate from the trait so the runner can also call it directly (and unit tests
+    /// can exercise the mapping without a `RunContext`).
+    pub fn evidence_from(&self, op_id: &str, outcome: &ProcessOutcome) -> RawChannelEvidence {
+        match self.channel {
+            CHAN_EXIT_CODE => RawChannelEvidence {
+                channel: CHAN_EXIT_CODE.to_string(),
+                operation: op_id.to_string(),
+                present: true,
+                // A signal-terminated process has no exit code (`null`), which stays
+                // distinct from a captured `0` (FR-018).
+                value: match outcome.exit_code {
+                    Some(code) => serde_json::json!(code),
+                    None => serde_json::Value::Null,
+                },
+            },
+            CHAN_STDOUT => RawChannelEvidence {
+                channel: CHAN_STDOUT.to_string(),
+                operation: op_id.to_string(),
+                present: true,
+                value: serde_json::Value::String(String::from_utf8_lossy(&outcome.stdout).into()),
+            },
+            CHAN_STDERR => RawChannelEvidence {
+                channel: CHAN_STDERR.to_string(),
+                operation: op_id.to_string(),
+                present: true,
+                value: serde_json::Value::String(String::from_utf8_lossy(&outcome.stderr).into()),
+            },
+            CHAN_STRUCTURED_OUTPUT => structured_output_evidence(op_id, outcome),
+            // `for_channel` only ever constructs one of the four above.
+            other => RawChannelEvidence {
+                channel: other.to_string(),
+                operation: op_id.to_string(),
+                present: false,
+                value: serde_json::Value::Null,
+            },
+        }
+    }
+}
+
+impl ChannelObserver for CliProcessObserver {
+    fn channel(&self) -> &'static str {
+        self.channel
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        match ctx.outcome(&op.id) {
+            Some(outcome) => Ok(self.evidence_from(&op.id, outcome)),
+            // The operation did not run (or its outcome was not recorded): the channel
+            // was not captured for this op (FR-018), NOT a captured-empty value.
+            None => Ok(RawChannelEvidence {
+                channel: self.channel.to_string(),
+                operation: op.id.clone(),
+                present: false,
+                value: serde_json::Value::Null,
+            }),
+        }
+    }
+}
+
+/// The parsed-JSON structured-output evidence (T020). Reuses the same "is this valid
+/// JSON?" decision as [`crate::exec::Invocation::stdout_json`]: parseable stdout →
+/// present with the parsed value; non-JSON stdout → `present:false` (the structured
+/// channel was not observable for this op), which stays distinct from a captured empty
+/// document (FR-018). There is no fallback to comparing raw bytes here — a case that
+/// declares `chan-structured-output` against non-JSON stdout verdicts as a divergence
+/// in `compare`, not a silent pass.
+fn structured_output_evidence(op_id: &str, outcome: &ProcessOutcome) -> RawChannelEvidence {
+    let text = String::from_utf8_lossy(&outcome.stdout);
+    match serde_json::from_str::<serde_json::Value>(text.trim()) {
+        Ok(value) => RawChannelEvidence {
+            channel: CHAN_STRUCTURED_OUTPUT.to_string(),
+            operation: op_id.to_string(),
+            present: true,
+            value,
+        },
+        Err(_) => RawChannelEvidence {
+            channel: CHAN_STRUCTURED_OUTPUT.to_string(),
+            operation: op_id.to_string(),
+            present: false,
+            value: serde_json::Value::Null,
+        },
+    }
+}
+
+/// Infer the [`FailurePhase`] (closed set §8) for a FAILED operation from its
+/// subcommand (FR-009). This is the coarse, subcommand-anchored inference US1 needs for
+/// config-only cases: `read-configuration`/`doctor` can only fail during
+/// config-resolution. The finer, lifecycle-aware inference (which lifecycle hook a
+/// container op failed in) lands with the temporal observer (US5); the mapping below is
+/// the deacon phase each subcommand fails in when it fails as a whole.
+pub fn infer_failure_phase(subcommand: &str) -> FailurePhase {
+    match subcommand {
+        "read-configuration" | "doctor" => FailurePhase::ConfigResolution,
+        "build" => FailurePhase::Build,
+        "up" => FailurePhase::ContainerCreate,
+        "exec" | "run-user-commands" | "templates-apply" => FailurePhase::Exec,
+        // Any other (already validated to be in the consumer surface) op that fails
+        // before it does anything meaningful is a config-resolution failure.
+        _ => FailurePhase::ConfigResolution,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(exit: Option<i32>, stdout: &str, phase: Option<FailurePhase>) -> ProcessOutcome {
+        ProcessOutcome {
+            exit_code: exit,
+            success: exit == Some(0),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+            failure_phase: phase,
+        }
+    }
+
+    #[test]
+    fn exit_code_evidence_preserves_null_for_signal() {
+        let obs = CliProcessObserver::for_channel(CHAN_EXIT_CODE).unwrap();
+        assert_eq!(
+            obs.evidence_from("op", &outcome(Some(0), "", None)).value,
+            serde_json::json!(0)
+        );
+        assert_eq!(
+            obs.evidence_from("op", &outcome(None, "", None)).value,
+            serde_json::Value::Null,
+            "signal termination → null exit code, distinct from 0"
+        );
+    }
+
+    #[test]
+    fn structured_output_present_only_when_json() {
+        let obs = CliProcessObserver::for_channel(CHAN_STRUCTURED_OUTPUT).unwrap();
+        let json = obs.evidence_from("op", &outcome(Some(0), r#"{"a":1}"#, None));
+        assert!(json.present);
+        assert_eq!(json.value, serde_json::json!({"a":1}));
+
+        let not_json = obs.evidence_from("op", &outcome(Some(0), "not json", None));
+        assert!(
+            !not_json.present,
+            "non-JSON stdout → structured channel not captured (present:false)"
+        );
+    }
+
+    #[test]
+    fn stdout_is_a_string() {
+        let obs = CliProcessObserver::for_channel(CHAN_STDOUT).unwrap();
+        assert_eq!(
+            obs.evidence_from("op", &outcome(Some(0), "hello", None))
+                .value,
+            serde_json::json!("hello")
+        );
+    }
+
+    #[test]
+    fn failure_phase_inference_matches_subcommand() {
+        assert_eq!(
+            infer_failure_phase("read-configuration"),
+            FailurePhase::ConfigResolution
+        );
+        assert_eq!(infer_failure_phase("build"), FailurePhase::Build);
+        assert_eq!(infer_failure_phase("up"), FailurePhase::ContainerCreate);
+        assert_eq!(infer_failure_phase("exec"), FailurePhase::Exec);
+    }
+
+    #[test]
+    fn for_channel_rejects_non_cli_channels() {
+        assert!(CliProcessObserver::for_channel("chan-image").is_none());
+        assert!(CliProcessObserver::for_channel(CHAN_STDERR).is_some());
+    }
+}

--- a/crates/parity-harness/src/observe/container_graph.rs
+++ b/crates/parity-harness/src/observe/container_graph.rs
@@ -1,0 +1,91 @@
+//! Container-graph observer (`chan-process-graph`, T054, FR-012): the container's mount
+//! / network / volume graph.
+//!
+//! Captures `.Mounts` (normalized to `{ source, target, type, ro }`), the network names
+//! from `.NetworkSettings.Networks`, and the volume names (volume-type mounts). The
+//! shared normalizer applies `mount_source_canonical` to each mount `source` and
+//! `path_token` elsewhere (`normalize::normalize_process_graph`); nothing is removed
+//! (FR-029).
+
+use deacon_conformance::model::{CHAN_PROCESS_GRAPH, Operation};
+use serde_json::{Value, json};
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+
+/// Captures `chan-process-graph` from the case's container.
+#[derive(Debug, Clone, Copy)]
+pub struct ContainerGraphObserver;
+
+impl ChannelObserver for ContainerGraphObserver {
+    fn channel(&self) -> &'static str {
+        CHAN_PROCESS_GRAPH
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        let Some(id) = &ctx.container_id else {
+            return Ok(not_captured(CHAN_PROCESS_GRAPH, &op.id));
+        };
+        let Some(inspect) = docker_inspect(id)? else {
+            return Ok(not_captured(CHAN_PROCESS_GRAPH, &op.id));
+        };
+
+        // Mounts → { source, target, type, ro }; volume mounts also contribute a volume.
+        let mut mounts = Vec::new();
+        let mut volumes = Vec::new();
+        if let Some(arr) = inspect["Mounts"].as_array() {
+            for m in arr {
+                let mount_type = m["Type"].as_str().unwrap_or("").to_string();
+                let source = m["Source"].as_str().unwrap_or("").to_string();
+                mounts.push(json!({
+                    "source": source,
+                    "target": m["Destination"].as_str().unwrap_or(""),
+                    "type": mount_type,
+                    "ro": !m["RW"].as_bool().unwrap_or(true),
+                }));
+                if mount_type == "volume" {
+                    if let Some(name) = m["Name"].as_str() {
+                        volumes.push(Value::String(name.to_string()));
+                    }
+                }
+            }
+        }
+
+        let networks: Vec<Value> = inspect["NetworkSettings"]["Networks"]
+            .as_object()
+            .map(|o| o.keys().map(|k| Value::String(k.clone())).collect())
+            .unwrap_or_default();
+
+        Ok(RawChannelEvidence {
+            channel: CHAN_PROCESS_GRAPH.to_string(),
+            operation: op.id.clone(),
+            present: true,
+            value: json!({
+                "mounts": mounts,
+                "networks": networks,
+                "volumes": volumes,
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_container_is_not_captured() {
+        let ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+        let op = Operation {
+            id: "op".to_string(),
+            subcommand: "up".to_string(),
+            ..Operation::default()
+        };
+        assert!(!ContainerGraphObserver.capture(&ctx, &op).unwrap().present);
+    }
+}

--- a/crates/parity-harness/src/observe/filesystem.rs
+++ b/crates/parity-harness/src/observe/filesystem.rs
@@ -1,0 +1,168 @@
+//! Filesystem observer (`chan-filesystem` / `chan-file-content`): presence, attributes,
+//! and contents of the case's declared `fsAllowlist` paths — ALLOWLIST-SCOPED, never a
+//! full-tree diff (clarify Q1, FR-010, T044).
+//!
+//! Capture is rooted at [`RunContext::workspace`] and covers ONLY the paths in
+//! [`RunContext::fs_allowlist`]. `path_token` is applied by the shared normalizer
+//! afterward. The raw value keys are workspace-RELATIVE paths (portable already); file
+//! modes and contents are captured verbatim.
+
+use std::path::Path;
+
+use deacon_conformance::model::{CHAN_FILE_CONTENT, CHAN_FILESYSTEM, Operation};
+use serde_json::{Map, Value};
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{ChannelObserver, RunContext};
+
+/// Observer for the two filesystem channels. One instance per channel.
+#[derive(Debug, Clone, Copy)]
+pub struct FilesystemObserver {
+    channel: &'static str,
+}
+
+impl FilesystemObserver {
+    /// Construct the observer for a filesystem channel, or `None` otherwise.
+    pub fn for_channel(channel: &str) -> Option<FilesystemObserver> {
+        let channel = match channel {
+            CHAN_FILESYSTEM => CHAN_FILESYSTEM,
+            CHAN_FILE_CONTENT => CHAN_FILE_CONTENT,
+            _ => return None,
+        };
+        Some(FilesystemObserver { channel })
+    }
+
+    /// Capture the allowlisted paths under `workspace` for this channel. Kept separate
+    /// from the trait so unit tests can drive it without a full [`RunContext`].
+    pub fn capture_scoped(
+        &self,
+        op_id: &str,
+        workspace: &Path,
+        allowlist: &[String],
+    ) -> RawChannelEvidence {
+        let mut map = Map::new();
+        for rel in allowlist {
+            let abs = workspace.join(rel);
+            let entry = match self.channel {
+                CHAN_FILESYSTEM => filesystem_entry(&abs),
+                CHAN_FILE_CONTENT => file_content_entry(&abs),
+                _ => Value::Null,
+            };
+            map.insert(rel.clone(), entry);
+        }
+        RawChannelEvidence {
+            channel: self.channel.to_string(),
+            operation: op_id.to_string(),
+            // `present:false` only when the case declared NO allowlist for this channel;
+            // an allowlisted-but-absent path is captured as `{exists:false}` (distinct).
+            present: !allowlist.is_empty(),
+            value: Value::Object(map),
+        }
+    }
+}
+
+impl ChannelObserver for FilesystemObserver {
+    fn channel(&self) -> &'static str {
+        self.channel
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        Ok(self.capture_scoped(&op.id, &ctx.workspace, &ctx.fs_allowlist))
+    }
+}
+
+/// `chan-filesystem` entry: `{ "exists": bool, "mode": "0644"|null }`. An absent path is
+/// captured (`exists:false`), never dropped (FR-018/FR-029).
+fn filesystem_entry(abs: &Path) -> Value {
+    match std::fs::metadata(abs) {
+        Ok(meta) => serde_json::json!({ "exists": true, "mode": mode_string(&meta) }),
+        Err(_) => serde_json::json!({ "exists": false, "mode": Value::Null }),
+    }
+}
+
+/// `chan-file-content` entry: the file's UTF-8 content, or `null` when absent/unreadable
+/// (captured-but-empty stays distinct from a captured empty string).
+fn file_content_entry(abs: &Path) -> Value {
+    match std::fs::read_to_string(abs) {
+        Ok(content) => Value::String(content),
+        Err(_) => Value::Null,
+    }
+}
+
+/// The file mode as a 4-digit octal string on Unix; `null` elsewhere (mode is a
+/// Unix-only attribute — matching the repo's cross-platform convention).
+#[cfg(unix)]
+fn mode_string(meta: &std::fs::Metadata) -> Value {
+    use std::os::unix::fs::MetadataExt;
+    Value::String(format!("{:04o}", meta.mode() & 0o7777))
+}
+
+#[cfg(not(unix))]
+fn mode_string(_meta: &std::fs::Metadata) -> Value {
+    Value::Null
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn captures_present_and_absent_allowlisted_paths() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".devcontainer")).unwrap();
+        std::fs::write(dir.path().join(".devcontainer/devcontainer.json"), "{}").unwrap();
+
+        let obs = FilesystemObserver::for_channel(CHAN_FILESYSTEM).unwrap();
+        let ev = obs.capture_scoped(
+            "op",
+            dir.path(),
+            &[
+                ".devcontainer/devcontainer.json".to_string(),
+                "does-not-exist".to_string(),
+            ],
+        );
+        assert!(ev.present, "a declared allowlist → present");
+        assert_eq!(ev.value[".devcontainer/devcontainer.json"]["exists"], true);
+        assert_eq!(
+            ev.value["does-not-exist"]["exists"], false,
+            "an absent allowlisted path is captured, not dropped (FR-018)"
+        );
+    }
+
+    #[test]
+    fn empty_allowlist_is_present_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let obs = FilesystemObserver::for_channel(CHAN_FILESYSTEM).unwrap();
+        let ev = obs.capture_scoped("op", dir.path(), &[]);
+        assert!(!ev.present, "no allowlist declared → channel not captured");
+    }
+
+    #[test]
+    fn file_content_captured_and_absent_is_null() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("marker.txt"), "hello").unwrap();
+        let obs = FilesystemObserver::for_channel(CHAN_FILE_CONTENT).unwrap();
+        let ev = obs.capture_scoped(
+            "op",
+            dir.path(),
+            &["marker.txt".to_string(), "gone.txt".to_string()],
+        );
+        assert_eq!(ev.value["marker.txt"], Value::String("hello".to_string()));
+        assert_eq!(
+            ev.value["gone.txt"],
+            Value::Null,
+            "absent file → null content"
+        );
+    }
+
+    #[test]
+    fn for_channel_rejects_non_fs_channels() {
+        assert!(FilesystemObserver::for_channel("chan-exit-code").is_none());
+        assert!(FilesystemObserver::for_channel(CHAN_FILE_CONTENT).is_some());
+    }
+}

--- a/crates/parity-harness/src/observe/image.rs
+++ b/crates/parity-harness/src/observe/image.rs
@@ -1,0 +1,67 @@
+//! Image observer (`chan-image`, T053, FR-011): the built-image configuration and
+//! metadata a container was created from — image ref, labels, env, entrypoint, cmd.
+//!
+//! Captures the RAW `.Config` slice from `docker inspect <container>`; the shared
+//! normalizer applies `label_semantic` (labels → canonical key/value) and
+//! `null_preserving` (`normalize::normalize_image`). Nothing is blanket-removed (FR-029).
+
+use deacon_conformance::model::{CHAN_IMAGE, Operation};
+use serde_json::json;
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+
+/// Captures `chan-image` from the case's container.
+#[derive(Debug, Clone, Copy)]
+pub struct ImageObserver;
+
+impl ChannelObserver for ImageObserver {
+    fn channel(&self) -> &'static str {
+        CHAN_IMAGE
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        let Some(id) = &ctx.container_id else {
+            return Ok(not_captured(CHAN_IMAGE, &op.id));
+        };
+        let Some(inspect) = docker_inspect(id)? else {
+            return Ok(not_captured(CHAN_IMAGE, &op.id));
+        };
+        let config = &inspect["Config"];
+        let get = |k: &str| config.get(k).cloned().unwrap_or(serde_json::Value::Null);
+        Ok(RawChannelEvidence {
+            channel: CHAN_IMAGE.to_string(),
+            operation: op.id.clone(),
+            present: true,
+            value: json!({
+                "image": get("Image"),
+                "labels": get("Labels"),
+                "env": get("Env"),
+                "entrypoint": get("Entrypoint"),
+                "cmd": get("Cmd"),
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_container_is_not_captured() {
+        let ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+        let op = Operation {
+            id: "op".to_string(),
+            subcommand: "up".to_string(),
+            ..Operation::default()
+        };
+        let ev = ImageObserver.capture(&ctx, &op).unwrap();
+        assert!(!ev.present, "no container id → not captured (FR-018)");
+    }
+}

--- a/crates/parity-harness/src/observe/injected_process.rs
+++ b/crates/parity-harness/src/observe/injected_process.rs
@@ -1,0 +1,75 @@
+//! Injected-process observer (`chan-injected-process`, T055, FR-013): the process
+//! context a command runs under inside the case's container — environment, user, cwd,
+//! PATH, and TTY.
+//!
+//! Captures the container's `.Config` process context (`User`, `WorkingDir`, `Env`,
+//! `Tty`); `env` is parsed into an object and `path` is the `PATH` env value. The shared
+//! normalizer applies `path_env_segmented` (PATH → segments, with the executable-probe
+//! resolution seam left from US3), `null_preserving`, and `path_token`
+//! (`normalize::normalize_injected_process`). Signal forwarding and exit propagation are
+//! exec-semantic and are surfaced through the CLI-process channels (exit-code) — the
+//! configured process context (env/user/cwd/PATH/TTY) is what this channel captures.
+
+use deacon_conformance::model::{CHAN_INJECTED_PROCESS, Operation};
+use serde_json::{Value, json};
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{
+    ChannelObserver, RunContext, docker_inspect, env_array_to_object, not_captured,
+};
+
+/// Captures `chan-injected-process` from the case's container.
+#[derive(Debug, Clone, Copy)]
+pub struct InjectedProcessObserver;
+
+impl ChannelObserver for InjectedProcessObserver {
+    fn channel(&self) -> &'static str {
+        CHAN_INJECTED_PROCESS
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        let Some(id) = &ctx.container_id else {
+            return Ok(not_captured(CHAN_INJECTED_PROCESS, &op.id));
+        };
+        let Some(inspect) = docker_inspect(id)? else {
+            return Ok(not_captured(CHAN_INJECTED_PROCESS, &op.id));
+        };
+        let config = &inspect["Config"];
+        let env = env_array_to_object(config.get("Env").unwrap_or(&Value::Null));
+        // PATH is captured as the raw string; the normalizer segments it.
+        let path = env.get("PATH").cloned().unwrap_or(Value::Null);
+        Ok(RawChannelEvidence {
+            channel: CHAN_INJECTED_PROCESS.to_string(),
+            operation: op.id.clone(),
+            present: true,
+            value: json!({
+                "env": env,
+                "user": config.get("User").cloned().unwrap_or(Value::Null),
+                "cwd": config.get("WorkingDir").cloned().unwrap_or(Value::Null),
+                "path": path,
+                "tty": config.get("Tty").cloned().unwrap_or(Value::Null),
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_container_is_not_captured() {
+        let ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+        let op = Operation {
+            id: "op".to_string(),
+            subcommand: "exec".to_string(),
+            ..Operation::default()
+        };
+        assert!(!InjectedProcessObserver.capture(&ctx, &op).unwrap().present);
+    }
+}

--- a/crates/parity-harness/src/observe/mod.rs
+++ b/crates/parity-harness/src/observe/mod.rs
@@ -1,0 +1,218 @@
+//! Per-channel observers for the declarative conformance runner (research D7, contract
+//! observer-channel.md, 022-conformance-runner).
+//!
+//! One module per observable channel, each implementing the small [`ChannelObserver`]
+//! contract. The runner invokes ONLY the observers a case's `expected`/`fsAllowlist`
+//! declares, so a pure `read-configuration` CLI case pays nothing for Docker
+//! inspection (research D7). Filesystem capture is allowlist-scoped, never a full-tree
+//! diff (clarify Q1).
+//!
+//! MODULE STATUS: the contract ([`ChannelObserver`] + [`RunContext`]) is defined here,
+//! and the CLI-process observer (`cli_process`, covering exit-code / stdout / stderr /
+//! structured-output) is implemented for User Story 1. The remaining observers land per
+//! user story: `filesystem` in US3 (T044), and `image` / `container_graph` /
+//! `injected_process` / `temporal` in US5 (T053–T056) — those submodules are still
+//! scaffolding.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use deacon_conformance::model::{
+    CHAN_EXIT_CODE, CHAN_FILE_CONTENT, CHAN_FILESYSTEM, CHAN_STDERR, CHAN_STDOUT,
+    CHAN_STRUCTURED_OUTPUT, FailurePhase, Operation,
+};
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+
+pub mod cli_process;
+pub mod container_graph;
+pub mod filesystem;
+pub mod image;
+pub mod injected_process;
+pub mod temporal;
+
+/// The process-level result of running one operation's CLI invocation, captured once by
+/// the runner and read by the CLI-process observer(s) for that operation.
+///
+/// Holding the outcome on the [`RunContext`] (rather than having each observer re-run
+/// the command) means the operation runs exactly once and every declared channel
+/// observes the SAME invocation — the model the Docker channels also follow (they
+/// inspect state left behind by the single run).
+#[derive(Debug, Clone)]
+pub struct ProcessOutcome {
+    /// Exit code, or `None` when terminated by signal.
+    pub exit_code: Option<i32>,
+    /// Whether the process exited successfully (status 0).
+    pub success: bool,
+    /// Verbatim stdout bytes.
+    pub stdout: Vec<u8>,
+    /// Verbatim stderr bytes.
+    pub stderr: Vec<u8>,
+    /// The inferred failure phase, present ONLY when the operation failed (FR-009,
+    /// closed set §8). `None` on success.
+    pub failure_phase: Option<FailurePhase>,
+}
+
+/// What the runner hands each observer for a capture: the workspace the case ran in,
+/// (once a container exists) its id for the Docker-backed channels, and the per-op
+/// process outcomes captured by the runner.
+///
+/// This grows as the Docker observers land (a container runtime handle, probed env) —
+/// always via additive fields so existing observers keep compiling.
+#[derive(Debug, Clone)]
+pub struct RunContext {
+    /// The workspace the case's operations ran against (US5 makes this an isolated
+    /// external temp dir; US1 config-only cases run against the committed fixture dir).
+    pub workspace: PathBuf,
+    /// The container id, once the case has brought one up. `None` for pure CLI-process
+    /// cases that never create a container.
+    pub container_id: Option<String>,
+    /// The case's `fsAllowlist` — the path/glob allowlist the filesystem observer is
+    /// scoped to (clarify Q1: allowlist-scoped, never a full-tree diff). Empty for cases
+    /// with no filesystem expectation.
+    pub fs_allowlist: Vec<String>,
+    /// Per-operation process outcomes, keyed by `Operation::id`, populated by the runner
+    /// before observers run.
+    outcomes: HashMap<String, ProcessOutcome>,
+    /// Per-operation container snapshots (the container id + temporal state AT that op's
+    /// boundary), keyed by `Operation::id`. Populated by the runner after each Docker op
+    /// so the invariant/metamorphic oracle can compare state ACROSS operations (US6).
+    op_snapshots: HashMap<String, OpSnapshot>,
+}
+
+/// The container state captured at one operation's boundary (US6 metamorphic evaluation).
+#[derive(Debug, Clone, PartialEq)]
+pub struct OpSnapshot {
+    /// The primary container id observed after this op (`None` = no container / removed).
+    /// This is the first of [`OpSnapshot::container_ids`] — kept for callers that need a
+    /// single id.
+    pub container_id: Option<String>,
+    /// EVERY container id matching this op's workspace label at its boundary, sorted. The
+    /// metamorphic oracle needs the full SET, not just one: a non-idempotent op that left a
+    /// SECOND container behind has `len > 1`, and observing a single id would mask exactly
+    /// the failure the idempotence relationship exists to catch (finding #3).
+    pub container_ids: Vec<String>,
+    /// The `chan-temporal` evidence value at this op's boundary (status/running/restart).
+    pub temporal: serde_json::Value,
+}
+
+impl RunContext {
+    /// A context for a container-less run rooted at `workspace`.
+    pub fn new(workspace: PathBuf) -> RunContext {
+        RunContext {
+            workspace,
+            container_id: None,
+            fs_allowlist: Vec::new(),
+            outcomes: HashMap::new(),
+            op_snapshots: HashMap::new(),
+        }
+    }
+
+    /// Record an operation's process outcome (runner-side, before observers run).
+    pub fn record_outcome(&mut self, op_id: impl Into<String>, outcome: ProcessOutcome) {
+        self.outcomes.insert(op_id.into(), outcome);
+    }
+
+    /// The process outcome captured for `op_id`, if the operation ran.
+    pub fn outcome(&self, op_id: &str) -> Option<&ProcessOutcome> {
+        self.outcomes.get(op_id)
+    }
+
+    /// Record the container snapshot at an operation's boundary (runner-side, US6).
+    pub fn record_op_snapshot(&mut self, op_id: impl Into<String>, snapshot: OpSnapshot) {
+        self.op_snapshots.insert(op_id.into(), snapshot);
+    }
+
+    /// The container snapshot captured at `op_id`'s boundary, if any (US6).
+    pub fn op_snapshot(&self, op_id: &str) -> Option<&OpSnapshot> {
+        self.op_snapshots.get(op_id)
+    }
+}
+
+/// The contract every channel observer implements (contract observer-channel.md).
+///
+/// An observer captures its one channel's evidence for a single operation. It returns
+/// [`RawChannelEvidence`] with `present:false` when the channel could not be observed
+/// for this op (distinct from a captured-but-empty value, FR-018), or a cause-specific
+/// [`HarnessError`] when capture itself faults (never a silent skip, constitution IV).
+pub trait ChannelObserver {
+    /// The channel id this observer captures (`chan-…`), matching `channels.json`.
+    fn channel(&self) -> &'static str;
+
+    /// Capture this channel's evidence for `op` under `ctx`.
+    fn capture(&self, ctx: &RunContext, op: &Operation)
+    -> Result<RawChannelEvidence, HarnessError>;
+}
+
+/// Resolve the observer for a declared channel, or `None` when no observer for that
+/// channel exists yet (the runner turns `None` into a fail-loud error — a case must
+/// never declare a channel the harness cannot observe, constitution IV).
+///
+/// US1 wires the four CLI-process channels; US3 the filesystem channels; US5 the four
+/// Docker channels.
+pub fn observer_for(channel: &str) -> Option<Box<dyn ChannelObserver>> {
+    use deacon_conformance::model::{
+        CHAN_IMAGE, CHAN_INJECTED_PROCESS, CHAN_PROCESS_GRAPH, CHAN_TEMPORAL,
+    };
+    match channel {
+        CHAN_EXIT_CODE | CHAN_STDOUT | CHAN_STDERR | CHAN_STRUCTURED_OUTPUT => {
+            cli_process::CliProcessObserver::for_channel(channel)
+                .map(|o| Box::new(o) as Box<dyn ChannelObserver>)
+        }
+        CHAN_FILESYSTEM | CHAN_FILE_CONTENT => filesystem::FilesystemObserver::for_channel(channel)
+            .map(|o| Box::new(o) as Box<dyn ChannelObserver>),
+        CHAN_IMAGE => Some(Box::new(image::ImageObserver)),
+        CHAN_PROCESS_GRAPH => Some(Box::new(container_graph::ContainerGraphObserver)),
+        CHAN_INJECTED_PROCESS => Some(Box::new(injected_process::InjectedProcessObserver)),
+        CHAN_TEMPORAL => Some(Box::new(temporal::TemporalObserver)),
+        _ => None,
+    }
+}
+
+/// Evidence for a channel that could NOT be observed for this op (no container, or the
+/// container is gone) — `present:false`, distinct from a captured-empty value (FR-018).
+pub(crate) fn not_captured(channel: &'static str, op_id: &str) -> RawChannelEvidence {
+    RawChannelEvidence {
+        channel: channel.to_string(),
+        operation: op_id.to_string(),
+        present: false,
+        value: serde_json::Value::Null,
+    }
+}
+
+/// Run `docker inspect <id>` and return the first result object, `None` when the object
+/// does not exist (container/image removed — a legitimate not-captured state), or a
+/// fail-loud [`HarnessError::DockerUnavailable`] when `docker` itself cannot run.
+pub(crate) fn docker_inspect(id: &str) -> Result<Option<serde_json::Value>, HarnessError> {
+    let output = std::process::Command::new("docker")
+        .args(["inspect", id])
+        .output()
+        .map_err(|e| HarnessError::DockerUnavailable {
+            cause: format!("could not run `docker inspect {id}`: {e}"),
+        })?;
+    if !output.status.success() {
+        // Non-zero for "No such object" — treat as not-present, not a harness fault.
+        return Ok(None);
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).map_err(|e| HarnessError::DockerUnavailable {
+            cause: format!("`docker inspect {id}` returned non-JSON: {e}"),
+        })?;
+    Ok(parsed.as_array().and_then(|a| a.first()).cloned())
+}
+
+/// Parse a Docker `Env` array of `"KEY=VALUE"` strings into a `{ key: value }` object
+/// (shared by the image + injected-process observers).
+pub(crate) fn env_array_to_object(env: &serde_json::Value) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    if let Some(items) = env.as_array() {
+        for item in items {
+            if let Some(s) = item.as_str() {
+                let (k, v) = s.split_once('=').unwrap_or((s, ""));
+                map.insert(k.to_string(), serde_json::Value::String(v.to_string()));
+            }
+        }
+    }
+    serde_json::Value::Object(map)
+}

--- a/crates/parity-harness/src/observe/temporal.rs
+++ b/crates/parity-harness/src/observe/temporal.rs
@@ -1,0 +1,83 @@
+//! Temporal observer (`chan-temporal`, T056, FR-014): lifecycle-transition state of the
+//! case's container — current status, first-create vs restart, and cleanup.
+//!
+//! Captures DETERMINISTIC transition markers from `docker inspect`: `.State.Status`
+//! (`created` / `running` / `exited` / `paused`), `.State.Running`, and `.RestartCount`
+//! (docker's restart-POLICY auto-restart count — a manual restart does NOT change it).
+//! Wall-clock timestamps (`StartedAt` / `FinishedAt`) are DELIBERATELY excluded — they
+//! are non-deterministic and would break byte-stable snapshots (contract
+//! observer-channel.md: ordering-preserving plus `null_preserving`, no timestamps). A
+//! removed container (cleanup) is `present:false`, which is exactly how the cleanup
+//! transition is observed (FR-018).
+//!
+//! The `first-create vs restart` DISTINCTION is a metamorphic RELATIONSHIP across two
+//! `up` operations (US6) — it compares two temporal captures — not a property derivable
+//! from a single inspect (deacon's up-reuse does not bump docker's `RestartCount`).
+//! Likewise fine-grained lifecycle-COMMAND ordering (onCreate then postCreate then more)
+//! is surfaced via the fixture's marker files on the filesystem channel; this channel
+//! captures the container-STATE transitions.
+
+use deacon_conformance::model::{CHAN_TEMPORAL, Operation};
+use serde_json::json;
+
+use crate::HarnessError;
+use crate::evidence::RawChannelEvidence;
+use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+
+/// Captures `chan-temporal` from the case's container.
+#[derive(Debug, Clone, Copy)]
+pub struct TemporalObserver;
+
+impl ChannelObserver for TemporalObserver {
+    fn channel(&self) -> &'static str {
+        CHAN_TEMPORAL
+    }
+
+    fn capture(
+        &self,
+        ctx: &RunContext,
+        op: &Operation,
+    ) -> Result<RawChannelEvidence, HarnessError> {
+        let Some(id) = &ctx.container_id else {
+            // No container OR it was cleaned up: the cleanup transition is exactly a
+            // not-captured temporal channel (FR-018).
+            return Ok(not_captured(CHAN_TEMPORAL, &op.id));
+        };
+        let Some(inspect) = docker_inspect(id)? else {
+            return Ok(not_captured(CHAN_TEMPORAL, &op.id));
+        };
+        Ok(RawChannelEvidence {
+            channel: CHAN_TEMPORAL.to_string(),
+            operation: op.id.clone(),
+            present: true,
+            value: temporal_from_inspect(&inspect),
+        })
+    }
+}
+
+/// Build the deterministic `chan-temporal` value (status / running / restartCount, no
+/// timestamps) from a `docker inspect` object. Shared by the observer and the runner's
+/// per-op snapshot capture (US6 metamorphic evaluation).
+pub(crate) fn temporal_from_inspect(inspect: &serde_json::Value) -> serde_json::Value {
+    json!({
+        "status": inspect["State"]["Status"].clone(),
+        "running": inspect["State"]["Running"].clone(),
+        "restartCount": inspect["RestartCount"].as_i64().unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_container_is_not_captured() {
+        let ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+        let op = Operation {
+            id: "op".to_string(),
+            subcommand: "up".to_string(),
+            ..Operation::default()
+        };
+        assert!(!TemporalObserver.capture(&ctx, &op).unwrap().present);
+    }
+}

--- a/crates/parity-harness/src/oracle_type.rs
+++ b/crates/parity-harness/src/oracle_type.rs
@@ -1,0 +1,514 @@
+//! Oracle-type dispatch (research D8, T022, 022-conformance-runner).
+//!
+//! Dispatches on a case's [`OracleType`] to one of four distinct strategies:
+//! **spec-expectation** (compare normalized observables to the declared `expected`, no
+//! reference run), **snapshot** (compare to the committed provenance-checked snapshot),
+//! **live-differential** (run deacon + the verified pinned oracle and compare), and
+//! **invariant-metamorphic** (evaluate a declared relationship across ≥2 operations).
+//! Re-pointing a case changes only `oracleType` (FR-007).
+//!
+//! MODULE STATUS: `spec-expectation` and `live-differential` are wired for User Story 1.
+//! `snapshot` dispatch lands in US2 (T036) and the finalized four-way dispatch +
+//! invariant/metamorphic evaluation in US6 (T068/T069). Until then those two types are
+//! fail-loud (`HarnessError`), never a silent skip.
+
+use deacon_conformance::model::{ExpectedObservable, OracleType, TestCase};
+use deacon_conformance::snapshot;
+
+use crate::HarnessError;
+use crate::compare::{Tolerances, verdict_differential, verdict_spec_expectation};
+use crate::evidence::{ChannelVerdict, NormalizedChannelEvidence, Outcome};
+use crate::exec::Side;
+use crate::runner::{self, RunConfig};
+
+/// The result of evaluating a case's oracle: the per-channel verdicts plus the STALE
+/// allowed differences (declared tolerances whose divergence did not reproduce this run,
+/// FR-034) for the report.
+pub type Evaluation = (Vec<ChannelVerdict>, Vec<String>);
+
+/// Evaluate every declared channel of `case` under its `oracleType`, producing the
+/// per-channel verdicts the runner aggregates into a [`CaseVerdict`](crate::evidence::CaseVerdict)
+/// plus the stale allowed differences.
+pub async fn evaluate(case: &TestCase, cfg: &RunConfig<'_>) -> Result<Evaluation, HarnessError> {
+    match case.oracle_type {
+        Some(OracleType::SpecExpectation) => spec_expectation(case, cfg).await,
+        Some(OracleType::LiveDifferential) => live_differential(case, cfg).await,
+        Some(OracleType::Snapshot) => snapshot_oracle(case, cfg).await,
+        Some(OracleType::InvariantMetamorphic) => invariant_metamorphic(case, cfg).await,
+        None => Err(HarnessError::NormalizationFailed {
+            channel: format!("case:{}", case.id),
+            cause: "declarative case has no `oracleType`".to_string(),
+        }),
+    }
+}
+
+/// spec-expectation: run deacon, capture + normalize each declared channel, evaluate the
+/// declared `assertion` against it. Every `expected` MUST carry an assertion (validation
+/// V16 guarantees it for a well-formed case; the runner still fails loud if one is
+/// missing rather than silently pass).
+async fn spec_expectation(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<Evaluation, HarnessError> {
+    let (ctx, _ws) = runner::execute_ops(Side::Deacon, cfg.deacon_path, case, cfg).await?;
+    let mut channels = Vec::with_capacity(case.expected.len());
+    for exp in &case.expected {
+        let normalized = runner::capture_normalized(case, exp, &ctx)?;
+        let assertion =
+            exp.assertion
+                .as_ref()
+                .ok_or_else(|| HarnessError::NormalizationFailed {
+                    channel: exp.channel.clone(),
+                    cause: format!(
+                        "spec-expectation case {:?} declares channel {:?} without an assertion",
+                        case.id, exp.channel
+                    ),
+                })?;
+        let mut verdict = verdict_spec_expectation(&exp.channel, &normalized, assertion)?;
+        runner::attach_failure_phase(&mut verdict, case, exp, &ctx);
+        channels.push(verdict);
+    }
+    // Allowed differences do not apply to spec-expectation (no reference to diverge from);
+    // no stale computation here.
+    Ok((channels, Vec::new()))
+}
+
+/// live-differential: run deacon AND the verified pinned oracle over the same
+/// operations, capture + normalize each declared channel on both sides, and compare
+/// them. A missing oracle is fail-loud (never a silent skip); an `assertion`, when
+/// present, is ignored (the reference supplies the expectation, data-model §5).
+async fn live_differential(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<Evaluation, HarnessError> {
+    let oracle = cfg.oracle.ok_or_else(|| HarnessError::OracleMissing {
+        hint: format!(
+            "live-differential case {:?} requires the verified pinned oracle, but none was \
+             supplied to the runner",
+            case.id
+        ),
+    })?;
+
+    let (deacon_ctx, _deacon_ws) =
+        runner::execute_ops(Side::Deacon, cfg.deacon_path, case, cfg).await?;
+    let (oracle_ctx, _oracle_ws) =
+        runner::execute_ops(Side::Oracle, &oracle.path, case, cfg).await?;
+
+    let tolerances = Tolerances::new(&case.allowed_differences, &case.behaviors);
+    let mut consumed = std::collections::HashSet::new();
+    let mut channels = Vec::with_capacity(case.expected.len());
+    for exp in &case.expected {
+        let deacon_norm = runner::capture_normalized(case, exp, &deacon_ctx)?;
+        let oracle_norm = runner::capture_normalized(case, exp, &oracle_ctx)?;
+        let mut verdict = verdict_differential(
+            &exp.channel,
+            &deacon_norm,
+            &oracle_norm,
+            &tolerances,
+            &mut consumed,
+        );
+        runner::attach_failure_phase(&mut verdict, case, exp, &deacon_ctx);
+        channels.push(verdict);
+    }
+    Ok((channels, tolerances.stale(&consumed)))
+}
+
+/// snapshot: resolve the committed snapshot for the current `os-arch`, gate on
+/// provenance staleness, then compare deacon's freshly-normalized evidence to the
+/// snapshot's committed normalized evidence (T036, D5). Emits `no-reference-for-platform`
+/// when no snapshot exists for the platform, `stale` (all channels) when a provenance
+/// field drifted, else per-channel `agree`/`diverge` against the recorded evidence.
+async fn snapshot_oracle(case: &TestCase, cfg: &RunConfig<'_>) -> Result<Evaluation, HarnessError> {
+    let os_arch = snapshot::current_os_arch();
+    let resolution = snapshot::resolve(cfg.snapshots_root, &os_arch, &case.id).map_err(|e| {
+        HarnessError::NormalizationFailed {
+            channel: format!("case:{}", case.id),
+            cause: format!("could not load committed snapshot: {e}"),
+        }
+    })?;
+    let snap = match resolution {
+        snapshot::Resolution::NoReferenceForPlatform { os_arch } => {
+            return Ok((
+                all_channels(case, Outcome::NoReferenceForPlatform, || {
+                    Some(serde_json::json!({ "osArch": os_arch }))
+                }),
+                Vec::new(),
+            ));
+        }
+        snapshot::Resolution::Found(s) => *s,
+    };
+
+    // Staleness gate: recompute the evidence-determining inputs and compare to committed
+    // provenance. Host tool versions (node/docker/compose) are informational, NOT staleness
+    // signals (see `snapshot::compare_staleness`), so they are neither re-probed nor
+    // compared — a snapshot recorded under a different Node/Docker/Compose must replay
+    // fresh across machines (SC-003).
+    let (case_hash, fixture_hash) = runner::snapshot_hashes(case, cfg)?;
+    let mut current = snap.provenance.clone();
+    current.case_hash = case_hash;
+    current.fixture_hash = fixture_hash;
+    current.source_revision = deacon_conformance::CURRENT_SPEC_PIN.to_string();
+    current.normalizer_version = snapshot::NORMALIZER_VERSION.to_string();
+    if let Some(v) = snapshot::current_oracle_version_pin() {
+        current.oracle_version = v;
+    }
+    if let snapshot::Staleness::Stale { field, .. } =
+        snapshot::compare_staleness(&snap.provenance, &current)
+    {
+        return Ok((
+            all_channels(case, Outcome::Stale, || {
+                Some(serde_json::json!({ "staleField": field }))
+            }),
+            Vec::new(),
+        ));
+    }
+
+    // Fresh: run deacon and compare its normalized evidence to the recorded evidence.
+    let recorded: Vec<NormalizedChannelEvidence> = serde_json::from_value(snap.normalized.clone())
+        .map_err(|e| HarnessError::NormalizationFailed {
+            channel: format!("case:{}", case.id),
+            cause: format!("committed normalized.json is not channel evidence: {e}"),
+        })?;
+    let (ctx, _ws) = runner::execute_ops(Side::Deacon, cfg.deacon_path, case, cfg).await?;
+    let tolerances = Tolerances::new(&case.allowed_differences, &case.behaviors);
+    let mut consumed = std::collections::HashSet::new();
+    let mut channels = Vec::with_capacity(case.expected.len());
+    for exp in &case.expected {
+        let deacon_norm = runner::capture_normalized(case, exp, &ctx)?;
+        let op = runner::resolve_expected_op(case, exp)?;
+        match recorded
+            .iter()
+            .find(|e| e.channel == exp.channel && e.operation == op.id)
+        {
+            Some(rec) => channels.push(verdict_differential(
+                &exp.channel,
+                &deacon_norm,
+                rec,
+                &tolerances,
+                &mut consumed,
+            )),
+            None => channels.push(ChannelVerdict {
+                channel: exp.channel.clone(),
+                outcome: Outcome::Diverge,
+                detail: Some(
+                    serde_json::json!({ "reason": "channel absent from committed snapshot" }),
+                ),
+            }),
+        }
+    }
+    Ok((channels, tolerances.stale(&consumed)))
+}
+
+/// invariant-metamorphic: run the case's operations and verdict on the DECLARED
+/// RELATIONSHIP between operations (idempotence / first-create-vs-restart / resume),
+/// NOT against a fixed expected output (FR-008, T069). Each operation that declares a
+/// `relationship` is evaluated against its sibling operation's container snapshot,
+/// producing one `chan-temporal` verdict per relationship.
+async fn invariant_metamorphic(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<Evaluation, HarnessError> {
+    let (ctx, _ws) = runner::execute_ops(Side::Deacon, cfg.deacon_path, case, cfg).await?;
+
+    let mut channels = Vec::new();
+    for op in &case.operations {
+        if let Some(rel) = &op.relationship {
+            channels.push(evaluate_relationship(&op.id, rel, &ctx));
+        }
+    }
+    if channels.is_empty() {
+        // Validation (V20) guarantees a metamorphic case declares a relationship; the
+        // runner still fails loud rather than silently pass an unverifiable case.
+        return Err(HarnessError::NormalizationFailed {
+            channel: format!("case:{}", case.id),
+            cause: "invariant/metamorphic case declares no operation `relationship` to evaluate"
+                .to_string(),
+        });
+    }
+    Ok((channels, Vec::new()))
+}
+
+/// Evaluate one declared relationship between `op_id` and its sibling `relationship.againstOp`
+/// on their container snapshots, producing a `chan-temporal` verdict. `agree` when the
+/// relationship holds; `diverge` (with a path-free reason) when it is violated or the
+/// state needed to evaluate it is missing.
+fn evaluate_relationship(
+    op_id: &str,
+    relationship: &deacon_conformance::model::Relationship,
+    ctx: &crate::observe::RunContext,
+) -> ChannelVerdict {
+    use deacon_conformance::model::{CHAN_TEMPORAL, RelationshipKind};
+
+    let temporal = CHAN_TEMPORAL.to_string();
+    let this = ctx.op_snapshot(op_id);
+    let sibling = ctx.op_snapshot(&relationship.against_op);
+    let (this, sibling) = match (this, sibling) {
+        (Some(t), Some(s)) => (t, s),
+        _ => {
+            return ChannelVerdict {
+                channel: temporal,
+                outcome: Outcome::Diverge,
+                detail: Some(serde_json::json!({
+                    "kind": "metamorphic",
+                    "relationship": format!("{:?}", relationship.kind),
+                    "reason": "missing container snapshot for the operation or its sibling \
+                               (a metamorphic case must be Docker-backed)",
+                })),
+            };
+        }
+    };
+
+    // The core invariant across all three kinds: the sibling created a container, and this
+    // operation REUSED THE SAME SINGLE container (deacon did not recreate it OR leave a
+    // second one behind) and it is running. `this.container_ids` is the FULL set matching
+    // the workspace at this op's boundary — a non-idempotent op that created a second
+    // container has `len > 1`, which must NOT count as "reused"; checking a single id would
+    // mask exactly the failure this oracle exists to catch (finding #3).
+    let this_count = this.container_ids.len();
+    let same_container =
+        this_count == 1 && this.container_id.is_some() && this.container_id == sibling.container_id;
+    let running = this.temporal.get("running") == Some(&serde_json::Value::Bool(true));
+
+    let (holds, detail_reason) = match relationship.kind {
+        // Re-running the op is a no-op on the container: same single container, still running.
+        RelationshipKind::Idempotence => (
+            same_container && running,
+            "re-run reuses the same single running container (no new create)",
+        ),
+        // The first op created the container; this op restarted/reused it (not recreated).
+        RelationshipKind::FirstCreateVsRestart => (
+            sibling.container_id.is_some() && same_container && running,
+            "the sibling created the container; this op reused it (restart, not recreate)",
+        ),
+        // This op reattached to the sibling's existing container.
+        RelationshipKind::Resume => (
+            same_container && running,
+            "this op resumed the sibling's existing container",
+        ),
+    };
+
+    ChannelVerdict {
+        channel: temporal,
+        outcome: if holds {
+            Outcome::Agree
+        } else {
+            Outcome::Diverge
+        },
+        detail: Some(serde_json::json!({
+            "kind": "metamorphic",
+            "relationship": format!("{:?}", relationship.kind),
+            "againstOp": relationship.against_op,
+            "held": holds,
+            "expectation": detail_reason,
+            "sameContainer": same_container,
+            "containerCount": this_count,
+            "running": running,
+        })),
+    }
+}
+
+/// Build one [`ChannelVerdict`] per declared channel with a fixed `outcome` and a
+/// per-channel `detail` (used for the case-level `no-reference-for-platform` / `stale`
+/// outcomes, which apply to every channel).
+fn all_channels(
+    case: &TestCase,
+    outcome: Outcome,
+    detail: impl Fn() -> Option<serde_json::Value>,
+) -> Vec<ChannelVerdict> {
+    if case.expected.is_empty() {
+        // No declared channel: still surface the case-level outcome on a synthetic row.
+        return vec![ChannelVerdict {
+            channel: "case".to_string(),
+            outcome,
+            detail: detail(),
+        }];
+    }
+    case.expected
+        .iter()
+        .map(|exp: &ExpectedObservable| ChannelVerdict {
+            channel: exp.channel.clone(),
+            outcome,
+            detail: detail(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_conformance::model::OracleType;
+
+    fn cfg<'a>(
+        fixtures_root: &'a std::path::Path,
+        snapshots_root: &'a std::path::Path,
+    ) -> RunConfig<'a> {
+        RunConfig {
+            deacon_path: std::path::Path::new("/bin/true"),
+            oracle: None,
+            fixtures_root,
+            report_root: std::path::Path::new("/tmp"),
+            snapshots_root,
+        }
+    }
+
+    #[tokio::test]
+    async fn metamorphic_case_with_no_relationship_fails_loud() {
+        // A metamorphic case that declares no operation `relationship` is unverifiable —
+        // fail loud rather than silently pass (validation V20 also rejects it).
+        let case = TestCase {
+            id: "case-x".to_string(),
+            oracle_type: Some(OracleType::InvariantMetamorphic),
+            operations: vec![deacon_conformance::model::Operation {
+                id: "op".to_string(),
+                subcommand: "read-configuration".to_string(),
+                ..Default::default()
+            }],
+            ..TestCase::default()
+        };
+        let tmp = std::path::Path::new("/tmp");
+        assert!(evaluate(&case, &cfg(tmp, tmp)).await.is_err());
+    }
+
+    #[test]
+    fn evaluate_relationship_verdicts_on_the_declared_relationship() {
+        use crate::observe::{OpSnapshot, RunContext};
+        use deacon_conformance::model::{Relationship, RelationshipKind};
+
+        let running =
+            serde_json::json!({ "status": "running", "running": true, "restartCount": 0 });
+        let mut ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+        // op-up-1 created container "c1"; op-up-2 REUSED "c1" (idempotent re-up).
+        ctx.record_op_snapshot(
+            "op-up-1",
+            OpSnapshot {
+                container_id: Some("c1".to_string()),
+                container_ids: vec!["c1".to_string()],
+                temporal: running.clone(),
+            },
+        );
+        ctx.record_op_snapshot(
+            "op-up-2",
+            OpSnapshot {
+                container_id: Some("c1".to_string()),
+                container_ids: vec!["c1".to_string()],
+                temporal: running.clone(),
+            },
+        );
+        let rel = Relationship {
+            kind: RelationshipKind::Idempotence,
+            against_op: "op-up-1".to_string(),
+        };
+        // The relationship HOLDS: same single running container → agree (NOT a fixed value).
+        let held = evaluate_relationship("op-up-2", &rel, &ctx);
+        assert_eq!(held.outcome, Outcome::Agree, "idempotence holds: {held:?}");
+        assert_eq!(held.channel, deacon_conformance::model::CHAN_TEMPORAL);
+
+        // If op-up-2 had RECREATED the container (different id), idempotence is VIOLATED.
+        let mut ctx2 = RunContext::new(std::path::PathBuf::from("/tmp"));
+        ctx2.record_op_snapshot(
+            "op-up-1",
+            OpSnapshot {
+                container_id: Some("c1".to_string()),
+                container_ids: vec!["c1".to_string()],
+                temporal: running.clone(),
+            },
+        );
+        ctx2.record_op_snapshot(
+            "op-up-2",
+            OpSnapshot {
+                container_id: Some("c2-recreated".to_string()),
+                container_ids: vec!["c2-recreated".to_string()],
+                temporal: running.clone(),
+            },
+        );
+        let violated = evaluate_relationship("op-up-2", &rel, &ctx2);
+        assert_eq!(
+            violated.outcome,
+            Outcome::Diverge,
+            "a recreated container violates idempotence: {violated:?}"
+        );
+
+        // If op-up-2 LEFT A SECOND container behind (old "c1" kept + new "c2" created), the
+        // set matching the workspace is {c1, c2}. The primary id still equals the sibling's
+        // "c1", so an id-only check would FALSELY pass — the count guard (finding #3) catches
+        // it: two containers is not "reused the same single container".
+        let mut ctx3 = RunContext::new(std::path::PathBuf::from("/tmp"));
+        ctx3.record_op_snapshot(
+            "op-up-1",
+            OpSnapshot {
+                container_id: Some("c1".to_string()),
+                container_ids: vec!["c1".to_string()],
+                temporal: running.clone(),
+            },
+        );
+        ctx3.record_op_snapshot(
+            "op-up-2",
+            OpSnapshot {
+                container_id: Some("c1".to_string()),
+                container_ids: vec!["c1".to_string(), "c2".to_string()],
+                temporal: running,
+            },
+        );
+        let two_containers = evaluate_relationship("op-up-2", &rel, &ctx3);
+        assert_eq!(
+            two_containers.outcome,
+            Outcome::Diverge,
+            "a second leftover container violates idempotence even when the primary id \
+             matches (finding #3): {two_containers:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_missing_for_platform_yields_no_reference() {
+        // No committed snapshot under the empty snapshots root → no-reference-for-platform.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let case = TestCase {
+            id: "case-missing-snap".to_string(),
+            oracle_type: Some(OracleType::Snapshot),
+            operations: vec![deacon_conformance::model::Operation {
+                id: "op".to_string(),
+                subcommand: "read-configuration".to_string(),
+                ..Default::default()
+            }],
+            expected: vec![deacon_conformance::model::ExpectedObservable {
+                channel: deacon_conformance::model::CHAN_EXIT_CODE.to_string(),
+                operation: Some("op".to_string()),
+                assertion: None,
+            }],
+            ..TestCase::default()
+        };
+        let (channels, _stale) = evaluate(&case, &cfg(dir.path(), dir.path()))
+            .await
+            .expect("no-reference is a verdict, not an error");
+        assert!(
+            channels
+                .iter()
+                .all(|c| c.outcome == Outcome::NoReferenceForPlatform),
+            "a missing snapshot for this os-arch is no-reference-for-platform, got {channels:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_differential_without_oracle_fails_loud() {
+        let case = TestCase {
+            id: "case-x".to_string(),
+            oracle_type: Some(OracleType::LiveDifferential),
+            operations: vec![deacon_conformance::model::Operation {
+                id: "op".to_string(),
+                subcommand: "read-configuration".to_string(),
+                ..Default::default()
+            }],
+            expected: vec![deacon_conformance::model::ExpectedObservable {
+                channel: deacon_conformance::model::CHAN_EXIT_CODE.to_string(),
+                operation: None,
+                assertion: None,
+            }],
+            ..TestCase::default()
+        };
+        let tmp = std::path::Path::new("/tmp");
+        assert!(matches!(
+            evaluate(&case, &cfg(tmp, tmp)).await,
+            Err(HarnessError::OracleMissing { .. })
+        ));
+    }
+}

--- a/crates/parity-harness/src/registry.rs
+++ b/crates/parity-harness/src/registry.rs
@@ -627,7 +627,11 @@ mod tests {
     #[test]
     fn embedded_registry_parses_and_matches_expected() {
         let reg = ParityRegistry::load().expect("embedded registry must parse");
-        assert_eq!(reg.live_binaries.len(), 9, "6 scenario + 3 corpus");
+        assert_eq!(
+            reg.live_binaries.len(),
+            10,
+            "7 scenario (incl. parity_conformance_runner, 022) + 3 corpus"
+        );
         assert_eq!(reg.internal_consistency_binaries.len(), 2);
         assert!(reg.corpus("tier1").is_some());
         assert!(reg.corpus("errors").is_some());

--- a/crates/parity-harness/src/report.rs
+++ b/crates/parity-harness/src/report.rs
@@ -232,6 +232,73 @@ pub fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
+// ===========================================================================
+// Declarative conformance runner verdict report (T024, contract runner-cli.md)
+// ===========================================================================
+
+/// The deterministic verdict report: a single JSON document on stdout listing every
+/// case's per-channel verdict (contract runner-cli.md). It carries NO timestamps and NO
+/// absolute paths (paths are tokenized by normalization), and records are in declaration
+/// order (`Vec`, never `BTreeMap`) — so the body is byte-stable across runs (VI output
+/// contract, T018). Logs/progress go to stderr via `tracing`, never into this document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerdictReport {
+    /// Report schema version.
+    pub schema_version: u32,
+    /// The `NORMALIZER_VERSION` the verdicts were produced under (FR-030).
+    pub normalizer_version: String,
+    /// Per-case verdicts, in declaration order.
+    pub cases: Vec<crate::evidence::CaseVerdict>,
+}
+
+impl VerdictReport {
+    /// Build a report over `cases` at the current [`crate::normalize::NORMALIZER_VERSION`].
+    pub fn new(cases: Vec<crate::evidence::CaseVerdict>) -> VerdictReport {
+        VerdictReport {
+            schema_version: 1,
+            normalizer_version: crate::normalize::NORMALIZER_VERSION.to_string(),
+            cases,
+        }
+    }
+
+    /// Render the report to its deterministic, byte-stable JSON string (2-space indent,
+    /// trailing newline). Ordering is fixed by struct/`Vec` order; there are no
+    /// timestamps or absolute paths in the body.
+    pub fn render(&self) -> Result<String, HarnessError> {
+        let mut out = serde_json::to_string_pretty(self).map_err(|e| HarnessError::Report {
+            cause: format!("could not serialize verdict report: {e}"),
+        })?;
+        out.push('\n');
+        Ok(out)
+    }
+
+    /// Emit the report as the single JSON document on stdout (contract runner-cli.md).
+    /// The caller writes all logs/progress to stderr via `tracing`.
+    pub fn emit_stdout(&self) -> Result<(), HarnessError> {
+        print!("{}", self.render()?);
+        Ok(())
+    }
+
+    /// The process exit code the runner should use (contract runner-cli.md §"Runner exit
+    /// codes"): 0 when every case is `agree`/`allowed-difference`; 1 on any `diverge`;
+    /// 3 on any `stale`; 4 on any harness `error`. The worst wins.
+    pub fn exit_code(&self) -> i32 {
+        use crate::evidence::Outcome;
+        let mut code = 0;
+        for case in &self.cases {
+            let this = match case.overall {
+                Outcome::Agree | Outcome::AllowedDifference | Outcome::NoReferenceForPlatform => 0,
+                Outcome::Diverge => 1,
+                Outcome::Stale => 3,
+                Outcome::Error => 4,
+            };
+            code = code.max(this);
+        }
+        code
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/parity-harness/src/runner.rs
+++ b/crates/parity-harness/src/runner.rs
@@ -1,0 +1,585 @@
+//! The declarative conformance runner orchestration (T023, 022-conformance-runner).
+//!
+//! [`run_case`] loads a declarative [`TestCase`], runs its operations against the
+//! target(s), invokes the declared observers, normalizes (the single
+//! [`crate::normalize`]), compares per `oracleType` ([`crate::oracle_type`]), and emits
+//! a [`CaseVerdict`]. Missing oracle / missing fixtures / unsupported channels are
+//! fail-loud [`HarnessError`]s, never a silent skip (constitution IV).
+//!
+//! US1 wires the CLI-process channels for the `spec-expectation` and `live-differential`
+//! oracle types. Config-only operations (`read-configuration`, `doctor`) run against the
+//! committed fixture directory directly (read-only, no mutation); the isolated external
+//! temp workspace + RAII cleanup for Docker-backed cases lands in US5 (`workspace.rs`).
+
+use std::path::{Path, PathBuf};
+
+use deacon_conformance::model::{
+    CHAN_EXIT_CODE, CaseKind, ExpectedObservable, Operation, ResourceGroup, TestCase,
+};
+
+use crate::HarnessError;
+use crate::evidence::{CaseVerdict, ChannelVerdict, NormalizedChannelEvidence, RawChannelEvidence};
+use crate::exec::{ExecKind, Side, run_and_capture};
+use crate::observe::{ProcessOutcome, RunContext, cli_process, observer_for};
+use crate::oracle::VerifiedOracle;
+use crate::workspace::DockerWorkspace;
+
+/// The raw-capture binary key for the runner's invocations (the `raw/<binary>/…`
+/// subtree under the report root).
+pub const RUNNER_BINARY: &str = "conformance_runner";
+
+/// The `${WORKSPACE}` token substituted in an operation's argv with the resolved
+/// workspace path (contract case-schema.md).
+const WORKSPACE_TOKEN: &str = "${WORKSPACE}";
+
+/// Everything the runner needs from its caller: the deacon binary under test, the
+/// verified oracle (required only for `live-differential`), where fixtures live, and
+/// where to write raw capture. The binary paths are supplied explicitly — only the test
+/// crate can expand `env!("CARGO_BIN_EXE_deacon")`, and the harness never guesses a
+/// `target/…` path (mirrors [`crate::exec`]).
+#[derive(Debug, Clone)]
+pub struct RunConfig<'a> {
+    /// Path to the deacon binary under test.
+    pub deacon_path: &'a Path,
+    /// The verified pinned oracle (required for `live-differential`; `None` otherwise).
+    pub oracle: Option<&'a VerifiedOracle>,
+    /// Root under which a fixture id resolves to `<fixtures_root>/<fixture-id>/`.
+    pub fixtures_root: &'a Path,
+    /// Root the raw stdout/stderr artifacts are written under (atomic temp+rename).
+    pub report_root: &'a Path,
+    /// Committed-snapshots root (`conformance/snapshots`) — the `snapshot` oracle type
+    /// resolves `<snapshots_root>/<os-arch>/<case-id>/` here. Unused by
+    /// spec-expectation / live-differential.
+    pub snapshots_root: &'a Path,
+}
+
+/// Run one declarative case end to end and produce its [`CaseVerdict`].
+pub async fn run_case(case: &TestCase, cfg: &RunConfig<'_>) -> Result<CaseVerdict, HarnessError> {
+    // Only declarative cases run through the runner; a legacy/mixed/neither record is a
+    // fail-loud authoring error (the loader/validator already reject it, but the runner
+    // never silently accepts one either).
+    match case.classify() {
+        Ok(CaseKind::Declarative) => {}
+        Ok(CaseKind::Legacy) => {
+            return Err(shape_error(
+                case,
+                "legacy binary-backed case cannot be run by the declarative runner",
+            ));
+        }
+        Err(shape) => return Err(shape_error(case, shape.message())),
+    }
+    let oracle_type = case
+        .oracle_type
+        .ok_or_else(|| shape_error(case, "declarative case has no `oracleType`"))?;
+
+    let (channels, stale_allowed_differences) = crate::oracle_type::evaluate(case, cfg).await?;
+    let overall = CaseVerdict::compute_overall(&channels);
+    Ok(CaseVerdict {
+        case_id: case.id.clone(),
+        oracle_type,
+        behaviors: case.behaviors.clone(),
+        channels,
+        overall,
+        stale_allowed_differences,
+    })
+}
+
+/// Run every operation of `case` against `program` on `side`, returning a
+/// [`RunContext`] carrying each operation's [`ProcessOutcome`]. Shared by the
+/// spec-expectation (deacon only) and live-differential (deacon + oracle) paths.
+pub(crate) async fn execute_ops(
+    side: Side,
+    program: &Path,
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<(RunContext, Option<DockerWorkspace>), HarnessError> {
+    // Docker-backed cases run in an ISOLATED external temp workspace (US5) so their
+    // container identity + labels are unique (collision-safe) and an RAII guard reclaims
+    // every resource on success AND unwind. Config-only cases run against the committed
+    // fixture directory directly (read-only, no container).
+    let docker_case = is_docker_case(case);
+    let mut docker_ws: Option<DockerWorkspace> = None;
+    let isolated_workspace: Option<PathBuf> = if docker_case {
+        let ws = DockerWorkspace::new(Some(cfg.deacon_path)).map_err(|e| {
+            HarnessError::DockerUnavailable {
+                cause: format!("could not create an isolated workspace: {e}"),
+            }
+        })?;
+        for id in unique_fixture_ids(case) {
+            let dir = cfg.fixtures_root.join(&id);
+            if !dir.is_dir() {
+                return Err(HarnessError::FixtureMissing { path: dir });
+            }
+            ws.materialize(&dir)
+                .map_err(|e| HarnessError::FixtureMissing {
+                    path: dir.join(format!("<materialize failed: {e}>")),
+                })?;
+        }
+        let path = ws.path().to_path_buf();
+        docker_ws = Some(ws);
+        Some(path)
+    } else {
+        None
+    };
+
+    let mut context_workspace: Option<PathBuf> = None;
+    let mut outcomes: Vec<(String, ProcessOutcome)> = Vec::new();
+    let mut op_snapshots: Vec<(String, crate::observe::OpSnapshot)> = Vec::new();
+    let mut container_id: Option<String> = None;
+
+    for op in &case.operations {
+        // Docker cases: one isolated workspace for every op. Config-only: per-op fixture.
+        let workspace = match &isolated_workspace {
+            Some(ws) => ws.clone(),
+            None => resolve_workspace(case, op, cfg)?,
+        };
+        if context_workspace.is_none() {
+            context_workspace = Some(workspace.clone());
+        }
+        // For a Docker case every op shares the ISOLATED workspace (materialized once), so
+        // `${WORKSPACE}` always resolves even for a later op that declares no fixture.
+        let argv = substitute_argv(case, op, &workspace, isolated_workspace.is_some())?;
+        let mut full: Vec<String> = Vec::with_capacity(argv.len() + 1);
+        full.push(op.subcommand.clone());
+        full.extend(argv);
+        let args: Vec<&str> = full.iter().map(String::as_str).collect();
+
+        let raw_case = format!("{}__{}", case.id, op.id);
+        let inv = run_and_capture(
+            side,
+            RUNNER_BINARY,
+            &raw_case,
+            program,
+            &args,
+            &workspace,
+            exec_kind(&op.subcommand).bound(),
+            cfg.report_root,
+        )
+        .await?;
+
+        // For a Docker op, snapshot the container at THIS op's boundary so the observers
+        // (final state) and the invariant/metamorphic oracle (state ACROSS ops, US6) can
+        // both read it. The final `up`'s container id is what the channel observers use.
+        if docker_case && matches!(op.subcommand.as_str(), "up" | "exec") && inv.success {
+            // Capture EVERY container matching this op's workspace label (not just one), so
+            // the metamorphic oracle can detect a non-idempotent op that left a second
+            // container behind (finding #3).
+            let this_ids = containers_for_workspace(&workspace);
+            let this_id = this_ids.first().cloned();
+            let temporal = this_id
+                .as_deref()
+                .and_then(|id| crate::observe::docker_inspect(id).ok().flatten())
+                .map(|inspect| crate::observe::temporal::temporal_from_inspect(&inspect))
+                .unwrap_or(serde_json::Value::Null);
+            op_snapshots.push((
+                op.id.clone(),
+                crate::observe::OpSnapshot {
+                    container_id: this_id.clone(),
+                    container_ids: this_ids,
+                    temporal,
+                },
+            ));
+            if op.subcommand == "up" {
+                container_id = this_id;
+            }
+        }
+
+        let failure_phase = if inv.success {
+            None
+        } else {
+            Some(cli_process::infer_failure_phase(&op.subcommand))
+        };
+        outcomes.push((
+            op.id.clone(),
+            ProcessOutcome {
+                exit_code: inv.exit_code,
+                success: inv.success,
+                stdout: inv.stdout,
+                stderr: inv.stderr,
+                failure_phase,
+            },
+        ));
+    }
+
+    let workspace = context_workspace.unwrap_or_else(|| cfg.fixtures_root.to_path_buf());
+    let mut ctx = RunContext::new(workspace);
+    // Scope the filesystem observer to the case's declared allowlist (clarify Q1).
+    ctx.fs_allowlist = case.fs_allowlist.clone();
+    ctx.container_id = container_id;
+    for (op_id, outcome) in outcomes {
+        ctx.record_outcome(op_id, outcome);
+    }
+    for (op_id, snapshot) in op_snapshots {
+        ctx.record_op_snapshot(op_id, snapshot);
+    }
+    Ok((ctx, docker_ws))
+}
+
+/// Whether a case runs Docker-backed (its `resourceGroup` requests a Docker group). Such
+/// cases get an isolated workspace + the RAII cleanup guard.
+pub(crate) fn is_docker_case(case: &TestCase) -> bool {
+    matches!(
+        case.resource_group,
+        Some(ResourceGroup::DockerShared) | Some(ResourceGroup::DockerExclusive)
+    )
+}
+
+/// The de-duplicated, sorted fixture ids a case's operations reference.
+fn unique_fixture_ids(case: &TestCase) -> Vec<String> {
+    let mut ids: Vec<String> = case
+        .operations
+        .iter()
+        .flat_map(|op| op.fixtures.iter().cloned())
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Find EVERY container deacon created for `workspace` via its `devcontainer.local_folder`
+/// label (unique per isolated workspace, so collision-safe), sorted+deduped for a
+/// deterministic result. Returning the full set — not just the first match — lets the
+/// metamorphic oracle detect a non-idempotent op that left a second container behind
+/// (finding #3). Empty when none is found or `docker` cannot run.
+fn containers_for_workspace(workspace: &Path) -> Vec<String> {
+    let ws = workspace.to_string_lossy();
+    let Ok(output) = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "-aq",
+            "--filter",
+            &format!("label=devcontainer.local_folder={ws}"),
+        ])
+        .output()
+    else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let mut ids: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Which operation produced an expected observable: the explicit `operation`, else the
+/// case's LAST operation (data-model §5).
+pub(crate) fn resolve_expected_op<'a>(
+    case: &'a TestCase,
+    exp: &ExpectedObservable,
+) -> Result<&'a Operation, HarnessError> {
+    let target = match &exp.operation {
+        Some(id) => case.operations.iter().find(|o| &o.id == id),
+        None => case.operations.last(),
+    };
+    target.ok_or_else(|| {
+        shape_error(
+            case,
+            &format!("expected channel {:?} refers to no operation", exp.channel),
+        )
+    })
+}
+
+/// Capture `exp`'s channel from `ctx` as BOTH raw and normalized evidence — the shared
+/// step of spec-expectation and live-differential. Resolves the observer, captures raw,
+/// then applies the named per-channel normalization rules with the workspace token map
+/// (US3). Raw and normalized are returned separately (FR-016) so callers persist/compare
+/// each independently.
+pub(crate) fn capture_channel(
+    case: &TestCase,
+    exp: &ExpectedObservable,
+    ctx: &RunContext,
+) -> Result<(RawChannelEvidence, NormalizedChannelEvidence), HarnessError> {
+    let op = resolve_expected_op(case, exp)?;
+    let observer = observer_for(&exp.channel).ok_or_else(|| HarnessError::NormalizationFailed {
+        channel: exp.channel.clone(),
+        cause: "no observer for this channel yet (Docker channels land in US5)".to_string(),
+    })?;
+    let raw = observer.capture(ctx, op)?;
+    let tokens = crate::normalize::TokenMap::workspace(&ctx.workspace);
+    let normalized = crate::normalize::normalize_channel(&exp.channel, &raw, &tokens);
+    Ok((raw, normalized))
+}
+
+/// Convenience: the normalized-only capture (spec-expectation / differential comparison
+/// operate on normalized evidence).
+pub(crate) fn capture_normalized(
+    case: &TestCase,
+    exp: &ExpectedObservable,
+    ctx: &RunContext,
+) -> Result<NormalizedChannelEvidence, HarnessError> {
+    Ok(capture_channel(case, exp, ctx)?.1)
+}
+
+/// Run a case's operations against deacon and collect its [`CaseEvidence`] — raw and
+/// normalized held SEPARATELY (FR-016) for every declared channel. Used by the
+/// spec-expectation path and exposed so record/replay (US2) and tests can retrieve raw
+/// and normalized independently.
+pub async fn collect_spec_evidence(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<crate::evidence::CaseEvidence, HarnessError> {
+    // `_ws` (the RAII cleanup guard) is held until after every channel is captured, then
+    // dropped to reclaim the container/network/volume/temp dir (FR-039).
+    let (ctx, _ws) = execute_ops(Side::Deacon, cfg.deacon_path, case, cfg).await?;
+    let mut evidence = crate::evidence::CaseEvidence::new();
+    for exp in &case.expected {
+        let (raw, normalized) = capture_channel(case, exp, &ctx)?;
+        evidence.push(raw, normalized);
+    }
+    Ok(evidence)
+}
+
+/// Run a case's operations against the given `program` (`Side::Deacon` or
+/// `Side::Oracle`) and collect its [`CaseEvidence`] — the record path for snapshots.
+pub async fn collect_evidence_on(
+    side: Side,
+    program: &std::path::Path,
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<crate::evidence::CaseEvidence, HarnessError> {
+    let (ctx, _ws) = execute_ops(side, program, case, cfg).await?;
+    let mut evidence = crate::evidence::CaseEvidence::new();
+    for exp in &case.expected {
+        let (raw, normalized) = capture_channel(case, exp, &ctx)?;
+        evidence.push(raw, normalized);
+    }
+    Ok(evidence)
+}
+
+/// Build the 13-field [`Provenance`] for a snapshot recording (T035, data-model §7):
+/// recompute the case/fixture hashes, take the oracle version from the verified oracle,
+/// probe Node/Docker/Compose versions (via the shared
+/// [`deacon_conformance::snapshot::probe_environment`]), and stamp the source revision +
+/// normalizer version. `imageDigests` is empty for config-only cases (they pull no
+/// images); the Docker-image digest probe lands with the Docker channels (US5).
+///
+/// Provenance fields are recorded verbatim from the environment — NEVER fabricated
+/// (constitution IV). A missing Node/Docker/Compose tool records an empty string (the
+/// refresh bin fail-loud-checks Docker/Node presence before calling this, so in practice
+/// they are always present at record time).
+pub fn capture_provenance(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+    oracle_version: &str,
+) -> Result<deacon_conformance::snapshot::Provenance, HarnessError> {
+    use deacon_conformance::snapshot;
+
+    let (case_hash, fixture_hash) = snapshot_hashes(case, cfg)?;
+    let env = snapshot::probe_environment();
+
+    Ok(deacon_conformance::snapshot::Provenance {
+        oracle_version: oracle_version.to_string(),
+        source_revision: deacon_conformance::CURRENT_SPEC_PIN.to_string(),
+        case_hash,
+        fixture_hash,
+        argv: tokenized_argv(case),
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        node_version: env.node_version.unwrap_or_default(),
+        docker_version: env.docker_version.unwrap_or_default(),
+        compose_version: env.compose_version.unwrap_or_default(),
+        image_digests: Default::default(),
+        normalizer_version: crate::normalize::NORMALIZER_VERSION.to_string(),
+        captured_at: crate::report::now_rfc3339(),
+    })
+}
+
+/// Recompute `(caseHash, fixtureHash)` for `case`, mapping the shared conformance helper's
+/// IO error to a fail-loud [`HarnessError`].
+pub fn snapshot_hashes(
+    case: &TestCase,
+    cfg: &RunConfig<'_>,
+) -> Result<(String, String), HarnessError> {
+    deacon_conformance::case_hash::hashes_for_case(case, cfg.fixtures_root).map_err(|e| {
+        HarnessError::FixtureMissing {
+            path: cfg.fixtures_root.join(format!("<case {}>: {e}", case.id)),
+        }
+    })
+}
+
+/// The primary operation's argv (`[subcommand] ++ argv`) with `${WORKSPACE}` tokenized to
+/// `<WORKSPACE>` — the portable argv recorded in provenance (contract snapshot-provenance.md).
+fn tokenized_argv(case: &TestCase) -> Vec<String> {
+    let Some(op) = case.operations.first() else {
+        return Vec::new();
+    };
+    let mut argv = vec![op.subcommand.clone()];
+    for a in &op.argv {
+        argv.push(a.replace(WORKSPACE_TOKEN, "<WORKSPACE>"));
+    }
+    argv
+}
+
+/// Attach the failure phase to the `chan-exit-code` verdict's detail when the producing
+/// operation failed (FR-009). Path-free and deterministic, so the report stays
+/// byte-stable (T018).
+pub(crate) fn attach_failure_phase(
+    verdict: &mut ChannelVerdict,
+    case: &TestCase,
+    exp: &ExpectedObservable,
+    ctx: &RunContext,
+) {
+    if verdict.channel != CHAN_EXIT_CODE {
+        return;
+    }
+    let Ok(op) = resolve_expected_op(case, exp) else {
+        return;
+    };
+    let Some(phase) = ctx.outcome(&op.id).and_then(|o| o.failure_phase) else {
+        return;
+    };
+    let phase_value = serde_json::to_value(phase).unwrap_or(serde_json::Value::Null);
+    match verdict.detail.as_mut() {
+        Some(serde_json::Value::Object(map)) => {
+            map.insert("failurePhase".to_string(), phase_value);
+        }
+        _ => {
+            verdict.detail = Some(serde_json::json!({ "failurePhase": phase_value }));
+        }
+    }
+}
+
+/// The per-invocation time bound class for a subcommand (config-only vs lifecycle).
+fn exec_kind(subcommand: &str) -> ExecKind {
+    match subcommand {
+        "read-configuration" | "doctor" => ExecKind::Config,
+        _ => ExecKind::Lifecycle,
+    }
+}
+
+/// Resolve the workspace an operation runs against. US1 supports a single fixture id
+/// mapping to `<fixtures_root>/<id>/`; zero fixtures runs against `fixtures_root`
+/// itself. Multiple fixtures per op (merged into one isolated workspace) is US5 —
+/// fail-loud until then rather than silently pick one.
+fn resolve_workspace(
+    case: &TestCase,
+    op: &Operation,
+    cfg: &RunConfig<'_>,
+) -> Result<PathBuf, HarnessError> {
+    match op.fixtures.as_slice() {
+        [] => Ok(cfg.fixtures_root.to_path_buf()),
+        [one] => {
+            let dir = cfg.fixtures_root.join(one);
+            if dir.is_dir() {
+                Ok(dir)
+            } else {
+                Err(HarnessError::FixtureMissing { path: dir })
+            }
+        }
+        _ => Err(shape_error(
+            case,
+            &format!(
+                "operation {:?} references {} fixtures; multi-fixture workspaces land in US5",
+                op.id,
+                op.fixtures.len()
+            ),
+        )),
+    }
+}
+
+/// Substitute `${WORKSPACE}` in an operation's argv with the resolved workspace path. An
+/// argv that references the token with no resolvable fixture is a fail-loud authoring
+/// error.
+fn substitute_argv(
+    case: &TestCase,
+    op: &Operation,
+    workspace: &Path,
+    workspace_is_rooted: bool,
+) -> Result<Vec<String>, HarnessError> {
+    let ws = workspace.to_string_lossy();
+    let mut out = Vec::with_capacity(op.argv.len());
+    for arg in &op.argv {
+        // A config-only op that uses `${WORKSPACE}` must declare a fixture to root the
+        // token; a Docker op shares the already-rooted isolated workspace.
+        if arg.contains(WORKSPACE_TOKEN) && op.fixtures.is_empty() && !workspace_is_rooted {
+            return Err(shape_error(
+                case,
+                &format!(
+                    "operation {:?} uses {WORKSPACE_TOKEN} but declares no fixture to root it",
+                    op.id
+                ),
+            ));
+        }
+        out.push(arg.replace(WORKSPACE_TOKEN, &ws));
+    }
+    Ok(out)
+}
+
+/// A fail-loud case-shape / authoring error, surfaced as a normalization-class failure
+/// so it carries the case id in its channel slot.
+fn shape_error(case: &TestCase, cause: &str) -> HarnessError {
+    HarnessError::NormalizationFailed {
+        channel: format!("case:{}", case.id),
+        cause: cause.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_conformance::model::OracleType;
+
+    fn case_with_op(argv: &[&str], fixtures: &[&str]) -> TestCase {
+        TestCase {
+            id: "case-x".to_string(),
+            oracle_type: Some(OracleType::SpecExpectation),
+            operations: vec![Operation {
+                id: "op-1".to_string(),
+                subcommand: "read-configuration".to_string(),
+                argv: argv.iter().map(|s| s.to_string()).collect(),
+                fixtures: fixtures.iter().map(|s| s.to_string()).collect(),
+                ..Operation::default()
+            }],
+            ..TestCase::default()
+        }
+    }
+
+    #[test]
+    fn substitute_argv_requires_a_fixture_for_the_token() {
+        let case = case_with_op(&["--workspace-folder", "${WORKSPACE}"], &[]);
+        // Config-only (not rooted) + no fixture → fail loud.
+        let err = substitute_argv(&case, &case.operations[0], Path::new("/tmp/ws"), false)
+            .expect_err("token with no fixture must fail loud");
+        assert!(matches!(err, HarnessError::NormalizationFailed { .. }));
+        // But a rooted (isolated Docker) workspace resolves the token even with no fixture.
+        let ok = substitute_argv(&case, &case.operations[0], Path::new("/tmp/ws"), true)
+            .expect("rooted workspace resolves the token");
+        assert_eq!(ok, vec!["--workspace-folder", "/tmp/ws"]);
+    }
+
+    #[test]
+    fn substitute_argv_replaces_token() {
+        let case = case_with_op(&["--workspace-folder", "${WORKSPACE}"], &["fx-x"]);
+        let out = substitute_argv(&case, &case.operations[0], Path::new("/tmp/ws"), false).unwrap();
+        assert_eq!(out, vec!["--workspace-folder", "/tmp/ws"]);
+    }
+
+    #[test]
+    fn exec_kind_classifies_config_only() {
+        assert_eq!(exec_kind("read-configuration"), ExecKind::Config);
+        assert_eq!(exec_kind("up"), ExecKind::Lifecycle);
+    }
+
+    #[test]
+    fn resolve_expected_op_defaults_to_last() {
+        let mut case = case_with_op(&[], &[]);
+        case.operations.push(Operation {
+            id: "op-2".to_string(),
+            subcommand: "read-configuration".to_string(),
+            ..Operation::default()
+        });
+        let exp = ExpectedObservable {
+            channel: CHAN_EXIT_CODE.to_string(),
+            operation: None,
+            assertion: None,
+        };
+        assert_eq!(resolve_expected_op(&case, &exp).unwrap().id, "op-2");
+    }
+}

--- a/crates/parity-harness/src/workspace.rs
+++ b/crates/parity-harness/src/workspace.rs
@@ -1,0 +1,218 @@
+//! Isolated external workspaces + guaranteed resource cleanup for Docker-backed cases
+//! (research D10, T052, FR-036/037/039).
+//!
+//! Each Docker case runs in an isolated external temp workspace ([`tempfile`]) with a
+//! collision-resistant run id. Because deacon derives its container identity (and the
+//! `devcontainer.local_folder` label) from the workspace path, a unique temp workspace
+//! yields non-colliding container/network/volume names for free — two concurrent cases
+//! never collide (FR-037). [`DockerWorkspace`] is an RAII cleanup GUARD: its `Drop`
+//! reclaims every resource — `deacon down`, a container sweep by the workspace label, and
+//! any tracked images/networks/volumes — on success AND on unwind (panic / early return),
+//! then the temp dir removes itself (FR-039). Cleanup is synchronous + best-effort (Drop
+//! cannot be async and must never itself panic).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tempfile::TempDir;
+
+/// Process-wide monotonic counter → the collision-resistant run-id suffix.
+static RUN_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// An isolated external temp workspace for a Docker-backed case, and the RAII guard that
+/// reclaims its Docker resources on drop.
+#[derive(Debug)]
+pub struct DockerWorkspace {
+    /// Auto-removed on drop (after Docker cleanup).
+    tempdir: TempDir,
+    /// Collision-resistant id, unique per process across concurrent cases.
+    run_id: String,
+    /// `deacon` binary path for `down` (best-effort); `None` skips the down call.
+    deacon_path: Option<PathBuf>,
+    /// Image tags to `docker rmi -f` on cleanup.
+    images: Vec<String>,
+    /// Network names to `docker network rm` on cleanup.
+    networks: Vec<String>,
+    /// Volume names to `docker volume rm -f` on cleanup.
+    volumes: Vec<String>,
+    /// Set once cleanup has run so `Drop` does not double-reclaim.
+    reclaimed: bool,
+}
+
+impl DockerWorkspace {
+    /// Create an isolated temp workspace with a collision-resistant run id. `deacon_path`
+    /// is used for `deacon down` at cleanup; pass `None` to rely on the label sweep only.
+    pub fn new(deacon_path: Option<&Path>) -> std::io::Result<DockerWorkspace> {
+        let tempdir = tempfile::Builder::new().prefix("deacon-conf-").tempdir()?;
+        let seq = RUN_SEQ.fetch_add(1, Ordering::Relaxed);
+        let run_id = format!("dcr-{}-{seq}", std::process::id());
+        Ok(DockerWorkspace {
+            tempdir,
+            run_id,
+            deacon_path: deacon_path.map(Path::to_path_buf),
+            images: Vec::new(),
+            networks: Vec::new(),
+            volumes: Vec::new(),
+            reclaimed: false,
+        })
+    }
+
+    /// The isolated workspace directory (the `--workspace-folder` for the case's ops).
+    pub fn path(&self) -> &Path {
+        self.tempdir.path()
+    }
+
+    /// The collision-resistant run id — unique across concurrent cases in this process.
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    /// A collision-resistant resource name of the form `<run-id>-<kind>` for any resource
+    /// the case names explicitly (network, volume, built image tag).
+    pub fn resource_name(&self, kind: &str) -> String {
+        format!("{}-{kind}", self.run_id)
+    }
+
+    /// Materialize a fixture directory tree into the workspace (recursive copy). Repeated
+    /// calls layer fixtures into the same workspace.
+    pub fn materialize(&self, fixture_dir: &Path) -> std::io::Result<()> {
+        copy_tree(fixture_dir, self.tempdir.path())
+    }
+
+    /// Track a built image tag for removal at cleanup.
+    pub fn track_image(&mut self, tag: impl Into<String>) {
+        self.images.push(tag.into());
+    }
+
+    /// Track a network name for removal at cleanup.
+    pub fn track_network(&mut self, name: impl Into<String>) {
+        self.networks.push(name.into());
+    }
+
+    /// Track a volume name for removal at cleanup.
+    pub fn track_volume(&mut self, name: impl Into<String>) {
+        self.volumes.push(name.into());
+    }
+
+    /// Explicitly reclaim all Docker resources now (idempotent). `Drop` calls this too,
+    /// so a test can invoke it and then assert zero residual resources.
+    pub fn cleanup_now(&mut self) {
+        self.reclaim();
+    }
+
+    /// Best-effort synchronous resource reclamation (never panics). Order: `deacon down`
+    /// (removes deacon's container + its network/volumes for this workspace), then a
+    /// label sweep for any straggler containers, then tracked images/networks/volumes.
+    fn reclaim(&mut self) {
+        if self.reclaimed {
+            return;
+        }
+        self.reclaimed = true;
+        let ws = self.tempdir.path().to_string_lossy().into_owned();
+
+        if let Some(deacon) = &self.deacon_path {
+            let _ = std::process::Command::new(deacon)
+                .args(["down", "--remove", "--workspace-folder", &ws])
+                .current_dir(self.tempdir.path())
+                .output();
+        }
+
+        // Sweep any container still labeled with THIS workspace (collision-safe — the
+        // workspace path is unique).
+        let list = std::process::Command::new("docker")
+            .args([
+                "ps",
+                "-aq",
+                "--filter",
+                &format!("label=devcontainer.local_folder={ws}"),
+            ])
+            .output();
+        if let Ok(out) = list {
+            if out.status.success() {
+                for id in String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .map(str::trim)
+                    .filter(|l| !l.is_empty())
+                {
+                    let _ = std::process::Command::new("docker")
+                        .args(["rm", "-f", id])
+                        .output();
+                }
+            }
+        }
+
+        for image in &self.images {
+            let _ = std::process::Command::new("docker")
+                .args(["rmi", "-f", image])
+                .output();
+        }
+        for network in &self.networks {
+            let _ = std::process::Command::new("docker")
+                .args(["network", "rm", network])
+                .output();
+        }
+        for volume in &self.volumes {
+            let _ = std::process::Command::new("docker")
+                .args(["volume", "rm", "-f", volume])
+                .output();
+        }
+    }
+}
+
+impl Drop for DockerWorkspace {
+    fn drop(&mut self) {
+        // RAII guarantee: reclaim on success AND on unwind (panic / early return). The
+        // TempDir field drops after this, removing the workspace directory (FR-039).
+        self.reclaim();
+    }
+}
+
+/// Recursively copy `src`'s contents into `dst` (creating `dst`), preserving the tree.
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_ids_are_collision_resistant() {
+        let a = DockerWorkspace::new(None).expect("workspace a");
+        let b = DockerWorkspace::new(None).expect("workspace b");
+        assert_ne!(a.run_id(), b.run_id(), "concurrent run ids must differ");
+        assert_ne!(a.path(), b.path(), "temp workspaces must be distinct");
+        // Names derived from run ids are also distinct.
+        assert_ne!(a.resource_name("net"), b.resource_name("net"));
+    }
+
+    #[test]
+    fn materialize_copies_the_fixture_tree() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        std::fs::create_dir_all(fixture.path().join(".devcontainer")).unwrap();
+        std::fs::write(fixture.path().join(".devcontainer/devcontainer.json"), "{}").unwrap();
+        let ws = DockerWorkspace::new(None).expect("workspace");
+        ws.materialize(fixture.path()).expect("materialize");
+        assert!(ws.path().join(".devcontainer/devcontainer.json").is_file());
+    }
+
+    #[test]
+    fn tempdir_is_removed_on_drop() {
+        let path = {
+            let ws = DockerWorkspace::new(None).expect("workspace");
+            ws.path().to_path_buf()
+        };
+        assert!(!path.exists(), "the temp workspace is removed on drop");
+    }
+}

--- a/crates/parity-harness/tests/docker_channels.rs
+++ b/crates/parity-harness/tests/docker_channels.rs
@@ -1,0 +1,322 @@
+//! Docker-backed conformance-runner tests (022-conformance-runner US5, T049/T050/T051).
+//!
+//! These run REAL Docker (the `docker-shared` nextest group — unique resource names, so
+//! concurrent execution is safe). They assert, via actual `docker` sweeps, that the four
+//! Docker channel observers produce genuine evidence against a real container, that the
+//! RAII cleanup guard leaves ZERO residual resources on success AND on unwind, and that
+//! two concurrent cases allocate non-colliding names. Docker-only and hence
+//! `#[cfg(unix)]`-guarded (the harness's Docker lanes are Linux/macOS).
+
+#![cfg(unix)]
+
+use std::process::Command;
+
+use deacon_conformance::model::{
+    CHAN_IMAGE, CHAN_INJECTED_PROCESS, CHAN_PROCESS_GRAPH, CHAN_TEMPORAL, Operation,
+};
+use parity_harness::normalize::{TokenMap, normalize_channel};
+use parity_harness::observe::container_graph::ContainerGraphObserver;
+use parity_harness::observe::image::ImageObserver;
+use parity_harness::observe::injected_process::InjectedProcessObserver;
+use parity_harness::observe::temporal::TemporalObserver;
+use parity_harness::observe::{ChannelObserver, RunContext};
+use parity_harness::workspace::DockerWorkspace;
+
+const IMAGE: &str = "alpine:3.19";
+
+/// Run `docker <args>` and return trimmed stdout, panicking on failure (fail-loud — these
+/// tests only run in Docker lanes).
+fn docker(args: &[&str]) -> String {
+    let out = Command::new("docker")
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("could not run docker {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "docker {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// `docker` allowing failure (for best-effort teardown / existence probes).
+fn docker_try(args: &[&str]) -> (bool, String) {
+    match Command::new("docker").args(args).output() {
+        Ok(out) => (
+            out.status.success(),
+            String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        ),
+        Err(_) => (false, String::new()),
+    }
+}
+
+/// Container ids labeled `devcontainer.local_folder=<ws>` (the cleanup sweep predicate).
+fn containers_for(ws: &str) -> Vec<String> {
+    let (ok, out) = docker_try(&[
+        "ps",
+        "-aq",
+        "--filter",
+        &format!("label=devcontainer.local_folder={ws}"),
+    ]);
+    if !ok {
+        return Vec::new();
+    }
+    out.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn ctx_for(container_id: &str) -> RunContext {
+    let mut ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
+    ctx.container_id = Some(container_id.to_string());
+    ctx
+}
+
+fn up_op() -> Operation {
+    Operation {
+        id: "op-up".to_string(),
+        subcommand: "up".to_string(),
+        ..Operation::default()
+    }
+}
+
+// ---------------------------------------------------------------------------------
+// T051: per-channel capture against a real container.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn observers_capture_real_container_evidence() {
+    // A DockerWorkspace guard makes the test LEAK-PROOF: even if an assertion below
+    // panics, its Drop sweeps the labeled container + tracked network/volume.
+    let mut ws = DockerWorkspace::new(None).expect("workspace");
+    let ws_label = ws.path().to_string_lossy().into_owned();
+    let network = ws.resource_name("net");
+    let volume = ws.resource_name("vol");
+    ws.track_network(&network);
+    ws.track_volume(&volume);
+
+    let _ = docker_try(&["network", "create", &network]);
+    let _ = docker_try(&["volume", "create", &volume]);
+    let id = docker(&[
+        "run",
+        "-d",
+        "--label",
+        &format!("devcontainer.local_folder={ws_label}"),
+        "--label",
+        "org.opencontainers.image.title=Probe",
+        "--network",
+        &network,
+        "-v",
+        &format!("{volume}:/data"),
+        "-e",
+        "FOO=bar",
+        "-w",
+        "/work",
+        IMAGE,
+        "sleep",
+        "120",
+    ]);
+
+    let ctx = ctx_for(&id);
+    let tokens = TokenMap::new();
+    let op = up_op();
+
+    // chan-image: labels + env, normalized (label_semantic keeps labels an object).
+    let img_raw = ImageObserver.capture(&ctx, &op).expect("image capture");
+    assert!(img_raw.present);
+    let img = normalize_channel(CHAN_IMAGE, &img_raw, &tokens);
+    assert_eq!(
+        img.value["labels"]["org.opencontainers.image.title"], "Probe",
+        "image labels captured + parsed semantically: {img:?}"
+    );
+    assert!(
+        img.value["env"]
+            .as_array()
+            .is_some_and(|a| a.iter().any(|e| e == "FOO=bar")),
+        "image env captured (nothing blanket-removed)"
+    );
+
+    // chan-process-graph: the mount graph + networks + volume.
+    let graph_raw = ContainerGraphObserver
+        .capture(&ctx, &op)
+        .expect("graph capture");
+    let graph = normalize_channel(CHAN_PROCESS_GRAPH, &graph_raw, &tokens);
+    assert!(
+        graph.value["mounts"]
+            .as_array()
+            .is_some_and(|a| a.iter().any(|m| m["target"] == "/data")),
+        "the volume mount at /data is captured: {graph:?}"
+    );
+    assert!(
+        graph.value["networks"]
+            .as_array()
+            .is_some_and(|a| a.iter().any(|n| n == &serde_json::json!(network))),
+        "the custom network is captured"
+    );
+    assert!(
+        graph.value["volumes"]
+            .as_array()
+            .is_some_and(|a| a.iter().any(|v| v == &serde_json::json!(volume))),
+        "the named volume is captured"
+    );
+
+    // chan-injected-process: env/user/cwd/PATH (segmented)/tty.
+    let inj_raw = InjectedProcessObserver
+        .capture(&ctx, &op)
+        .expect("injected capture");
+    let inj = normalize_channel(CHAN_INJECTED_PROCESS, &inj_raw, &tokens);
+    assert_eq!(inj.value["env"]["FOO"], "bar", "injected env captured");
+    assert_eq!(inj.value["cwd"], "/work", "cwd captured");
+    assert_eq!(inj.value["tty"], false, "tty captured");
+    assert!(
+        inj.value["path"].as_array().is_some_and(|a| !a.is_empty()),
+        "PATH captured segment-wise (path_env_segmented): {inj:?}"
+    );
+
+    // chan-temporal: state markers (no wall-clock timestamps).
+    let temp_raw = TemporalObserver
+        .capture(&ctx, &op)
+        .expect("temporal capture");
+    let temp = normalize_channel(CHAN_TEMPORAL, &temp_raw, &tokens);
+    assert_eq!(temp.value["status"], "running");
+    assert_eq!(temp.value["running"], true);
+    assert!(
+        temp.value.get("startedAt").is_none() && temp.value.get("StartedAt").is_none(),
+        "no wall-clock timestamp in temporal evidence (determinism)"
+    );
+
+    // `ws` drops here → sweeps the container + tracked network/volume (leak-proof).
+    drop(ws);
+}
+
+#[test]
+fn temporal_state_and_cleanup_transitions() {
+    // Leak-proof: label the container with the workspace so the guard sweeps it even on
+    // an assertion panic.
+    let ws = DockerWorkspace::new(None).expect("workspace");
+    let ws_label = ws.path().to_string_lossy().into_owned();
+    let id = docker(&[
+        "run",
+        "-d",
+        "--label",
+        &format!("devcontainer.local_folder={ws_label}"),
+        IMAGE,
+        "sleep",
+        "120",
+    ]);
+    let op = up_op();
+
+    // Running → status=running.
+    let running = TemporalObserver.capture(&ctx_for(&id), &op).unwrap();
+    assert_eq!(running.value["status"], "running");
+    assert_eq!(running.value["running"], true);
+
+    // Stopped → status=exited (a real state transition, deterministic).
+    docker(&["stop", "-t", "1", &id]);
+    let stopped = TemporalObserver.capture(&ctx_for(&id), &op).unwrap();
+    assert_eq!(
+        stopped.value["status"], "exited",
+        "stop → exited: {stopped:?}"
+    );
+    assert_eq!(stopped.value["running"], false);
+
+    // Cleanup transition: a removed container is `present:false` (FR-018).
+    docker(&["rm", "-f", &id]);
+    let gone = TemporalObserver.capture(&ctx_for(&id), &op).unwrap();
+    assert!(
+        !gone.present,
+        "a removed container is not-captured (cleanup transition)"
+    );
+}
+
+// ---------------------------------------------------------------------------------
+// T049: guaranteed cleanup — zero residual resources on success AND unwind.
+// ---------------------------------------------------------------------------------
+
+/// Start a container labeled with the workspace so the guard's sweep can find it.
+fn start_labeled_container(ws: &str, name: &str) -> String {
+    docker(&[
+        "run",
+        "-d",
+        "--name",
+        name,
+        "--label",
+        &format!("devcontainer.local_folder={ws}"),
+        IMAGE,
+        "sleep",
+        "120",
+    ])
+}
+
+#[test]
+fn cleanup_leaves_zero_residual_on_success() {
+    let mut ws = DockerWorkspace::new(None).expect("workspace");
+    let ws_path = ws.path().to_string_lossy().into_owned();
+    let name = format!("{}-c", ws.run_id());
+    let _id = start_labeled_container(&ws_path, &name);
+    assert_eq!(containers_for(&ws_path).len(), 1, "container is up");
+
+    ws.cleanup_now();
+    assert!(
+        containers_for(&ws_path).is_empty(),
+        "cleanup_now leaves zero residual containers (SC-009)"
+    );
+    // The temp workspace directory is removed when the guard drops.
+    drop(ws);
+}
+
+#[test]
+fn cleanup_runs_on_unwind_drop() {
+    // Simulate a forced-failure / early-return: the guard reclaims on Drop, not just on
+    // an explicit call. A scope exit (as an unwind would) must reclaim.
+    let ws_path;
+    let name;
+    {
+        let ws = DockerWorkspace::new(None).expect("workspace");
+        ws_path = ws.path().to_string_lossy().into_owned();
+        name = format!("{}-c", ws.run_id());
+        let _id = start_labeled_container(&ws_path, &name);
+        assert_eq!(containers_for(&ws_path).len(), 1, "container is up");
+        // No explicit cleanup — the guard drops here (the unwind path).
+    }
+    assert!(
+        containers_for(&ws_path).is_empty(),
+        "Drop reclaims the container on unwind/early-return (SC-009)"
+    );
+    // Belt-and-suspenders teardown in case of assertion failure above.
+    let _ = docker_try(&["rm", "-f", &name]);
+}
+
+// ---------------------------------------------------------------------------------
+// T050: two concurrent Docker cases allocate non-colliding names.
+// ---------------------------------------------------------------------------------
+
+#[test]
+fn concurrent_cases_do_not_collide_on_names() {
+    let mut a = DockerWorkspace::new(None).expect("ws a");
+    let mut b = DockerWorkspace::new(None).expect("ws b");
+    assert_ne!(a.run_id(), b.run_id());
+    assert_ne!(a.path(), b.path());
+
+    let a_ws = a.path().to_string_lossy().into_owned();
+    let b_ws = b.path().to_string_lossy().into_owned();
+    let a_name = a.resource_name("c");
+    let b_name = b.resource_name("c");
+    assert_ne!(a_name, b_name, "resource names must be distinct");
+
+    // Both run concurrently, each with its own labeled container.
+    let _a_id = start_labeled_container(&a_ws, &a_name);
+    let _b_id = start_labeled_container(&b_ws, &b_name);
+    assert_eq!(containers_for(&a_ws).len(), 1);
+    assert_eq!(containers_for(&b_ws).len(), 1);
+
+    // Cleaning up A removes only A's container; B is untouched (scoped cleanup).
+    a.cleanup_now();
+    assert!(containers_for(&a_ws).is_empty(), "A cleaned");
+    assert_eq!(containers_for(&b_ws).len(), 1, "B untouched by A's cleanup");
+
+    b.cleanup_now();
+    assert!(containers_for(&b_ws).is_empty(), "B cleaned");
+}

--- a/crates/parity-harness/tests/runner_record_replay.rs
+++ b/crates/parity-harness/tests/runner_record_replay.rs
@@ -1,0 +1,519 @@
+//! Hermetic runner tests (022-conformance-runner, US1 T016/T017/T018).
+//!
+//! The runner is driven over DECLARATIVE cases (data) against a stub "deacon" binary, so
+//! adding a case never adds a Rust test function (SC-001). The stub stands in for the
+//! real binary — a parity-harness test cannot expand `CARGO_BIN_EXE_deacon`; the real
+//! read-configuration case runs against real deacon in the parity lane
+//! (`parity_conformance_runner`). The record/replay-equivalence + 13-field-provenance
+//! assertions land in User Story 2 (T030).
+
+use deacon_conformance::model::{
+    CHAN_EXIT_CODE, CHAN_STRUCTURED_OUTPUT, ExpectedObservable, Operation, OracleType, TestCase,
+};
+use parity_harness::evidence::{CaseVerdict, ChannelVerdict, Outcome};
+use parity_harness::report::VerdictReport;
+
+/// A declarative spec-expectation case: read-configuration on `fx-x`, asserting exit 0
+/// and a structured-output subset. Pure data — the same shape a `cases.json` record is.
+fn spec_case() -> TestCase {
+    TestCase {
+        id: "case-runner-spec".to_string(),
+        behaviors: vec!["bhv-x".to_string()],
+        oracle_type: Some(OracleType::SpecExpectation),
+        operations: vec![Operation {
+            id: "op-read".to_string(),
+            subcommand: "read-configuration".to_string(),
+            argv: vec!["--workspace-folder".to_string(), "${WORKSPACE}".to_string()],
+            fixtures: vec!["fx-x".to_string()],
+            ..Operation::default()
+        }],
+        expected: vec![
+            ExpectedObservable {
+                channel: CHAN_EXIT_CODE.to_string(),
+                operation: Some("op-read".to_string()),
+                assertion: Some(serde_json::json!({ "equals": 0 })),
+            },
+            ExpectedObservable {
+                channel: CHAN_STRUCTURED_OUTPUT.to_string(),
+                operation: Some("op-read".to_string()),
+                assertion: Some(
+                    serde_json::json!({ "jsonSubset": { "configuration": { "customUnknownKey": "preserved" } } }),
+                ),
+            },
+        ],
+        ..TestCase::default()
+    }
+}
+
+// ------------------------------------------------------------------------------------
+// T018: report determinism (no exec — construct verdicts directly, cross-platform).
+// ------------------------------------------------------------------------------------
+
+#[test]
+fn verdict_report_is_byte_stable_and_path_free() {
+    let verdict = CaseVerdict {
+        case_id: "case-runner-spec".to_string(),
+        oracle_type: OracleType::SpecExpectation,
+        behaviors: vec!["bhv-x".to_string()],
+        channels: vec![
+            ChannelVerdict {
+                channel: CHAN_EXIT_CODE.to_string(),
+                outcome: Outcome::Agree,
+                detail: None,
+            },
+            ChannelVerdict {
+                channel: CHAN_STRUCTURED_OUTPUT.to_string(),
+                outcome: Outcome::Agree,
+                detail: None,
+            },
+        ],
+        overall: Outcome::Agree,
+        stale_allowed_differences: Vec::new(),
+    };
+    let report = VerdictReport::new(vec![verdict]);
+    let a = report.render().expect("render");
+    let b = report.render().expect("render again");
+    assert_eq!(
+        a, b,
+        "the verdict report must be byte-stable across renders"
+    );
+
+    // No timestamps and no absolute paths in the body (contract runner-cli.md, T018).
+    assert!(
+        !a.contains("T00:") && !a.to_lowercase().contains("capturedat") && !a.contains("/tmp/"),
+        "report body must carry no timestamps or absolute paths:\n{a}"
+    );
+    // Declaration order: exit-code precedes structured-output as declared.
+    let exit_at = a.find("chan-exit-code").expect("exit-code present");
+    let struct_at = a
+        .find("chan-structured-output")
+        .expect("structured present");
+    assert!(exit_at < struct_at, "channels must be in declaration order");
+    assert_eq!(report.exit_code(), 0, "all-agree report exits 0");
+}
+
+// ------------------------------------------------------------------------------------
+// T016/T017: spec-expectation agree/diverge + failure-phase (stub deacon, Unix only —
+// the stub is a POSIX shell script).
+// ------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+mod spec_expectation {
+    use super::*;
+
+    use std::path::{Path, PathBuf};
+
+    use parity_harness::runner::{RunConfig, collect_spec_evidence, run_case};
+
+    /// Write an executable stub "deacon" that prints `stdout` and exits with `code`.
+    fn write_stub(dir: &Path, name: &str, stdout: &str, code: i32) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        // `printf '%s'` avoids a trailing newline mattering; the runner trims for JSON.
+        let body = format!("#!/bin/sh\nprintf '%s' '{stdout}'\nexit {code}\n");
+        std::fs::write(&p, body).expect("write stub");
+        let mut perms = std::fs::metadata(&p).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).expect("chmod");
+        p
+    }
+
+    /// Write a stub that echoes its `--workspace-folder` arg ($3) into the structured
+    /// JSON, so the raw evidence carries the real (temp) workspace path.
+    fn write_echo_workspace_stub(dir: &Path, name: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        let body = "#!/bin/sh\nprintf '{\"configuration\":{\"customUnknownKey\":\"preserved\"},\"root\":\"%s\"}' \"$3\"\nexit 0\n";
+        std::fs::write(&p, body).expect("write stub");
+        let mut perms = std::fs::metadata(&p).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).expect("chmod");
+        p
+    }
+
+    /// Create `<root>/fixtures/fx-x/` so `${WORKSPACE}` resolves for the op.
+    fn make_fixtures(root: &Path) -> PathBuf {
+        let fixtures = root.join("fixtures");
+        std::fs::create_dir_all(fixtures.join("fx-x")).expect("mkdir fixture");
+        fixtures
+    }
+
+    const GOOD_STDOUT: &str = r#"{"configuration":{"customUnknownKey":"preserved","name":"x"}}"#;
+
+    /// T041: raw and normalized evidence are persisted SEPARATELY and independently
+    /// retrievable — raw keeps the real temp workspace path, normalized shows the
+    /// `<WORKSPACE>` token (real per-channel normalization, not pass-through).
+    #[tokio::test]
+    async fn raw_and_normalized_evidence_are_separate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = write_echo_workspace_stub(dir.path(), "deacon-echo");
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+            snapshots_root: &dir.path().join("snapshots"),
+        };
+        let evidence = collect_spec_evidence(&spec_case(), &cfg)
+            .await
+            .expect("collect");
+
+        let raw = evidence
+            .raw_for(CHAN_STRUCTURED_OUTPUT, "op-read")
+            .expect("raw structured evidence");
+        let norm = evidence
+            .normalized_for(CHAN_STRUCTURED_OUTPUT, "op-read")
+            .expect("normalized structured evidence");
+
+        // The real workspace path is fixtures/fx-x — raw preserves it verbatim.
+        let ws = fixtures.join("fx-x");
+        assert_eq!(
+            raw.value["root"],
+            serde_json::json!(ws.to_string_lossy()),
+            "raw evidence preserves the temp workspace path"
+        );
+        assert_eq!(
+            norm.value["root"],
+            serde_json::json!("<WORKSPACE>"),
+            "normalized evidence tokenizes the workspace path (FR-024)"
+        );
+        assert_ne!(
+            raw.value, norm.value,
+            "raw and normalized are separate (FR-016)"
+        );
+    }
+
+    #[tokio::test]
+    async fn correct_output_agrees() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = write_stub(dir.path(), "deacon-good", GOOD_STDOUT, 0);
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+            snapshots_root: &dir.path().join("snapshots"),
+        };
+        let verdict = run_case(&spec_case(), &cfg).await.expect("run");
+        assert_eq!(
+            verdict.overall,
+            Outcome::Agree,
+            "matching output must agree: {verdict:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_exit_code_diverges() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Emits the right JSON but exits 1 → the exit-code assertion `{equals:0}` fails.
+        let stub = write_stub(dir.path(), "deacon-badexit", GOOD_STDOUT, 1);
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+            snapshots_root: &dir.path().join("snapshots"),
+        };
+        let verdict = run_case(&spec_case(), &cfg).await.expect("run");
+        assert_eq!(
+            verdict.overall,
+            Outcome::Diverge,
+            "wrong exit code must diverge: {verdict:?}"
+        );
+        let exit = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_EXIT_CODE)
+            .expect("exit-code channel");
+        assert_eq!(exit.outcome, Outcome::Diverge);
+    }
+
+    /// A negative case: read-configuration fails (exit 1, non-JSON stdout). The runner
+    /// records PARTIAL evidence (exit-code captured; structured-output not captured) and
+    /// the correct closed-set FailurePhase (config-resolution) on the exit-code channel.
+    fn failure_case() -> TestCase {
+        let mut case = spec_case();
+        case.id = "case-runner-failure".to_string();
+        // Expect the failure: exit is non-zero; structured output is still declared, so
+        // its absence is observed as a divergence (partial capture).
+        case.expected[0].assertion = Some(serde_json::json!({ "nonZero": true }));
+        case
+    }
+
+    #[tokio::test]
+    async fn failed_op_records_partial_evidence_and_failure_phase() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = write_stub(dir.path(), "deacon-fail", "error: bad config", 1);
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+            snapshots_root: &dir.path().join("snapshots"),
+        };
+        let verdict = run_case(&failure_case(), &cfg).await.expect("run");
+
+        // Exit-code channel: the op failed (exit 1) → `nonZero` agrees, and the
+        // failure phase is recorded in the detail.
+        let exit = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_EXIT_CODE)
+            .expect("exit-code channel");
+        assert_eq!(exit.outcome, Outcome::Agree, "nonZero matched the failure");
+        let phase = exit
+            .detail
+            .as_ref()
+            .and_then(|d| d.get("failurePhase"))
+            .and_then(|p| p.as_str());
+        assert_eq!(
+            phase,
+            Some("config-resolution"),
+            "read-configuration failure phase must be config-resolution: {exit:?}"
+        );
+
+        // Structured-output channel: stdout was NOT valid JSON → partial capture, the
+        // declared assertion diverges (never a silent pass).
+        let structured = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_STRUCTURED_OUTPUT)
+            .expect("structured channel");
+        assert_eq!(structured.outcome, Outcome::Diverge);
+    }
+}
+
+// ------------------------------------------------------------------------------------
+// T030: record/replay equivalence for a snapshot-oracle case (stub reference + stub
+// deacon, Unix only). Records a snapshot to a temp tree, then replays via the snapshot
+// dispatch and asserts the SAME verdict (agree) + 13-field provenance.
+// ------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+mod snapshot_replay {
+    use deacon_conformance::model::{CHAN_EXIT_CODE, ExpectedObservable, OracleType};
+    use deacon_conformance::snapshot;
+
+    use parity_harness::evidence::write_snapshot;
+    use parity_harness::exec::Side;
+    use parity_harness::runner::{RunConfig, capture_provenance, collect_evidence_on, run_case};
+
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    fn write_exit0_stub(dir: &Path, name: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        std::fs::write(&p, "#!/bin/sh\nexit 0\n").expect("write stub");
+        let mut perms = std::fs::metadata(&p).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).expect("chmod");
+        p
+    }
+
+    fn snapshot_case() -> TestCase {
+        TestCase {
+            id: "case-replay".to_string(),
+            behaviors: vec!["bhv-x".to_string()],
+            oracle_type: Some(OracleType::Snapshot),
+            operations: vec![Operation {
+                id: "op-read".to_string(),
+                subcommand: "read-configuration".to_string(),
+                argv: vec!["--workspace-folder".to_string(), "${WORKSPACE}".to_string()],
+                fixtures: vec!["fx-x".to_string()],
+                ..Operation::default()
+            }],
+            expected: vec![ExpectedObservable {
+                channel: CHAN_EXIT_CODE.to_string(),
+                operation: Some("op-read".to_string()),
+                assertion: None,
+            }],
+            ..TestCase::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn recorded_case_replays_to_the_same_verdict_with_full_provenance() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("fixtures").join("fx-x")).expect("fixture");
+        let fixtures = dir.path().join("fixtures");
+        let snapshots = dir.path().join("snapshots");
+        let reports = dir.path().join("report");
+        let case = snapshot_case();
+
+        // A stub that exits 0 stands in for BOTH the reference (record) and deacon
+        // (replay) — the recorded exit-code (0) must equal deacon's on replay.
+        let stub = write_exit0_stub(dir.path(), "exit0");
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &reports,
+            snapshots_root: &snapshots,
+        };
+
+        // RECORD: capture the reference evidence + provenance and write the snapshot for
+        // the CURRENT os-arch (so the replay dispatch resolves it).
+        let evidence = collect_evidence_on(Side::Oracle, &stub, &case, &cfg)
+            .await
+            .expect("record evidence");
+        let provenance = capture_provenance(&case, &cfg, "0.87.0").expect("provenance");
+        let os_arch = snapshot::current_os_arch();
+        let case_dir = snapshot::snapshot_case_dir(&snapshots, &os_arch, &case.id);
+        write_snapshot(&case_dir, &provenance, &evidence)
+            .await
+            .expect("write snapshot");
+
+        // Provenance carries all 13 fields (SC-002) — reload and check the non-derived ones.
+        let reloaded = snapshot::load_provenance(&case_dir).expect("provenance loads");
+        assert_eq!(reloaded.oracle_version, "0.87.0");
+        assert_eq!(reloaded.normalizer_version, snapshot::NORMALIZER_VERSION);
+        assert_eq!(reloaded.source_revision, "113500f4");
+        assert_eq!(reloaded.case_hash.len(), 64);
+        assert_eq!(reloaded.fixture_hash.len(), 64);
+        assert!(!reloaded.captured_at.is_empty());
+
+        // REPLAY: the snapshot dispatch resolves the committed snapshot, gates on
+        // provenance freshness (same machine → fresh), runs deacon (exit 0), and compares
+        // to the recorded exit-code (0) → agree. Record/replay equivalence (SC-011).
+        let verdict = run_case(&case, &cfg).await.expect("replay");
+        assert_eq!(
+            verdict.overall,
+            Outcome::Agree,
+            "a recorded case replays to the same (agree) verdict: {verdict:?}"
+        );
+    }
+}
+
+// ------------------------------------------------------------------------------------
+// T066: one case under all four oracle types applies DISTINCT semantics, and re-pointing
+// changes ONLY `oracleType` (not the operations/expected shape). Unix (stub deacon).
+// ------------------------------------------------------------------------------------
+
+#[cfg(unix)]
+mod oracle_types {
+    use super::*;
+
+    use std::path::{Path, PathBuf};
+
+    use parity_harness::oracle_type::evaluate;
+    use parity_harness::runner::{RunConfig, run_case};
+
+    fn exit0_stub(dir: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join("deacon-exit0");
+        std::fs::write(&p, "#!/bin/sh\nexit 0\n").expect("write stub");
+        let mut perms = std::fs::metadata(&p).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).expect("chmod");
+        p
+    }
+
+    /// A base case (read-configuration, no ${WORKSPACE}, exit-code assertion) whose
+    /// operations + expected are IDENTICAL across every oracle type — only `oracleType`
+    /// changes between the variants below (FR-007).
+    fn base_case(oracle_type: OracleType) -> TestCase {
+        TestCase {
+            id: "case-repointed".to_string(),
+            behaviors: vec!["bhv-x".to_string()],
+            oracle_type: Some(oracle_type),
+            operations: vec![Operation {
+                id: "op".to_string(),
+                subcommand: "read-configuration".to_string(),
+                ..Operation::default()
+            }],
+            expected: vec![ExpectedObservable {
+                channel: CHAN_EXIT_CODE.to_string(),
+                operation: Some("op".to_string()),
+                assertion: Some(serde_json::json!({ "equals": 0 })),
+            }],
+            ..TestCase::default()
+        }
+    }
+
+    #[test]
+    fn re_pointing_changes_only_oracle_type() {
+        let a = base_case(OracleType::SpecExpectation);
+        let b = base_case(OracleType::LiveDifferential);
+        let c = base_case(OracleType::Snapshot);
+        let d = base_case(OracleType::InvariantMetamorphic);
+        // Every variant is identical EXCEPT `oracleType` — re-pointing is a one-field edit.
+        for other in [&b, &c, &d] {
+            assert_eq!(
+                a.operations, other.operations,
+                "operations must be identical"
+            );
+            assert_eq!(a.expected, other.expected, "expected must be identical");
+            assert_eq!(a.fixtures_shape(), other.fixtures_shape());
+            assert_ne!(a.oracle_type, other.oracle_type, "only oracleType differs");
+        }
+    }
+
+    #[tokio::test]
+    async fn four_oracle_types_apply_distinct_semantics() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = exit0_stub(dir.path());
+        let empty_snapshots = dir.path().join("snapshots"); // no committed snapshots
+
+        // spec-expectation: runs deacon, evaluates the assertion → a real Agree verdict.
+        let spec_cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: dir.path(),
+            report_root: &dir.path().join("report"),
+            snapshots_root: &empty_snapshots,
+        };
+        let spec = run_case(&base_case(OracleType::SpecExpectation), &spec_cfg)
+            .await
+            .expect("spec-expectation runs");
+        assert_eq!(
+            spec.overall,
+            Outcome::Agree,
+            "spec-expectation compares to the declared assertion: {spec:?}"
+        );
+
+        // live-differential WITHOUT an oracle → fail-loud OracleMissing (needs a reference).
+        let live = evaluate(&base_case(OracleType::LiveDifferential), &spec_cfg).await;
+        assert!(
+            matches!(
+                live,
+                Err(parity_harness::HarnessError::OracleMissing { .. })
+            ),
+            "live-differential requires the reference oracle: {live:?}"
+        );
+
+        // snapshot with no committed snapshot for this platform → no-reference-for-platform
+        // (a distinct coverage-gap outcome, not a verdict against a fixed value).
+        let (snap_channels, _stale) = evaluate(&base_case(OracleType::Snapshot), &spec_cfg)
+            .await
+            .expect("snapshot resolves to a verdict, not an error");
+        assert!(
+            snap_channels
+                .iter()
+                .all(|c| c.outcome == Outcome::NoReferenceForPlatform),
+            "snapshot with no committed reference is no-reference-for-platform: {snap_channels:?}"
+        );
+
+        // invariant-metamorphic with NO declared relationship → fail-loud (the relationship
+        // IS the oracle; there is nothing to evaluate against a fixed value).
+        let meta = evaluate(&base_case(OracleType::InvariantMetamorphic), &spec_cfg).await;
+        assert!(
+            meta.is_err(),
+            "invariant-metamorphic needs a declared relationship: {meta:?}"
+        );
+    }
+}
+
+/// A shape fingerprint of a case's fixtures for the re-pointing assertion (helper trait).
+trait FixturesShape {
+    fn fixtures_shape(&self) -> Vec<Vec<String>>;
+}
+impl FixturesShape for TestCase {
+    fn fixtures_shape(&self) -> Vec<Vec<String>> {
+        self.operations.iter().map(|o| o.fixtures.clone()).collect()
+    }
+}

--- a/fixtures/parity-corpus/registry.json
+++ b/fixtures/parity-corpus/registry.json
@@ -8,7 +8,8 @@
     { "name": "parity_state_diff",         "kind": "scenario", "docker_required": true },
     { "name": "parity_corpus_tier1",       "kind": "corpus",   "docker_required": false, "corpus": "tier1" },
     { "name": "parity_corpus_merged",      "kind": "corpus",   "docker_required": false, "corpus": "tier1" },
-    { "name": "parity_corpus_errors",      "kind": "corpus",   "docker_required": false, "corpus": "errors" }
+    { "name": "parity_corpus_errors",      "kind": "corpus",   "docker_required": false, "corpus": "errors" },
+    { "name": "parity_conformance_runner", "kind": "scenario", "docker_required": false }
   ],
   "internal_consistency_binaries": [
     "consistency_remote_env_flags",

--- a/specs/022-conformance-runner/checklists/requirements.md
+++ b/specs/022-conformance-runner/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Declarative Conformance Runner
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Domain terms that are inherent to the feature scope (conformance registry, waiver, nextest resource group, reference CLI oracle) appear in Assumptions/Dependencies as *integration context*, not as prescribed implementation. They name existing project machinery the runner must integrate with, per constitution I (spec-parity) and the project's conformance model — not a technology choice being introduced by this spec.
+- The feature's "users" are conformance/test authors, maintainers, and CI. Requirements are framed around their outcomes (author a case without new Rust code, trust replayed evidence, scope tolerated divergences), keeping the spec stakeholder-readable.

--- a/specs/022-conformance-runner/contracts/case-schema.md
+++ b/specs/022-conformance-runner/contracts/case-schema.md
@@ -1,0 +1,73 @@
+# Contract: Declarative Case Schema
+
+Extends the existing `conformance/registry/cases.json` record. Consumed by `deacon-conformance` (load + validate) and `parity-harness` (execute). Legacy binary-backed records remain valid; a record is legacy **or** declarative, never both.
+
+## Declarative case (canonical example)
+
+```json
+{
+  "id": "case-up-postcreate-env",
+  "behaviors": ["bhv-lifecycle-postcreate-env"],
+  "context": ["single-container"],
+  "oracleType": "live-differential",
+  "resourceGroup": "docker-shared",
+  "operations": [
+    {
+      "id": "op-up",
+      "subcommand": "up",
+      "argv": ["--workspace-folder", "${WORKSPACE}"],
+      "fixtures": ["fx-devcontainer-postcreate"]
+    },
+    {
+      "id": "op-exec-env",
+      "subcommand": "exec",
+      "argv": ["--workspace-folder", "${WORKSPACE}", "printenv", "MY_VAR"]
+    }
+  ],
+  "expected": [
+    { "channel": "chan-exit-code", "operation": "op-exec-env", "assertion": { "equals": 0 } },
+    { "channel": "chan-injected-process", "operation": "op-exec-env",
+      "assertion": { "env": { "MY_VAR": "hello" } } }
+  ],
+  "allowedDifferences": [
+    { "behavior": "bhv-lifecycle-postcreate-env", "context": ["single-container"],
+      "observablePath": "chan-injected-process.env.TZ",
+      "rationale": "reference leaks host TZ; deacon does not — characterized",
+      "waiverId": "wvr-postcreate-tz" }
+  ],
+  "fsAllowlist": [],
+  "cleanup": { "containers": true, "images": "case-built", "networks": true, "volumes": true, "tempdir": true },
+  "notes": "Exercises postCreateCommand env injection parity."
+}
+```
+
+## Field rules (enforced at load — fail-loud, FR-003)
+
+| Rule | Violation |
+|------|-----------|
+| Exactly one of `operations` (declarative) or `executable` (legacy) present | new V-series |
+| `behaviors` non-empty, each resolves in registry | V3 / V1 |
+| every `expected[].channel` declared in `channels.json` | V9 |
+| `oracleType` ∈ 4 enum values | new V-series |
+| `oracleType=invariant-metamorphic` ⇒ ≥2 ops + a `relationship` referencing a sibling op id | new V-series (arity) |
+| `oracleType=spec-expectation` ⇒ every `expected[].assertion` present | new V-series |
+| `fsAllowlist` non-empty **iff** an `expected` filesystem channel exists | new V-series |
+| each `operations[].subcommand` ∈ consumer surface | new V-series (Principle II) |
+| `allowedDifferences` well-formed & scoped (see allowed-difference rules below) | new V-series |
+
+## Allowed-difference rules (FR-031..035)
+
+- MUST carry `behavior`, `context`, `observablePath`, `rationale`, and exactly one of `waiverId`/`divergenceId`.
+- `waiverId`/`divergenceId` MUST resolve to an existing registry `wvr-*` / `ext-*`/intentional-divergence record (dangling → V1-style).
+- `observablePath` MUST be a dotted path *within* a channel; a bare channel with no path is rejected unless the `behavior` is inherently channel-wide (guard against global ignore lists, FR-032).
+- Two `allowedDifferences` with the same `(behavior, observablePath)` and differing bodies → load error (FR-035).
+- A difference matches **only** its `(behavior, observablePath, context)`; identical differences elsewhere still fail (FR-033).
+
+## Hashing (FR-020 / research D3)
+
+`caseHash = SHA256(canonical_json({ operations, oracleType, expected, fsAllowlist, fixtureHashes }))`.
+`notes`, `allowedDifferences`, and human prose are **excluded** — editing them does not invalidate snapshots.
+
+## Coexistence & migration
+
+Legacy `{ executable, outcomes }` records keep running under their Rust binaries. Migrating one = replace `executable`/`outcomes` with `operations`/`expected`/`oracleType`, delete the bespoke `parity_*` test if no longer referenced, and (if it was a live binary) update `fixtures/parity-corpus/registry.json` + nextest overrides accordingly.

--- a/specs/022-conformance-runner/contracts/observer-channel.md
+++ b/specs/022-conformance-runner/contracts/observer-channel.md
@@ -1,0 +1,53 @@
+# Contract: Observer Channel
+
+Each observable channel is captured by one module in `parity-harness/src/observe/` implementing a small `ChannelObserver` contract. The runner invokes only the observers a case's `expected`/`fsAllowlist` declares (a pure `read-configuration` CLI case pays nothing for Docker inspection).
+
+## `ChannelObserver` (conceptual)
+
+```text
+capture(ctx: &RunContext, op: &Operation) -> Result<RawChannelEvidence, HarnessError>
+```
+
+`RawChannelEvidence = { channel, operation, present: bool, value: serde_json::Value }`.
+`present:false` when the channel could not be observed for this op (distinct from a captured empty value — FR-018).
+
+## Channels, capture, assertion shape, and named normalization rules
+
+| Channel | Captures | `assertion` shape (spec-expectation) | Normalization rules applied |
+|---------|----------|--------------------------------------|-----------------------------|
+| `chan-exit-code` | process exit status | `{ equals: <int> }` / `{ nonZero: true }` | none |
+| `chan-stdout` | raw stdout bytes | `{ equals } / { contains } / { matches }` | `path_token` |
+| `chan-stderr` | raw stderr bytes | `{ contains } / { matches }` | `path_token` |
+| `chan-structured-output` | parsed JSON result doc | `{ jsonEquals } / { jsonSubset }` | `path_token`, `null_preserving` |
+| `chan-filesystem` | presence/attrs of allowlisted paths (NOT full tree) | `{ exists } / { absent } / { mode }` | `path_token` |
+| `chan-file-content` | contents of an allowlisted file | `{ equals } / { contains }` | `path_token`, `null_preserving` |
+| `chan-image` | built-image config + labels | `{ labels: {...}, env: [...], entrypoint: [...] }` | `label_semantic`, `null_preserving` |
+| `chan-process-graph` | container/network/volume/mount graph | `{ mounts: [...], networks: [...], volumes: [...] }` | `mount_source_canonical`, `path_token` |
+| `chan-injected-process` | env, user, cwd, PATH, signals, TTY, exit propagation | `{ env: {...}, user, cwd, path: [...], tty: bool }` | `path_env_segmented`, `null_preserving`, `path_token` |
+| `chan-temporal` | lifecycle ordering, first-create vs restart, resume, cleanup | `{ order: [...], firstCreate: {...}, restart: {...} }` | ordering-preserving; `null_preserving` |
+
+## Named normalization rules (extend the single `normalize.rs` — FR-022..030)
+
+| Rule | Effect | Guard |
+|------|--------|-------|
+| `path_token` | temp workspace/project paths → `<WORKSPACE>` / `<PROJECT>` tokens | rewrite, never delete (FR-024) |
+| `label_semantic` | parse metadata labels into key/value; compare semantically | not opaque strings (FR-026); no blanket label removal (FR-029) |
+| `mount_source_canonical` | canonicalize mount `source` before compare | compare after substitution (FR-027) |
+| `path_env_segmented` | split PATH into segments; optional executable probe | segment-wise, not string-equal (FR-028) |
+| `null_preserving` | keep missing / null / empty / defaulted distinct | only a named rule may collapse a specific field (FR-025) |
+
+`NORMALIZER_VERSION` is bumped when any rule changes; recorded in provenance; participates in staleness (FR-030). No rule may blanket-remove env vars, labels, mount sources, entrypoints, commands, or networks (FR-029) — the reclassified former `NOISE_ENV_KEYS`/`INTENTIONAL_LABEL_PREFIXES` become named, scoped, rationale-carrying rules (research D6).
+
+## Failure phase (FR-009 / clarify Q5)
+
+When an operation fails, `chan-*` observers still record whatever was captured, and the CLI-process observer records `failurePhase` from the closed set:
+`config-resolution · build · container-create · lifecycle:onCreate · lifecycle:updateContent · lifecycle:postCreate · lifecycle:postStart · lifecycle:postAttach · exec`.
+
+## Per-channel verdict (FR-015)
+
+```text
+ChannelVerdict = { channel, outcome, detail }
+outcome ∈ { agree, diverge, allowed-difference, no-reference-for-platform, stale, error }
+```
+
+`allowed-difference` is emitted only when a divergence is fully covered by a scoped `AllowedDifference` matching `(behavior, observablePath, context)`; otherwise the raw divergence stands as `diverge`. `CaseVerdict.overall` = the worst channel outcome; the case is attributable to its linked behavior(s) (FR-042).

--- a/specs/022-conformance-runner/contracts/runner-cli.md
+++ b/specs/022-conformance-runner/contracts/runner-cli.md
@@ -1,0 +1,74 @@
+# Contract: Runner & Refresh CLI
+
+Dev-only tooling — **not** a shipped `deacon` subcommand (Principle II). Two entry points, split hermetic vs live (research D5).
+
+## 1. Hermetic — `deacon-conformance` bin (`cargo run -p deacon-conformance -- …`)
+
+Extends the existing `conformance` subcommand group (`validate`/`report`/`certify`/`inventory`/`clause`) with `snapshot`:
+
+| Command | Effect | Lane | Writes? |
+|---------|--------|------|---------|
+| `snapshot check [--case <id>] [--platform <os-arch>]` | recompute hashes + probe env; compare to committed provenance; report stale / no-reference-for-platform | dev-fast / PR | no |
+| `snapshot diff <old-dir> <new-dir> [--format json\|md]` | deterministic drift between two snapshot trees | dev-fast | no |
+
+`validate` gains the new case/allowed-difference/snapshot violation classes (continues V-series). `certify` (release gate) surfaces snapshot coverage + any `no-reference-for-platform` as non-blocking info, and blocks on unclassified/gap as today.
+
+### Exit codes (hermetic)
+
+| Code | Meaning |
+|------|---------|
+| 0 | all checks pass |
+| 1 | staleness / validation violation (names the mismatched field/record) |
+| 2 | malformed input / dangling reference (fail-loud, FR-003) |
+
+## 2. Live — `parity-harness` `conformance-snapshot` bin (`cargo run -p parity-harness --bin conformance-snapshot -- …`)
+
+Requires the verified pinned oracle + Docker/Node; fail-loud (`HarnessError`) if absent — no skip.
+
+| Command | Effect | Writes? |
+|---------|--------|---------|
+| `refresh [--case <id>] [--platform <os-arch>]` | run cases against the reference, capture + normalize, write `provenance/raw/normalized` atomically; print review diff | yes (reviewed) |
+
+## 3. Live differential run — `parity_conformance_runner` (nextest binary)
+
+The thin test-binary shell (`crates/deacon/tests/parity_conformance_runner.rs`) that drives the runner over declarative cases under `--profile parity` only. Fail-loud on missing prereqs; never `#[ignore]`.
+
+- Registered in `fixtures/parity-corpus/registry.json`.
+- nextest overrides added in **all** profiles: parity `default-filter` allow-list (add its `binary(=…)`), plus the `dev-fast`/`default`/`full`/`ci`/`mvp-integration` exclusions — mirror the CLAUDE.md "3-spot" rule for a docker-exclusive binary. `parity_registry_check` fails if any spot is missing.
+
+## Report shape (FR-041 — deterministic, VI output contract)
+
+Single JSON document on **stdout**; all logs/progress on **stderr** via `tracing`:
+
+```json
+{
+  "schemaVersion": 1,
+  "normalizerVersion": "2",
+  "cases": [
+    {
+      "caseId": "case-up-postcreate-env",
+      "oracleType": "live-differential",
+      "behaviors": ["bhv-lifecycle-postcreate-env"],
+      "channels": [
+        { "channel": "chan-exit-code", "outcome": "agree", "detail": null },
+        { "channel": "chan-injected-process", "outcome": "allowed-difference",
+          "detail": { "observablePath": "chan-injected-process.env.TZ", "waiverId": "wvr-postcreate-tz" } }
+      ],
+      "overall": "allowed-difference"
+    }
+  ]
+}
+```
+
+Records are emitted in declaration order (`Vec`/`IndexMap`, never `BTreeMap`) — VI ordering compliance. Determinism: no timestamps, no absolute paths in the report body (paths are tokenized), matching `deacon-conformance report`'s byte-stable convention.
+
+## Runner exit codes (live)
+
+| Code | Meaning |
+|------|---------|
+| 0 | every case `overall ∈ { agree, allowed-difference }` |
+| 1 | at least one `diverge` (uncharacterized divergence) |
+| 3 | at least one `stale` snapshot on a snapshot-oracle case |
+| 4 | harness error (missing oracle/Docker/Node, normalization failure) — cause-specific `HarnessError` |
+
+(Codes are distinct so CI can tell an uncharacterized divergence from stale evidence from an environment fault — FR-041, Constitution IV/VI.)

--- a/specs/022-conformance-runner/contracts/snapshot-provenance.md
+++ b/specs/022-conformance-runner/contracts/snapshot-provenance.md
@@ -1,0 +1,80 @@
+# Contract: Snapshot & Provenance
+
+Committed under `conformance/snapshots/<os>-<arch>/<case-id>/`. Three files; raw and normalized evidence are **separate** (FR-016). Written atomically (temp file + `fs::rename`) by the reviewed refresh only; never during ordinary runs (FR-021).
+
+## Layout
+
+```text
+conformance/snapshots/
+└── linux-x86_64/
+    └── case-up-postcreate-env/
+        ├── provenance.json     # the 13 required elements
+        ├── raw.json            # verbatim per-channel evidence
+        └── normalized.json     # rule-normalized per-channel evidence
+```
+
+## `provenance.json`
+
+```json
+{
+  "oracleVersion": "0.80.0",
+  "sourceRevision": "113500f4",
+  "caseHash": "9f2a…",
+  "fixtureHash": "3c71…",
+  "argv": ["up", "--workspace-folder", "<WORKSPACE>"],
+  "platform": "linux",
+  "arch": "x86_64",
+  "nodeVersion": "20.11.1",
+  "dockerVersion": "27.1.1",
+  "composeVersion": "2.29.1",
+  "imageDigests": { "mcr.microsoft.com/devcontainers/base:bookworm": "sha256:…" },
+  "normalizerVersion": "2",
+  "capturedAt": "2026-07-24T00:00:00Z"
+}
+```
+
+The twelve fields above are the FR-017 identity/environment elements; the thirteenth FR-017 element — the captured observables — is the sibling `raw.json`/`normalized.json` (below), NOT `provenance.json`. `capturedAt` is an informational provenance-file field, not one of the thirteen and excluded from staleness. `argv` is the complete argument vector with temporary paths tokenized (workspace path → `<WORKSPACE>`) for portability; `raw.json` retains the verbatim argv. `imageDigests` covers every pinned image the operations used.
+
+## `raw.json` / `normalized.json`
+
+Array of channel evidence objects:
+
+```json
+[
+  { "channel": "chan-exit-code", "operation": "op-exec-env", "present": true, "value": 0 },
+  { "channel": "chan-injected-process", "operation": "op-exec-env", "present": true,
+    "value": { "env": { "MY_VAR": "hello", "TZ": "<HOST-TZ>" }, "user": "vscode", "cwd": "<WORKSPACE>",
+               "path": ["/usr/local/bin", "/usr/bin", "/bin"] } }
+]
+```
+
+`present:false` ⇒ channel not captured; `value:null`/`""`/`[]` are captured-but-empty and remain distinct (FR-018/FR-025). `raw.json` preserves temp paths verbatim; `normalized.json` shows the `<WORKSPACE>`/`<HOST-TZ>` tokens (FR-024). Nothing is blanket-removed (FR-029).
+
+## Staleness (replay gate — FR-020, SC-003)
+
+On replay, recompute the evidence-determining inputs. Compare to `provenance.json`. **Fail as stale**, naming the FIRST mismatched field, if any differ:
+
+`caseHash · fixtureHash · oracleVersion · sourceRevision · imageDigests · normalizerVersion`
+
+`capturedAt` is informational (never triggers staleness). `platform`/`arch` are **selectors**, not staleness fields:
+- match → use that snapshot;
+- no snapshot for the current `<os>-<arch>` → **`no-reference-for-platform`** verdict (a coverage gap, distinct from stale and from a silent skip — FR-016a).
+
+The host tool versions `nodeVersion`/`dockerVersion`/`composeVersion` are recorded for reproducibility but are **NOT** staleness fields. The reference CLI's output is independent of the host Node runtime, and any Docker/Compose-version effect on recorded evidence surfaces as a real *divergence* on replay — not a false stale. Gating on host tool versions would make every committed snapshot stale on every machine but the recorder's, defeating cross-machine CI replay (SC-003) — e.g. a snapshot recorded under Node 22 would falsely fail the parity lane's Node 20.
+
+## Refresh (reviewed action only — FR-022)
+
+`cargo run -p parity-harness --bin conformance-snapshot -- refresh [--case <id>] [--platform <os-arch>]`:
+1. Requires the verified pinned oracle + Docker/Node (fail-loud otherwise).
+2. Runs each case's operations against the reference, captures + normalizes, writes the three files atomically.
+3. Emits a summary diff (raw + normalized) for the reviewer; the git diff is the review surface.
+
+Ordinary test runs call only the **read/compare** path (`conformance snapshot check`, hermetic) — they never write (FR-021). CI asserts this: `snapshot check` in the PR lane fails if committed snapshots are stale, but never rewrites them.
+
+## Hermetic vs live split
+
+| Operation | Tool | Lane |
+|-----------|------|------|
+| `snapshot check` (staleness compare, hermetic) | `deacon-conformance` bin | dev-fast / PR |
+| `snapshot diff <old> <new>` (deterministic drift) | `deacon-conformance` bin | dev-fast |
+| `refresh` (live re-record, writes files) | `parity-harness` `conformance-snapshot` bin | manual / reviewed |

--- a/specs/022-conformance-runner/data-model.md
+++ b/specs/022-conformance-runner/data-model.md
@@ -1,0 +1,182 @@
+# Phase 1 Data Model: Declarative Conformance Runner
+
+**Feature**: 022-conformance-runner | **Date**: 2026-07-24
+
+All records are strict-JSON, version-controlled, hand-editable (snapshots are machine-written by the reviewed refresh, then committed). Field names are `camelCase` to match the existing registry. "Existing" marks fields already present in `cases.json`/`channels.json`.
+
+---
+
+## 1. Case (extends `conformance/registry/cases.json` record)
+
+The declarative unit. A record is **legacy** (has `executable.binary`) or **declarative** (has `operations`); never both.
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `id` | string | ✓ | *existing*; `case-…`, globally unique (V2) |
+| `behaviors` | string[] | ✓ | *existing*; ≥1 `bhv-…` in registry (V3) |
+| `context` | string[] | ✓ | *existing*; may be empty; V10 intersection with behavior context |
+| `oracleType` | enum | ✓ (declarative) | `spec-expectation` \| `snapshot` \| `live-differential` \| `invariant-metamorphic` |
+| `operations` | Operation[] | ✓ (declarative) | ordered; ≥1; the actions the runner performs |
+| `expected` | ExpectedObservable[] | ✓ (declarative) | per-channel expectations; each `channel` ∈ `channels.json` (V9) |
+| `allowedDifferences` | AllowedDifference[] | — | scoped tolerances; default `[]` |
+| `fsAllowlist` | string[] | — | path/glob allowlist for the filesystem channel (rooted at workspace or declared out-dir); required iff a `chan-filesystem`/`chan-file-content` expectation exists |
+| `cleanup` | Cleanup | ✓ (declarative) | resources to reclaim after run (success or failure) |
+| `resourceGroup` | enum | — | nextest group for Docker cases: `docker-shared` \| `docker-exclusive` \| `fs-heavy` \| `none` (default `none`) |
+| `notes` | string | — | prose; **excluded from `caseHash`** |
+| `executable` | object | ✓ (legacy) | *existing* `{ binary, corpus?, case? }`; legacy path only |
+| `outcomes` | object[] | ✓ (legacy) | *existing* `{ channel, expectation }`; legacy path only |
+
+**Validation** (new V-series classes, continuing after V14):
+- A record MUST be exactly one of legacy/declarative (both or neither → violation).
+- `oracleType: invariant-metamorphic` MUST declare ≥2 operations and a `relationship` (see Operation) — arity check.
+- Every `expected.channel` and every `allowedDifferences[].observablePath` root MUST reference a declared channel.
+- `fsAllowlist` required-iff a filesystem-channel expectation exists (and forbidden otherwise, to keep capture scoped).
+
+**caseHash**: SHA-256 over canonical JSON of `{operations, oracleType, expected, fsAllowlist, referenced fixtureHashes}` — **not** `notes`/`allowedDifferences`/`behaviors` prose. (research D3)
+
+---
+
+## 2. Operation
+
+A single action the runner performs. Ordered within a case.
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `id` | string | ✓ | unique within the case (referenced by metamorphic `relationship`) |
+| `subcommand` | enum | ✓ | consumer surface only: `up`\|`down`\|`exec`\|`build`\|`read-configuration`\|`run-user-commands`\|`templates-apply`\|`doctor` (Principle II) |
+| `argv` | string[] | ✓ | args after the subcommand; part of `caseHash` |
+| `fixtures` | string[] | — | fixture ids this op materializes into the workspace |
+| `stdin` | string | — | optional stdin payload |
+| `expectFailurePhase` | enum | — | for negative cases: one of the closed failure-phase set (§8) |
+| `relationship` | Relationship | — | invariant/metamorphic only: `{ kind: idempotence\|first-create-vs-restart\|resume, againstOp: <op id> }` |
+
+---
+
+## 3. Fixture
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `id` | string | ✓ | referenced by `Operation.fixtures` |
+| `path` | string | ✓ | repo-relative source (pinned inputs; images pinned by digest/tag, no `latest`) |
+| `fixtureHash` | string | ✓ (derived) | SHA-256 of the fixture bytes; feeds `caseHash` and provenance |
+
+---
+
+## 4. Channel (extends `conformance/registry/channels.json`)
+
+*Existing*: `chan-exit-code`, `chan-stdout`, `chan-stderr`, `chan-filesystem`, `chan-file-content`, `chan-container-state`.
+**New** (this feature):
+
+| id | Covers |
+|----|--------|
+| `chan-structured-output` | Parsed structured (JSON) result document distinct from raw `chan-stdout` |
+| `chan-image` | Built-image configuration + metadata (labels parsed semantically) |
+| `chan-process-graph` | Container + network + volume + mount graph |
+| `chan-injected-process` | Env, user, cwd, PATH resolution, signals, TTY, exit propagation |
+| `chan-temporal` | Lifecycle ordering, first-create vs restart, resume, cleanup transitions |
+
+(`chan-container-state` is retained for legacy cases; new cases use the finer-grained `chan-process-graph`/`chan-image`/`chan-injected-process`.)
+
+---
+
+## 5. ExpectedObservable
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `channel` | string | ✓ | a declared channel |
+| `operation` | string | — | which op produced it (default: last) |
+| `assertion` | object | ✓ | channel-specific expectation shape (see contracts/observer-channel.md) |
+
+For `oracleType: live-differential`/`snapshot`, `assertion` MAY be omitted for a channel (the reference/snapshot supplies the expectation); for `spec-expectation` it is required.
+
+---
+
+## 6. AllowedDifference (research D9)
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `behavior` | string | ✓ | a `bhv-…` linked by the case |
+| `context` | string[] | ✓ | context tags the tolerance applies under |
+| `observablePath` | string | ✓ | dotted path within a channel (e.g. `chan-injected-process.env.TZ`); NOT a whole channel unless the behavior is channel-wide |
+| `rationale` | string | ✓ | why this difference is acceptable |
+| `waiverId` \| `divergenceId` | string | ✓ (one) | resolves to `conformance/registry/waivers/wvr-*` or an `ext-`/intentional-divergence record |
+
+**Rules**: applies only to `(behavior, observablePath)` (FR-033); duplicate `(behavior, observablePath)` with differing definitions → load error (FR-035); any construct matching a whole channel with no path and no behavior-wide justification → rejected as a global ignore list (FR-032).
+
+---
+
+## 7. Snapshot & Provenance (committed under `conformance/snapshots/<os>-<arch>/<case-id>/`)
+
+Three files, raw and normalized **separate** (FR-016).
+
+### `provenance.json` — the 13 required elements (FR-017)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `oracleVersion` | string | pinned `@devcontainers/cli` version (verified via `oracle.rs`) |
+| `sourceRevision` | string | pinned spec/source revision (e.g. `113500f4`) |
+| `caseHash` | string | §1 |
+| `fixtureHash` | string | combined fixture hash |
+| `argv` | string[] | full argv actually executed |
+| `platform` | string | OS (e.g. `linux`, `darwin`) |
+| `arch` | string | architecture (e.g. `x86_64`, `aarch64`) |
+| `nodeVersion` | string | Node used by the oracle |
+| `dockerVersion` | string | Docker engine version |
+| `composeVersion` | string | Compose version |
+| `imageDigests` | map<string,string> | image ref → digest for every pinned image used |
+| `normalizerVersion` | string | `NORMALIZER_VERSION` constant (research D6) |
+| `capturedAt` | string | provenance timestamp (informational; NOT one of FR-017's thirteen; not part of staleness) |
+
+The twelve rows above `capturedAt` are the FR-017 identity/environment elements stored in `provenance.json`. `capturedAt` is an informational thirteenth *provenance-file* field — **not** one of FR-017's thirteen and **excluded** from staleness. The final FR-017 element — the captured observables — is stored in the sibling `raw.json`/`normalized.json` (FR-016), not in `provenance.json`. `argv` is the complete argument vector with temporary paths tokenized (`<WORKSPACE>`) for portability; `raw.json` retains the verbatim argv.
+
+`raw.json`: verbatim per-channel captured evidence. `normalized.json`: rule-normalized evidence.
+
+### Staleness (FR-020, SC-003)
+
+Replay recomputes the evidence-determining inputs. Replay **fails as stale**, naming the first mismatch, when any of: `caseHash`, `fixtureHash`, `oracleVersion`, `sourceRevision`, `imageDigests`, `normalizerVersion` differs. `platform`/`arch` mismatch is **not** staleness — it selects a different snapshot; absence of a snapshot for the current `os-arch` → **"no reference for platform"** verdict (FR-016a). The host tool versions `nodeVersion`/`dockerVersion`/`composeVersion` are recorded for reproducibility but are **not** staleness signals — gating on them would make a snapshot stale on every machine but the recorder's, defeating cross-machine CI replay (SC-003); a genuine host-version effect on evidence surfaces as a divergence on replay instead.
+
+---
+
+## 8. Failure Phase (closed set — clarify Q5)
+
+Reuses deacon's lifecycle/execution vocabulary; not an open string:
+`config-resolution` → `build` → `container-create` → `lifecycle:onCreate` → `lifecycle:updateContent` → `lifecycle:postCreate` → `lifecycle:postStart` → `lifecycle:postAttach` → `exec`.
+
+---
+
+## 9. Evidence & Verdict (runtime, not committed except via snapshot)
+
+- **RawChannelEvidence**: `{ channel, operation, present: bool, value: Value }` — `present:false` distinguishes not-captured from captured-but-empty (FR-018).
+- **NormalizedChannelEvidence**: same shape after named rules; `null`/empty/default kept distinct (FR-025).
+- **ChannelVerdict**: `{ channel, outcome: agree|diverge|allowed-difference|no-reference-for-platform|stale|error, detail }` (FR-015).
+- **CaseVerdict**: `{ caseId, oracleType, channels: ChannelVerdict[], overall }` — `overall = worst channel outcome`. Attributable to the linked behavior(s) (FR-042).
+
+---
+
+## Entity relationships
+
+```text
+Case 1─* Operation *─* Fixture
+Case *─* Behavior (registry)        Case 1─* ExpectedObservable ─1 Channel
+Case 1─* AllowedDifference ─1 (Behavior, observablePath) ─1 Waiver|Divergence (registry)
+Case 1─* Snapshot (per os-arch) ─1 Provenance ─ {raw.json, normalized.json}
+Runner: Case × Target(deacon|reference|snapshot) → Evidence(raw,normalized) → CaseVerdict(ChannelVerdict[])
+```
+
+## State transitions (a run)
+
+```text
+load case ──(malformed/unknown behavior)──▶ FAIL-LOUD (FR-003)
+   │ ok
+materialize fixtures in isolated external workspace (Docker cases)
+   │
+for each operation: execute against target ──(missing oracle/Docker)──▶ FAIL-LOUD (no skip)
+   │  (crash mid-op → record partial evidence + failurePhase)
+capture declared channels → raw evidence
+   │
+normalize (named rules) → normalized evidence (raw + normalized persisted separately)
+   │
+compare per oracleType, applying scoped allowed differences
+   │
+emit CaseVerdict ──▶ cleanup (RAII, runs on success AND failure)
+```

--- a/specs/022-conformance-runner/plan.md
+++ b/specs/022-conformance-runner/plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Declarative Conformance Runner
+
+**Branch**: `022-conformance-runner` | **Date**: 2026-07-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/022-conformance-runner/spec.md`
+
+## Summary
+
+Turn conformance cases from *pointers to hand-written Rust test binaries* into *fully declarative data records* that a shared **runner** executes against one of three targets (deacon under test, the pinned reference CLI, or a stored snapshot), capturing six observable channels, normalizing them with named field-specific rules, and emitting a per-channel verdict attributable to a registry behavior. Today `conformance/registry/cases.json` records carry `executable: { binary: "parity_…" }` — a named Rust test. This feature adds a declarative `operations` + `expected` + `allowedDifferences` + `cleanup` shape so a new fixture/assertion needs **no new Rust function**, plus committed, provenance-stamped snapshots under `conformance/` with staleness gating and a reviewed-only refresh path.
+
+The work reuses, not reinvents: `parity-harness` already owns oracle resolution/verification (`oracle.rs`), bounded exec with raw capture (`exec.rs`), the single normalization module (`normalize.rs`), and report fragments (`report.rs`); `deacon-conformance` (`crates/conformance`) already owns the registry data model, loaders, and the V1–V14 validation engine that gates every PR. This plan extends both crates along their existing seams — the hermetic data/validation/staleness logic lands in `deacon-conformance`; the live execution/observation/record logic lands in `parity-harness`.
+
+## Technical Context
+
+**Language/Version**: Rust, Edition 2024, MSRV 1.95 (`unsafe_code = "deny"` workspace-wide)  
+**Primary Dependencies**: existing workspace deps only — `serde`/`serde_json`, `indexmap` (declaration order), `sha2` (already used in `deacon-conformance` for `hash8`/fingerprints → case/fixture hashing), `tokio` (bounded async exec + streamed capture, already in `parity-harness`), `thiserror` (`HarnessError`/domain errors), `tracing`, `toml` (nextest-profile drift check, already a `parity-harness` dep), `tempfile` (isolated external workspaces, dev-dep); no new runtime crates  
+**Storage**: strict-JSON, version-controlled — extend `conformance/registry/cases.json` (declarative case shape) + `channels.json` (new channels); new committed evidence tree `conformance/snapshots/<os>-<arch>/<case-id>/{provenance,raw,normalized}.json` (atomic temp-file + `fs::rename` writes)  
+**Testing**: `cargo-nextest` only. Hermetic case-schema/validation/staleness/normalization/allowed-difference tests run in `default`/`dev-fast`; the live differential + Docker channel-capture binary runs **only** under `--profile parity` (and Docker channels under the `docker` profile's resource groups). One new live binary `crates/deacon/tests/parity_conformance_runner.rs`, registered in `fixtures/parity-corpus/registry.json` + overrides in ALL profiles.  
+**Target Platform**: Linux + macOS (full, incl. Docker/live channels); Windows runs the hermetic slice only (`dev-fast`, no Docker) — Docker-backed and host-hook channels are `#[cfg(unix)]`-gated with a one-line reason, matching the repo's cross-platform convention  
+**Project Type**: Rust workspace — dev-only test/conformance tooling across two existing crates (`crates/conformance`, `crates/parity-harness`) + registry data; NOT a shipped `deacon` subcommand  
+**Performance Goals**: the hermetic slice (schema load, staleness compare, pure normalization rules) stays in `dev-fast` at unit-test speed; live/Docker cases inherit the parity/docker lanes' existing budgets (no new perf ceiling introduced)  
+**Constraints**: fail-loud, never silent-skip (missing oracle/Docker/normalizer error → run fails with a cause-specific `HarnessError`); atomic evidence writes; snapshots keyed by `os-arch`; case hash covers only behavior-affecting inputs; no global ignore lists (scoped allowed differences only)  
+**Scale/Scope**: dozens→low-hundreds of declarative cases; six observable channels; four oracle types; one new live test binary; two crates extended; one new committed snapshot tree
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Verdict |
+|-----------|-----------|---------|
+| **I. Spec-Parity as Source of Truth** | The runner *enforces* parity; snapshots pin `oracle version` + `source revision` in provenance and verify exactness (reusing `oracle.rs::VerifiedOracle`). Live-differential compares deacon vs the pinned oracle. | ✅ Reinforces |
+| **II. Consumer-Only Scope** | Cases exercise only consumer commands (`up`/`down`/`exec`/`build`/`read-configuration`/`run-user-commands`/`templates apply`/`doctor`). The runner is dev tooling — **no new shipped `deacon` subcommand**; refresh is a dev-only bin. | ✅ Pass |
+| **III. Keep the Build Green** | Hermetic slice in `dev-fast`; live/Docker isolated to `parity`/`docker` profiles; new binary added to ALL profiles + `registry.json` so `parity_registry_check` stays green. | ✅ Pass |
+| **IV. No Silent Fallbacks — Fail Fast** | The feature's *purpose* is anti-silent-skip: no global ignore lists (FR-032), fail-loud on missing oracle/Docker/normalizer, stale snapshot → hard fail (FR-020), unknown behavior/malformed case → load error (FR-003). | ✅ Reinforces |
+| **V. Idiomatic, Safe Rust** | `thiserror` domain errors (extend `HarnessError` + conformance errors); modular observers (one module per channel); async `tokio` exec (already present); no `unsafe`; imports std→ext→local. | ✅ Pass |
+| **VI. Observability & Output Contracts** | Deterministic verdict report: single JSON doc on stdout, `tracing` logs on stderr; ordered records via `IndexMap`/`Vec`; distinct exit codes (pass / diverge / stale / harness-error). | ✅ Pass |
+| **VII. Testing Completeness** | 12 mandatory acceptance areas (SC-012) map to hermetic + gated tests; new live binary gets nextest overrides in every profile + `registry.json` entry (V-series `parity_registry_check`). | ✅ Pass |
+| **VIII. Subcommand Consistency & Shared Abstractions** | **Central gate.** MUST reuse `parity-harness` `exec`/`normalize`/`oracle`/`report` and the `deacon-conformance` loader/validator — extend the single `normalize.rs`, do NOT fork a second normalizer or waiver mechanism (FR-043). | ✅ Pass (enforced by design) |
+| **IX. Executable & Self-Verifying Examples** | Not applicable — no `examples/` directory is touched (dev/test tooling). | ✅ N/A |
+
+**Initial Constitution Check: PASS** — no violations; Complexity Tracking left empty. The one live risk is a Principle VIII violation (forking normalization/waiver logic); the design pins all shared logic to the existing modules to prevent it.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-conformance-runner/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — decisions D1–D10
+├── data-model.md        # Phase 1 output — entities, fields, validation, states
+├── quickstart.md        # Phase 1 output — author-a-case + record/refresh walkthrough
+├── contracts/           # Phase 1 output
+│   ├── case-schema.md            # Declarative case record (extends cases.json)
+│   ├── snapshot-provenance.md    # Snapshot + provenance JSON + staleness rules
+│   ├── runner-cli.md             # Runner + refresh CLI surface, exit codes, report JSON
+│   └── observer-channel.md       # Per-channel observer contract + verdict shape
+└── checklists/
+    └── requirements.md  # (from /speckit.specify)
+```
+
+### Source Code (repository root)
+
+Extends two existing crates + registry data. No new crate (Principle VIII — reuse the harness).
+
+```text
+crates/conformance/                        # deacon-conformance — HERMETIC (no Docker/Node)
+├── src/
+│   ├── model.rs                           # + declarative Case fields (operations, oracleType,
+│   │                                      #   expected, allowedDifferences, cleanup, resourceGroup,
+│   │                                      #   fsAllowlist); Channel/OracleType/AllowedDifference types
+│   ├── case_hash.rs                       # NEW — case hash (behavior-affecting inputs only) + fixture hash (sha2)
+│   ├── snapshot.rs                        # NEW — Provenance + Snapshot model, load, staleness compare
+│   ├── load.rs                            # + load/parse the new case + snapshot records
+│   ├── validate.rs                        # + new violation classes (continue V-series): case operations well-formed,
+│   │                                      #   oracle-type arity, allowed-difference scoping + conflict, snapshot provenance
+│   ├── coverage.rs / certify.rs / report.rs  # + surface snapshot coverage + "no reference for platform" in report/certify
+│   └── bin/conformance.rs                 # + `snapshot check|diff` (hermetic staleness/diff); NOT record
+└── tests/                                 # NEW hermetic acceptance tests (run in dev-fast/default)
+    ├── case_schema_valid.rs               # FR-001..004, FR-003 fail-loud
+    ├── snapshot_staleness.rs              # FR-020, SC-003 (each provenance field + case/fixture hash)
+    ├── allowed_difference_scoping.rs      # FR-031..035, SC-008 (scope + conflict + no global ignore)
+    └── normalization_semantics.rs         # FR-024..029 null/empty/default, path token, label, mount, PATH (pure)
+
+crates/parity-harness/                     # DEV-ONLY — has oracle/Docker/Node access in the parity lane
+├── src/
+│   ├── normalize.rs                       # EXTEND (single normalizer): named rules — path-token rewrite,
+│   │                                      #   label semantic parse, mount-source substitution, PATH segment/probe,
+│   │                                      #   null/empty/default preservation; bump NORMALIZER_VERSION
+│   ├── runner.rs                          # NEW — orchestrate: load case → run ops against target → observe → normalize → compare
+│   ├── observe/                           # NEW — one module per observable channel (Principle V modularity)
+│   │   ├── cli_process.rs                 # exit code, stdout, stderr, structured output, failure phase (closed phase set)
+│   │   ├── filesystem.rs                  # per-case declared allowlist capture (NOT full-tree)
+│   │   ├── image.rs                       # built-image config + metadata (labels parsed semantically)
+│   │   ├── container_graph.rs             # container/network/volume/mount graph
+│   │   ├── injected_process.rs            # env, user, cwd, PATH resolution, signals, TTY, exit propagation
+│   │   └── temporal.rs                    # lifecycle ordering, first-create vs restart, resume, cleanup
+│   ├── evidence.rs                        # NEW — raw + normalized evidence, persisted SEPARATELY (atomic)
+│   ├── compare.rs                         # NEW — per-channel verdict; applies scoped allowed differences
+│   ├── oracle_type.rs                     # NEW — dispatch: spec-expectation | snapshot | live-differential | invariant/metamorphic
+│   ├── workspace.rs                       # NEW — isolated external tempdir + collision-resistant names + RAII cleanup guard
+│   └── bin/conformance-snapshot.rs        # NEW — reviewed REFRESH (record mode; runs live oracle, writes committed snapshots)
+└── tests/
+    └── runner_record_replay.rs            # NEW hermetic-ish: record/replay equivalence on a fixture (SC-011)
+
+crates/deacon/tests/
+└── parity_conformance_runner.rs           # NEW live binary (thin shell): drive runner over declarative cases (parity profile only)
+
+conformance/
+├── registry/
+│   ├── cases.json                         # EXTEND records with declarative shape (coexists with legacy binary-backed)
+│   └── channels.json                      # ADD channels: chan-image, chan-process-graph, chan-injected-process, chan-temporal
+└── snapshots/                             # NEW committed evidence tree, keyed by os-arch
+    └── <os>-<arch>/<case-id>/{provenance.json,raw.json,normalized.json}
+
+fixtures/parity-corpus/registry.json       # + register parity_conformance_runner (parity_registry_check gate)
+.config/nextest.toml                       # + parity_conformance_runner overrides in ALL profiles; docker resource groups for channel tests
+```
+
+**Structure Decision**: Extend the two existing conformance/parity crates along their current module seams rather than adding a crate — mandated by Principle VIII (reuse shared abstractions) and by the crate dependency direction (`parity-harness` → `deacon-conformance`). Hermetic data/validation/staleness logic lands in `deacon-conformance` (runnable in `dev-fast`, gates every PR); live execution/observation/record logic lands in `parity-harness` (Docker/Node lane). The declarative case schema is an **extension** of the already-validated `cases.json`, so the existing V1–V14 engine and `certify` gate cover it for free once new classes are added.
+
+## Complexity Tracking
+
+> No constitution violations. Section intentionally empty.

--- a/specs/022-conformance-runner/quickstart.md
+++ b/specs/022-conformance-runner/quickstart.md
@@ -1,0 +1,110 @@
+# Quickstart: Declarative Conformance Runner
+
+Author a conformance case as **data** (no new Rust function), run it, and — for reference oracles — record a committed, provenance-stamped snapshot.
+
+## 1. Add a declarative case
+
+Append a record to `conformance/registry/cases.json` (`records[]`). Minimal `spec-expectation` case (no Docker, hermetic):
+
+```json
+{
+  "id": "case-readconfig-echo",
+  "behaviors": ["bhv-readconfig-unknown-field-preserved"],
+  "context": [],
+  "oracleType": "spec-expectation",
+  "operations": [
+    { "id": "op-read", "subcommand": "read-configuration",
+      "argv": ["--workspace-folder", "${WORKSPACE}"],
+      "fixtures": ["fx-config-with-unknown-field"] }
+  ],
+  "expected": [
+    { "channel": "chan-exit-code", "assertion": { "equals": 0 } },
+    { "channel": "chan-structured-output",
+      "assertion": { "jsonSubset": { "configuration": { "customUnknownKey": "preserved" } } } }
+  ],
+  "cleanup": { "tempdir": true },
+  "notes": "Unknown top-level keys round-trip (Constitution IV faithful-on-unmodeled)."
+}
+```
+
+Add the fixture file it references, then register it (id + hash are derived by the loader).
+
+## 2. Validate (hermetic — fails loud on mistakes)
+
+```bash
+cargo run -p deacon-conformance -- validate
+```
+
+Catches: unknown behavior, undeclared channel, legacy+declarative mix, bad oracle-type arity, unscoped allowed differences, dangling waiver ids. Fix any violation before proceeding (FR-003).
+
+## 3. Run it
+
+- **Hermetic (spec-expectation / snapshot oracle)** — runs in the fast lane:
+  ```bash
+  cargo nextest run -p deacon-conformance          # case-schema + staleness + scoping + normalization
+  ```
+- **Live differential / Docker channels** — the parity lane only (needs Docker + pinned oracle):
+  ```bash
+  cargo nextest run --profile parity -E 'binary(=parity_conformance_runner)'
+  ```
+
+## 4. Record a reference snapshot (only for `oracleType: snapshot`)
+
+Recording is a **reviewed** action — it runs the live oracle and writes committed files:
+
+```bash
+cargo run -p parity-harness --bin conformance-snapshot -- refresh --case case-readconfig-echo
+```
+
+This writes `conformance/snapshots/<os>-<arch>/case-readconfig-echo/{provenance,raw,normalized}.json` atomically and prints a review diff. Commit them; the git diff is the review surface. Ordinary runs never write these (FR-021).
+
+## 5. Confirm replay stays honest
+
+```bash
+cargo run -p deacon-conformance -- snapshot check --case case-readconfig-echo   # PASS
+# edit an operation's argv, then:
+cargo run -p deacon-conformance -- snapshot check --case case-readconfig-echo   # FAIL: stale (caseHash mismatch)
+```
+
+Editing only `notes` does **not** trip staleness (caseHash excludes prose — clarify Q4).
+
+## 6. Add a Docker-backed case
+
+Set `resourceGroup` and declare cleanup + fs allowlist:
+
+```json
+{
+  "id": "case-up-mounts",
+  "behaviors": ["bhv-workspace-mount-source"],
+  "context": ["single-container"],
+  "oracleType": "live-differential",
+  "resourceGroup": "docker-shared",
+  "operations": [ { "id": "op-up", "subcommand": "up",
+                    "argv": ["--workspace-folder", "${WORKSPACE}"], "fixtures": ["fx-basic-devcontainer"] } ],
+  "expected": [ { "channel": "chan-process-graph",
+                  "assertion": { "mounts": [ { "target": "/workspaces/proj" } ] } } ],
+  "fsAllowlist": [],
+  "cleanup": { "containers": true, "images": "case-built", "networks": true, "volumes": true, "tempdir": true }
+}
+```
+
+The runner creates an **isolated external temp workspace**, uses **collision-resistant** container/network/volume names, pins all images, and reclaims every resource on success **and** failure (RAII guard) — SC-009/SC-010.
+
+## 7. Characterize an intentional divergence (instead of a global ignore)
+
+Never add a global ignore. Scope it to a behavior + observable path + waiver:
+
+```json
+"allowedDifferences": [
+  { "behavior": "bhv-workspace-mount-source", "context": ["single-container"],
+    "observablePath": "chan-process-graph.mounts[0].consistency",
+    "rationale": "reference sets 'consistent' on Linux; deacon omits (no-op on Linux) — characterized",
+    "waiverId": "wvr-mount-consistency-linux" }
+]
+```
+
+The tolerance applies **only** to that path; the same difference on another mount still fails (FR-033), and a self-invalidating `wvr-` fails as stale once the difference stops reproducing (FR-034).
+
+## What did NOT require Rust
+
+Steps 1, 4, 6, 7 are pure data edits. Adding cases/fixtures/assertions never adds a Rust test function (SC-001). Rust changes only when a *new observable channel* or *normalization rule* is introduced — a rare, reviewed extension of `observe/` + `normalize.rs`.

--- a/specs/022-conformance-runner/research.md
+++ b/specs/022-conformance-runner/research.md
@@ -1,0 +1,87 @@
+# Phase 0 Research: Declarative Conformance Runner
+
+**Feature**: 022-conformance-runner | **Date**: 2026-07-24
+
+The spec's Technical Context has no open `NEEDS CLARIFICATION` markers — the five clarify-session answers plus the fixed toolchain (Edition 2024 / MSRV 1.95, existing workspace deps) resolve the stack. The research below records the design *decisions* that shape Phase 1, each grounded in the existing `deacon-conformance` and `parity-harness` machinery so the build-out reuses rather than reinvents (Constitution VIII).
+
+---
+
+## D1. Crate placement — extend two existing crates, add none
+
+- **Decision**: Hermetic data/validation/staleness/pure-normalization-rule logic lands in `crates/conformance` (`deacon-conformance`); live execution/observation/record logic lands in `crates/parity-harness`. No new crate.
+- **Rationale**: `parity-harness` already depends on `deacon-conformance` and already owns `exec`/`normalize`/`oracle`/`report`/`waiver`. The dependency direction forces the split: the case *schema* and *loader* must live in `deacon-conformance` (so `validate`/`certify`/`report` see it), while *executing* a case needs Docker/Node, which is `parity-harness` territory. A third crate would duplicate loaders and violate Principle VIII.
+- **Alternatives considered**: (a) A new `conformance-runner` crate — rejected: re-exposes the registry loader and normalizer, inviting drift. (b) All in `parity-harness` — rejected: hermetic validation must run in `dev-fast`/PR lanes without Docker, and `certify` (release gate) lives in `deacon-conformance`.
+
+## D2. Case schema — extend `cases.json`, coexist with legacy binary-backed cases
+
+- **Decision**: Extend the existing `cases.json` record (`id`, `behaviors[]`, `context[]`, `executable`, `outcomes[]`) with a declarative block: `operations[]`, `oracleType`, `expected` (per-channel), `allowedDifferences[]`, `cleanup`, `resourceGroup`, `fsAllowlist[]`. A record is either **legacy** (`executable.binary` → a Rust test) or **declarative** (`operations` present); the loader accepts both, and validation forbids mixing.
+- **Rationale**: `cases.json` is already loaded and gated by V3/V9/V10. Extending it means the new cases inherit behavior-linkage validation, coverage counting, and `certify` for free. Coexistence lets legacy `parity_*` binaries migrate incrementally instead of a big-bang rewrite (Constitution I phased implementation).
+- **Alternatives considered**: A separate `case-specs/` directory — rejected: fragments the coverage/certify view across two files; the registry's whole value is one authoritative `cases.json`.
+
+## D3. Case hash & fixture hash — reuse `sha2`, hash behavior-affecting inputs only
+
+- **Decision**: Compute `caseHash` as SHA-256 over the **canonicalized behavior-affecting inputs** (operations, argv, oracle type, referenced fixture hashes) — excluding `rationale`/`notes`/`allowedDifferences` prose. `fixtureHash` is SHA-256 over the fixture file bytes (sorted, path-relative). Reuse the `sha2::{Digest, Sha256}` + `hash8` pattern already in `crates/conformance/src/clause.rs`.
+- **Rationale**: Matches the clarify answer (Q4) — annotating a case must not force re-recording. Mirrors the substance-anchored clause-id design (location/prose excluded from the hash) already proven in 021.
+- **Alternatives considered**: Hash the whole record — rejected: every prose edit invalidates snapshots, defeating reviewable annotation. Content-addressed fixtures via git object ids — rejected: adds a git dependency to a pure-data hash.
+
+## D4. Snapshot layout & provenance — committed, os-arch-keyed, atomic
+
+- **Decision**: `conformance/snapshots/<os>-<arch>/<case-id>/` holds `provenance.json`, `raw.json`, `normalized.json` (raw and normalized **separate**, per FR-016). `provenance.json` carries the 13 fields of FR-017. Writes use the temp-file + `fs::rename` atomic pattern (`crates/core/src/cache/disk.rs::save_index`, already the harness convention). Snapshots are committed and reviewed as ordinary registry changes.
+- **Rationale**: Clarify answers Q2 (committed → reviewable diff) and Q3 (os-arch keyed). Committed storage is the *only* way FR-022's "refresh surfaces a reviewable diff" works. Atomic writes satisfy FR-019 and the "concurrent refresh must not corrupt" edge case.
+- **Alternatives considered**: `target/` (ephemeral) — rejected: a refresh would leave no reviewable diff and replay would be non-hermetic. A single combined evidence file — rejected: FR-016 mandates raw/normalized separation.
+
+## D5. Staleness detection — pure comparison in `deacon-conformance`, live re-record in `parity-harness`
+
+- **Decision**: Staleness is a **pure** comparison (recorded provenance/hashes vs current inputs + current environment probe) implemented in `deacon-conformance::snapshot` and exposed via `conformance snapshot check`; it names the first mismatched field and fails (FR-020). Live *re-recording* (running the oracle to regenerate evidence) is `parity-harness`'s `conformance-snapshot` bin, run only as a reviewed action. A missing snapshot for the current `os-arch` yields a distinct **"no reference for platform"** verdict — not stale, not a silent skip (FR-016a).
+- **Rationale**: Separates the hermetic gate (can run in `dev-fast`/PR, no Docker) from the Docker/Node record path. Reuses the existing `oracle.rs` version verification for the `oracleVersion` field and a lightweight env probe for Docker/Compose/Node versions.
+- **Alternatives considered**: Fold record + check into one Docker-only tool — rejected: staleness must be enforceable in the hermetic PR lane, else rot ships silently.
+
+## D6. Normalization — extend the single `normalize.rs`, never fork it
+
+- **Decision**: Add **named, field-specific rules** to the existing `crates/parity-harness/src/normalize.rs` (not a new module): `path_token` (rewrite temp workspace/project paths → stable tokens, FR-024), `label_semantic` (parse metadata labels, FR-026), `mount_source_canonical` (path-substitute mount sources before compare, FR-027), `path_env_segmented` (segment-wise PATH + optional executable probe, FR-028), and `null_preserving` (keep missing/null/empty/default distinct, FR-025). Bump a `NORMALIZER_VERSION` constant recorded in provenance and used in staleness (FR-030).
+- **Rationale**: Constitution VIII — there is exactly one normalizer. The current `normalize.rs` already has `NOISE_ENV_KEYS`/`INTENTIONAL_LABEL_PREFIXES` and `container_state`; these are refactored so nothing is *blanket-removed* (FR-029) — noise keys become named, scoped rules with recorded rationale.
+- **Risk & mitigation**: The existing `NOISE_ENV_KEYS`/`INTENTIONAL_LABEL_PREFIXES` are close to the "blanket remove" the spec forbids. Mitigation: reclassify each as a *named rule with a rationale*, scoped to a channel/field, covered by `normalization_semantics.rs` asserting no un-named removal occurs.
+- **Alternatives considered**: A second normalizer tuned for the new channels — rejected outright (Principle VIII violation; two normalizers = guaranteed drift).
+
+## D7. Observers — one module per channel behind a small trait
+
+- **Decision**: `parity-harness/src/observe/` has one module per channel (`cli_process`, `filesystem`, `image`, `container_graph`, `injected_process`, `temporal`), each implementing a `ChannelObserver` contract (`capture(ctx) -> RawChannelEvidence`). The runner invokes only the observers a case's `expected`/`fsAllowlist` declares. Filesystem capture is allowlist-scoped (Q1), never a full-tree diff.
+- **Rationale**: Modular boundaries (Principle V); a case pays only for the channels it asserts; failure phase is captured from deacon's existing lifecycle vocabulary (Q5) rather than an ad-hoc string.
+- **Alternatives considered**: One monolithic capture function — rejected: unreviewable, and forces every case to pay for Docker inspection even for a pure `read-configuration` CLI-process case.
+
+## D8. Oracle-type dispatch — four explicit strategies
+
+- **Decision**: `oracle_type.rs` dispatches on the case's `oracleType`: **spec-expectation** (compare normalized observables to declared `expected`, no reference run), **snapshot** (compare to committed provenance-checked snapshot), **live-differential** (run deacon + pinned oracle, compare normalized), **invariant/metamorphic** (evaluate a declared relationship across ≥2 operations — idempotence, first-create vs restart, resume — not a fixed output). Re-pointing a case at a different type changes only the `oracleType` field (FR-007).
+- **Rationale**: The four are semantically distinct verdicts (spec FR-006/US6); conflating them weakens conformance claims. Live-differential reuses `oracle.rs` + `exec.rs`; snapshot reuses D4/D5.
+- **Alternatives considered**: Treat snapshot as "differential vs a cached reference" — rejected: snapshot carries provenance/staleness semantics a live diff does not.
+
+## D9. Allowed differences — scoped records, reuse the registry waiver model
+
+- **Decision**: An `AllowedDifference` is `{ behavior, context, observablePath, rationale, waiverId | divergenceId }`. It applies **only** to its `(behavior, observablePath)`; the same difference elsewhere still fails (FR-033). Load-time validation rejects conflicting duplicates (FR-035) and rejects any construct that would function as a global ignore list (FR-032). `waiverId`/`divergenceId` must resolve to an existing `conformance/registry/waivers/` `wvr-*` or an `ext-`/intentional-divergence record — no parallel mechanism (FR-043).
+- **Rationale**: Reuses the self-invalidating waiver model (a `wvr-` whose difference stops reproducing already fails as stale in `waiver.rs`), so FR-034 falls out of existing machinery. Keeps every tolerance auditable and tied to a characterized behavior.
+- **Alternatives considered**: A per-case `ignore: [fields]` list — rejected: this *is* the global ignore list the spec forbids.
+
+## D10. Test selection & profiles — hermetic in dev-fast, live in parity, Docker in docker groups
+
+- **Decision**: Hermetic tests (`case_schema_valid`, `snapshot_staleness`, `allowed_difference_scoping`, `normalization_semantics`, `runner_record_replay`) run in `default`/`dev-fast`. The single live binary `parity_conformance_runner` runs **only** under `--profile parity` and is added to `fixtures/parity-corpus/registry.json` + overrides in **all** nextest profiles (parity selection + exclusions), or `parity_registry_check` fails. Docker-backed channel capture uses `docker-shared` where names are unique, `docker-exclusive` only where state is shared. Missing oracle/Docker → fail-loud `HarnessError` (no `#[ignore]`, no skip).
+- **Rationale**: Matches the harness's truthful-non-selection model — a green `dev-fast` never implies live/Docker ran. Constitution VII nextest requirements + the CLAUDE.md "3-spot" override rule for new docker-exclusive binaries.
+- **Alternatives considered**: An env-var opt-in (`DEACON_PARITY=1` style) — rejected: that gate was retired in 018; selection is profile-based only.
+
+---
+
+## Resolved unknowns summary
+
+| Unknown | Resolution |
+|---------|-----------|
+| Where does the runner live? | Two existing crates, split hermetic/live (D1) |
+| Case data format & location | Extend `cases.json`; coexist with legacy (D2) |
+| What triggers staleness | `caseHash` over behavior-affecting inputs only, `sha2` (D3) |
+| Snapshot storage | Committed `conformance/snapshots/<os>-<arch>/…`, atomic, raw+normalized separate (D4) |
+| Cross-platform replay | os-arch keyed; missing → "no reference for platform" verdict (D5) |
+| Normalization approach | Extend the single `normalize.rs` with named rules; reclassify existing noise lists (D6) |
+| Channel capture | One observer module per channel; allowlist-scoped filesystem (D7) |
+| Oracle types | Four explicit dispatch strategies (D8) |
+| Tolerated differences | Scoped `AllowedDifference` reusing the waiver model (D9) |
+| Test selection | Hermetic dev-fast + one live parity binary + docker groups (D10) |
+
+No `NEEDS CLARIFICATION` remain. Proceed to Phase 1.

--- a/specs/022-conformance-runner/spec.md
+++ b/specs/022-conformance-runner/spec.md
@@ -1,0 +1,267 @@
+# Feature Specification: Declarative Conformance Runner
+
+**Feature Branch**: `022-conformance-runner`  
+**Created**: 2026-07-24  
+**Status**: Draft  
+**Input**: User description: "Create a feature specification for a declarative conformance runner that can execute one registered case against Deacon, the pinned reference CLI, or a stored reference snapshot and compare all relevant observable outcomes."
+
+## Overview
+
+The project already records *what* is conformant in the conformance registry (behaviors, dispositions, waivers, gaps) and *surfaces* deacon-vs-reference differences through the parity harness. What is missing is a single, **data-driven execution engine** that takes one registered case, runs it against a chosen oracle (deacon itself, the pinned reference CLI, or a stored snapshot), captures **every relevant observable channel**, normalizes the evidence with named rules, and produces a pass/fail verdict scoped to characterized behaviors.
+
+Today, exercising a new observable outcome typically means writing a new Rust test function. This feature makes cases and assertions **declarative**: a case author adds a data record and fixtures, and the runner does the rest. The result is broader, cheaper conformance coverage with durable, auditable evidence.
+
+## Clarifications
+
+### Session 2026-07-24
+
+- Q: How is "host filesystem effects" capture scoped? → A: A per-case declared allowlist of paths/globs (rooted at the isolated workspace or a declared output directory), compared after path-token normalization — not a full-tree diff.
+- Q: Where are reference snapshots stored? → A: Committed, version-controlled under the `conformance/` area, so a refresh appears as a reviewable PR diff and replay is hermetic.
+- Q: How does snapshot replay behave on a platform/arch with no matching snapshot? → A: Snapshots are keyed by platform + architecture; a case with no snapshot for the current platform/arch yields an explicit "no reference for platform" verdict — a coverage gap, distinct from a staleness failure and from a silent skip.
+- Q: What does the case hash cover (i.e., what triggers staleness)? → A: Only behavior-affecting inputs (operations, argv, fixtures, oracle type); editing rationale, notes, or allowed-difference prose does not change the case hash.
+- Q: What is the failure-phase vocabulary? → A: Reuse deacon's existing lifecycle/execution phase vocabulary (config-resolution, build, container-create, lifecycle hooks, exec) as the closed set, rather than a new enum.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Author and run a declarative case against a selectable oracle (Priority: P1)
+
+A conformance author defines a case as data — its behaviors, context, inputs, operations, oracle mode, expected observables, allowed differences, and cleanup requirements — and runs it. The runner executes the case's operations against the selected target (deacon under test, the pinned reference CLI, or a stored reference snapshot) and compares all relevant observable channels, reporting a per-channel verdict. Adding this case, or adding a new assertion to it, requires **no new Rust test function**.
+
+**Why this priority**: This is the core value. Without declarative case execution and multi-channel comparison, nothing else matters. It is the minimum viable slice: one case, one run, one comparison.
+
+**Independent Test**: Register a single case (e.g., a `read-configuration` invocation) as data with expected CLI-process observables, run it against deacon and against the reference oracle, and confirm the runner reports a per-channel verdict — all without editing Rust source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered case declaring its behaviors, context, inputs, operations, oracle mode, expected observables, allowed differences, and cleanup, **When** the author runs the case against deacon, **Then** the runner executes the operations and reports a per-channel pass/fail verdict against the expected observables.
+2. **Given** the same case, **When** the author runs it in live-differential mode, **Then** the runner executes both deacon and the pinned reference CLI and reports per-channel agreement or divergence.
+3. **Given** an existing case, **When** the author adds a new fixture and a new expected observable to the case data, **Then** the new assertion is exercised on the next run with no change to any Rust test function.
+4. **Given** a case that references an unknown behavior or a malformed field, **When** it is loaded, **Then** the runner fails loudly with a specific, actionable error rather than silently skipping the case.
+
+---
+
+### User Story 2 - Record and replay provenance-tracked snapshots with staleness gating (Priority: P2)
+
+A maintainer captures a reference snapshot for a case and later replays cases against that stored snapshot instead of invoking the live reference CLI. Every snapshot carries full provenance. When the case inputs, fixtures, or environment that produced a snapshot no longer match, replay **fails as stale** rather than passing on outdated evidence. Refreshing a snapshot is an explicit, reviewed action that never happens during an ordinary test run.
+
+**Why this priority**: Snapshot replay makes conformance runs fast, hermetic, and runnable without Node/Docker, but only if snapshots cannot silently rot. Staleness gating and governed refresh are what make stored evidence trustworthy.
+
+**Independent Test**: Record a snapshot for a case, replay the case and confirm it passes, then change a case input (or its fixture) and confirm the replay now fails as stale — and that an ordinary run never rewrites the snapshot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a case with an oracle mode of "pinned snapshot", **When** it is recorded, **Then** the stored snapshot includes oracle version, source revision, case hash, fixture hash, full argv, platform, architecture, Node version, Docker version, Compose version, image digests, normalizer version, and the captured observables.
+2. **Given** a recorded snapshot, **When** the case is replayed with matching provenance and inputs, **Then** the replay reproduces the recorded verdict.
+3. **Given** a recorded snapshot, **When** the case hash, fixture hash, or a provenance field no longer matches the current inputs/environment, **Then** replay fails with a staleness error naming the mismatched field.
+4. **Given** an ordinary conformance run (any profile), **When** it executes, **Then** no snapshot is created, overwritten, or deleted.
+5. **Given** an explicit, reviewed refresh action, **When** it runs, **Then** snapshots are regenerated and the change is surfaced for review (diff of raw and normalized evidence).
+
+---
+
+### User Story 3 - Normalize evidence semantically, storing raw and normalized separately (Priority: P2)
+
+The runner persists both the raw captured evidence and a normalized copy, kept separate. Normalization uses named, field-specific canonicalization rules — never a blanket scrub. Temporary workspace and project paths are rewritten to stable tokens (not deleted). Semantic distinctions between missing, null, empty, and defaulted values are preserved unless a named rule says otherwise. Metadata labels are parsed semantically, mount sources are compared after canonical path substitution, and PATH is compared segment-wise (with executable probes where appropriate).
+
+**Why this priority**: Comparison is only meaningful if normalization is faithful. Over-normalization (blanket ignore lists, collapsing null/empty) hides real divergences; under-normalization produces false failures from incidental paths. Named rules make every canonicalization auditable.
+
+**Independent Test**: Capture evidence containing a temp workspace path, a null field, an empty field, a defaulted field, a metadata label, a mount source, and a PATH; run normalization and confirm the temp path became a stable token, the null/empty/default distinctions survived, and no environment variable, label, mount source, entrypoint, command, or network was blanket-removed.
+
+**Acceptance Scenarios**:
+
+1. **Given** raw evidence, **When** normalization runs, **Then** the raw evidence and the normalized evidence are both persisted and distinguishable.
+2. **Given** evidence containing a temporary workspace or project path, **When** normalized, **Then** the path is rewritten to a stable, named token rather than removed.
+3. **Given** fields that are respectively missing, null, empty, and defaulted, **When** normalized, **Then** the four states remain distinguishable unless an explicit named rule collapses them.
+4. **Given** built-image metadata labels, **When** normalized, **Then** labels are parsed and compared semantically, not as opaque strings.
+5. **Given** two mount graphs whose sources differ only by a temporary path, **When** compared, **Then** they compare equal after canonical path substitution.
+6. **Given** two PATH values, **When** compared, **Then** the comparison is segment-wise and, where a named rule requires it, verified by probing the resolved executable — not a raw string equality that a reordering would break.
+7. **Given** any normalization run, **When** it completes, **Then** it has not blanket-removed environment variables, labels, mount sources, entrypoints, commands, or networks.
+
+---
+
+### User Story 4 - Scope allowed differences to a behavior and a waiver identity (Priority: P3)
+
+When deacon and the reference legitimately differ, the case author records an **allowed difference** scoped to a specific behavior, context, and observable path, with a rationale and a registry waiver or intentional-divergence identity. There are no broad, global ignore lists: a difference is tolerated only where it is characterized and only for the observable path it names.
+
+**Why this priority**: This is what keeps the runner honest. Global ignore lists silently mask regressions; scoped, waiver-backed differences keep every tolerated divergence tied to an auditable registry record that self-invalidates when it stops reproducing.
+
+**Independent Test**: Characterize one divergence as a scoped allowed difference tied to a waiver identity, confirm the case passes only for that behavior/observable-path, and confirm that the same divergence appearing on a different observable path or behavior still fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** a characterized divergence, **When** an allowed difference is declared, **Then** it names a behavior, a context, an observable path, a rationale, and a registry waiver or intentional-divergence identity.
+2. **Given** an allowed difference scoped to observable path A, **When** the same kind of difference appears on observable path B, **Then** the run still fails for path B.
+3. **Given** an allowed difference whose backing difference no longer reproduces, **When** the case runs, **Then** the allowed difference is reported as stale (mirroring the registry's self-invalidating waiver model).
+4. **Given** a case, **When** an author attempts to suppress a channel with a broad global ignore list, **Then** the runner rejects it in favor of scoped allowed differences.
+
+---
+
+### User Story 5 - Run Docker-backed cases in isolated workspaces with reliable cleanup (Priority: P2)
+
+Cases that require Docker run in isolated, external temporary workspaces with collision-resistant resource names and deterministic pinned inputs. Resources (containers, images built for the case, networks, volumes, temp directories) are reliably cleaned up whether the case succeeds or fails, and each Docker case is assigned an appropriate resource group so concurrent runs do not interfere.
+
+**Why this priority**: The most valuable conformance evidence (image config, container/network/volume/mount graph, injected process behavior, temporal lifecycle transitions) requires Docker. Without isolation and guaranteed cleanup, these cases leak resources and become flaky, which erodes trust in the whole runner.
+
+**Independent Test**: Run a Docker-backed case to success and to a forced failure; in both outcomes confirm no residual containers, images, networks, volumes, or temp directories remain, and that concurrently running two Docker cases does not collide on resource names.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Docker-backed case, **When** it runs, **Then** it operates in an isolated external temporary workspace, not the repository tree.
+2. **Given** two Docker-backed cases running concurrently, **When** they allocate resources, **Then** their container/network/volume names do not collide.
+3. **Given** a Docker-backed case that succeeds, **When** it finishes, **Then** all resources it created are removed.
+4. **Given** a Docker-backed case that fails or is interrupted, **When** it terminates, **Then** cleanup still removes all resources it created.
+5. **Given** a Docker-backed case, **When** it is registered, **Then** it declares the resource group that governs its concurrency.
+
+---
+
+### User Story 6 - Choose the oracle type per case (Priority: P3)
+
+A case declares which oracle type governs its verdict, and the four oracle types are treated as distinct: (a) specification expectations, (b) pinned reference snapshots, (c) live differential comparison against the reference CLI, and (d) invariant or metamorphic assertions. The runner applies the semantics of the declared oracle type; the same case can be re-pointed at a different oracle type without rewriting its inputs or fixtures.
+
+**Why this priority**: Different conformance questions need different oracles — an absolute spec expectation, a recorded reference, a live cross-check, or a relationship that must hold regardless of the exact output. Conflating them produces weak or misleading verdicts.
+
+**Independent Test**: Take one case and evaluate it under each of the four oracle types, confirming the runner applies distinct semantics (e.g., a metamorphic assertion checks a relationship between two operations rather than a fixed expected output).
+
+**Acceptance Scenarios**:
+
+1. **Given** a case with oracle type "specification expectation", **When** it runs, **Then** the verdict is against declared expected observables independent of the reference CLI.
+2. **Given** oracle type "pinned reference snapshot", **When** it runs, **Then** the verdict is against the stored, provenance-checked snapshot.
+3. **Given** oracle type "live differential", **When** it runs, **Then** the verdict is deacon-vs-reference agreement on the normalized observables.
+4. **Given** oracle type "invariant/metamorphic", **When** it runs, **Then** the verdict is whether a declared relationship holds (e.g., idempotence of re-`up`, first-create vs restart consistency) rather than a fixed output match.
+
+---
+
+### Edge Cases
+
+- **Reference/Docker unavailable**: A live-differential or Docker case run where the reference CLI or Docker daemon is absent must fail loudly with a cause-specific error (no silent skip), consistent with the harness's truthful-non-selection principle.
+- **Partial capture**: An operation that crashes mid-way (a failure phase) must still record whatever observables were captured and identify the phase at which it failed, rather than discarding evidence.
+- **Provenance drift with unchanged inputs**: If environment provenance (oracle/Node/Docker/Compose versions, image digests) changed but case inputs did not, replay must still flag the environment mismatch as stale.
+- **Non-deterministic output**: Observables that legitimately vary run-to-run (timestamps, generated IDs, temp paths) must be handled by a named normalization rule, never by deleting the field.
+- **Conflicting allowed differences**: Two allowed differences claiming the same behavior/observable path with contradictory rationales must be rejected at load time.
+- **Concurrent snapshot refresh**: A reviewed refresh running while ordinary runs read snapshots must not corrupt stored evidence (atomic writes).
+- **Empty vs missing observable**: A channel that produced nothing (e.g., empty stderr) must be distinguishable from a channel that was not captured.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Case model (data-driven)
+
+- **FR-001**: The system MUST represent each case as declarative data that identifies its behaviors, context(s), inputs, operations, oracle mode, expected observables, allowed differences, and cleanup requirements.
+- **FR-002**: The system MUST allow adding a new case, a new fixture, or a new assertion to an existing case without adding or modifying any Rust test function.
+- **FR-003**: The system MUST validate every case at load time and fail loudly with a specific error when a case references an unknown behavior, omits a required field, or is otherwise malformed — never silently skipping it.
+- **FR-004**: Each case MUST link to one or more behaviors in the conformance registry so verdicts are attributable to characterized behaviors.
+
+#### Oracle modes and execution targets
+
+- **FR-005**: The system MUST be able to execute one registered case against deacon (the subject under test), the pinned reference CLI, or a stored reference snapshot.
+- **FR-006**: The system MUST support four distinct oracle types — specification expectation, pinned reference snapshot, live differential comparison, and invariant/metamorphic assertion — and apply the correct verdict semantics for the declared type.
+- **FR-007**: The system MUST allow re-pointing a case at a different oracle type/target without changing its inputs or fixtures.
+- **FR-008**: For invariant/metamorphic oracles, the system MUST evaluate a declared relationship between operations (e.g., idempotence, first-create vs restart consistency, resume) rather than a fixed expected output.
+
+#### Observable channels
+
+- **FR-009**: The system MUST capture and compare CLI-process observables: exit code, stdout, stderr, structured output, and the failure phase when an operation fails. The failure phase MUST be drawn from deacon's existing lifecycle/execution phase vocabulary (config-resolution, build, container-create, lifecycle hooks, exec) as a closed set, not an ad-hoc per-case string.
+- **FR-010**: The system MUST capture and compare host filesystem effects produced by a case, scoped to a per-case declared allowlist of paths/globs (rooted at the isolated workspace or a declared output directory) and compared after path-token normalization. A full-tree diff MUST NOT be used.
+- **FR-011**: The system MUST capture and compare built-image configuration and metadata.
+- **FR-012**: The system MUST capture and compare the container, network, volume, and mount graph.
+- **FR-013**: The system MUST capture and compare injected process behavior: environment, user, working directory, PATH resolution, signals, TTY, and exit propagation.
+- **FR-014**: The system MUST capture and compare temporal transitions: lifecycle ordering, first-create versus restart behavior, resume, and cleanup.
+- **FR-015**: Each observable channel MUST produce an independent per-channel verdict so a case reports which channels agreed and which diverged.
+
+#### Evidence and provenance
+
+- **FR-016**: The system MUST persist raw evidence and normalized evidence separately and keep them distinguishable. Reference snapshots MUST be stored version-controlled under the `conformance/` area (committed), so replay is hermetic and a refresh appears as a reviewable diff.
+- **FR-016a**: Snapshots MUST be keyed by platform and architecture. A case with no snapshot for the current platform/architecture MUST yield an explicit "no reference for platform" verdict — a coverage gap, distinct from a staleness failure and from a silent skip.
+- **FR-017**: Every recorded snapshot MUST include thirteen elements: oracle version, source revision, case hash, fixture hash, full argv (temporary paths tokenized for portability; the verbatim argv is retained in the raw evidence), platform, architecture, Node version, Docker version, Compose version, image digests, normalizer version, and the captured observables. The first twelve are stored in the snapshot's provenance record; the thirteenth — the captured observables — is stored in the sibling raw and normalized evidence (per FR-016). An informational `capturedAt` timestamp MAY also be recorded but is not one of the thirteen and is excluded from staleness (FR-020).
+- **FR-018**: The system MUST distinguish an observable that was captured-but-empty from one that was not captured, and preserve that distinction in stored evidence.
+- **FR-019**: The system MUST write stored evidence atomically so concurrent readers never observe a partially written snapshot.
+
+#### Snapshot replay and refresh governance
+
+- **FR-020**: Snapshot replay MUST fail when provenance or case inputs are stale (any recorded provenance field or the case/fixture hash no longer matches current inputs/environment), naming the mismatched field. The case hash MUST cover only behavior-affecting inputs (operations, argv, fixtures, oracle type); editing rationale, notes, or allowed-difference prose MUST NOT change the case hash or force re-recording.
+- **FR-021**: Ordinary test/conformance runs MUST NOT create, overwrite, or delete any snapshot.
+- **FR-022**: Refreshing snapshots MUST be an explicit, separately invoked, reviewed action that surfaces the change (a diff of raw and normalized evidence) for human review.
+
+#### Normalization
+
+- **FR-023**: Normalization MUST use named, field-specific canonicalization rules; a blanket/global scrub is prohibited.
+- **FR-024**: Normalization MUST rewrite temporary workspace and project paths to stable, named tokens rather than deleting them.
+- **FR-025**: Normalization MUST preserve distinctions between missing, null, empty, and defaulted values unless an explicit named rule collapses a specific field.
+- **FR-026**: The system MUST parse metadata labels semantically for comparison rather than treating them as opaque strings.
+- **FR-027**: The system MUST compare mount sources after canonical path substitution.
+- **FR-028**: The system MUST compare PATH segment-wise, and MUST verify resolution via executable probes where a named rule requires it.
+- **FR-029**: Normalization MUST NOT blanket-remove environment variables, labels, mount sources, entrypoints, commands, or networks.
+- **FR-030**: The normalizer MUST carry a version identity that is recorded in provenance and participates in staleness detection.
+
+#### Allowed differences (scoped)
+
+- **FR-031**: An allowed difference MUST be scoped to a behavior, a context, an observable path, a rationale, and a registry waiver or intentional-divergence identity.
+- **FR-032**: The system MUST reject broad, global ignore lists as a means of tolerating differences.
+- **FR-033**: An allowed difference MUST apply only to the observable path and behavior it names; the same class of difference on another path or behavior MUST still fail.
+- **FR-034**: An allowed difference whose backing difference no longer reproduces MUST be reported as stale, consistent with the registry's self-invalidating waiver model.
+- **FR-035**: The system MUST reject, at load time, two allowed differences that claim the same behavior and observable path with conflicting definitions.
+
+#### Docker case execution
+
+- **FR-036**: Docker-backed cases MUST run in isolated external temporary workspaces (outside the repository tree).
+- **FR-037**: Docker-backed cases MUST use collision-resistant resource names so concurrent runs do not interfere.
+- **FR-038**: Docker-backed cases MUST use deterministic, pinned inputs (pinned images/tags, no floating `latest`).
+- **FR-039**: Docker-backed cases MUST reliably clean up every resource they create (containers, case-built images, networks, volumes, temp directories) on both success and failure/interruption.
+- **FR-040**: Each Docker-backed case MUST declare the resource group that governs its concurrency, so the runner schedules it safely alongside other cases.
+
+#### Reporting and integration
+
+- **FR-041**: The runner MUST produce a deterministic per-case, per-channel verdict report suitable for CI consumption and human review.
+- **FR-042**: Verdicts MUST be attributable to the linked registry behavior(s), so a divergence maps to a characterized behavior, a scoped allowed difference, or an uncharacterized failure.
+- **FR-043**: The system MUST integrate with the existing conformance registry and waiver model rather than introducing a parallel tolerance mechanism.
+
+### Key Entities *(include if feature involves data)*
+
+- **Case**: The declarative unit of conformance. Identifies behaviors, contexts, inputs, operations, oracle mode/type, expected observables, allowed differences, and cleanup requirements. Carries a stable case hash computed over only its behavior-affecting inputs (operations, argv, fixtures, oracle type) — rationale/notes/allowed-difference prose are excluded so annotations do not force re-recording.
+- **Fixture**: The concrete inputs (config files, workspace contents, pinned image references) a case operates on. Carries a fixture hash.
+- **Operation**: A single action the runner performs for a case (e.g., a CLI invocation, an inspection). Records the argv and the failure phase if it fails.
+- **Observable Channel**: One of the capturable dimensions — CLI process, host filesystem, built-image config/metadata, container/network/volume/mount graph, injected process behavior, temporal transitions.
+- **Evidence (Raw / Normalized)**: The captured observables in two forms — verbatim raw and rule-normalized — persisted separately.
+- **Snapshot**: A stored, version-controlled (committed under `conformance/`) reference evidence set plus its full provenance (oracle version, source revision, case hash, fixture hash, full argv, platform, architecture, Node version, Docker/Compose versions, image digests, normalizer version, captured observables). Keyed by platform + architecture.
+- **Provenance Record**: The metadata that makes a snapshot reproducible and staleness-checkable.
+- **Normalization Rule**: A named, field-specific canonicalization (path-token rewrite, label parse, mount-source substitution, PATH segmentation/probe, null-preservation). Versioned as a set.
+- **Allowed Difference**: A scoped tolerance tied to a behavior, context, observable path, rationale, and a registry waiver / intentional-divergence identity.
+- **Oracle Type**: Specification expectation, pinned reference snapshot, live differential, or invariant/metamorphic.
+- **Verdict**: The per-channel and per-case outcome (agree / diverge / allowed-difference / stale / error) attributable to a registry behavior.
+- **Resource Group**: The concurrency classification governing how a (typically Docker-backed) case is scheduled.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A conformance author can add a new case with fixtures and assertions covering at least one observable channel with **zero** new or modified Rust test functions.
+- **SC-002**: **100%** of recorded snapshots carry all thirteen required elements — the twelve identity/environment fields in the provenance record (oracle version, source revision, case hash, fixture hash, full argv [temp paths tokenized], platform, architecture, Node version, Docker version, Compose version, image digests, normalizer version) plus the thirteenth, the captured observables, in the sibling raw/normalized evidence. (`capturedAt` is informational, not counted, and excluded from staleness.)
+- **SC-003**: **100%** of replays with a stale provenance field or changed case/fixture input fail as stale and name the mismatched field; **0%** pass on stale evidence.
+- **SC-004**: **0** snapshots are created, overwritten, or deleted during ordinary runs; snapshot refresh occurs only via the explicit reviewed action.
+- **SC-005**: All **six** observable channels (CLI process, host filesystem, built-image config/metadata, container/network/volume/mount graph, injected process behavior, temporal transitions) each have at least one passing acceptance case producing an independent verdict.
+- **SC-006**: Raw and normalized evidence are stored separately for **100%** of runs and are independently retrievable.
+- **SC-007**: Normalization preserves the missing/null/empty/defaulted distinction in **100%** of cases except where a named rule explicitly collapses a field; **0** unintended collapses.
+- **SC-008**: **0** allowed differences are expressed as broad global ignore lists; **100%** are scoped to a behavior, context, observable path, rationale, and waiver/divergence identity.
+- **SC-009**: Docker-backed cases leave **0** residual containers, case-built images, networks, volumes, or temp directories after both successful and forced-failure runs.
+- **SC-010**: Two Docker-backed cases run concurrently with **0** resource-name collisions.
+- **SC-011**: A recorded case replayed from its snapshot yields the same verdict as its original recording (record/replay equivalence) for **100%** of unchanged cases.
+- **SC-012**: Mandatory acceptance tests exist and pass for each observable channel, raw-vs-normalized evidence, stale snapshots, canonicalization, metadata labels, mounts, PATH, null semantics, allowed-difference scoping, process failures, resource cleanup, and record/replay equivalence.
+
+## Assumptions
+
+- **Builds on existing machinery**: This runner extends, and integrates with, the existing conformance registry (behaviors, dispositions, waivers, gaps) and reuses the parity harness's normalization/equivalence concepts and oracle-pinning; it does not introduce a second, parallel tolerance or waiver mechanism.
+- **Consumer-only scope**: Cases exercise deacon's consumer surface (`up`, `down`, `exec`, `build`, `read-configuration`, `run-user-commands`, `templates apply`, `doctor`). Feature-authoring surfaces remain out of scope.
+- **Oracle pinning**: The "reference CLI" is the pinned `@devcontainers/cli` oracle at the recorded version; the "source revision" is the pinned spec/source revision. Both are recorded in provenance and verified for exactness.
+- **Case data format**: Cases are expressed in the project's existing strict-JSON registry style (hand-editable, version-controlled); the exact file layout is an implementation detail for planning, not a scope decision here.
+- **Selection is profile-based**: Live-differential and Docker cases run under dedicated nextest profiles/resource groups (never an env-var opt-in), and non-selection is truthful — a green fast run never implies live/Docker cases ran.
+- **Fail loud, never skip silently**: Missing reference CLI, missing Docker, or a normalization failure fails the run with a cause-specific error rather than a silent skip.
+- **Reviewed refresh**: Snapshot refresh is a developer/maintainer action reviewed like any other registry change (diff surfaced in a PR); CI ordinary runs never refresh. This is only possible because snapshots are committed, version-controlled under `conformance/` (per FR-016), keyed by platform + architecture.
+- **Platform reality**: Docker/live-differential cases require a Docker daemon and Node; they run in CI lanes and local environments that provide them, and are excluded (by non-selection) elsewhere.
+
+## Dependencies
+
+- The conformance registry (`conformance/registry/`) for behaviors, dispositions, waivers, and intentional-divergence records that verdicts and allowed differences reference.
+- The parity harness's oracle resolution/verification and normalization vocabulary, reused rather than reimplemented.
+- A pinned reference CLI oracle and pinned spec/source revision.
+- Docker (and Compose) plus Node for live-differential and Docker-backed cases.
+- nextest resource groups/profiles for scheduling and truthful selection.

--- a/specs/022-conformance-runner/tasks.md
+++ b/specs/022-conformance-runner/tasks.md
@@ -1,0 +1,308 @@
+---
+description: "Task list for Declarative Conformance Runner (022-conformance-runner)"
+---
+
+# Tasks: Declarative Conformance Runner
+
+**Input**: Design documents from `/specs/022-conformance-runner/`
+**Prerequisites**: plan.md, spec.md, research.md (D1–D10), data-model.md, contracts/ (case-schema, snapshot-provenance, observer-channel, runner-cli)
+
+**Tests**: INCLUDED — acceptance tests are mandatory for this feature (spec SC-012 + Constitution VII "Testing Completeness"). Hermetic tests run in `dev-fast`/`default`; the single live binary runs only under `--profile parity`; Docker channel tests use docker resource groups.
+
+**Organization**: Grouped by user story (US1–US6) in priority order (P1 → P2 → P3). Each story is independently testable.
+
+## Path conventions
+
+- Hermetic data/validation/staleness → `crates/conformance/` (`deacon-conformance`)
+- Live execution/observation/record → `crates/parity-harness/`
+- Registry data → `conformance/registry/`, committed snapshots → `conformance/snapshots/`
+- Live test binary → `crates/deacon/tests/parity_conformance_runner.rs`
+- Wiring → `.config/nextest.toml`, `fixtures/parity-corpus/registry.json`
+
+**Green-build cadence (Constitution III)**: after every task run `cargo fmt --all && cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D warnings`, then the narrowest relevant `make test-nextest-*`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create module scaffolding + registry data so the workspace compiles and new binaries are discoverable.
+
+- [X] T001 Create stub modules and register them so the workspace builds: `crates/conformance/src/case_hash.rs`, `crates/conformance/src/snapshot.rs` (declared in `crates/conformance/src/lib.rs`); `crates/parity-harness/src/{runner.rs,evidence.rs,compare.rs,oracle_type.rs,workspace.rs}` and `crates/parity-harness/src/observe/mod.rs` with per-channel stub files `observe/{cli_process,filesystem,image,container_graph,injected_process,temporal}.rs` (declared in `crates/parity-harness/src/lib.rs`)
+- [X] T002 [P] Extend `conformance/registry/channels.json` with five new channel records: `chan-structured-output`, `chan-image`, `chan-process-graph`, `chan-injected-process`, `chan-temporal` (descriptions per data-model.md §4)
+- [X] T003 [P] Add empty hermetic test-binary stubs `crates/conformance/tests/{case_schema_valid,snapshot_staleness,allowed_difference_scoping,normalization_semantics}.rs` and `crates/parity-harness/tests/runner_record_replay.rs` so nextest lists them
+- [X] T004 [P] Add these hermetic test binaries to `.config/nextest.toml` (they run in `default`/`dev-fast`; no docker group), following the existing conformance-test override pattern
+
+**Checkpoint**: `cargo build` and `cargo nextest list` succeed with all new modules/binaries present (stubbed).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core types, hashing, base loader/validation, evidence/verdict scaffolding, observer contract, and the normalization entry point — everything every story builds on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T005 Add core declarative types to `crates/conformance/src/model.rs`: `OracleType` enum (4 variants), `Operation`, `Fixture`, `ExpectedObservable`, `Channel` id constants, `Cleanup`, `ResourceGroup` enum, and the declarative fields on the `Case` record (`operations`, `oracleType`, `expected`, `allowedDifferences` (typed later), `fsAllowlist`, `cleanup`, `resourceGroup`, `notes`) per data-model.md §1–§5
+- [X] T006 [P] Implement `caseHash` (behavior-affecting inputs only) and `fixtureHash` (fixture bytes) in `crates/conformance/src/case_hash.rs` reusing the `sha2::{Digest,Sha256}` pattern from `crates/conformance/src/clause.rs` (research D3)
+- [X] T007 Extend the loader in `crates/conformance/src/load.rs` to parse legacy vs declarative case records (mutually exclusive) and reject a mixed/neither record with a located, fail-loud error (FR-003)
+- [X] T008 Add the closed `FailurePhase` enum (config-resolution, build, container-create, lifecycle:onCreate/updateContent/postCreate/postStart/postAttach, exec) to `crates/conformance/src/model.rs` (data-model.md §8, clarify Q5)
+- [X] T009 [P] Add evidence/verdict base types to `crates/parity-harness/src/evidence.rs`: `RawChannelEvidence`/`NormalizedChannelEvidence` (with `present: bool` distinguishing not-captured from empty, FR-018), `ChannelVerdict`, `CaseVerdict`, and the `outcome` enum (agree/diverge/allowed-difference/no-reference-for-platform/stale/error)
+- [X] T010 [P] Define the `ChannelObserver` contract and `RunContext` in `crates/parity-harness/src/observe/mod.rs` (`capture(ctx, op) -> Result<RawChannelEvidence, HarnessError>`, contracts/observer-channel.md)
+- [X] T011 [P] Add the single normalization entry point + `NORMALIZER_VERSION` constant to `crates/parity-harness/src/normalize.rs` as a pass-through (real named rules land in US3); expose `normalize_channel(channel, raw) -> NormalizedChannelEvidence`
+- [X] T012 [P] Extend `HarnessError` in `crates/parity-harness/src/lib.rs` with cause-specific variants: `DockerUnavailable`, `NodeUnavailable`, `NormalizationFailed`, `SnapshotStale{field}`, `NoReferenceForPlatform{os_arch}` (Constitution IV fail-loud)
+- [X] T013 Add core case-well-formedness validation classes to `crates/conformance/src/validate.rs` (continue the V-series): exactly-one-of legacy/declarative, `oracleType` enum, each `operations[].subcommand` in the consumer surface (Principle II), `spec-expectation` ⇒ every `expected.assertion` present, `fsAllowlist` present iff a filesystem-channel expectation exists
+- [X] T014 [P] Extend the conformance CLI in `crates/conformance/src/bin/conformance.rs` with a `Snapshot` subcommand group skeleton (`check`, `diff`) wired to stub handlers (implemented in US2)
+
+**Checkpoint**: Core types + hashing + base validation compile and are unit-referenced; `cargo run -p deacon-conformance -- validate` runs (new classes active) against the existing registry without regressions.
+
+---
+
+## Phase 3: User Story 1 - Author and run a declarative case against a selectable oracle (Priority: P1) 🎯 MVP
+
+**Goal**: A declarative case runs against deacon (spec-expectation) and, in the parity lane, against the pinned reference (live-differential), producing per-channel CLI-process verdicts — with no new Rust test function per case.
+
+**Independent Test**: Register a `read-configuration` case as data with expected CLI-process/structured-output observables; `cargo nextest run -p deacon-conformance` proves the hermetic spec-expectation verdict; a malformed case fails loudly at load.
+
+### Tests for User Story 1
+
+- [X] T015 [P] [US1] In `crates/conformance/tests/case_schema_valid.rs`: assert a well-formed declarative case loads; unknown behavior, undeclared channel, legacy+declarative mix, and a non-consumer subcommand each fail loudly with a located message (FR-001..004, FR-003)
+- [X] T016 [P] [US1] In `crates/parity-harness/tests/runner_record_replay.rs` (spec-expectation section): a fixture case with an intentional wrong exit-code expectation yields a `diverge` verdict; a correct one yields `agree` (FR-015)
+- [X] T017 [P] [US1] Add a CLI-process failure-phase test: a case whose op fails records partial evidence + the correct `FailurePhase` from the closed set (spec Edge "Partial capture", FR-009)
+- [X] T018 [P] [US1] Add a report-determinism test asserting the verdict report is byte-stable (declaration order, no timestamps/absolute paths) per contracts/runner-cli.md
+
+### Implementation for User Story 1
+
+- [X] T019 [P] [US1] Implement the `cli_process` observer in `crates/parity-harness/src/observe/cli_process.rs` (exit code, stdout, stderr, failure phase) reusing `exec.rs::Invocation` capture
+- [X] T020 [P] [US1] Implement the `structured_output` capture path in `crates/parity-harness/src/observe/cli_process.rs` (parsed JSON result doc → `chan-structured-output`) reusing `Invocation::stdout_json`
+- [X] T021 [US1] Implement per-channel comparison in `crates/parity-harness/src/compare.rs` for CLI-process/structured-output channels producing `ChannelVerdict`s (allowed-difference integration deferred to US4)
+- [X] T022 [US1] Implement `spec-expectation` and `live-differential` dispatch in `crates/parity-harness/src/oracle_type.rs` (live-differential runs deacon + the verified pinned oracle via `oracle.rs`; snapshot + invariant deferred to US2/US6)
+- [X] T023 [US1] Implement the runner orchestration in `crates/parity-harness/src/runner.rs`: load case → run operations against the target → invoke declared observers → normalize (pass-through) → compare → emit `CaseVerdict` (fail-loud on missing oracle)
+- [X] T024 [US1] Implement the deterministic verdict report writer (single JSON on stdout, `tracing` logs on stderr, ordered records) in `crates/parity-harness/src/report.rs` per contracts/runner-cli.md
+- [X] T025 [US1] Add a hermetic spec-expectation fixture case to `conformance/registry/cases.json` (read-configuration) + its fixture files, mirroring quickstart.md §1
+- [X] T026 [US1] Create the live test binary `crates/deacon/tests/parity_conformance_runner.rs` (thin shell driving the runner over declarative cases; fail-loud on missing prereqs, no `#[ignore]`)
+- [X] T027 [US1] Register `parity_conformance_runner` in `fixtures/parity-corpus/registry.json` AND add nextest overrides in ALL profiles per the CLAUDE.md 3-spot rule (parity `default-filter` allow-list + `dev-fast` default-filter exclusion + `dev-fast`/`default`/`full`/`ci`/`mvp-integration` override exclusions), so `parity_registry_check` stays green
+
+**Checkpoint**: US1 fully functional — a data-only case runs and verdicts in dev-fast (spec-expectation) and in the parity lane (live-differential). MVP complete.
+
+---
+
+## Phase 4: User Story 2 - Record and replay provenance-tracked snapshots with staleness gating (Priority: P2)
+
+**Goal**: Committed, os-arch-keyed snapshots with 13-field provenance; replay fails as stale on any drift; refresh is a reviewed-only action; ordinary runs never write.
+
+**Independent Test**: Record a snapshot; `snapshot check` passes; edit an operation → `snapshot check` fails as stale naming `caseHash`; editing only `notes` does not; an ordinary run writes nothing.
+
+### Tests for User Story 2
+
+- [X] T028 [P] [US2] In `crates/conformance/tests/snapshot_staleness.rs`: each of `caseHash/fixtureHash/oracleVersion/sourceRevision/nodeVersion/dockerVersion/composeVersion/imageDigests/normalizerVersion` drift makes `check` fail as stale naming the field; `capturedAt`/`platform`/`arch` do not (FR-020, SC-003)
+- [X] T029 [P] [US2] Assert a missing snapshot for the current `os-arch` yields `no-reference-for-platform` (distinct from stale and from skip) (FR-016a, clarify Q3)
+- [X] T030 [P] [US2] In `crates/parity-harness/tests/runner_record_replay.rs` (replay section): a recorded case replays to the same verdict as its recording (record/replay equivalence) and provenance carries all 13 fields (SC-011, SC-002)
+
+### Implementation for User Story 2
+
+- [X] T031 [P] [US2] Implement `Provenance` + `Snapshot` model and load in `crates/conformance/src/snapshot.rs` (13 fields, os-arch key, raw/normalized separate) per contracts/snapshot-provenance.md
+- [X] T032 [US2] Implement pure staleness comparison in `crates/conformance/src/snapshot.rs` (recorded vs recomputed hashes + probed env; name first mismatch; platform/arch as selectors, not staleness) (FR-020, D5)
+- [X] T033 [US2] Implement `snapshot check` and `snapshot diff` handlers in `crates/conformance/src/bin/conformance.rs` (hermetic; exit codes per contracts/runner-cli.md); add snapshot provenance validation classes to `crates/conformance/src/validate.rs`
+- [X] T034 [P] [US2] Implement atomic evidence writes (temp file + `fs::rename`) for `provenance.json`/`raw.json`/`normalized.json` in `crates/parity-harness/src/evidence.rs`, with a unit test covering the temp-file+rename path so a shorter payload never leaves trailing bytes (FR-019, D4)
+- [X] T035 [US2] Implement the environment probe (oracle version via `oracle.rs`, Node/Docker/Compose versions, image digests) in `crates/parity-harness/src/runner.rs` for provenance capture
+- [X] T036 [US2] Add `snapshot` oracle-type dispatch in `crates/parity-harness/src/oracle_type.rs` (compare normalized evidence to the provenance-checked committed snapshot; emit `stale`/`no-reference-for-platform`)
+- [X] T037 [US2] Create the reviewed refresh bin `crates/parity-harness/src/bin/conformance-snapshot.rs` (`refresh [--case] [--platform]`; requires verified oracle + Docker/Node fail-loud; writes atomically; prints review diff) per contracts/runner-cli.md
+- [X] T038 [US2] Add a snapshot-oracle fixture case + its committed `conformance/snapshots/<os>-<arch>/<case-id>/` evidence recorded via the refresh bin; assert ordinary `cargo nextest run` never rewrites it (FR-021, SC-004). **Record only after US3 finalizes `NORMALIZER_VERSION`** (see Ordering constraint) — otherwise the committed snapshot is immediately stale.
+
+**Checkpoint**: US2 works independently — record, replay, staleness gating, and reviewed-only refresh.
+
+---
+
+## Phase 5: User Story 3 - Normalize evidence semantically, storing raw and normalized separately (Priority: P2)
+
+**Goal**: Named, field-specific normalization rules replace the pass-through; raw and normalized evidence persisted separately; null/empty/default preserved; nothing blanket-removed.
+
+**Independent Test**: Evidence with a temp path, null/empty/default fields, a label, a mount source, and a PATH normalizes to a `<WORKSPACE>` token with the four null states intact and no blanket removals.
+
+### Tests for User Story 3
+
+- [X] T039 [P] [US3] In `crates/conformance/tests/normalization_semantics.rs` (or a parity-harness normalize test): temp path → stable token (not deleted); missing/null/empty/defaulted stay distinct; no env/label/mount/entrypoint/command/network blanket-removed (FR-024/025/029, SC-007)
+- [X] T040 [P] [US3] Assert `label_semantic` parses labels to key/value and compares semantically; `mount_source_canonical` makes two mounts differing only by temp path compare equal; `path_env_segmented` compares PATH segment-wise (FR-026/027/028)
+- [X] T041 [P] [US3] Assert raw and normalized evidence are persisted separately and independently retrievable for a run (FR-016, SC-006); assert a not-captured channel (`present:false`) stays distinguishable from a captured-but-empty value (`present:true`, empty/null) (FR-018)
+
+### Implementation for User Story 3
+
+- [X] T042 [US3] Implement the named rules in `crates/parity-harness/src/normalize.rs`: `path_token`, `label_semantic`, `mount_source_canonical`, `path_env_segmented` (segment-wise PATH **plus the optional executable probe where a rule requires it**, FR-028), `null_preserving`; reclassify the existing `NOISE_ENV_KEYS`/`INTENTIONAL_LABEL_PREFIXES` as named, scoped, rationale-carrying rules (research D6, FR-023/029)
+- [X] T043 [US3] Bump `NORMALIZER_VERSION` and wire it into provenance + staleness (FR-030); replace the T011 pass-through with per-channel rule application
+- [X] T044 [P] [US3] Implement the `filesystem` observer in `crates/parity-harness/src/observe/filesystem.rs` (allowlist-scoped capture rooted at workspace/out-dir, NOT full-tree) applying `path_token` (FR-010, clarify Q1)
+- [X] T045 [US3] Persist raw + normalized evidence separately in `crates/parity-harness/src/evidence.rs` and thread through the runner (FR-016)
+- [X] T046 [P] [US3] Add a filesystem-channel fixture case to `conformance/registry/cases.json` with an `fsAllowlist` and expected file effects
+- [X] T047 [US3] Ensure `compare.rs` operates on normalized evidence for stdout/stderr/structured-output/filesystem channels (path-tokenized comparison)
+- [X] T048 [US3] Update `crates/conformance/src/report.rs`/`coverage.rs` so the conformance `report` surfaces normalized-evidence coverage per channel
+
+**Checkpoint**: US3 works — faithful normalization + separate raw/normalized persistence; US1/US2 comparisons now use real rules.
+
+---
+
+## Phase 6: User Story 5 - Run Docker-backed cases in isolated workspaces with reliable cleanup (Priority: P2)
+
+**Goal**: Docker cases run in isolated external temp workspaces with collision-resistant names, pinned inputs, guaranteed cleanup on success/failure, and correct resource groups — enabling the image/graph/injected-process/temporal channels.
+
+**Independent Test**: Run a Docker case to success and to forced failure; both leave zero residual containers/images/networks/volumes/temp dirs; two concurrent cases don't collide on names.
+
+### Tests for User Story 5
+
+- [X] T049 [P] [US5] Add a docker-group cleanup test asserting zero residual resources after a Docker case on BOTH success and forced-failure/interruption (FR-039, SC-009); assert via `docker run <tag> cat <marker>` / `docker ps -a` sweeps, not just JSON outcome
+- [X] T050 [P] [US5] Add a collision test: two Docker cases concurrently allocate non-colliding container/network/volume names (FR-037, SC-010)
+- [X] T051 [P] [US5] Add per-channel capture tests for `chan-image` (labels), `chan-process-graph` (mounts/networks/volumes), `chan-injected-process` (env/user/cwd/PATH/TTY), `chan-temporal` (lifecycle order, first-create vs restart, cleanup) (SC-005)
+
+### Implementation for User Story 5
+
+- [X] T052 [US5] Implement `crates/parity-harness/src/workspace.rs`: isolated external temp workspace (`tempfile`), collision-resistant resource names, and an RAII cleanup guard that reclaims resources on success AND unwind (FR-036/037/039)
+- [X] T053 [P] [US5] Implement the `image` observer in `crates/parity-harness/src/observe/image.rs` (built-image config + labels via `label_semantic`) (FR-011)
+- [X] T054 [P] [US5] Implement the `container_graph` observer in `crates/parity-harness/src/observe/container_graph.rs` (container/network/volume/mount graph via `mount_source_canonical`) (FR-012)
+- [X] T055 [P] [US5] Implement the `injected_process` observer in `crates/parity-harness/src/observe/injected_process.rs` (env, user, cwd, PATH via `path_env_segmented` including executable-probe resolution where a rule requires it (FR-028), signals, TTY, exit propagation) (FR-013)
+- [X] T056 [P] [US5] Implement the `temporal` observer in `crates/parity-harness/src/observe/temporal.rs` (lifecycle ordering, first-create vs restart, resume, cleanup transitions) (FR-014)
+- [X] T057 [US5] Wire `resourceGroup` from the case into scheduling and add nextest overrides for the Docker channel tests in ALL profiles (`docker-shared` where names are unique, `docker-exclusive` only where state is shared) per Constitution VII / CLAUDE.md
+- [X] T058 [US5] Add pinned-input enforcement (reject `latest`, require digest/tag) at case load for Docker cases in `crates/conformance/src/validate.rs` (FR-038)
+- [X] T059 [US5] Add Docker-backed fixture cases to `conformance/registry/cases.json` (up/exec) exercising image/graph/injected/temporal channels; `#[cfg(unix)]`-gate host-hook/Docker-only assertions with a one-line reason (cross-platform convention)
+
+**Checkpoint**: US5 works — Docker isolation, guaranteed cleanup, and the four Docker-requiring channels.
+
+---
+
+## Phase 7: User Story 4 - Scope allowed differences to a behavior and a waiver identity (Priority: P3)
+
+**Goal**: Tolerated divergences are scoped to `(behavior, context, observablePath)` + a resolvable waiver/divergence id; no global ignore lists; conflicts rejected at load; self-invalidating.
+
+**Independent Test**: A scoped allowed-difference lets its `(behavior, path)` pass while the same difference on another path still fails; a conflicting duplicate fails at load; a global ignore list is rejected.
+
+### Tests for User Story 4
+
+- [X] T060 [P] [US4] In `crates/conformance/tests/allowed_difference_scoping.rs`: a scoped difference tolerates only its `(behavior, observablePath, context)`; the same difference on path B still fails; a conflicting duplicate and a global-ignore-style construct both fail at load (FR-031/032/033/035, SC-008)
+- [X] T061 [P] [US4] Assert an allowed difference whose backing `wvr-`/divergence no longer reproduces is reported stale, reusing the registry's self-invalidating waiver check (FR-034)
+
+### Implementation for User Story 4
+
+- [X] T062 [US4] Implement the typed `AllowedDifference` model + parsing in `crates/conformance/src/model.rs`/`load.rs` (behavior, context, observablePath, rationale, waiverId|divergenceId) per data-model.md §6
+- [X] T063 [US4] Add allowed-difference validation to `crates/conformance/src/validate.rs`: dangling waiver/divergence id, `(behavior, observablePath)` conflict, bare-channel/global-ignore rejection (FR-031/032/035)
+- [X] T064 [US4] Integrate allowed differences into `crates/parity-harness/src/compare.rs`: a covered divergence becomes `allowed-difference` (with waiver id in detail); uncovered stays `diverge` (FR-033)
+- [X] T065 [US4] Resolve `waiverId`/`divergenceId` against `conformance/registry/waivers/`/`ext-` records reusing `parity-harness/src/waiver.rs` (no parallel mechanism, FR-043); surface stale allowed-differences in the report
+
+**Checkpoint**: US4 works — honest, scoped tolerance with no global ignore lists.
+
+---
+
+## Phase 8: User Story 6 - Choose the oracle type per case (Priority: P3)
+
+**Goal**: All four oracle types are explicit and distinct; invariant/metamorphic evaluates a declared relationship across operations; a case can be re-pointed by changing only `oracleType`.
+
+**Independent Test**: One case evaluated under each oracle type applies distinct semantics; a metamorphic case checks idempotence/first-create-vs-restart/resume rather than a fixed output.
+
+### Tests for User Story 6
+
+- [X] T066 [P] [US6] Add a test evaluating one fixture case under all four oracle types, asserting distinct verdict semantics and that re-pointing changes only `oracleType` (FR-006/007)
+- [X] T067 [P] [US6] Add a metamorphic test: an idempotence relationship (re-`up`) and a first-create-vs-restart relationship each verdict on the declared relationship, not a fixed output (FR-008)
+
+### Implementation for User Story 6
+
+- [X] T068 [US6] Finalize explicit four-way dispatch in `crates/parity-harness/src/oracle_type.rs` (spec-expectation, snapshot, live-differential, invariant-metamorphic) with a single entry consumed by the runner
+- [X] T069 [US6] Implement invariant/metamorphic evaluation (relationship kinds idempotence, first-create-vs-restart, resume across ≥2 operations) in `crates/parity-harness/src/oracle_type.rs` (FR-008)
+- [X] T070 [US6] Add oracle-type arity validation to `crates/conformance/src/validate.rs` (invariant-metamorphic ⇒ ≥2 ops + a `relationship` referencing a sibling op id) per data-model.md §1
+- [X] T071 [US6] Add a metamorphic fixture case to `conformance/registry/cases.json` (idempotent re-`up`) using the `chan-temporal` channel
+
+**Checkpoint**: All six user stories independently functional.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, gate wiring, and end-to-end validation across stories.
+
+- [X] T072 [P] Update `CLAUDE.md` (Conformance Registry + Parity sections) to document the declarative case shape, snapshot tree, and the runner/refresh split
+- [X] T073 Ensure `certify` (`crates/conformance/src/certify.rs`) surfaces snapshot coverage + `no-reference-for-platform` as non-blocking info and still blocks on gaps/unclassified (FR-042, release-gate integrity)
+- [X] T074 [P] Add a section to `specs/018-harden-parity-harness/quickstart.md`-style docs or `conformance/RULES.md` noting the runner is dev-only (no shipped `deacon` subcommand, Principle II)
+- [X] T075 Run `cargo nextest run --profile parity -E 'binary(=parity_conformance_runner)'` locally (needs Docker + pinned oracle) to confirm the live lane is green; rely on the `parity / live-certification` CI lane otherwise
+- [X] T076 [P] Run the quickstart.md end-to-end (author → validate → run → record → staleness → characterize) and fix any drift
+- [X] T077 Full gate before PR: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `make test-nextest`, and confirm `parity_registry_check` + `registry_valid` pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (P1)**: no dependencies.
+- **Foundational (P2)**: depends on Setup — BLOCKS all user stories.
+- **US1 (P1)**: depends on Foundational. MVP.
+- **US2 / US3 / US5 (P2)**: depend on Foundational; independently testable. US2's meaningful *normalized* snapshots and US5's *normalized* channel comparisons are sharper after US3 lands, but each story's independent test does not require US3 (US2 staleness is provenance/hash-based; US5 can assert on raw capture).
+  - **Ordering constraint (normalizer version)**: US3 finalizes `NORMALIZER_VERSION`. Any snapshot recorded in US2 (T038) *before* US3 lands is invalidated as stale on the next run (normalizerVersion drift, FR-030). Therefore committed US2 snapshots MUST be recorded only after US3's normalizer is final — the single-track order below enforces this by running **US3 before US2**. If US2 is implemented first, its snapshots MUST be re-recorded after US3.
+- **US4 / US6 (P3)**: depend on Foundational; US4 integrates into `compare.rs` (US1), US6 into `oracle_type.rs` (US1/US2) — both add isolated logic and are independently testable.
+- **Polish (P9)**: depends on all targeted stories.
+
+### Recommended order (single track)
+
+Setup → Foundational → **US1 (MVP)** → US3 → US2 → US5 → US4 → US6 → Polish.
+(US3 pulled ahead of US2/US5 among the P2s so normalization is real before snapshots/Docker channels rely on it — reduces rework.)
+
+### Within each story
+
+Tests first (must fail) → models → observers/services → runner/dispatch integration → fixtures/wiring.
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: T002, T003, T004 in parallel (distinct files) after T001.
+- **Foundational**: T006, T009, T010, T011, T012, T014 in parallel (distinct files); T005/T007/T013 touch shared `model.rs`/`load.rs`/`validate.rs` — serialize those.
+- **US1**: tests T015–T018 in parallel; impl T019/T020 in parallel; T021–T024 serialize (shared `compare`/`oracle_type`/`runner`/`report`).
+- **US3**: tests T039–T041 parallel; T044 parallel with T042/T043.
+- **US5**: tests T049–T051 parallel; observers T053–T056 fully parallel (distinct files).
+- **US4/US6**: tests parallel; implementation mostly serial within each story.
+- **Cross-story**: once Foundational is done, US1/US3/US2/US5 can be staffed in parallel by different developers (distinct primary files), integrating through `runner.rs`/`compare.rs`/`oracle_type.rs`.
+
+### Parallel example: User Story 5 observers
+
+```bash
+Task: "Implement image observer in crates/parity-harness/src/observe/image.rs"
+Task: "Implement container_graph observer in crates/parity-harness/src/observe/container_graph.rs"
+Task: "Implement injected_process observer in crates/parity-harness/src/observe/injected_process.rs"
+Task: "Implement temporal observer in crates/parity-harness/src/observe/temporal.rs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first (US1 only)
+
+1. Setup → Foundational → US1.
+2. **STOP & VALIDATE**: a data-only `read-configuration` case verdicts in dev-fast (spec-expectation) and in the parity lane (live-differential), with zero new Rust test functions per case (SC-001).
+3. Demo: adding a second case is a pure `cases.json` edit.
+
+### Incremental delivery
+
+US1 (author+run) → US3 (real normalization) → US2 (snapshots+staleness) → US5 (Docker channels+cleanup) → US4 (scoped allowed diffs) → US6 (oracle types). Each adds value without breaking prior stories; `parity_registry_check`/`registry_valid` stay green throughout.
+
+### SC → task coverage map (SC-012 acceptance areas)
+
+| Acceptance area (SC-012) | Task(s) |
+|--------------------------|---------|
+| Each observable channel | T017/T019/T020 (CLI), T044/T046 (fs), T051/T053–T056 (image/graph/injected/temporal), T020 (structured) |
+| Raw vs normalized evidence | T041, T045 |
+| Stale snapshots | T028, T032 |
+| Canonicalization | T039, T042 |
+| Metadata labels | T040, T053 |
+| Mounts | T040, T054 |
+| PATH | T040, T055 |
+| Null semantics | T039, T042 |
+| Allowed-difference scoping | T060, T063, T064 |
+| Process failures | T017, T019 |
+| Resource cleanup | T049, T052 |
+| Record/replay equivalence | T030 |
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete-task dependency.
+- `[USx]` maps each task to its user story for traceability.
+- Every task keeps the build green (fmt + clippy + narrowest `make test-nextest-*`); full gate (T077) before PR.
+- The runner is **dev-only** — never add a shipped `deacon` subcommand (Constitution II).
+- Reuse, don't fork: one normalizer (`normalize.rs`), one waiver mechanism (`waiver.rs` + registry), one loader (`deacon-conformance`) — Constitution VIII.
+- Each build-out step is its own small CI-gated PR (Conventional-Commit `feat`/`fix`/`chore`, never `test`/`style`).


### PR DESCRIPTION
## Declarative conformance runner (022)

Implements the 022-conformance-runner spec: conformance cases become **data** a shared runner executes, not pointers to hand-written Rust tests. Adding a case/assertion/fixture is a pure data edit — no new Rust function (SC-001).

### What's included
- **Declarative case shape** in `conformance/registry/cases.json` — ordered `operations[]`, `oracleType`, per-channel `expected[]`, scoped `allowedDifferences[]`, `fsAllowlist`, `cleanup`, `resourceGroup`. A record is exactly one of legacy (binary-backed) or declarative, enforced fail-loud at load.
- **Four oracle types** (`oracle_type.rs`, one explicit dispatch): `spec-expectation`, `live-differential` (deacon vs the pinned oracle), `snapshot` (vs a committed provenance-checked snapshot), `invariant-metamorphic` (relationship across ≥2 ops).
- **Observable channels + observers** (`observe/`): CLI-process (exit/stdout/stderr/structured-output), allowlist-scoped filesystem/file-content, and the four Docker channels (image/process-graph/injected-process/temporal). Evidence captured raw then normalized by the single `normalize.rs`; raw + normalized persisted separately.
- **Docker cases** run in an isolated external temp workspace with RAII cleanup (reclaims container/network/volume/temp-dir on success and unwind).
- **Committed snapshots** under `conformance/snapshots/<os-arch>/<case-id>/` with 13-field provenance + staleness gating; a reviewed `conformance-snapshot refresh` bin is the only writer.
- **Scoped allowed differences** — `(behavior, context, observablePath)` + exactly one resolvable `waiverId`/`divergenceId`; no global ignore lists; self-invalidating when stale.
- **New validation classes** V16–V20 (`validate.rs`), all block a PR via `registry_valid`; `certify` surfaces snapshot coverage as non-blocking info.
- **New live binary** `parity_conformance_runner` (parity profile only), registered in the parity registry + wired into all nextest profiles.

### Review fixes folded in (from `/code-review xhigh`)
- **Snapshot staleness no longer gates on host tool versions** (`node`/`docker`/`compose`). They are informational provenance only; gating on them made every committed snapshot stale on every machine but the recorder's, which would have turned the parity lane red on CI (recorded Node 22.23.1 vs CI Node 20). Staleness now compares only the evidence-determining inputs (case/fixture hashes, oracle/source pins, imageDigests, normalizer).
- **`no-reference-for-platform` is non-blocking in the live binary** — surfaced (never silently skipped) but not a hard failure, consistent with the runner exit-code contract and `certify`.
- **Metamorphic idempotence check observes the full container set**, not just the first match, so a non-idempotent op that leaves a second container behind is detected instead of masked.
- Aligned `snapshot check`'s snapshot root with the `certify`/`validate` sibling-resolution.
- Fixed an unrelated pre-existing bug: `--force-tty-if-json` now honors its documented case-insensitive env vocabulary via clap's `BoolishValueParser`.

### Verification
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Full hermetic conformance + parity suite green (incl. real-Docker channel tests, record/replay, staleness).
- Live `parity_conformance_runner` passes against real Docker + the pinned oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT
