### PR TITLE
ci(parity): establish BuildKit as an explicit precondition of the parity lane

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -90,6 +90,29 @@ jobs:
       - name: Verify oracle version
         run: devcontainer --version
 
+      # 024 Phase 7: an EXPLICIT BuildKit precondition, landed before the runner starts
+      # depending on it so the runner change is never the thing that reddens the lane.
+      #
+      # Declarative cases with a `build` operation need BuildKit. The GitHub runner ships
+      # buildx today, so this step is mostly an assertion — which is the point: the
+      # alternative was an outcome-conditional assertion inside the case data, tolerating
+      # "succeeded OR failed" because BuildKit's presence was unknown. That was nearly
+      # vacuous, since every one of those invocations passes `--output-format json` and
+      # deacon's JSON ERROR document also contains `"outcome"`. Establishing the
+      # precondition here, and checking it in `prereq::require_buildkit()`, dissolves the
+      # need for that assertion shape entirely.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Verify BuildKit is available
+        # Fail LOUD and early rather than letting a `build` case report a divergence that
+        # is really a missing builder. `require_buildkit()` performs the same check inside
+        # the harness for local runs.
+        run: |
+          docker buildx version
+          docker buildx inspect --bootstrap >/dev/null
+          echo "BuildKit is available"
+
       - name: Build deacon
         run: cargo build -p deacon
 


### PR DESCRIPTION
Lands the buildx setup + verification step **before** the runner starts depending on it, so the runner change is never the thing that reddens the lane. First of step 7.

## Why a precondition instead of a cleverer assertion

Declarative cases with a `build` operation need BuildKit. Without a precondition, the only way to express those cases was an **outcome-conditional assertion** — tolerating "succeeded OR failed" because BuildKit's presence was unknown.

That shape was nearly vacuous. Every one of those invocations passes `--output-format json`, and deacon's JSON **error** document also contains `"outcome"` — so the assertion held whichever way the build went. Establishing the precondition dissolves the need for that assertion shape entirely, rather than arguing about how to express it.

## What the steps do

| Step | Purpose |
|---|---|
| `docker/setup-buildx-action@v3` | ensures a builder exists (the runner ships buildx today, so this is mostly belt-and-braces) |
| `docker buildx version` + `inspect --bootstrap` | **fails loud and early**, so a missing builder cannot surface later as a `build` case reporting a divergence that is really a missing builder |

The matching in-harness check (`prereq::require_buildkit()`, called for any case with a `build` op) follows in the next PR, so local runs get the same guarantee.

## Verification

`parity_registry_check` 10/10 pass, including `no_surface_globs_a_removed_path` — the guard added in 023 T116 after two workflow steps silently globbed a removed path and kept exiting 0.

This PR touches only `.github/workflows/parity.yml`; the lane's existing redness (the 51 `chan-structured-output` T113 cases) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UCGzJEFZd85HJqz1Wx2kE