### PR TITLE
fix(parity): warm compose-declared fixture images too

### DIFF
--- a/scripts/parity/prepull-fixture-images.sh
+++ b/scripts/parity/prepull-fixture-images.sh
@@ -53,6 +53,25 @@ config_image() {
   sed -nE 's/.*"image"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$1" | head -n1
 }
 
+# A compose fixture names its base in the COMPOSE file, not in devcontainer.json — that
+# config carries `dockerComposeFile` + `service` and no `image` key at all. Warming only
+# the JSON-declared images therefore left every compose base cold, which is the same
+# "discovery that matches nothing is not an error" failure this script's header describes,
+# one file format down: `fx-tier1-compose-array` pulls
+# `mcr.microsoft.com/devcontainers/base:bookworm` on the merged-configuration read, blows
+# the harness's 120s bound, and the runner reports a HANG naming the case rather than the
+# download. Because that abort is fail-loud, it also takes the whole run with it — no other
+# case gets to report.
+#
+# ALL images are read, not the first: a compose project legitimately has several services
+# (`fx-tier1-compose-postgres` has an app and a database), and warming one of them is the
+# same cold-cache stall on the other. `${VAR}` interpolation is skipped — it is not a
+# resolvable reference here, and a fixture that needed one would be unpinned (V18).
+compose_images() {
+  sed -nE 's/^[[:space:]]+image:[[:space:]]*"?([^"[:space:]#]+)"?.*/\1/p' "$1" \
+    | grep -v '\$' || true
+}
+
 for df in "${fixtures}"/*/image/Dockerfile; do
   [ -e "${df}" ] || continue
   dir="$(dirname "${df}")"
@@ -67,16 +86,32 @@ for df in "${fixtures}"/*/image/Dockerfile; do
     || echo "prepull: WARN could not build ${tag} (the parity run will report its own cause)" >&2
 done
 
-images="$(printf '%s\n' "${configs}" \
-          | while read -r cfg; do config_image "${cfg}"; done \
-          | sort -u \
-          | grep -v ':local$' || true)"
+config_images="$(printf '%s\n' "${configs}" \
+                 | while read -r cfg; do config_image "${cfg}"; done)"
 
-if [ -z "${images}" ]; then
+if [ -z "${config_images}" ]; then
   echo "prepull: FATAL no image reference found in any of these configs:" >&2
   printf '%s\n' "${configs}" >&2
   exit 1
 fi
+
+# Compose files are discovered the same way the configs are — by search at any depth, both
+# extensions — never by a fixed relative path. Finding none is NOT fatal: a fixture tree
+# with no compose fixture is legitimate, unlike a tree with no devcontainer config at all.
+compose_files="$(find "${fixtures}" \
+                   \( -name '*.yml' -o -name '*.yaml' \) \
+                   -type f 2>/dev/null | sort)"
+
+compose_declared="$(printf '%s\n' "${compose_files}" \
+                    | while read -r yml; do
+                        [ -n "${yml}" ] || continue
+                        compose_images "${yml}"
+                      done)"
+
+images="$(printf '%s\n%s\n' "${config_images}" "${compose_declared}" \
+          | sed '/^$/d' \
+          | sort -u \
+          | grep -v ':local$' || true)"
 
 while read -r img; do
   [ -n "${img}" ] || continue


### PR DESCRIPTION
## Why

`scripts/parity/prepull-fixture-images.sh` read image references only out of `devcontainer.json` / `devcontainer.jsonc`. **A compose fixture does not have one** — its config carries `dockerComposeFile` + `service` and no `image` key at all — so its bases were invisible to the warmer.

Concretely, of the three images fixtures declare in compose YAML:

| Image | Also in a JSON config? | Warmed today? |
|---|---|---|
| `alpine:3.19` | yes | yes |
| `mcr.microsoft.com/devcontainers/base:bookworm` | yes, by an unrelated fixture | by coincidence |
| `postgres:16-bookworm` | **no** | **no** |

This is the same failure the script's own header describes — *discovery that matches nothing is not an error* — reproduced one file format down from the glob bug it was written to prevent (023 T116).

The consequence is also the one documented there: `read-configuration --include-merged-configuration` pulls on a cache miss to match the reference (#307), a cold pull outruns the harness's 120s per-invocation bound, and the runner reports a **hang naming a case** rather than a download. Because that abort is fail-loud, it takes the rest of the run with it — no other case gets to report. I hit exactly this locally driving `parity_conformance_runner` directly (which skips the warm step `make test-parity` performs):

```
parity case `case-merged-decl-compose-array__op-read`: CLI exceeded its 120s bound
```

## What

Compose files are discovered the **same way the configs are** — by search, at any depth, both extensions — never by a fixed relative path.

Three deliberate choices:

- **Finding no compose file is NOT fatal**, unlike finding no devcontainer config. A fixture tree with no compose fixture is legitimate; a tree with no devcontainer config means discovery is broken.
- **All services' images are read, not the first.** A compose project legitimately has several (`fx-tier1-compose-postgres` has an app and a database), and warming one leaves the same cold-cache stall on the other.
- **`${VAR}` interpolation is skipped.** It is not a resolvable reference here, and a fixture that needed one would be unpinned (V18).

## Verification

`bash -n` clean. Discovery now resolves 18 images (16 from configs, `+ postgres:16-bookworm` newly, `+ base:bookworm` now from both sources), with `:local` tags still excluded so the build loop above keeps owning them:

```
compose  alpine:3.19
compose  mcr.microsoft.com/devcontainers/base:bookworm
compose  postgres:16-bookworm        <-- previously warmed by nothing
json     ... (unchanged)
```

Behavior is otherwise unchanged: the fatal-on-no-configs check, the `:local` build loop, and the non-fatal per-image pull warnings all stay as they were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)