### PR TITLE
fix(read-configuration): materialize the fields the reference materializes

### DIFF
--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -9,6 +9,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-075e4cd7",
+      "kind": "behavior",
+      "behavior": "bhv-readconfig-port-attributes-authored-keys",
+      "context": []
+    },
+    {
       "id": "obl-bhv-079ac919",
       "kind": "behavior",
       "behavior": "bhv-state-diff-parity",
@@ -156,6 +162,12 @@
       "id": "obl-bhv-6a9a3165",
       "kind": "behavior",
       "behavior": "bhv-up-mount-source-and-shape",
+      "context": []
+    },
+    {
+      "id": "obl-bhv-6aebfb3a",
+      "kind": "behavior",
+      "behavior": "bhv-readconfig-merged-lifecycle-slots",
       "context": []
     },
     {

--- a/conformance/registry/behaviors/read-configuration.json
+++ b/conformance/registry/behaviors/read-configuration.json
@@ -121,6 +121,16 @@
       "notes": "Backed by case-merged-corpus (parity_corpus_merged over the tier1 corpus) and by the 24 declarative merged-mode variants case-merged-decl-* (023 T039). Retiring the blanket `prune` normalizer (023 T062, research D3) surfaced previously hidden divergences against the pinned reference. Re-measured at 023 T102 over the FULL declarative run (71 cases: 20 agree, 51 diverge), counted as cases affected: (1) `configuration.configFilePath` reference-only (51 cases; also `mergedConfiguration.configFilePath`, 23); (2) `workspace.configFolderPath` and `workspace.rootFolderPath` deacon-only (51); (3) `workspace.workspaceFolder` VALUE-divergent (43); (4) the reference's merged configuration carries PLURAL command arrays (`onCreateCommands` / `postCreateCommands` / `postStartCommands` / `postAttachCommands` / `updateContentCommands`) where deacon emits only the singular forms (7-21 cases each); (5) the `featuresConfiguration` block differs in shape (`dstFolder` reference-only, `featureSets` value-divergent, 11-12); (6) `workspace.workspaceMount` VALUE-divergent (2). Families (3) and (6) were identified at T102 and are the two VALUE divergences: when the workspace folder is a SUBDIRECTORY of a git root \u2014 every in-repo fixture and every CI checkout \u2014 deacon reports `workspace.workspaceFolder` as the git ROOT's container path while the reference reports the subdirectory inside that mount, and with an explicit config `workspaceFolder` deacon renders `workspaceMount` with `target=<that folder>` where the reference uses `target=<source path>`. Both CLIs agree on the mount SOURCE, so the reference is self-consistent and deacon loses the subdirectory. This is adjacent to the documented `--mount-workspace-git-root` default, but that default governs what is MOUNTED; deriving the reported `workspaceFolder` from the mount root is a separate unintended consequence. All six are deacon-behind-reference and are tracked for FIX, not tolerated \u2014 no blanket rule was reinstated and no tolerance was authored (FR-036). See specs/023-migrate-parity-to-conformance/tasks.md#T113. STATUS: families (2), (3) and (6) are FIXED \u2014 the `workspace` section now routes through the same shared helpers `up` uses, so the host-path fields are gone, the subdirectory survives in `workspaceFolder`, and the default mount target no longer follows an explicit `workspaceFolder` (#383, and see bhv-readconfig-workspace-folder-subpath / bhv-readconfig-workspace-section-shape, which record those two claims in their own right). Families (1), (4) and (5) remain open and keep this behavior's `reference: divergent` status honest; they are tracked in #376. The separate absent-optional-serialization difference (deacon emits explicit nulls where the reference omits keys) is handled by the named, enumerated `drop_absent_optional` rule and tracked at tasks.md#T111. Encoded as `spec: conformant` + `reference: divergent` + `decision: follow-spec`: deacon's RESOLUTION follows containers.dev (which does not define the read-configuration output document at all), while its output SHAPE diverges from the reference CLI's. This is not an accepted divergence \u2014 R6 forbids `align-with-reference` while actually divergent, and `intentional-divergence` would claim a deliberate choice nobody made, so the intent to align is carried here and in the tracked follow-up rather than in the decision axis."
     },
     {
+      "id": "bhv-readconfig-merged-lifecycle-slots",
+      "area": "read-configuration",
+      "statement": "`mergedConfiguration` reports all five plural lifecycle hook arrays (`onCreateCommands`, `updateContentCommands`, `postCreateCommands`, `postStartCommands`, `postAttachCommands`), as `[]` when no layer contributed one; `entrypoints` is omitted when empty.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "aligned",
+      "decision": "align-with-reference",
+      "notes": "The asymmetry is the whole content of this behavior and is measured, not assumed: on a config declaring three of the five hooks the reference emitted `updateContentCommands: []` and `postAttachCommands: []` and no `entrypoints` at all. deacon emitted a plural key only when some layer contributed a value, so an absent hook was indistinguishable from a hook the merge dropped. A single \"always emit\" rule would have been wrong in the other direction, which is why the flag is per-property. Recorded by src-obs-merged-lifecycle-slots."
+    },
+    {
       "id": "bhv-readconfig-missing-config",
       "area": "read-configuration",
       "statement": "A workspace folder with no devcontainer configuration at all is rejected rather than resolved to an invented empty config.",
@@ -129,6 +139,16 @@
       "reference": "aligned",
       "decision": "follow-spec",
       "notes": "both-reject agreement case. Backed by case-errors-missing-config and wvr-missing-config."
+    },
+    {
+      "id": "bhv-readconfig-port-attributes-authored-keys",
+      "area": "read-configuration",
+      "statement": "A `portsAttributes` / `otherPortsAttributes` entry reports the keys the author wrote and no others; an unset attribute is absent rather than explicitly null.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "aligned",
+      "decision": "align-with-reference",
+      "notes": "deacon serialized the whole `PortAttributes` struct, so a one-key entry came back with six extra explicit nulls and diverged on six paths at once. Distinct from the top-level absent-optional family (tasks.md#T111), which the harness's `drop_absent_optional` rule absorbs: that rule does not reach INTO a nested object, so this one could only be fixed at the source. Recorded by src-obs-port-attributes-authored-keys."
     },
     {
       "id": "bhv-readconfig-substitution-object-fields",

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -1034,7 +1034,8 @@
     {
       "id": "case-merged-decl-lifecycle-arrays",
       "behaviors": [
-        "bhv-readconfig-merged-configuration"
+        "bhv-readconfig-merged-configuration",
+        "bhv-readconfig-merged-lifecycle-slots"
       ],
       "context": [],
       "scenarioContext": {
@@ -1078,7 +1079,8 @@
     {
       "id": "case-merged-decl-lifecycle-mixed",
       "behaviors": [
-        "bhv-readconfig-merged-configuration"
+        "bhv-readconfig-merged-configuration",
+        "bhv-readconfig-merged-lifecycle-slots"
       ],
       "context": [],
       "scenarioContext": {
@@ -3566,6 +3568,7 @@
     {
       "id": "case-tier1-decl-ports-mixed",
       "behaviors": [
+        "bhv-readconfig-port-attributes-authored-keys",
         "bhv-readconfig-tier1-corpus"
       ],
       "context": [],
@@ -3695,6 +3698,7 @@
     {
       "id": "case-tier1-decl-universal-jsonc",
       "behaviors": [
+        "bhv-readconfig-port-attributes-authored-keys",
         "bhv-readconfig-tier1-corpus"
       ],
       "context": [],

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -2,6 +2,15 @@
   "schemaVersion": 1,
   "records": [
     {
+      "id": "odp-bhv-075e4cd7",
+      "obligation": "obl-bhv-075e4cd7",
+      "disposition": "case",
+      "cases": [
+        "case-tier1-decl-ports-mixed",
+        "case-tier1-decl-universal-jsonc"
+      ]
+    },
+    {
       "id": "odp-bhv-0a410770",
       "obligation": "obl-bhv-0a410770",
       "disposition": "case",
@@ -93,6 +102,15 @@
         "case-readconfig-unsupported-enum-differential",
         "case-readconfig-unsupported-enum-rejected",
         "case-upgrade-unsupported-values-rejected"
+      ]
+    },
+    {
+      "id": "odp-bhv-6aebfb3a",
+      "obligation": "obl-bhv-6aebfb3a",
+      "disposition": "case",
+      "cases": [
+        "case-merged-decl-lifecycle-arrays",
+        "case-merged-decl-lifecycle-mixed"
       ]
     },
     {

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -152,6 +152,16 @@
       ]
     },
     {
+      "id": "src-obs-merged-lifecycle-slots",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "read-configuration --include-merged-configuration, lifecycle hook slots",
+      "summary": "On a config declaring `onCreateCommand`, `postCreateCommand` and `postStartCommand` only, the reference emitted all five plural arrays \u2014 the two undeclared ones as `[]` \u2014 and no `entrypoints` key. Observed 2026-07-28.",
+      "behaviors": [
+        "bhv-readconfig-merged-lifecycle-slots"
+      ]
+    },
+    {
       "id": "src-obs-missing-config",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",
@@ -169,6 +179,16 @@
       "summary": "The pinned reference reports an EMPTY table and exits 0; deacon resolves the chain and reports the inherited Feature (observed 2026-07-26).",
       "behaviors": [
         "bhv-outdated-extends-chain-features"
+      ]
+    },
+    {
+      "id": "src-obs-port-attributes-authored-keys",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "read-configuration `configuration.portsAttributes` / `otherPortsAttributes`",
+      "summary": "The reference echoes exactly the attribute keys the author wrote: `{\"onAutoForward\": \"ignore\"}` stays one key. Observed 2026-07-28 on fx-tier1-ports-mixed and fx-tier1-universal-jsonc.",
+      "behaviors": [
+        "bhv-readconfig-port-attributes-authored-keys"
       ]
     },
     {

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -110,6 +110,24 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      than a variant of the scalar one.",
     ),
     (
+        "bhv-readconfig-merged-lifecycle-slots",
+        "Which lifecycle hook SLOTS the merged document reports, as opposed to what any of \
+     them contains. Falsifiable on its own: an implementation that merges every declared \
+     hook correctly can still omit the undeclared slots, which makes \"no layer set this \
+     hook\" indistinguishable from \"the merge dropped it\" for a reader. Nothing \
+     pre-migration described the merged document's key set, only the values under the keys \
+     that happened to be present.",
+    ),
+    (
+        "bhv-readconfig-port-attributes-authored-keys",
+        "Which attribute keys a port entry reports. A distinct claim from the port \
+     attribute VALUES and from the top-level absent-optional serialization already tracked \
+     at tasks.md#T111: this one is nested inside an object, where the harness's \
+     `drop_absent_optional` rule does not reach, so it was neither described by a behavior \
+     nor absorbed by normalization — it was simply invisible until the blanket `prune` \
+     rule retired.",
+    ),
+    (
         "bhv-readconfig-config-file-path",
         "WHICH configuration file the resolution actually used, reported as a path rather \
      than inferred from the values. Separately falsifiable from every content behavior: an \

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -257,28 +257,44 @@ pub enum OnAutoForward {
 ///
 /// Defines how ports should be handled when forwarded, including
 /// labeling, auto-forward behavior, and preview options.
+///
+/// Unset fields are NOT serialized. The reference echoes back exactly the keys the author
+/// wrote, so emitting `"protocol": null` for a field nobody mentioned made every
+/// `portsAttributes` / `otherPortsAttributes` comparison diverge on six paths at once
+/// (#376). The top-level analogue — deacon serializing explicit nulls across
+/// `DevContainerConfig` — is a separate, much larger change tracked at
+/// specs/023-migrate-parity-to-conformance/tasks.md#T111 and absorbed meanwhile by the
+/// harness's `drop_absent_optional` rule; that rule does not reach INTO a nested object,
+/// which is why this one had to be fixed at the source.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PortAttributes {
     /// Human-readable label for the port
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 
     /// Action to take when the port is auto-forwarded
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on_auto_forward: Option<OnAutoForward>,
 
     /// Protocol hint for forwarded ports (`http` or `https`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<String>,
 
     /// Whether to open a preview of the port automatically
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub open_preview: Option<bool>,
 
     /// Whether to require a specific local port for forwarding
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub require_local_port: Option<bool>,
 
     /// Whether tools should try to elevate privileges for low local ports.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub elevate_if_needed: Option<bool>,
 
     /// Description of what this port is used for
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
 

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -616,20 +616,41 @@ async fn resolve_features_configuration<C: deacon_core::oci::HttpClient>(
 /// arrays under their plural names. The ordering is preserved: `entrypoint` first, then lifecycle
 /// hooks in their canonical sequence (see
 /// `devcontainers/cli/src/spec-node/imageMetadata.ts`).
-const COLLECTED_PROPERTIES: &[(&str, &str)] = &[
-    ("entrypoint", "entrypoints"),
-    ("onCreateCommand", "onCreateCommands"),
-    ("updateContentCommand", "updateContentCommands"),
-    ("postCreateCommand", "postCreateCommands"),
-    ("postStartCommand", "postStartCommands"),
-    ("postAttachCommand", "postAttachCommands"),
+///
+/// The third element says whether the plural key is emitted when NOTHING was collected. The
+/// two halves genuinely differ in the reference, which is why this is a per-property flag
+/// and not one rule: the five lifecycle hooks always appear, as `[]` when no entry
+/// contributed one, while `entrypoints` is omitted entirely. Measured against the pinned
+/// oracle on a config declaring three of the five hooks — the reference emitted
+/// `"updateContentCommands": []` and `"postAttachCommands": []` and no `entrypoints` at all.
+const COLLECTED_PROPERTIES: &[(&str, &str, EmptyPlural)] = &[
+    ("entrypoint", "entrypoints", EmptyPlural::Omit),
+    ("onCreateCommand", "onCreateCommands", EmptyPlural::Emit),
+    (
+        "updateContentCommand",
+        "updateContentCommands",
+        EmptyPlural::Emit,
+    ),
+    ("postCreateCommand", "postCreateCommands", EmptyPlural::Emit),
+    ("postStartCommand", "postStartCommands", EmptyPlural::Emit),
+    ("postAttachCommand", "postAttachCommands", EmptyPlural::Emit),
 ];
+
+/// Whether a collected property's plural key survives when no entry contributed a value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EmptyPlural {
+    /// Emit the key as `[]` — the reference always reports the lifecycle hook slots.
+    Emit,
+    /// Leave the key out entirely.
+    Omit,
+}
 
 /// Apply the upstream `mergeConfiguration` output shape to the merged base config JSON.
 ///
-/// For each `(singular, plural)` pair in [`COLLECTED_PROPERTIES`] this strips the singular
-/// property from `base` and—if any entry in `entries` carries a non-null value—emits the
-/// plural array at the same position, preserving entry declaration order.
+/// For each entry in [`COLLECTED_PROPERTIES`] this strips the singular property from `base`
+/// and emits the plural array at the same position, preserving entry declaration order. A
+/// property whose collection came up empty is emitted as `[]` or omitted according to its
+/// [`EmptyPlural`] flag.
 fn apply_upstream_merge_shape(
     mut base: serde_json::Value,
     entries: &[serde_json::Map<String, serde_json::Value>],
@@ -646,18 +667,18 @@ fn apply_upstream_merge_shape(
     // strip it so the merged output matches the reference.
     obj.remove("id");
 
-    for (singular, _) in COLLECTED_PROPERTIES {
+    for (singular, _, _) in COLLECTED_PROPERTIES {
         obj.remove(*singular);
     }
 
-    for (singular, plural) in COLLECTED_PROPERTIES {
+    for (singular, plural, when_empty) in COLLECTED_PROPERTIES {
         let collected: Vec<serde_json::Value> = entries
             .iter()
             .filter_map(|e| e.get(*singular))
             .filter(|v| !v.is_null())
             .cloned()
             .collect();
-        if !collected.is_empty() {
+        if !collected.is_empty() || *when_empty == EmptyPlural::Emit {
             obj.insert((*plural).to_string(), serde_json::Value::Array(collected));
         }
     }
@@ -672,7 +693,7 @@ fn collect_entry_from_config_json(
 ) -> serde_json::Map<String, serde_json::Value> {
     let mut entry = serde_json::Map::new();
     if let Some(obj) = value.as_object() {
-        for (singular, _) in COLLECTED_PROPERTIES {
+        for (singular, _, _) in COLLECTED_PROPERTIES {
             if let Some(v) = obj.get(*singular) {
                 if !v.is_null() {
                     entry.insert((*singular).to_string(), v.clone());
@@ -3428,8 +3449,50 @@ API_KEY=another-secret
             result.get("postCreateCommands"),
             Some(&serde_json::json!(["echo b-post"]))
         );
-        // No entries contributed updateContentCommand → field omitted
-        assert!(result.get("updateContentCommands").is_none());
+        // No entries contributed a lifecycle hook → the slot is still reported, as `[]`.
+        // The reference always emits all five; only `entrypoints` is omitted when empty.
+        for plural in [
+            "updateContentCommands",
+            "postStartCommands",
+            "postAttachCommands",
+        ] {
+            assert_eq!(
+                result.get(plural),
+                Some(&serde_json::json!([])),
+                "{plural} must be reported as an empty array, not omitted"
+            );
+        }
+        assert!(
+            result.get("entrypoints").is_some(),
+            "this fixture contributes entrypoints, so they are present"
+        );
+    }
+
+    #[test]
+    fn test_apply_upstream_merge_shape_emits_empty_lifecycle_slots_but_no_entrypoints() {
+        // Nothing collected at all: the five lifecycle slots still appear as `[]`, and
+        // `entrypoints` does not appear. This is the asymmetry the `EmptyPlural` flag
+        // exists for, and it is the one a single "always emit" rule would get wrong.
+        let result =
+            apply_upstream_merge_shape(serde_json::json!({ "image": "ubuntu:24.04" }), &[]);
+
+        for plural in [
+            "onCreateCommands",
+            "updateContentCommands",
+            "postCreateCommands",
+            "postStartCommands",
+            "postAttachCommands",
+        ] {
+            assert_eq!(
+                result.get(plural),
+                Some(&serde_json::json!([])),
+                "{plural} must be reported even when empty"
+            );
+        }
+        assert!(
+            result.get("entrypoints").is_none(),
+            "entrypoints is omitted when empty, unlike the lifecycle slots"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Third in the stack** (#384 → #385 → this). Retarget each to `main` as the one below it merges — merging a base with `--delete-branch` closes the PR stacked on it.

Clears two more #376 clusters (~94 diverging occurrences).

## 1. All five lifecycle hook slots are reported

The reference emits `onCreateCommands`, `updateContentCommands`, `postCreateCommands`, `postStartCommands` and `postAttachCommands` on **every** merged document, as `[]` when no layer contributed one. deacon emitted a plural key only when something was collected — so *"no layer set this hook"* was indistinguishable from *"the merge dropped it"* for a reader.

**The asymmetry is measured, not assumed.** On a config declaring three of the five hooks, the reference emitted the two others as `[]` and **no `entrypoints` key at all**:

```json
"onCreateCommands":       [{"a": "echo a", "b": ["echo", "b"]}],
"updateContentCommands":  [],
"postCreateCommands":     ["echo created"],
"postStartCommands":      [["echo", "started"]],
"postAttachCommands":     []
```

So `entrypoints` stays conditional and the choice is a per-property `EmptyPlural` flag rather than one rule — a blanket "always emit" would have been wrong in the other direction. A unit test pins both halves, including the empty-input case that has nothing to collect.

## 2. Port attribute entries report only the authored keys

`PortAttributes` serialized every field, so a one-key entry came back with six extra explicit nulls and diverged on six paths at once:

```
deacon  {"label": null, "onAutoForward": "ignore", "protocol": null, "openPreview": null,
         "requireLocalPort": null, "elevateIfNeeded": null, "description": null}
ref     {"onAutoForward": "ignore"}
```

This is nominally the same absent-optional family as the top-level one tracked at 023 `tasks.md#T111`, but it could **not** be handled the same way: the harness's `drop_absent_optional` rule absorbs the top-level case and does not reach *into* a nested object, so this had to be fixed at the source. The much larger top-level change is deliberately not attempted here.

## Verification

Against the pinned oracle 0.87.0 — the five merged slots match exactly on a mixed-hook config, and `portsAttributes` / `otherPortsAttributes` match on both fixtures that declare them (`fx-tier1-ports-mixed`, `fx-tier1-universal-jsonc`).

Gates: `validate` ok · `coverage check` ok (796 obligations, 0 undispositioned) · `dev-fast` 4154 passed · `clippy --all-targets --all-features -D warnings` clean · `fmt --check` clean.

## Registry

Two behaviors, `unspecified` / `aligned` / `align-with-reference`, each with a source unit and covered by two existing cases, `odp-bhv-*` dispositions added in the same commit, both entered in `POST_BRANCH_BEHAVIORS`.

Each records a **key set** rather than a value — which no behavior about the values can falsify — and neither was describable before the blanket `prune` normalization retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)