### PR TITLE
fix(up): build the feature layer on a builder that can see the base image

### DIFF
--- a/crates/core/src/dockerfile_generator.rs
+++ b/crates/core/src/dockerfile_generator.rs
@@ -457,6 +457,27 @@ impl DockerfileGenerator {
             "--load".to_string(),
         ];
 
+        // This build's `FROM` names an image that may exist ONLY in the local daemon store —
+        // for the Dockerfile shape it is the `deacon-build:<hash>` tag deacon created moments
+        // ago. A `docker-container` driver builder runs in an isolated BuildKit container
+        // that cannot read that store, so it falls through to the registry and fails with a
+        // bare "pull access denied" naming a repository nobody ever pushed (#391). `--load`
+        // does not help: it governs where the OUTPUT goes, not how INPUTS resolve.
+        //
+        // So pin the invocation to the docker-driver builder, which shares the daemon's
+        // store. That is not a preference being overridden — an isolated builder cannot
+        // execute this build at all. A caller who names a builder explicitly still wins:
+        // `to_docker_args` emits its `--builder` after this one and buildx takes the last
+        // occurrence, so an explicit choice is honored and fails on its own terms.
+        //
+        // Only the ACTIVE builder is implicated, which is why this was invisible locally and
+        // reddened only CI: `docker/setup-buildx-action` creates a container-driver builder
+        // and makes it current, while a stock install leaves the docker driver in place.
+        if build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
+            args.push("--builder".to_string());
+            args.push("default".to_string());
+        }
+
         // Add cache/builder arguments from BuildOptions if provided and not default
         if let Some(opts) = build_options {
             if !opts.is_default() {
@@ -978,6 +999,53 @@ mod tests {
         assert!(!args.contains(&"--cache-from".to_string()));
         assert!(!args.contains(&"--cache-to".to_string()));
         assert!(!args.contains(&"--no-cache".to_string()));
-        assert!(!args.contains(&"--builder".to_string()));
+
+        // `--builder default` IS added, and is not a cache option: the build's `FROM` may
+        // name a daemon-local tag, which only the docker-driver builder can read (#391).
+        assert_eq!(
+            args.windows(2)
+                .find(|w| w[0] == "--builder")
+                .map(|w| w[1].as_str()),
+            Some("default"),
+            "the docker-driver builder must be selected when no builder was requested: {args:?}"
+        );
+    }
+
+    /// An explicitly requested builder wins over the default selection.
+    ///
+    /// buildx takes the LAST `--builder`, and `to_docker_args` emits the caller's after the
+    /// one added above — so a caller who names a builder gets it, and fails on its own terms
+    /// if that builder cannot see the base image.
+    #[test]
+    fn test_generate_build_args_explicit_builder_wins() {
+        let config = DockerfileConfig {
+            base_image: "ubuntu:22.04".to_string(),
+            target_stage: "dev_containers_target_stage".to_string(),
+            features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
+        };
+
+        let build_options = BuildOptions {
+            builder: Some("my-remote-builder".to_string()),
+            ..Default::default()
+        };
+
+        let generator = DockerfileGenerator::new(config);
+        let args = generator.generate_build_args(
+            Path::new("/tmp/Dockerfile.extended"),
+            "test:latest",
+            Some(&build_options),
+        );
+
+        let builders: Vec<&str> = args
+            .windows(2)
+            .filter(|w| w[0] == "--builder")
+            .map(|w| w[1].as_str())
+            .collect();
+        assert_eq!(
+            builders,
+            vec!["my-remote-builder"],
+            "an explicit builder must be the only one requested: {args:?}"
+        );
     }
 }

--- a/crates/core/src/dockerfile_generator.rs
+++ b/crates/core/src/dockerfile_generator.rs
@@ -445,11 +445,18 @@ impl DockerfileGenerator {
     /// - `cache_to`: optional cache destination
     /// - `builder`: optional buildx builder selection
     /// - When `build_options.is_default()` returns true, no extra arguments are added
+    ///
+    /// `select_default_builder` asks for the docker-driver builder to be named explicitly.
+    /// It is a parameter rather than an unconditional flag because only the Docker CLI
+    /// understands `--builder`: Podman drives builds through its own CLI, where the flag is
+    /// not a no-op but an error. The caller knows the runtime; this module deliberately
+    /// does not.
     pub fn generate_build_args(
         &self,
         dockerfile_path: &Path,
         image_tag: &str,
         build_options: Option<&BuildOptions>,
+        select_default_builder: bool,
     ) -> Vec<String> {
         let mut args = vec![
             "buildx".to_string(),
@@ -473,7 +480,7 @@ impl DockerfileGenerator {
         // Only the ACTIVE builder is implicated, which is why this was invisible locally and
         // reddened only CI: `docker/setup-buildx-action` creates a container-driver builder
         // and makes it current, while a stock install leaves the docker driver in place.
-        if build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
+        if select_default_builder && build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
             args.push("--builder".to_string());
             args.push("default".to_string());
         }
@@ -849,7 +856,12 @@ mod tests {
             host_ca_build_context: Some("/tmp/deacon-ca-ctx".to_string()),
             ..Default::default()
         })
-        .generate_build_args(std::path::Path::new("/tmp/Dockerfile"), "img:tag", None);
+        .generate_build_args(
+            std::path::Path::new("/tmp/Dockerfile"),
+            "img:tag",
+            None,
+            true,
+        );
         assert!(
             args.iter()
                 .any(|a| a == "deacon_ca_source=/tmp/deacon-ca-ctx")
@@ -915,6 +927,7 @@ mod tests {
             Path::new("/tmp/Dockerfile.extended"),
             "test:latest",
             None,
+            true,
         );
 
         assert!(args.contains(&"buildx".to_string()));
@@ -954,6 +967,7 @@ mod tests {
             Path::new("/tmp/Dockerfile.extended"),
             "test:latest",
             Some(&build_options),
+            true,
         );
 
         // Standard args still present
@@ -989,6 +1003,7 @@ mod tests {
             Path::new("/tmp/Dockerfile.extended"),
             "test:latest",
             Some(&build_options),
+            true,
         );
 
         // Standard args present
@@ -1008,6 +1023,31 @@ mod tests {
                 .map(|w| w[1].as_str()),
             Some("default"),
             "the docker-driver builder must be selected when no builder was requested: {args:?}"
+        );
+    }
+
+    /// Podman never gets `--builder`: it is a Docker CLI flag, and Podman's build path
+    /// would reject it rather than ignore it. The caller passes `false` there.
+    #[test]
+    fn test_generate_build_args_omits_builder_for_a_runtime_that_lacks_it() {
+        let config = DockerfileConfig {
+            base_image: "ubuntu:22.04".to_string(),
+            target_stage: "dev_containers_target_stage".to_string(),
+            features_source_dir: "/tmp/features".to_string(),
+            ..Default::default()
+        };
+
+        let generator = DockerfileGenerator::new(config);
+        let args = generator.generate_build_args(
+            Path::new("/tmp/Dockerfile.extended"),
+            "test:latest",
+            None,
+            false,
+        );
+
+        assert!(
+            !args.contains(&"--builder".to_string()),
+            "no builder may be named when the runtime does not support the flag: {args:?}"
         );
     }
 
@@ -1035,6 +1075,7 @@ mod tests {
             Path::new("/tmp/Dockerfile.extended"),
             "test:latest",
             Some(&build_options),
+            true,
         );
 
         let builders: Vec<&str> = args

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -360,6 +360,29 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
         "--load".to_string(),
     ];
 
+    // This build's `FROM` names a tag that exists ONLY in the local daemon image store —
+    // deacon built and tagged it moments ago. A `docker-container` driver builder runs in
+    // an isolated BuildKit container that cannot read that store, so it falls through to
+    // the registry and fails with a bare "pull access denied" naming a repository nobody
+    // ever pushed (#391). `--load` does not help: it governs where the OUTPUT goes, not how
+    // INPUTS resolve.
+    //
+    // So pin this invocation to the docker-driver builder, which shares the daemon's store.
+    // That is not a preference being overridden — an isolated builder cannot execute this
+    // build at all. A caller who names a builder explicitly still wins: `to_docker_args`
+    // emits its `--builder` after this one, and buildx takes the last occurrence, so an
+    // explicit choice is honored (and fails loudly on its own terms if it cannot see the
+    // base).
+    //
+    // The default builder is only implicated when nothing else is active, which is why this
+    // was invisible locally and only reddened CI: `docker/setup-buildx-action` creates a
+    // container-driver builder and makes it current, while a stock install leaves the
+    // docker driver in place.
+    if build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
+        build_args.push("--builder".to_string());
+        build_args.push("default".to_string());
+    }
+
     if let Some(opts) = build_options {
         if !opts.is_default() {
             build_args.extend(opts.to_docker_args());

--- a/crates/deacon/src/commands/up/features_build.rs
+++ b/crates/deacon/src/commands/up/features_build.rs
@@ -174,8 +174,14 @@ pub(crate) async fn build_image_with_features(
     log_cache_configuration(build_options);
 
     // Build image with BuildKit
-    let build_args =
-        generator.generate_build_args(&dockerfile_path, &extended_image_tag, build_options);
+    // `--builder` is a Docker CLI flag; Podman drives builds through its own CLI where it is
+    // an error, not a no-op. See the comment in `generate_build_args`.
+    let build_args = generator.generate_build_args(
+        &dockerfile_path,
+        &extended_image_tag,
+        build_options,
+        !cli.is_podman(),
+    );
 
     debug!("Building image with args: {:?}", build_args);
     let mode = build_options.map(|o| o.output_mode).unwrap_or_default();
@@ -378,7 +384,7 @@ pub(crate) async fn build_image_with_features_from_dockerfile(
     // was invisible locally and only reddened CI: `docker/setup-buildx-action` creates a
     // container-driver builder and makes it current, while a stock install leaves the
     // docker driver in place.
-    if build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
+    if !cli.is_podman() && build_options.map(|o| o.builder.is_none()).unwrap_or(true) {
         build_args.push("--builder".to_string());
         build_args.push("default".to_string());
     }


### PR DESCRIPTION
Closes #391. Unblocks the entire Docker half of the parity lane.

## The failure

`deacon up` on a Dockerfile config declaring Features fails outright whenever the active buildx builder uses the `docker-container` driver:

```
#4 [internal] load metadata for docker.io/library/deacon-build:0b95f889a95f
#4 ERROR: pull access denied, repository does not exist or may require authorization
```

The message blames a missing Docker Hub repository, which points nowhere near the cause.

## Root cause

The Feature layer builds `FROM deacon-build:<hash>` — a tag deacon created moments earlier that exists **only in the local daemon image store**. A container-driver builder runs in an isolated BuildKit container that cannot read that store, so the reference falls through to the registry and 404s on a repository nobody ever pushed.

`--load` does not help: it governs where the **output** goes, not how **inputs** resolve.

## The fix

Both build-arg sites (`dockerfile_generator::generate_build_args` and the hand-rolled args in `features_build`) select the docker-driver builder, which shares the daemon's store.

That is **not a preference being overridden** — an isolated builder cannot execute this build at all. A caller who names a builder explicitly still wins: buildx takes the last `--builder`, and `to_docker_args` emits the caller's after this one, so an explicit choice is honored and fails on its own terms. A test pins both halves.

## Why nothing caught it

Only the **active** builder is implicated. A stock install leaves the docker driver in place, so every local run works. `docker/setup-buildx-action` — which `.github/workflows/parity.yml` runs — creates a container-driver builder and makes it current. Any user who has run `docker buildx create --use` is in the same state.

A textbook works-on-my-machine divergence: invisible to every local run, red only in CI.

## Verification — reproduced, then fixed

```
$ docker buildx create --name conf-container-test --driver docker-container --use
$ deacon up --workspace-folder fx-up-dockerfile-feature
exit=1   ERROR: ... pull access denied ... deacon-build:7cb7686392c7

# after the change, same builder still active:
$ deacon up --workspace-folder fx-up-dockerfile-feature
exit=0   outcome: success
$ docker exec <cid> cat /usr/local/share/conformance/marker
dockerfile-feature
```

The marker check matters: it confirms the Feature layer actually ran and landed in the container, not merely that the build stopped erroring. With the docker driver restored, both before and after succeed — which is precisely why no existing test caught this.

## Why this blocks more than one case

`case-up-dockerfile-feature-image` is the first case in the Docker group, and it aborts the group fail-loud:

```
conformance case `case-up-dockerfile-feature-image` observed nothing:
no runtime-derived channel was captured
```

That guard is right — a case that observed nothing must never pass vacuously — but it means **the Docker half of the parity lane has been producing no evidence at all**. This unblocks it.

Gates: `dev-fast` 4156 passed · `clippy --all-targets --all-features -D warnings` clean · `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)