### PR TITLE
fix(conformance): async-safe docker probes + real imageDigests staleness

### DIFF
--- a/crates/parity-harness/src/observe/container_graph.rs
+++ b/crates/parity-harness/src/observe/container_graph.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 
 use crate::HarnessError;
 use crate::evidence::RawChannelEvidence;
-use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+use crate::observe::{ChannelObserver, RunContext, not_captured};
 
 /// Captures `chan-process-graph` from the case's container.
 #[derive(Debug, Clone, Copy)]
@@ -28,10 +28,8 @@ impl ChannelObserver for ContainerGraphObserver {
         ctx: &RunContext,
         op: &Operation,
     ) -> Result<RawChannelEvidence, HarnessError> {
-        let Some(id) = &ctx.container_id else {
-            return Ok(not_captured(CHAN_PROCESS_GRAPH, &op.id));
-        };
-        let Some(inspect) = docker_inspect(id)? else {
+        // Read the runner's pre-fetched inspect (finding #4) — no subprocess here.
+        let Some(inspect) = &ctx.container_inspect else {
             return Ok(not_captured(CHAN_PROCESS_GRAPH, &op.id));
         };
 

--- a/crates/parity-harness/src/observe/image.rs
+++ b/crates/parity-harness/src/observe/image.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 use crate::HarnessError;
 use crate::evidence::RawChannelEvidence;
-use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+use crate::observe::{ChannelObserver, RunContext, not_captured};
 
 /// Captures `chan-image` from the case's container.
 #[derive(Debug, Clone, Copy)]
@@ -26,10 +26,8 @@ impl ChannelObserver for ImageObserver {
         ctx: &RunContext,
         op: &Operation,
     ) -> Result<RawChannelEvidence, HarnessError> {
-        let Some(id) = &ctx.container_id else {
-            return Ok(not_captured(CHAN_IMAGE, &op.id));
-        };
-        let Some(inspect) = docker_inspect(id)? else {
+        // Read the runner's pre-fetched inspect (finding #4) — no subprocess here.
+        let Some(inspect) = &ctx.container_inspect else {
             return Ok(not_captured(CHAN_IMAGE, &op.id));
         };
         let config = &inspect["Config"];

--- a/crates/parity-harness/src/observe/injected_process.rs
+++ b/crates/parity-harness/src/observe/injected_process.rs
@@ -15,9 +15,7 @@ use serde_json::{Value, json};
 
 use crate::HarnessError;
 use crate::evidence::RawChannelEvidence;
-use crate::observe::{
-    ChannelObserver, RunContext, docker_inspect, env_array_to_object, not_captured,
-};
+use crate::observe::{ChannelObserver, RunContext, env_array_to_object, not_captured};
 
 /// Captures `chan-injected-process` from the case's container.
 #[derive(Debug, Clone, Copy)]
@@ -33,10 +31,8 @@ impl ChannelObserver for InjectedProcessObserver {
         ctx: &RunContext,
         op: &Operation,
     ) -> Result<RawChannelEvidence, HarnessError> {
-        let Some(id) = &ctx.container_id else {
-            return Ok(not_captured(CHAN_INJECTED_PROCESS, &op.id));
-        };
-        let Some(inspect) = docker_inspect(id)? else {
+        // Read the runner's pre-fetched inspect (finding #4) — no subprocess here.
+        let Some(inspect) = &ctx.container_inspect else {
             return Ok(not_captured(CHAN_INJECTED_PROCESS, &op.id));
         };
         let config = &inspect["Config"];

--- a/crates/parity-harness/src/observe/mod.rs
+++ b/crates/parity-harness/src/observe/mod.rs
@@ -68,6 +68,12 @@ pub struct RunContext {
     /// The container id, once the case has brought one up. `None` for pure CLI-process
     /// cases that never create a container.
     pub container_id: Option<String>,
+    /// The full `docker inspect` object for [`RunContext::container_id`], captured ONCE by
+    /// the runner (off the async executor via `spawn_blocking`) after the container exists.
+    /// The Docker channel observers read THIS instead of each spawning their own
+    /// `docker inspect` — so a case pays a single inspect, and no observer blocks the async
+    /// executor (finding #4). `None` when no container exists / it was removed.
+    pub container_inspect: Option<serde_json::Value>,
     /// The case's `fsAllowlist` — the path/glob allowlist the filesystem observer is
     /// scoped to (clarify Q1: allowlist-scoped, never a full-tree diff). Empty for cases
     /// with no filesystem expectation.
@@ -103,6 +109,7 @@ impl RunContext {
         RunContext {
             workspace,
             container_id: None,
+            container_inspect: None,
             fs_allowlist: Vec::new(),
             outcomes: HashMap::new(),
             op_snapshots: HashMap::new(),
@@ -184,7 +191,13 @@ pub(crate) fn not_captured(channel: &'static str, op_id: &str) -> RawChannelEvid
 /// Run `docker inspect <id>` and return the first result object, `None` when the object
 /// does not exist (container/image removed — a legitimate not-captured state), or a
 /// fail-loud [`HarnessError::DockerUnavailable`] when `docker` itself cannot run.
-pub(crate) fn docker_inspect(id: &str) -> Result<Option<serde_json::Value>, HarnessError> {
+///
+/// This is a BLOCKING call. Async callers (the runner) must invoke it via
+/// `tokio::task::spawn_blocking` so it never blocks the executor (finding #4); the
+/// one-shot refresh / `snapshot check` CLIs and the `Drop` cleanup guard call it directly
+/// (non-concurrent, like `Drop`). Observers never call it — they read the pre-fetched
+/// [`RunContext::container_inspect`].
+pub fn docker_inspect(id: &str) -> Result<Option<serde_json::Value>, HarnessError> {
     let output = std::process::Command::new("docker")
         .args(["inspect", id])
         .output()

--- a/crates/parity-harness/src/observe/temporal.rs
+++ b/crates/parity-harness/src/observe/temporal.rs
@@ -22,7 +22,7 @@ use serde_json::json;
 
 use crate::HarnessError;
 use crate::evidence::RawChannelEvidence;
-use crate::observe::{ChannelObserver, RunContext, docker_inspect, not_captured};
+use crate::observe::{ChannelObserver, RunContext, not_captured};
 
 /// Captures `chan-temporal` from the case's container.
 #[derive(Debug, Clone, Copy)]
@@ -38,19 +38,17 @@ impl ChannelObserver for TemporalObserver {
         ctx: &RunContext,
         op: &Operation,
     ) -> Result<RawChannelEvidence, HarnessError> {
-        let Some(id) = &ctx.container_id else {
-            // No container OR it was cleaned up: the cleanup transition is exactly a
-            // not-captured temporal channel (FR-018).
-            return Ok(not_captured(CHAN_TEMPORAL, &op.id));
-        };
-        let Some(inspect) = docker_inspect(id)? else {
+        // No container OR it was cleaned up: the cleanup transition is exactly a
+        // not-captured temporal channel (FR-018). Reads the runner's pre-fetched inspect
+        // (finding #4) — no subprocess here.
+        let Some(inspect) = &ctx.container_inspect else {
             return Ok(not_captured(CHAN_TEMPORAL, &op.id));
         };
         Ok(RawChannelEvidence {
             channel: CHAN_TEMPORAL.to_string(),
             operation: op.id.clone(),
             present: true,
-            value: temporal_from_inspect(&inspect),
+            value: temporal_from_inspect(inspect),
         })
     }
 }

--- a/crates/parity-harness/src/oracle_type.rs
+++ b/crates/parity-harness/src/oracle_type.rs
@@ -152,6 +152,19 @@ async fn snapshot_oracle(case: &TestCase, cfg: &RunConfig<'_>) -> Result<Evaluat
     if let Some(v) = snapshot::current_oracle_version_pin() {
         current.oracle_version = v;
     }
+    // Recompute imageDigests for a Docker case (finding #5) so a changed pinned image is
+    // caught; offloaded so the docker probe never blocks the async executor (finding #4).
+    // `None` (docker unreachable) carries the recorded digests rather than fabricating.
+    let case_for_digests = case.clone();
+    let fixtures_root = cfg.fixtures_root.to_path_buf();
+    let recomputed_digests = tokio::task::spawn_blocking(move || {
+        runner::image_digests_for_case(&case_for_digests, &fixtures_root)
+    })
+    .await
+    .map_err(runner::blocking_join_err)?;
+    if let Some(digests) = recomputed_digests {
+        current.image_digests = digests.into_iter().collect();
+    }
     if let snapshot::Staleness::Stale { field, .. } =
         snapshot::compare_staleness(&snap.provenance, &current)
     {

--- a/crates/parity-harness/src/runner.rs
+++ b/crates/parity-harness/src/runner.rs
@@ -126,6 +126,9 @@ pub(crate) async fn execute_ops(
     let mut outcomes: Vec<(String, ProcessOutcome)> = Vec::new();
     let mut op_snapshots: Vec<(String, crate::observe::OpSnapshot)> = Vec::new();
     let mut container_id: Option<String> = None;
+    // The final `up` container's full `docker inspect`, captured ONCE (off the executor)
+    // and handed to every Docker channel observer via `RunContext` (finding #4).
+    let mut container_inspect: Option<serde_json::Value> = None;
 
     for op in &case.operations {
         // Docker cases: one isolated workspace for every op. Config-only: per-op fixture.
@@ -163,13 +166,25 @@ pub(crate) async fn execute_ops(
         if docker_case && matches!(op.subcommand.as_str(), "up" | "exec") && inv.success {
             // Capture EVERY container matching this op's workspace label (not just one), so
             // the metamorphic oracle can detect a non-idempotent op that left a second
-            // container behind (finding #3).
-            let this_ids = containers_for_workspace(&workspace);
+            // container behind (finding #3). Both docker probes run via `spawn_blocking` so
+            // they never block the async executor (finding #4).
+            let ws_for_lookup = workspace.clone();
+            let this_ids =
+                tokio::task::spawn_blocking(move || containers_for_workspace(&ws_for_lookup))
+                    .await
+                    .map_err(blocking_join_err)?;
             let this_id = this_ids.first().cloned();
-            let temporal = this_id
-                .as_deref()
-                .and_then(|id| crate::observe::docker_inspect(id).ok().flatten())
-                .map(|inspect| crate::observe::temporal::temporal_from_inspect(&inspect))
+            let inspect = match this_id.clone() {
+                Some(id) => {
+                    tokio::task::spawn_blocking(move || crate::observe::docker_inspect(&id))
+                        .await
+                        .map_err(blocking_join_err)??
+                }
+                None => None,
+            };
+            let temporal = inspect
+                .as_ref()
+                .map(crate::observe::temporal::temporal_from_inspect)
                 .unwrap_or(serde_json::Value::Null);
             op_snapshots.push((
                 op.id.clone(),
@@ -180,7 +195,9 @@ pub(crate) async fn execute_ops(
                 },
             ));
             if op.subcommand == "up" {
+                // The final `up`'s container + its inspect are what the channel observers use.
                 container_id = this_id;
+                container_inspect = inspect;
             }
         }
 
@@ -206,6 +223,7 @@ pub(crate) async fn execute_ops(
     // Scope the filesystem observer to the case's declared allowlist (clarify Q1).
     ctx.fs_allowlist = case.fs_allowlist.clone();
     ctx.container_id = container_id;
+    ctx.container_inspect = container_inspect;
     for (op_id, outcome) in outcomes {
         ctx.record_outcome(op_id, outcome);
     }
@@ -234,6 +252,97 @@ fn unique_fixture_ids(case: &TestCase) -> Vec<String> {
     ids.sort();
     ids.dedup();
     ids
+}
+
+/// Map a `spawn_blocking` join failure (the offloaded blocking task panicked) to a
+/// fail-loud harness error. Used wherever the runner offloads a blocking docker probe so it
+/// never blocks the async executor (finding #4).
+pub(crate) fn blocking_join_err(e: tokio::task::JoinError) -> HarnessError {
+    HarnessError::DockerUnavailable {
+        cause: format!("a docker probe task failed to complete: {e}"),
+    }
+}
+
+/// The pinned-image digests a case's fixtures declare — the `imageDigests` provenance /
+/// staleness signal (FR-017, finding #5). A Docker case's snapshot MUST go stale when a
+/// pinned image's content changes upstream, so this recomputes the digest of every image
+/// the case's fixtures declare, at both record and replay time. Returns:
+///
+/// - `Some(empty)` for a NON-Docker case — it pulls no images, so its snapshot must NOT
+///   depend on any image digest (a `read-configuration` case gating on the base image would
+///   be the same false-staleness trap as gating on the host Node version); resolved without
+///   touching docker.
+/// - `Some(digests)` for a Docker case when `docker image inspect` resolves each declared
+///   image (sorted, deduped for determinism).
+/// - `None` for a Docker case when `docker` cannot be reached — the caller then carries the
+///   RECORDED digests rather than fabricating (e.g. the hermetic `snapshot check`, which has
+///   no docker: it cannot verify a Docker case's images and must not falsely flag them).
+///
+/// BLOCKING (it may shell out to `docker`); async callers offload it via `spawn_blocking`.
+pub fn image_digests_for_case(
+    case: &TestCase,
+    fixtures_root: &Path,
+) -> Option<Vec<(String, String)>> {
+    if !is_docker_case(case) {
+        return Some(Vec::new());
+    }
+    let mut out: Vec<(String, String)> = Vec::new();
+    for id in unique_fixture_ids(case) {
+        let Some(image) = fixture_image(&fixtures_root.join(&id)) else {
+            continue; // Dockerfile/compose fixture (no top-level `image` ref) — nothing to pin.
+        };
+        match image_digest(&image) {
+            Ok(Some(digest)) => out.push((image, digest)),
+            // Image not present locally / no digest — best-effort, skip (not a docker fault).
+            Ok(None) => {}
+            // `docker` itself cannot run — cannot determine; the caller carries recorded.
+            Err(()) => return None,
+        }
+    }
+    out.sort();
+    out.dedup();
+    Some(out)
+}
+
+/// The `image` ref a fixture's devcontainer config declares, if any (mirrors the conformance
+/// validator's `fixture_image`). A missing / unreadable / non-JSON config, or one with no
+/// top-level `image`, yields `None`.
+fn fixture_image(fixture_dir: &Path) -> Option<String> {
+    for rel in [".devcontainer/devcontainer.json", ".devcontainer.json"] {
+        let path = fixture_dir.join(rel);
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(doc) = serde_json::from_str::<serde_json::Value>(&raw) else {
+            continue;
+        };
+        if let Some(image) = doc.get("image").and_then(|v| v.as_str()) {
+            return Some(image.to_string());
+        }
+    }
+    None
+}
+
+/// The digest of a locally-available image `reference` via `docker image inspect`: its first
+/// `RepoDigests` entry (the registry digest), else its content `.Id`. `Ok(None)` when the
+/// image is absent locally / has neither; `Err(())` when `docker` itself cannot run.
+fn image_digest(reference: &str) -> Result<Option<String>, ()> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "image",
+            "inspect",
+            reference,
+            "--format",
+            "{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}",
+        ])
+        .output()
+        .map_err(|_| ())?;
+    if !output.status.success() {
+        // Non-zero is usually "No such image" (not pulled) — a not-present state, not a fault.
+        return Ok(None);
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if s.is_empty() { None } else { Some(s) })
 }
 
 /// Find EVERY container deacon created for `workspace` via its `devcontainer.local_folder`
@@ -357,8 +466,9 @@ pub async fn collect_evidence_on(
 /// recompute the case/fixture hashes, take the oracle version from the verified oracle,
 /// probe Node/Docker/Compose versions (via the shared
 /// [`deacon_conformance::snapshot::probe_environment`]), and stamp the source revision +
-/// normalizer version. `imageDigests` is empty for config-only cases (they pull no
-/// images); the Docker-image digest probe lands with the Docker channels (US5).
+/// normalizer version. `imageDigests` records the digest of each image a Docker case's
+/// fixtures pin ([`image_digests_for_case`]) so the snapshot goes stale if a pinned image's
+/// content changes; it is empty for config-only cases (they pull no images).
 ///
 /// Provenance fields are recorded verbatim from the environment — NEVER fabricated
 /// (constitution IV). A missing Node/Docker/Compose tool records an empty string (the
@@ -385,7 +495,12 @@ pub fn capture_provenance(
         node_version: env.node_version.unwrap_or_default(),
         docker_version: env.docker_version.unwrap_or_default(),
         compose_version: env.compose_version.unwrap_or_default(),
-        image_digests: Default::default(),
+        // Digests of the images a Docker case pins (empty for config-only cases); `.collect()`
+        // infers the `IndexMap` field type (finding #5).
+        image_digests: image_digests_for_case(case, cfg.fixtures_root)
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
         normalizer_version: crate::normalize::NORMALIZER_VERSION.to_string(),
         captured_at: crate::report::now_rfc3339(),
     })
@@ -565,6 +680,39 @@ mod tests {
     fn exec_kind_classifies_config_only() {
         assert_eq!(exec_kind("read-configuration"), ExecKind::Config);
         assert_eq!(exec_kind("up"), ExecKind::Lifecycle);
+    }
+
+    #[test]
+    fn image_digests_for_config_only_case_is_empty_without_docker() {
+        // A non-Docker case pulls no images → `Some(empty)`, resolved WITHOUT touching
+        // docker, so a read-configuration snapshot never gates on a base-image digest
+        // (finding #5). The path is nonexistent to prove no fixture/docker access happens.
+        let case = case_with_op(&[], &[]);
+        assert_eq!(
+            image_digests_for_case(&case, Path::new("/nonexistent")),
+            Some(Vec::new())
+        );
+    }
+
+    #[test]
+    fn fixture_image_reads_declared_image_else_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let dc = dir.path().join("fx/.devcontainer");
+        std::fs::create_dir_all(&dc).unwrap();
+        std::fs::write(
+            dc.join("devcontainer.json"),
+            r#"{ "image": "alpine:3.19" }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            fixture_image(&dir.path().join("fx")).as_deref(),
+            Some("alpine:3.19")
+        );
+        // A fixture with no top-level image (Dockerfile/compose) → None.
+        let dc2 = dir.path().join("fx2/.devcontainer");
+        std::fs::create_dir_all(&dc2).unwrap();
+        std::fs::write(dc2.join("devcontainer.json"), r#"{ "name": "x" }"#).unwrap();
+        assert_eq!(fixture_image(&dir.path().join("fx2")), None);
     }
 
     #[test]

--- a/crates/parity-harness/tests/docker_channels.rs
+++ b/crates/parity-harness/tests/docker_channels.rs
@@ -71,6 +71,12 @@ fn containers_for(ws: &str) -> Vec<String> {
 fn ctx_for(container_id: &str) -> RunContext {
     let mut ctx = RunContext::new(std::path::PathBuf::from("/tmp"));
     ctx.container_id = Some(container_id.to_string());
+    // The runner pre-fetches the inspect once and the observers read it (finding #4); this
+    // helper does the same so each observer sees the container's state AT this moment (the
+    // cleanup-transition test re-builds the context after stop/rm).
+    ctx.container_inspect = parity_harness::observe::docker_inspect(container_id)
+        .ok()
+        .flatten();
     ctx
 }
 


### PR DESCRIPTION
## Conformance runner: async-safe Docker probes + real `imageDigests` staleness

Two follow-up fixes from the `/code-review` of the 022 declarative conformance runner (findings #4 and #5). Both are contained to the dev-only `parity-harness` crate.

### #4 — no blocking `std::process::Command` on the async executor (Principle V)
The Docker channel observers each spawned their own blocking `docker inspect` from a sync `capture()` invoked inside `async fn`s, blocking the tokio executor.

- The runner now pre-fetches the container's full `docker inspect` **once**, off the executor via `tokio::task::spawn_blocking`, and stores it on `RunContext.container_inspect`.
- The four Docker observers (`image`/`process-graph`/`injected-process`/`temporal`) became **pure readers** of that pre-fetched value — no subprocess, no blocking.
- The workspace-container lookup in `execute_ops` is likewise offloaded via `spawn_blocking`.

Net effect: a Docker case now pays **one** inspect instead of 4+, and no observer blocks the async executor. `spawn_blocking` works on the current-thread runtime `#[tokio::test]` uses. The one-shot refresh / `snapshot check` CLIs and the `Drop` cleanup guard keep direct sync calls (non-concurrent, the sanctioned exception).

### #5 — `imageDigests` is now a real staleness signal
`imageDigests` was declared a staleness field but was never populated or recomputed — an image-content change on a future Docker snapshot case would go undetected.

- New `image_digests_for_case`: for a **Docker** case, recomputes the digest of each image its fixtures pin (`docker image inspect` → `RepoDigests`/`.Id`); for a **non-Docker** case it returns empty **without touching docker** (a `read-configuration` snapshot must never gate on a base-image digest — the same false-staleness trap avoided for host tool versions in #1).
- Wired into both the record path (`capture_provenance`) and the live replay gate (`snapshot_oracle`, offloaded). The hermetic `snapshot check` (no docker) keeps carrying the recorded digests — it cannot verify a Docker case's images, so it must not falsely flag them (returns `None` → carry recorded).

The only existing snapshot case (`case-readconfig-snapshot`) is config-only, so its `imageDigests` stays empty and the committed snapshot is unchanged.

### Verification
- `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Full hermetic conformance + parity suite green, incl. the real-Docker channel tests (now exercising the pre-fetch path) and new unit tests for `image_digests_for_case`/`fixture_image`.
- Live `parity_conformance_runner` passes against real Docker + the pinned oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vhr7Tcf8ybvSZSE1owqBT
