### PR TITLE
fix(read-configuration): emit configFilePath as the reference URI object

### DIFF
--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -207,6 +207,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-83f69534",
+      "kind": "behavior",
+      "behavior": "bhv-readconfig-config-file-path",
+      "context": []
+    },
+    {
       "id": "obl-bhv-9077557c",
       "kind": "behavior",
       "behavior": "bhv-readconfig-feature-resolution-order",

--- a/conformance/registry/behaviors/read-configuration.json
+++ b/conformance/registry/behaviors/read-configuration.json
@@ -31,6 +31,16 @@
       "decision": "follow-spec"
     },
     {
+      "id": "bhv-readconfig-config-file-path",
+      "area": "read-configuration",
+      "statement": "Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`, an absolute VS Code URI object (`$mid`, `fsPath`, `path`, `scheme: vscode-fileHost`) naming the resolved config file; container-only mode, which resolves no file, carries none.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "aligned",
+      "decision": "align-with-reference",
+      "notes": "The field is a consumer-facing contract, not spec prose: a tool reading `read-configuration` output already knows how to unmarshal a VS Code URI and knows nothing about a deacon-specific alternative, so the shape is reproduced rather than reinvented. deacon emitted nothing at all, leaving every structured-output comparison reference-only on this path (75 occurrences, #376). The `fsPath`/`path` split VS Code makes on Windows is deliberately NOT reproduced: it has not been observed against the pinned reference, and a guess would be a silent untested divergence rather than a visible omission. Recorded by src-obs-config-file-path."
+    },
+    {
       "id": "bhv-readconfig-discovery-locations",
       "area": "read-configuration",
       "statement": "Configuration discovery searches exactly the three locations the spec names \u2014 `.devcontainer/devcontainer.json`, `.devcontainer.json`, and `.devcontainer/<folder>/devcontainer.json` one level deep \u2014 and a plain `devcontainer.json` at the workspace root is not one of them.",

--- a/conformance/registry/behaviors/read-configuration.json
+++ b/conformance/registry/behaviors/read-configuration.json
@@ -33,12 +33,12 @@
     {
       "id": "bhv-readconfig-config-file-path",
       "area": "read-configuration",
-      "statement": "Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`, an absolute VS Code URI object (`$mid`, `fsPath`, `path`, `scheme: vscode-fileHost`) naming the resolved config file; container-only mode, which resolves no file, carries none.",
+      "statement": "Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`, an absolute VS Code URI object (`$mid`, `fsPath`, `path`, `scheme`) naming the resolved config file, whose `scheme` records HOW the file was located \u2014 `vscode-fileHost` when discovered, `file` when named with `--config`; container-only mode, which resolves no file, carries none.",
       "applicability": [],
       "spec": "unspecified",
       "reference": "aligned",
       "decision": "align-with-reference",
-      "notes": "The field is a consumer-facing contract, not spec prose: a tool reading `read-configuration` output already knows how to unmarshal a VS Code URI and knows nothing about a deacon-specific alternative, so the shape is reproduced rather than reinvented. deacon emitted nothing at all, leaving every structured-output comparison reference-only on this path (75 occurrences, #376). The `fsPath`/`path` split VS Code makes on Windows is deliberately NOT reproduced: it has not been observed against the pinned reference, and a guess would be a silent untested divergence rather than a visible omission. Recorded by src-obs-config-file-path."
+      "notes": "The field is a consumer-facing contract, not spec prose: a tool reading `read-configuration` output already knows how to unmarshal a VS Code URI and knows nothing about a deacon-specific alternative, so the shape is reproduced rather than reinvented. deacon emitted nothing at all, leaving every structured-output comparison reference-only on this path (75 occurrences, #376). The `scheme` is not a constant: the same path comes back as `vscode-fileHost` when the config was discovered and as `file` when it was named with `--config`. Hard-coding one of them looked right against every fixture that omits `--config` and was wrong for the two that pass it, which the live lane reported as a residual `configFilePath.scheme` divergence after the field itself was fixed. The `fsPath`/`path` split VS Code makes on Windows is deliberately NOT reproduced: it has not been observed against the pinned reference, and a guess would be a silent untested divergence rather than a visible omission. Recorded by src-obs-config-file-path."
     },
     {
       "id": "bhv-readconfig-discovery-locations",

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -1602,7 +1602,8 @@
     {
       "id": "case-readconfig-decl-basic",
       "behaviors": [
-        "bhv-readconfig-basic-parse"
+        "bhv-readconfig-basic-parse",
+        "bhv-readconfig-config-file-path"
       ],
       "context": [],
       "scenarioContext": {
@@ -1647,7 +1648,8 @@
     {
       "id": "case-readconfig-decl-with-variables",
       "behaviors": [
-        "bhv-readconfig-basic-parse"
+        "bhv-readconfig-basic-parse",
+        "bhv-readconfig-config-file-path"
       ],
       "context": [],
       "scenarioContext": {

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -943,6 +943,7 @@
     {
       "id": "case-merged-decl-go-minimal",
       "behaviors": [
+        "bhv-readconfig-config-file-path",
         "bhv-readconfig-merged-configuration",
         "bhv-readconfig-workspace-folder-subpath",
         "bhv-readconfig-workspace-section-shape"
@@ -3216,6 +3217,7 @@
     {
       "id": "case-tier1-decl-go-minimal",
       "behaviors": [
+        "bhv-readconfig-config-file-path",
         "bhv-readconfig-tier1-corpus",
         "bhv-readconfig-workspace-folder-subpath",
         "bhv-readconfig-workspace-section-shape"

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -135,6 +135,15 @@
       ]
     },
     {
+      "id": "odp-bhv-83f69534",
+      "obligation": "obl-bhv-83f69534",
+      "disposition": "case",
+      "cases": [
+        "case-merged-decl-go-minimal",
+        "case-tier1-decl-go-minimal"
+      ]
+    },
+    {
       "id": "odp-bhv-9077557c",
       "obligation": "obl-bhv-9077557c",
       "disposition": "case",

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -140,6 +140,8 @@
       "disposition": "case",
       "cases": [
         "case-merged-decl-go-minimal",
+        "case-readconfig-decl-basic",
+        "case-readconfig-decl-with-variables",
         "case-tier1-decl-go-minimal"
       ]
     },

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -42,6 +42,16 @@
       ]
     },
     {
+      "id": "src-obs-config-file-path",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "read-configuration `configuration.configFilePath` / `mergedConfiguration.configFilePath`",
+      "summary": "The reference emits `{\"$mid\": 1, \"fsPath\": <abs>, \"path\": <abs>, \"scheme\": \"vscode-fileHost\"}` on both documents, with `fsPath` and `path` identical and always absolute regardless of how the workspace folder was named on the command line. Observed 2026-07-28 over all 80 comparable conformance fixtures.",
+      "behaviors": [
+        "bhv-readconfig-config-file-path"
+      ]
+    },
+    {
       "id": "src-obs-container-identity-labels",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -46,7 +46,7 @@
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",
       "locator": "read-configuration `configuration.configFilePath` / `mergedConfiguration.configFilePath`",
-      "summary": "The reference emits `{\"$mid\": 1, \"fsPath\": <abs>, \"path\": <abs>, \"scheme\": \"vscode-fileHost\"}` on both documents, with `fsPath` and `path` identical and always absolute regardless of how the workspace folder was named on the command line. Observed 2026-07-28 over all 80 comparable conformance fixtures.",
+      "summary": "The reference emits `{\"$mid\": 1, \"fsPath\": <abs>, \"path\": <abs>, \"scheme\": <scheme>}` on both documents, with `fsPath` and `path` identical and always absolute regardless of how the workspace folder was named on the command line. `scheme` is `vscode-fileHost` for a discovered config and `file` for one named with `--config` \u2014 verified on the SAME path both ways, so the distinction is the lookup mode and nothing else. Observed 2026-07-28 over all 80 comparable conformance fixtures plus the two `--config` cases.",
       "behaviors": [
         "bhv-readconfig-config-file-path"
       ]

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -110,6 +110,16 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      than a variant of the scalar one.",
     ),
     (
+        "bhv-readconfig-config-file-path",
+        "WHICH configuration file the resolution actually used, reported as a path rather \
+     than inferred from the values. Separately falsifiable from every content behavior: an \
+     implementation can resolve the right file and name the wrong one, or name the right \
+     one having merged the wrong chain, and no behavior about the configuration's CONTENT \
+     distinguishes those. Newly recordable because the retired `prune` normalization \
+     dropped this key outright before comparison, which is why nothing pre-migration \
+     described it.",
+    ),
+    (
         "bhv-readconfig-workspace-folder-subpath",
         "Where the workspace lands INSIDE the container when the workspace folder is nested \
      under the mounted root, and what the default mount target is independently of \

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -201,6 +201,59 @@ pub struct ReadConfigurationOutput {
     pub merged_configuration: Option<serde_json::Value>,
 }
 
+/// Build the reference CLI's `configFilePath` value for a resolved config file.
+///
+/// The reference emits a VS Code URI object rather than a bare string:
+///
+/// ```json
+/// { "$mid": 1, "fsPath": "/ws/.devcontainer/devcontainer.json",
+///   "path": "/ws/.devcontainer/devcontainer.json", "scheme": "vscode-fileHost" }
+/// ```
+///
+/// `$mid: 1` is VS Code's marshalling marker for a URI. deacon reproduces the shape rather
+/// than inventing its own because the field is a consumer-facing contract: a tool reading
+/// `read-configuration` output already knows how to unmarshal this and knows nothing about
+/// a deacon-specific alternative. Emitting nothing — which deacon did — left every
+/// comparison reference-only on this path (75 occurrences, #376).
+///
+/// `fsPath` and `path` are emitted identically, which is what the reference produces on
+/// every POSIX observation. VS Code's URI type distinguishes them on Windows (`fsPath`
+/// keeps `\`, `path` uses `/` with a leading slash before the drive letter); that case is
+/// NOT reproduced here because it has not been observed against the pinned reference, and
+/// a guess would be a silent, untested divergence rather than an omission.
+fn config_file_path_value(config_path: &Path) -> serde_json::Value {
+    // Always absolute. The reference reports the real location of the file regardless of
+    // how the workspace was named on the command line, so a relative `--workspace-folder`
+    // must not leak a relative path into the output. Canonicalization is best-effort:
+    // if the file cannot be resolved the un-absolutized path is still better than nothing,
+    // and the caller only reaches here with a path a load already succeeded from.
+    let rendered = config_path
+        .canonicalize()
+        .or_else(|_| std::path::absolute(config_path))
+        .unwrap_or_else(|_| config_path.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    serde_json::json!({
+        "$mid": 1,
+        "fsPath": rendered,
+        "path": rendered,
+        "scheme": "vscode-fileHost",
+    })
+}
+
+/// Insert `configFilePath` into a configuration document, if it is an object.
+///
+/// A non-object document is left alone rather than coerced: the only way it is not an
+/// object is a bug elsewhere, and quietly wrapping it would hide that.
+fn insert_config_file_path(document: &mut serde_json::Value, config_path: &Path) {
+    if let Some(obj) = document.as_object_mut() {
+        obj.insert(
+            "configFilePath".to_string(),
+            config_file_path_value(config_path),
+        );
+    }
+}
+
 /// Resolve workspace configuration
 ///
 /// Computes the workspace configuration reported by `read-configuration`. Both values are
@@ -1801,17 +1854,30 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
     };
 
     // Build output payload
+    let mut configuration_document = if container_only_mode {
+        // Per spec line 310: "Only container flags provided (no config/workspace): returns { configuration: {}, ... }"
+        serde_json::Value::Object(serde_json::Map::new())
+    } else if let Some(raw) = &raw_config_for_output {
+        // Divergence B: emit the raw (un-merged) entry config with `extends`
+        // preserved, matching the reference CLI.
+        serde_json::to_value(raw)?
+    } else {
+        serde_json::to_value(&config)?
+    };
+
+    // `configFilePath` rides on both documents, exactly where the reference puts it. It is
+    // keyed off a RESOLVED path, so container-only mode — which has no config file — emits
+    // no such field, and neither does the reference.
+    let mut merged_configuration = merged_configuration;
+    if let Some(cfg_path) = resolved_config_path.as_deref() {
+        insert_config_file_path(&mut configuration_document, cfg_path);
+        if let Some(merged) = merged_configuration.as_mut() {
+            insert_config_file_path(merged, cfg_path);
+        }
+    }
+
     let output_payload = ReadConfigurationOutput {
-        configuration: if container_only_mode {
-            // Per spec line 310: "Only container flags provided (no config/workspace): returns { configuration: {}, ... }"
-            serde_json::Value::Object(serde_json::Map::new())
-        } else if let Some(raw) = &raw_config_for_output {
-            // Divergence B: emit the raw (un-merged) entry config with `extends`
-            // preserved, matching the reference CLI.
-            serde_json::to_value(raw)?
-        } else {
-            serde_json::to_value(&config)?
-        },
+        configuration: configuration_document,
         workspace: workspace_config,
         features_configuration: features_configuration_for_output,
         merged_configuration,

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -221,7 +221,12 @@ pub struct ReadConfigurationOutput {
 /// keeps `\`, `path` uses `/` with a leading slash before the drive letter); that case is
 /// NOT reproduced here because it has not been observed against the pinned reference, and
 /// a guess would be a silent, untested divergence rather than an omission.
-fn config_file_path_value(config_path: &Path) -> serde_json::Value {
+///
+/// `scheme` records HOW the file was located, not where it is. The reference emits
+/// `vscode-fileHost` for a config it discovered and plain `file` for one the caller named
+/// with `--config` — the same path yields different schemes depending only on that, which
+/// is why `explicitly_named` is a parameter rather than something derivable from the path.
+fn config_file_path_value(config_path: &Path, explicitly_named: bool) -> serde_json::Value {
     // Always absolute. The reference reports the real location of the file regardless of
     // how the workspace was named on the command line, so a relative `--workspace-folder`
     // must not leak a relative path into the output. Canonicalization is best-effort:
@@ -237,7 +242,7 @@ fn config_file_path_value(config_path: &Path) -> serde_json::Value {
         "$mid": 1,
         "fsPath": rendered,
         "path": rendered,
-        "scheme": "vscode-fileHost",
+        "scheme": if explicitly_named { "file" } else { "vscode-fileHost" },
     })
 }
 
@@ -245,11 +250,15 @@ fn config_file_path_value(config_path: &Path) -> serde_json::Value {
 ///
 /// A non-object document is left alone rather than coerced: the only way it is not an
 /// object is a bug elsewhere, and quietly wrapping it would hide that.
-fn insert_config_file_path(document: &mut serde_json::Value, config_path: &Path) {
+fn insert_config_file_path(
+    document: &mut serde_json::Value,
+    config_path: &Path,
+    explicitly_named: bool,
+) {
     if let Some(obj) = document.as_object_mut() {
         obj.insert(
             "configFilePath".to_string(),
-            config_file_path_value(config_path),
+            config_file_path_value(config_path, explicitly_named),
         );
     }
 }
@@ -1870,9 +1879,10 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
     // no such field, and neither does the reference.
     let mut merged_configuration = merged_configuration;
     if let Some(cfg_path) = resolved_config_path.as_deref() {
-        insert_config_file_path(&mut configuration_document, cfg_path);
+        let explicitly_named = args.config_path.is_some();
+        insert_config_file_path(&mut configuration_document, cfg_path, explicitly_named);
         if let Some(merged) = merged_configuration.as_mut() {
-            insert_config_file_path(merged, cfg_path);
+            insert_config_file_path(merged, cfg_path, explicitly_named);
         }
     }
 

--- a/crates/deacon/tests/integration_read_configuration_output.rs
+++ b/crates/deacon/tests/integration_read_configuration_output.rs
@@ -434,3 +434,63 @@ fn test_workspace_field_structure() -> Result<()> {
 
     Ok(())
 }
+
+/// `configFilePath` is emitted on both documents as the reference's VS Code URI object.
+///
+/// Shape and absoluteness are both asserted. The absolute check is the one that would have
+/// caught the original slip: the field was first emitted verbatim from the resolved path,
+/// so a relative `--workspace-folder` produced a relative `fsPath` while the reference
+/// always reports the real location. The parity harness always passes absolute paths, so
+/// no live comparison would have surfaced it.
+#[test]
+fn test_config_file_path_is_the_reference_uri_object() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let devcontainer_dir = temp_dir.path().join(".devcontainer");
+    fs::create_dir_all(&devcontainer_dir)?;
+    fs::write(
+        devcontainer_dir.join("devcontainer.json"),
+        r#"{ "name": "test-container", "image": "ubuntu:22.04" }"#,
+    )?;
+
+    // Deliberately relative: `current_dir` is the workspace, so "." names it.
+    let output = Command::cargo_bin("deacon")?
+        .current_dir(&temp_dir)
+        .arg("read-configuration")
+        .arg("--workspace-folder")
+        .arg(".")
+        .arg("--include-merged-configuration")
+        .output()?;
+    assert!(
+        output.status.success(),
+        "Command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())?;
+
+    for document in ["configuration", "mergedConfiguration"] {
+        let value = &parsed[document]["configFilePath"];
+        assert_eq!(value["$mid"], 1, "{document}: $mid marks a VS Code URI");
+        assert_eq!(
+            value["scheme"], "vscode-fileHost",
+            "{document}: scheme must match the reference"
+        );
+
+        let fs_path = value["fsPath"].as_str().expect("fsPath is a string");
+        let path = value["path"].as_str().expect("path is a string");
+        assert_eq!(
+            fs_path, path,
+            "{document}: the two renderings agree on POSIX"
+        );
+        assert!(
+            std::path::Path::new(fs_path).is_absolute(),
+            "{document}: configFilePath must be absolute even when --workspace-folder is \
+             relative, got {fs_path:?}"
+        );
+        assert!(
+            fs_path.ends_with("devcontainer.json"),
+            "{document}: must name the config file, got {fs_path:?}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/deacon/tests/integration_read_configuration_output.rs
+++ b/crates/deacon/tests/integration_read_configuration_output.rs
@@ -472,7 +472,7 @@ fn test_config_file_path_is_the_reference_uri_object() -> Result<()> {
         assert_eq!(value["$mid"], 1, "{document}: $mid marks a VS Code URI");
         assert_eq!(
             value["scheme"], "vscode-fileHost",
-            "{document}: scheme must match the reference"
+            "{document}: a DISCOVERED config carries the vscode-fileHost scheme"
         );
 
         let fs_path = value["fsPath"].as_str().expect("fsPath is a string");
@@ -491,6 +491,45 @@ fn test_config_file_path_is_the_reference_uri_object() -> Result<()> {
             "{document}: must name the config file, got {fs_path:?}"
         );
     }
+
+    Ok(())
+}
+
+/// The `scheme` records HOW the config was located, not where it is.
+///
+/// The reference emits `vscode-fileHost` for a config it discovered and plain `file` for
+/// one the caller named with `--config` — the SAME path yields different schemes depending
+/// only on that. Hard-coding one of them looked right against every fixture that omits
+/// `--config` and was wrong for the two that pass it.
+#[test]
+fn test_config_file_path_scheme_marks_an_explicitly_named_config() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let nested = temp_dir.path().join("nested");
+    fs::create_dir_all(&nested)?;
+    let config_path = nested.join("devcontainer.json");
+    fs::write(
+        &config_path,
+        r#"{ "name": "explicit", "image": "ubuntu:22.04" }"#,
+    )?;
+
+    let output = Command::cargo_bin("deacon")?
+        .arg("read-configuration")
+        .arg("--workspace-folder")
+        .arg(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .output()?;
+    assert!(
+        output.status.success(),
+        "Command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: Value = serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())?;
+
+    assert_eq!(
+        parsed["configuration"]["configFilePath"]["scheme"], "file",
+        "a config named with --config carries the file scheme"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
> **Stacked on #384.** Base is `fix/readconfig-workspace-section-parity`; both touch the same output-building code. Retarget this to `main` before merging #384, or merging #384 with `--delete-branch` will close this one (the gotcha recorded in CLAUDE.md).

Clears the largest remaining cluster in #376 (~75 diverging occurrences).

## Why

deacon emitted **no** `configFilePath` at all. The reference emits one on both documents:

```json
{ "$mid": 1,
  "fsPath": "/ws/.devcontainer/devcontainer.json",
  "path":   "/ws/.devcontainer/devcontainer.json",
  "scheme": "vscode-fileHost" }
```

Absent-versus-present, so no normalization rule can reconcile it. It is also the only field in the output that says **which file** the reported configuration came from.

## What

The shape is reproduced rather than reinvented. `$mid: 1` is VS Code's marshalling marker for a URI; a tool reading `read-configuration` output already knows how to unmarshal that and knows nothing about a deacon-specific alternative, so inventing a bare-string field would trade one divergence for another.

**The path is absolutized.** The first cut emitted the resolved path verbatim, so a relative `--workspace-folder` produced a relative `fsPath` where the reference always reports the real location. The parity harness only ever passes absolute paths, so no live comparison would have caught it — the added integration test passes `.` deliberately.

Two things deliberately **not** guessed:

- **Windows.** VS Code's URI type distinguishes `fsPath` (backslashes) from `path` (forward slashes, leading slash before the drive letter). That split has not been observed against the pinned reference, so it is not reproduced. A guess would be a silent untested divergence rather than a visible omission.
- **Container-only mode.** It resolves no config file, so it emits no field — which is what the reference does.

## Verification

Ran deacon and the pinned oracle 0.87.0 over all 93 conformance fixtures:

| | before | after |
|---|---:|---:|
| fixtures where `configuration.configFilePath` is byte-identical | 0 / 80 | **80 / 80** |

Gates: `validate` ok · `coverage check` ok (794 obligations, 0 undispositioned) · `dev-fast` 4152 passed · `clippy --all-targets --all-features -D warnings` clean · `fmt --check` clean.

## Registry

`bhv-readconfig-config-file-path` — `spec: unspecified` / `reference: aligned` / `align-with-reference`, with its source unit, covered by the tier-1 and merged-mode `go-minimal` cases, `odp-bhv-*` disposition added in the same commit.

Entered in `POST_BRANCH_BEHAVIORS` with a reason: it records *which file* resolution used, which no behavior about configuration **content** can falsify — an implementation can resolve the right file and name the wrong one, or name the right one having merged the wrong chain. Nothing pre-migration described it because the retired `prune` normalization dropped the key outright before comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)