### PR TITLE
feat(conformance): cover feature-contributed containerEnv on the compose path

### DIFF
--- a/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "ConformanceUs5ComposeEnvPrecedence",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"shutdownAction": "stopCompose",
+	"containerEnv": { "CONF_LAYER": "config-wins", "CONF_ONLY_CONFIG": "config" },
+	"features": { "./features/conf-env": {} },
+	"remoteUser": "root"
+}

--- a/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: alpine:3.19
+    volumes:
+      - ..:/workspace
+    command: sleep infinity

--- a/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/features/conf-env/devcontainer-feature.json
+++ b/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/features/conf-env/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+	"id": "conf-env",
+	"version": "1.0.0",
+	"name": "Conformance env layer",
+	"containerEnv": {
+		"CONF_LAYER": "feature-loses",
+		"CONF_ONLY_FEATURE": "feature"
+	}
+}

--- a/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/features/conf-env/install.sh
+++ b/conformance/fixtures/fx-us5-compose-env-precedence/.devcontainer/features/conf-env/install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+mkdir -p /opt/conf-feature/bin
+echo conf-feature > /opt/conf-feature/bin/conf-marker

--- a/conformance/registry/behaviors/up.json
+++ b/conformance/registry/behaviors/up.json
@@ -9,7 +9,7 @@
       "spec": "unspecified",
       "reference": "divergent",
       "decision": "intentional-divergence",
-      "notes": "Measured directly at oracle 0.87.0 against fx-up-stale-config: two `up` runs whose documents differ only in `name` and `containerEnv` return the IDENTICAL containerId from the reference and two different containerIds from deacon. deacon's direction is deliberate and is the safer branch — reattaching keeps a container whose Feature layer was built from the OLD configuration while every reported value comes from the NEW one, which is the failure the recreate avoids. It follows from deacon's `devcontainer.configHash` identity label (ext-container-identity-labels), which the reference does not set. The spec defines no re-entry policy for a changed configuration, hence `spec: unspecified`. Characterized by wvr-up-changed-config-recreates. What is NOT intended, and is a separate defect tracked at https://github.com/get2knowio/deacon/issues/371, is that the superseded container is left RUNNING — the recreate policy is the decision, the leak is a bug."
+      "notes": "Measured directly at oracle 0.87.0 against fx-up-stale-config: two `up` runs whose documents differ only in `name` and `containerEnv` return the IDENTICAL containerId from the reference and two different containerIds from deacon. deacon's direction is deliberate and is the safer branch \u2014 reattaching keeps a container whose Feature layer was built from the OLD configuration while every reported value comes from the NEW one, which is the failure the recreate avoids. It follows from deacon's `devcontainer.configHash` identity label (ext-container-identity-labels), which the reference does not set. The spec defines no re-entry policy for a changed configuration, hence `spec: unspecified`. Characterized by wvr-up-changed-config-recreates. What is NOT intended, and is a separate defect tracked at https://github.com/get2knowio/deacon/issues/371, is that the superseded container is left RUNNING \u2014 the recreate policy is the decision, the leak is a bug."
     },
     {
       "id": "bhv-up-container-env-merge-precedence",
@@ -19,7 +19,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Authored in 024 US5 after the de-suppression found deacon on the wrong side: `commands/up/container.rs` merged the Feature-built image's containerEnv over the configuration's with `extend`, so the FEATURE won a conflicting key. Measured against oracle 0.87.0 (reference: `CONF_LAYER=config-wins`; deacon: `CONF_LAYER=feature-loses`) and fixed in the same change, so this records the state AFTER the fix. The fixture deliberately carries a config-only and a feature-only variable alongside the conflicting one — without them a case cannot tell 'the configuration wins the conflict' from 'the Feature layer was dropped'."
+      "notes": "Authored in 024 US5 after the de-suppression found deacon on the wrong side: `commands/up/container.rs` merged the Feature-built image's containerEnv over the configuration's with `extend`, so the FEATURE won a conflicting key. Measured against oracle 0.87.0 (reference: `CONF_LAYER=config-wins`; deacon: `CONF_LAYER=feature-loses`) and fixed in the same change, so this records the state AFTER the fix. The fixture deliberately carries a config-only and a feature-only variable alongside the conflicting one \u2014 without them a case cannot tell 'the configuration wins the conflict' from 'the Feature layer was dropped'. The statement is over \"the created container\", so it spans BOTH container shapes, and the two failed it in different ways. The single-container path merged the Feature layer OVER the configuration's (fixed in 024 US5). The compose path was worse and was never checked: `commands/up/compose.rs` built the service's environment from `config.container_env` plus CLI `--remote-env` and never read `feature_build.combined_env`, so a Feature's `containerEnv` was baked into the extended image and then dropped from the service's `environment:` block \u2014 the configuration appeared to win only because the other layer was gone. Fixed in 8772e7c by folding `combined_env` into `project.additional_env` with `or_insert`, under the same must-run-after-`feature_build` constraint as the feature `mounts` merge. Covered by case-up-env-merge-precedence (single container) and case-up-compose-env-merge-precedence (compose); both assert a feature-ONLY variable alongside the conflicting one, because a regression that drops the Feature layer entirely passes a conflict-only assertion (#374)."
     },
     {
       "id": "bhv-up-effective-user-uid-gid",
@@ -49,17 +49,17 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "The two CLIs build the chain differently — deacon mounts a generated `/devcontainer/entrypoint-wrapper.sh`, the reference inlines the scripts into the container command — so the raw `Config.Entrypoint`/`Cmd` cannot be compared. What IS comparable is the effect: each Feature's entrypoint appends its own id to a file in the bind-mounted workspace, so the FILE is the chain and its order. `overrideFeatureInstallOrder` pins the order the two Features would otherwise leave ambiguous (US5 acceptance scenario 5)."
+      "notes": "The two CLIs build the chain differently \u2014 deacon mounts a generated `/devcontainer/entrypoint-wrapper.sh`, the reference inlines the scripts into the container command \u2014 so the raw `Config.Entrypoint`/`Cmd` cannot be compared. What IS comparable is the effect: each Feature's entrypoint appends its own id to a file in the bind-mounted workspace, so the FILE is the chain and its order. `overrideFeatureInstallOrder` pins the order the two Features would otherwise leave ambiguous (US5 acceptance scenario 5)."
     },
     {
       "id": "bhv-up-feature-install-failure",
       "area": "up",
-      "statement": "A Feature that cannot be installed — its install script exiting non-zero, or a dependency graph with no resolvable order — fails `up` rather than producing a container without the Feature.",
+      "statement": "A Feature that cannot be installed \u2014 its install script exiting non-zero, or a dependency graph with no resolvable order \u2014 fails `up` rather than producing a container without the Feature.",
       "applicability": [],
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Authored by the 024 US4 error-path tier. Deliberately separate from `bhv-up-feature-install-order`: that claim is about WHICH Features run and in what order on the success path, and an implementation that gets the order right while swallowing a failing install script satisfies it and not this one — the container it hands back looks complete and is missing the Feature. Both halves of the statement are exercised (a failing `install.sh`, and a two-Feature `dependsOn` cycle) because the two fail at different points: one inside the install, one before any install runs. Verified against oracle 0.87.0 — both sides fail on both inputs."
+      "notes": "Authored by the 024 US4 error-path tier. Deliberately separate from `bhv-up-feature-install-order`: that claim is about WHICH Features run and in what order on the success path, and an implementation that gets the order right while swallowing a failing install script satisfies it and not this one \u2014 the container it hands back looks complete and is missing the Feature. Both halves of the statement are exercised (a failing `install.sh`, and a two-Feature `dependsOn` cycle) because the two fail at different points: one inside the install, one before any install runs. Verified against oracle 0.87.0 \u2014 both sides fail on both inputs."
     },
     {
       "id": "bhv-up-feature-install-order",
@@ -69,7 +69,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Evidenced by a live differential on the outcome plus a spec-expectation case that reads the marker each Feature's install.sh writes INSIDE the container — the lesson from the --image-name defect, where an outcome-only assertion reported success for an image with no Feature in it."
+      "notes": "Evidenced by a live differential on the outcome plus a spec-expectation case that reads the marker each Feature's install.sh writes INSIDE the container \u2014 the lesson from the --image-name defect, where an outcome-only assertion reported success for an image with no Feature in it."
     },
     {
       "id": "bhv-up-lifecycle-command-cwd",
@@ -89,17 +89,17 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Each form writes its own marker file into the bind-mounted workspace, so the observation is the file rather than the exit code — a hook that silently did not run leaves an exit code of 0 behind it. The object form's two commands write SEPARATE files: the spec does not order named commands, so asserting one file's contents would pin an order neither CLI promises."
+      "notes": "Each form writes its own marker file into the bind-mounted workspace, so the observation is the file rather than the exit code \u2014 a hook that silently did not run leaves an exit code of 0 behind it. The object form's two commands write SEPARATE files: the spec does not order named commands, so asserting one file's contents would pin an order neither CLI promises."
     },
     {
       "id": "bhv-up-mount-source-and-shape",
       "area": "up",
-      "statement": "Each declared mount is applied with both its declared source and its declared shape — the mount type and the read-only flag — and two mounts differing only in source are distinguishable.",
+      "statement": "Each declared mount is applied with both its declared source and its declared shape \u2014 the mount type and the read-only flag \u2014 and two mounts differing only in source are distinguishable.",
       "applicability": [],
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "FR-053's two axes are separated by construction in the fixture: `/mnt/ro` and `/mnt/rw` have the SAME shape and different sources, `/mnt/rw` and `/mnt/vol` have the same read-only flag and different types. Before 024 US5 the source axis was unobservable — the snapshot recorded only `sourceTail`, the bind's leaf component, so two mounts from different host directories that happened to share a leaf name compared equal."
+      "notes": "FR-053's two axes are separated by construction in the fixture: `/mnt/ro` and `/mnt/rw` have the SAME shape and different sources, `/mnt/rw` and `/mnt/vol` have the same read-only flag and different types. Before 024 US5 the source axis was unobservable \u2014 the snapshot recorded only `sourceTail`, the bind's leaf component, so two mounts from different host directories that happened to share a leaf name compared equal."
     },
     {
       "id": "bhv-up-path-construction",
@@ -109,7 +109,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "PATH was captured but NOT compared until 024 US5: `drop_noise_env` removed it at capture, so the declarative container-state channel never saw it. It is compared segment-wise (the derived `pathSegments`) rather than as one string — a whole-string equality breaks on any base-image difference, and a substring test would match `/opt/a/bin` inside `/opt/a/bin-extra`."
+      "notes": "PATH was captured but NOT compared until 024 US5: `drop_noise_env` removed it at capture, so the declarative container-state channel never saw it. It is compared segment-wise (the derived `pathSegments`) rather than as one string \u2014 a whole-string equality breaks on any base-image difference, and a substring test would match `/opt/a/bin` inside `/opt/a/bin-extra`."
     },
     {
       "id": "bhv-up-restart-reuses-container",
@@ -119,7 +119,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Asserted as a metamorphic relationship (`first-create-vs-restart`) rather than against a fixed output, because what is being pinned is the relation between the two runs and not either run's document. The container-graph observation captures EVERY container matching the workspace label so a duplicate is visible; an exit code cannot show one. SCOPED TO AN UNCHANGED CONFIGURATION (024 follow-up): the statement previously read \"including when the configuration has changed since it was created\", which is not what deacon does — deacon's container identity includes a configHash, so a changed document is a different identity and produces a NEW container. That is recorded separately as bhv-up-changed-config-recreates-container; leaving the clause here made the record claim a behavior no case had ever verified."
+      "notes": "Asserted as a metamorphic relationship (`first-create-vs-restart`) rather than against a fixed output, because what is being pinned is the relation between the two runs and not either run's document. The container-graph observation captures EVERY container matching the workspace label so a duplicate is visible; an exit code cannot show one. SCOPED TO AN UNCHANGED CONFIGURATION (024 follow-up): the statement previously read \"including when the configuration has changed since it was created\", which is not what deacon does \u2014 deacon's container identity includes a configHash, so a changed document is a different identity and produces a NEW container. That is recorded separately as bhv-up-changed-config-recreates-container; leaving the clause here made the record claim a behavior no case had ever verified."
     }
   ]
 }

--- a/conformance/registry/cases/up.json
+++ b/conformance/registry/cases/up.json
@@ -46,7 +46,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Error-path tier, Feature-installation stage, failing EARLIER than the install-script case: two local Features whose `dependsOn` entries name each other, so no installation order exists. Every individual record is well-formed and configuration read accepts on both sides; the contradiction only appears once the dependency graph is resolved. Paired with the failing-`install.sh` case deliberately — one fails inside an install, the other before any install runs, and an implementation can propagate one while defaulting the other to declaration order and installing both Features anyway. Both sides fail (verified against oracle 0.87.0)."
+      "notes": "Error-path tier, Feature-installation stage, failing EARLIER than the install-script case: two local Features whose `dependsOn` entries name each other, so no installation order exists. Every individual record is well-formed and configuration read accepts on both sides; the contradiction only appears once the dependency graph is resolved. Paired with the failing-`install.sh` case deliberately \u2014 one fails inside an install, the other before any install runs, and an implementation can propagate one while defaulting the other to declaration order and installing both Features anyway. Both sides fail (verified against oracle 0.87.0)."
     },
     {
       "id": "case-errorpath-up-feature-install-failure",
@@ -93,7 +93,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Error-path tier, Feature-installation stage: a local Feature whose `install.sh` exits 29. Configuration read accepts on both sides — a Feature reference is just a key, and nothing reads the install script until it runs — and the failure appears while the Feature is being layered into the image, which is why the declared phase is `build`: on BOTH implementations Features are installed by a Docker build over the base image, so there is no separate install phase for the closed failure-phase set to name. The claim under test is that the failure PROPAGATES: swallowing it would produce a container that looks complete and is missing the Feature, which no success-path case can distinguish. Both sides fail (verified against oracle 0.87.0)."
+      "notes": "Error-path tier, Feature-installation stage: a local Feature whose `install.sh` exits 29. Configuration read accepts on both sides \u2014 a Feature reference is just a key, and nothing reads the install script until it runs \u2014 and the failure appears while the Feature is being layered into the image, which is why the declared phase is `build`: on BOTH implementations Features are installed by a Docker build over the base image, so there is no separate install phase for the closed failure-phase set to name. The claim under test is that the failure PROPAGATES: swallowing it would produce a container that looks complete and is missing the Feature, which no success-path case can distinguish. Both sides fail (verified against oracle 0.87.0)."
     },
     {
       "id": "case-errorpath-up-invalid-run-args",
@@ -140,7 +140,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Error-path tier, container-creation stage: `runArgs` carries `--cpus not-a-number`. The document is a well-formed array of strings and both CLIs read it without complaint — `runArgs` is passed through to the runtime verbatim by design, so neither can know the value is bad. The daemon rejects it at create time, after the image is resolved and before any container exists. Chosen over a malformed-config input precisely because nothing upstream of the daemon could have caught it, which is what makes it a later-STAGE failure rather than a slow configuration error. Both sides fail (verified against oracle 0.87.0)."
+      "notes": "Error-path tier, container-creation stage: `runArgs` carries `--cpus not-a-number`. The document is a well-formed array of strings and both CLIs read it without complaint \u2014 `runArgs` is passed through to the runtime verbatim by design, so neither can know the value is bad. The daemon rejects it at create time, after the image is resolved and before any container exists. Chosen over a malformed-config input precisely because nothing upstream of the daemon could have caught it, which is what makes it a later-STAGE failure rather than a slow configuration error. Both sides fail (verified against oracle 0.87.0)."
     },
     {
       "id": "case-errorpath-up-missing-mount-source",
@@ -187,7 +187,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Error-path tier, container-creation stage: a bind mount whose SOURCE path does not exist on the host. The mount string parses, the target is sane, and configuration read echoes it on both sides; only the daemon, at create time, can observe that the source is absent. Distinct from the `runArgs` case in where the rejection comes from — an argument the runtime CLI refuses to parse versus a request the daemon refuses to satisfy — and the two are worth pinning separately because a CLI can validate its own argv construction without ever asking the daemon. Both sides fail (verified against oracle 0.87.0)."
+      "notes": "Error-path tier, container-creation stage: a bind mount whose SOURCE path does not exist on the host. The mount string parses, the target is sane, and configuration read echoes it on both sides; only the daemon, at create time, can observe that the source is absent. Distinct from the `runArgs` case in where the rejection comes from \u2014 an argument the runtime CLI refuses to parse versus a request the daemon refuses to satisfy \u2014 and the two are worth pinning separately because a CLI can validate its own argv construction without ever asking the daemon. Both sides fail (verified against oracle 0.87.0)."
     },
     {
       "id": "case-up-boundary-empty-collections",
@@ -233,6 +233,67 @@
         "tempdir": true
       },
       "notes": "FR-040 boundary class for `up`: every collection-valued field present and empty. An empty `features` map, an empty `runArgs` and an empty `mounts` are each a plausible place to emit an argument with nothing after it, which fails at container creation rather than at configuration read."
+    },
+    {
+      "id": "case-up-compose-env-merge-precedence",
+      "behaviors": [
+        "bhv-up-container-env-merge-precedence"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "up",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "single",
+        "sdim-layering": "image-metadata",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "resourceGroup": "docker-shared",
+      "operations": [
+        {
+          "id": "op-up",
+          "subcommand": "up",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-us5-compose-env-precedence"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-up",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-container-state",
+          "operation": "op-up",
+          "assertion": {
+            "jsonSubset": {
+              "envMap": {
+                "CONF_LAYER": "config-wins",
+                "CONF_ONLY_CONFIG": "config",
+                "CONF_ONLY_FEATURE": "feature"
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "containers": true,
+        "images": false,
+        "networks": true,
+        "volumes": true,
+        "tempdir": true
+      },
+      "notes": "The COMPOSE half of `bhv-up-container-env-merge-precedence`, which is stated over \"the created container\" and not over one container shape. Its single-container twin `case-up-env-merge-precedence` could not have caught the compose defect: `commands/up/compose.rs` built the service's environment from `config.container_env` plus CLI `--remote-env` and never read `feature_build.combined_env`, so a Feature's `containerEnv` was baked into the extended image and then dropped from the compose service's `environment:` block. Fixed in 8772e7c; this case is the evidence (#374).\n\nThe same three variables as the twin, for the same reason: `CONF_LAYER` is declared by BOTH layers and must take the configuration's value, while `CONF_ONLY_CONFIG` and `CONF_ONLY_FEATURE` are declared by one layer each. Without the feature-only variable, a regression that made the configuration win by DROPPING the Feature layer entirely \u2014 which is precisely the compose defect \u2014 would pass."
     },
     {
       "id": "case-up-compose-feature-restart",
@@ -298,7 +359,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Covers the high-risk triple `hrt-up-compose-single-feature-restart`. The second `up` begins with the Compose project already running, so the declared `first-create-vs-restart` relationship is the oracle: re-entry must reattach to the project it created rather than stand up a second one. The process-graph channel is what makes a duplicated service container visible — an exit code cannot show it, and the observation captures EVERY container matching the workspace label for exactly that reason."
+      "notes": "Covers the high-risk triple `hrt-up-compose-single-feature-restart`. The second `up` begins with the Compose project already running, so the declared `first-create-vs-restart` relationship is the oracle: re-entry must reattach to the project it created rather than stand up a second one. The process-graph channel is what makes a duplicated service container visible \u2014 an exit code cannot show it, and the observation captures EVERY container matching the workspace label for exactly that reason."
     },
     {
       "id": "case-up-compose-project-resources",
@@ -361,7 +422,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "The Compose half of FR-054. The project-RELATIVE names are what the two CLIs must agree on; the project NAME itself is a characterized divergence (deacon derives `deacon_<workspaceHash>_<configHash>`, the reference `<dir>_devcontainer`). Until 024 US5 the `compose_project_prefix` rewrite that produces these relative names was applied but never registered, and it discarded the project name leaving no trace — `composeProjectResources.project` now records what was stripped."
+      "notes": "The Compose half of FR-054. The project-RELATIVE names are what the two CLIs must agree on; the project NAME itself is a characterized divergence (deacon derives `deacon_<workspaceHash>_<configHash>`, the reference `<dir>_devcontainer`). Until 024 US5 the `compose_project_prefix` rewrite that produces these relative names was applied but never registered, and it discarded the project name leaving no trace \u2014 `composeProjectResources.project` now records what was stripped."
     },
     {
       "id": "case-up-compose-project-resources-differential",
@@ -416,7 +477,7 @@
           "behavior": "bhv-compose-project-name-robust",
           "context": [],
           "observablePath": "chan-container-state.labelNamespaces.devcontainer",
-          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace — the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
+          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace \u2014 the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
           "divergenceId": "ext-container-identity-labels"
         },
         {
@@ -458,7 +519,7 @@
           "behavior": "bhv-compose-project-name-robust",
           "context": [],
           "observablePath": "chan-container-state.composeProjectResources.project",
-          "rationale": "deacon derives `deacon_<workspaceHash>_<configHash>`; the reference derives `<workspace-dir>_devcontainer`. Scoped to the project NAME — the project-relative `networks` and `volumes` alongside it stay compared, which is the whole reason the prefix rewrite exists.",
+          "rationale": "deacon derives `deacon_<workspaceHash>_<configHash>`; the reference derives `<workspace-dir>_devcontainer`. Scoped to the project NAME \u2014 the project-relative `networks` and `volumes` alongside it stay compared, which is the whole reason the prefix rewrite exists.",
           "divergenceId": "bhv-compose-project-name-robust"
         },
         {
@@ -493,7 +554,7 @@
           "behavior": "bhv-compose-project-name-robust",
           "context": [],
           "observablePath": "chan-container-state.mountSources./data",
-          "rationale": "A Compose named volume's real name carries the project prefix, so the raw mount SOURCE inherits the project-name difference. Scoped to this one destination — every other mount source, and the project-relative volume name in `composeProjectResources.volumes`, stay compared.",
+          "rationale": "A Compose named volume's real name carries the project prefix, so the raw mount SOURCE inherits the project-name difference. Scoped to this one destination \u2014 every other mount source, and the project-relative volume name in `composeProjectResources.volumes`, stay compared.",
           "divergenceId": "bhv-compose-project-name-robust"
         }
       ],
@@ -596,7 +657,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "The Compose counterpart of the image-backed Docker-channel case, and the third covering case for `chan-image` and `chan-process-graph` (SC-005's floor). Two claims a Compose `up` can only make on those channels. `chan-image`: the service container is created from the image the Compose file DECLARES (`alpine:3.19`) and still carries deacon's `devcontainer.*` identity alongside Compose's own labels — delegation to Compose without losing identity, which a derived-image substitution would break. `chan-process-graph`: both mounts the service declares are present with their SHAPE — the workspace bind and the named volume — which is what distinguishes a service brought up from its Compose definition from one created directly. The volume's `source` is deliberately not pinned: it is the daemon's `/var/lib/docker/volumes/<project>_...` path and the project name is workspace-derived, so pinning it would assert the temp directory rather than the graph. The network is left out for the same reason (`<project>_default`)."
+      "notes": "The Compose counterpart of the image-backed Docker-channel case, and the third covering case for `chan-image` and `chan-process-graph` (SC-005's floor). Two claims a Compose `up` can only make on those channels. `chan-image`: the service container is created from the image the Compose file DECLARES (`alpine:3.19`) and still carries deacon's `devcontainer.*` identity alongside Compose's own labels \u2014 delegation to Compose without losing identity, which a derived-image substitution would break. `chan-process-graph`: both mounts the service declares are present with their SHAPE \u2014 the workspace bind and the named volume \u2014 which is what distinguishes a service brought up from its Compose definition from one created directly. The volume's `source` is deliberately not pinned: it is the daemon's `/var/lib/docker/volumes/<project>_...` path and the project name is workspace-derived, so pinning it would assert the temp directory rather than the graph. The network is left out for the same reason (`<project>_default`)."
     },
     {
       "id": "case-up-docker-channels",
@@ -692,7 +753,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Declarative Docker-backed spec-expectation case (022-conformance-runner US5): `deacon up` in an ISOLATED external temp workspace (collision-resistant, guaranteed cleanup) exercises all four Docker channels — chan-image (deacon stamps devcontainer.source), chan-injected-process (containerEnv CONF_TOKEN injected), chan-process-graph (mount/network/volume graph captured), chan-temporal (container running). Image pinned to alpine:3.19 (V18). The chan-process-graph assertion was an empty `jsonSubset: {}` until 024 US6 — which matches ANY graph, so the channel was inert by construction: the case declared it, observed it, and could not fail on it. It now pins the workspace bind (source, type, read-write) and the network the container joined, which is the graph's headline claim and what reg-process-graph-workspace-mount-vanished perturbs."
+      "notes": "Declarative Docker-backed spec-expectation case (022-conformance-runner US5): `deacon up` in an ISOLATED external temp workspace (collision-resistant, guaranteed cleanup) exercises all four Docker channels \u2014 chan-image (deacon stamps devcontainer.source), chan-injected-process (containerEnv CONF_TOKEN injected), chan-process-graph (mount/network/volume graph captured), chan-temporal (container running). Image pinned to alpine:3.19 (V18). The chan-process-graph assertion was an empty `jsonSubset: {}` until 024 US6 \u2014 which matches ANY graph, so the channel was inert by construction: the case declared it, observed it, and could not fail on it. It now pins the workspace bind (source, type, read-write) and the network the container joined, which is the graph's headline claim and what reg-process-graph-workspace-mount-vanished perturbs."
     },
     {
       "id": "case-up-dockerfile-extends-chain",
@@ -738,7 +799,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Covers the high-risk triple `hrt-up-dockerfile-extends-chain-absent`. The `build.dockerfile` is declared by the PARENT document, so the build context has to be resolved relative to the directory of the file that declared it rather than the child's. Getting that wrong fails the build outright, which is why the exit code is a sufficient observable here and a differential is worth the reference run. The 024 live run showed the differential is one-sided: deacon builds and the REFERENCE fails, because oracle 0.87.0 has no `extends` support at all. That is the already-recorded deacon extension (ext-extends-resolution) surfacing in `up` rather than in `read-configuration`, so the case links bhv-readconfig-extends-merged and scopes a tolerance to the exit code. deacon's own half of the assertion — that the parent-declared build context resolves relative to the file that declared it — is unchanged and still the reason the case exists.",
+      "notes": "Covers the high-risk triple `hrt-up-dockerfile-extends-chain-absent`. The `build.dockerfile` is declared by the PARENT document, so the build context has to be resolved relative to the directory of the file that declared it rather than the child's. Getting that wrong fails the build outright, which is why the exit code is a sufficient observable here and a differential is worth the reference run. The 024 live run showed the differential is one-sided: deacon builds and the REFERENCE fails, because oracle 0.87.0 has no `extends` support at all. That is the already-recorded deacon extension (ext-extends-resolution) surfacing in `up` rather than in `read-configuration`, so the case links bhv-readconfig-extends-merged and scopes a tolerance to the exit code. deacon's own half of the assertion \u2014 that the parent-declared build context resolves relative to the file that declared it \u2014 is unchanged and still the reason the case exists.",
       "allowedDifferences": [
         {
           "behavior": "bhv-readconfig-extends-merged",
@@ -955,7 +1016,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-048: entrypoints contributed by TWO Features. The file's exact contents pin both that each entrypoint ran and the ORDER they ran in — `overrideFeatureInstallOrder` makes an order the two Features would otherwise leave ambiguous deterministic, which is US5 acceptance scenario 5. Raw `Config.Entrypoint` is deliberately not asserted: deacon mounts a generated wrapper and the reference inlines the scripts, so the mechanism differs while the effect does not."
+      "notes": "FR-048: entrypoints contributed by TWO Features. The file's exact contents pin both that each entrypoint ran and the ORDER they ran in \u2014 `overrideFeatureInstallOrder` makes an order the two Features would otherwise leave ambiguous deterministic, which is US5 acceptance scenario 5. Raw `Config.Entrypoint` is deliberately not asserted: deacon mounts a generated wrapper and the reference inlines the scripts, so the mechanism differs while the effect does not."
     },
     {
       "id": "case-up-env-merge-differential",
@@ -1010,7 +1071,7 @@
           "behavior": "bhv-up-container-env-merge-precedence",
           "context": [],
           "observablePath": "chan-container-state.labelNamespaces.devcontainer",
-          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace — the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
+          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace \u2014 the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
           "divergenceId": "ext-container-identity-labels"
         },
         {
@@ -1052,7 +1113,7 @@
           "behavior": "bhv-container-metadata-label-content",
           "context": [],
           "observablePath": "chan-container-state.labels.devcontainer.metadata",
-          "rationale": "deacon's `devcontainer.metadata` omits the per-Feature `{\"id\": …}` entries the reference records, and records substituted absolute paths where the reference records the unsubstituted `${localWorkspaceFolder}` template. Measured at oracle 0.87.0; both are deacon defects awaiting a `parity-drift` issue.",
+          "rationale": "deacon's `devcontainer.metadata` omits the per-Feature `{\"id\": \u2026}` entries the reference records, and records substituted absolute paths where the reference records the unsubstituted `${localWorkspaceFolder}` template. Measured at oracle 0.87.0; both are deacon defects awaiting a `parity-drift` issue.",
           "waiverId": "wvr-container-metadata-label-content"
         }
       ],
@@ -1063,7 +1124,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "The cross-CLI half of FR-049/FR-050, comparing the WHOLE container state — every environment variable and every PATH segment — with only the characterized keep-alive command and identity labels tolerated."
+      "notes": "The cross-CLI half of FR-049/FR-050, comparing the WHOLE container state \u2014 every environment variable and every PATH segment \u2014 with only the characterized keep-alive command and identity labels tolerated."
     },
     {
       "id": "case-up-env-merge-precedence",
@@ -1123,7 +1184,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-049. Three variables, because one is not enough: `CONF_LAYER` is declared by BOTH layers and must take the configuration's value; `CONF_ONLY_CONFIG` and `CONF_ONLY_FEATURE` are declared by one layer each, so a change that made the configuration win by DROPPING the Feature layer altogether fails here rather than passing. This case found a real defect — deacon merged the Feature layer over the configuration's — fixed in the same change."
+      "notes": "FR-049. Three variables, because one is not enough: `CONF_LAYER` is declared by BOTH layers and must take the configuration's value; `CONF_ONLY_CONFIG` and `CONF_ONLY_FEATURE` are declared by one layer each, so a change that made the configuration win by DROPPING the Feature layer altogether fails here rather than passing. This case found a real defect \u2014 deacon merged the Feature layer over the configuration's \u2014 fixed in the same change."
     },
     {
       "id": "case-up-exec-decl-traditional",
@@ -1183,7 +1244,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Migrated from parity_up_exec::traditional: after `up` on a traditional (non-compose) workspace, both CLIs' `exec` reach that workspace's own container and observe the same postCreate markers — including the #332 parity that neither CLI substitutes `${containerEnv:VAR}` inside a lifecycle command string (both must print the same EMPTY marker). Image pinned to alpine:3.19 (V18)."
+      "notes": "Migrated from parity_up_exec::traditional: after `up` on a traditional (non-compose) workspace, both CLIs' `exec` reach that workspace's own container and observe the same postCreate markers \u2014 including the #332 parity that neither CLI substitutes `${containerEnv:VAR}` inside a lifecycle command string (both must print the same EMPTY marker). Image pinned to alpine:3.19 (V18)."
     },
     {
       "id": "case-up-exec-parity",
@@ -1205,7 +1266,7 @@
           "expectation": "exec --container-id recovers the config-only remoteEnv from the container's devcontainer.metadata label, byte-identical to the reference"
         }
       ],
-      "notes": "Research D2's INVERSE defect, resolved (023 T054). `parity_up_exec` asserts two things — up/exec container parity AND `exec --container-id` recovering remoteUser/remoteEnv from the devcontainer.metadata label — but emits a SINGLE CaseResult (`traditional`), so the registry previously claimed two independently-evidenced cases from one reported outcome and one of them had no evidence of its own. Both assertions are genuinely exercised (a regression fails the binary); only the REPORTING granularity is coarse. The two pointer cases are therefore merged into this one: one reported outcome, two behaviors, stated rather than disguised. `bhv-up-exec-parity` additionally has independent declarative evidence in case-up-exec-decl-traditional; `bhv-exec-container-id-metadata` awaits its own independently-reported case, which needs a runtime-resolved container-id token in an operation's argv (deferred, tasks.md#T110). THIS CASE IS WHY `parity_up_exec.rs` SURVIVES: its equivalence verdict is clean, but it carries the ONLY evidence for bhv-exec-container-id-metadata, so deleting it would leave that behavior uncovered (V5). See tasks.md#T110."
+      "notes": "Research D2's INVERSE defect, resolved (023 T054). `parity_up_exec` asserts two things \u2014 up/exec container parity AND `exec --container-id` recovering remoteUser/remoteEnv from the devcontainer.metadata label \u2014 but emits a SINGLE CaseResult (`traditional`), so the registry previously claimed two independently-evidenced cases from one reported outcome and one of them had no evidence of its own. Both assertions are genuinely exercised (a regression fails the binary); only the REPORTING granularity is coarse. The two pointer cases are therefore merged into this one: one reported outcome, two behaviors, stated rather than disguised. `bhv-up-exec-parity` additionally has independent declarative evidence in case-up-exec-decl-traditional; `bhv-exec-container-id-metadata` awaits its own independently-reported case, which needs a runtime-resolved container-id token in an operation's argv (deferred, tasks.md#T110). THIS CASE IS WHY `parity_up_exec.rs` SURVIVES: its equivalence verdict is clean, but it carries the ONLY evidence for bhv-exec-container-id-metadata, so deleting it would leave that behavior uncovered (V5). See tasks.md#T110."
     },
     {
       "id": "case-up-feature-single-differential",
@@ -1250,7 +1311,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-032, the alignment half: both CLIs create a container from a pinned image with one LOCAL Feature installed. A local Feature is used deliberately — it keeps the case off the network and inside the Docker tier's budget while exercising the same resolution and install path an OCI Feature takes."
+      "notes": "FR-032, the alignment half: both CLIs create a container from a pinned image with one LOCAL Feature installed. A local Feature is used deliberately \u2014 it keeps the case off the network and inside the Docker tier's budget while exercising the same resolution and install path an OCI Feature takes."
     },
     {
       "id": "case-up-feature-single-installed",
@@ -1327,7 +1388,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "The content half: the differential shows the two CLIs agree on the outcome, which is not the same as showing the Feature was installed. This case reads the marker the Feature's `install.sh` wrote INSIDE the container — the lesson from the `--image-name` defect, where an outcome-only assertion reported success for an image that had no Feature in it."
+      "notes": "The content half: the differential shows the two CLIs agree on the outcome, which is not the same as showing the Feature was installed. This case reads the marker the Feature's `install.sh` wrote INSIDE the container \u2014 the lesson from the `--image-name` defect, where an outcome-only assertion reported success for an image that had no Feature in it."
     },
     {
       "id": "case-up-idempotent",
@@ -1383,7 +1444,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Declarative invariant-metamorphic case (022-conformance-runner US6): a second `deacon up` on the same isolated workspace must be IDEMPOTENT — it reuses the running container created by the first up (same container id, still running) rather than recreating it. The oracle verdicts on the DECLARED RELATIONSHIP between op-up-2 and op-up-1's chan-temporal state, not a fixed output (FR-008). Image pinned to alpine:3.19 (V18)."
+      "notes": "Declarative invariant-metamorphic case (022-conformance-runner US6): a second `deacon up` on the same isolated workspace must be IDEMPOTENT \u2014 it reuses the running container created by the first up (same container id, still running) rather than recreating it. The oracle verdicts on the DECLARED RELATIONSHIP between op-up-2 and op-up-1's chan-temporal state, not a fixed output (FR-008). Image pinned to alpine:3.19 (V18)."
     },
     {
       "id": "case-up-label-namespaces-and-network",
@@ -1460,7 +1521,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-052 and the non-Compose half of FR-054. The label assertion is on the derived NAMESPACE grouping, which is what makes 'one side populates a namespace the other leaves empty' an ordinary comparison instead of an enumeration of every key either CLI might ever emit; the differential cases carry the matching tolerance. `networks`, `cmd` and `entrypoint` are pinned here too — all three were captured but not compared before 024, and the keep-alive defect (#290) is what a captured-but-uncompared field costs."
+      "notes": "FR-052 and the non-Compose half of FR-054. The label assertion is on the derived NAMESPACE grouping, which is what makes 'one side populates a namespace the other leaves empty' an ordinary comparison instead of an enumeration of every key either CLI might ever emit; the differential cases carry the matching tolerance. `networks`, `cmd` and `entrypoint` are pinned here too \u2014 all three were captured but not compared before 024, and the keep-alive defect (#290) is what a captured-but-uncompared field costs."
     },
     {
       "id": "case-up-lifecycle-array-form",
@@ -1691,7 +1752,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-047, the object (named commands) form — and both spellings of a named command, a string and an argv array. Each command writes its OWN file: the spec does not order named commands, so asserting one file's contents would pin an order neither CLI promises."
+      "notes": "FR-047, the object (named commands) form \u2014 and both spellings of a named command, a string and an argv array. Each command writes its OWN file: the spec does not order named commands, so asserting one file's contents would pin an order neither CLI promises."
     },
     {
       "id": "case-up-malformed-config-rejected",
@@ -1740,7 +1801,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-040 malformed class for `up`: a hard JSONC syntax error stops the run at configuration resolution, before any container exists. The declared failure phase is the assertion that matters — an implementation that reached container creation and failed there would produce the same non-zero exit for a different reason."
+      "notes": "FR-040 malformed class for `up`: a hard JSONC syntax error stops the run at configuration resolution, before any container exists. The declared failure phase is the assertion that matters \u2014 an implementation that reached container creation and failed there would produce the same non-zero exit for a different reason."
     },
     {
       "id": "case-up-mount-source-shape-differential",
@@ -1794,7 +1855,7 @@
           "behavior": "bhv-up-mount-source-and-shape",
           "context": [],
           "observablePath": "chan-container-state.labelNamespaces.devcontainer",
-          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace — the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
+          "rationale": "deacon stamps five identity labels the reference does not set, so the `devcontainer` namespace's key SET differs. Scoped to that one namespace \u2014 the derived grouping is what makes a one-sided label visible (FR-052), and the per-key paths below stay named individually.",
           "divergenceId": "ext-container-identity-labels"
         },
         {
@@ -1836,7 +1897,7 @@
           "behavior": "bhv-container-metadata-label-content",
           "context": [],
           "observablePath": "chan-container-state.labels.devcontainer.metadata",
-          "rationale": "deacon's `devcontainer.metadata` omits the per-Feature `{\"id\": …}` entries the reference records, and records substituted absolute paths where the reference records the unsubstituted `${localWorkspaceFolder}` template. Measured at oracle 0.87.0; both are deacon defects awaiting a `parity-drift` issue.",
+          "rationale": "deacon's `devcontainer.metadata` omits the per-Feature `{\"id\": \u2026}` entries the reference records, and records substituted absolute paths where the reference records the unsubstituted `${localWorkspaceFolder}` template. Measured at oracle 0.87.0; both are deacon defects awaiting a `parity-drift` issue.",
           "waiverId": "wvr-container-metadata-label-content"
         }
       ],
@@ -1982,7 +2043,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-050. The Feature contributes `/opt/conf-feature/bin` through the `PATH=…:${PATH}` prepend idiom; the base image's own segments must survive it, which is why two of them are asserted too — a PATH that had been REPLACED rather than prepended would still contain the Feature's segment. PATH reached this channel only after 024 US5 stopped `drop_noise_env` removing it at capture."
+      "notes": "FR-050. The Feature contributes `/opt/conf-feature/bin` through the `PATH=\u2026:${PATH}` prepend idiom; the base image's own segments must survive it, which is why two of them are asserted too \u2014 a PATH that had been REPLACED rather than prepended would still contain the Feature's segment. PATH reached this channel only after 024 US5 stopped `drop_noise_env` removing it at capture."
     },
     {
       "id": "case-up-reference-lenient-wrong-type",
@@ -2121,7 +2182,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "`up` against a container that is ALREADY RUNNING — the pairwise combination `image` x `running`, and `running` x `features: none`, both previously gaps. The sibling metamorphic case proves re-entry does not create a second container; this one asserts what the reattached container's process context still IS, which the relationship oracle does not look at (it produces a `chan-temporal` verdict only). A reattach that silently dropped the configured `containerEnv`, or reattached to a container built before it was set, satisfies \"same container, still running\" and fails here."
+      "notes": "`up` against a container that is ALREADY RUNNING \u2014 the pairwise combination `image` x `running`, and `running` x `features: none`, both previously gaps. The sibling metamorphic case proves re-entry does not create a second container; this one asserts what the reattached container's process context still IS, which the relationship oracle does not look at (it produces a `chan-temporal` verdict only). A reattach that silently dropped the configured `containerEnv`, or reattached to a container built before it was set, satisfies \"same container, still running\" and fails here."
     },
     {
       "id": "case-up-stale-config-reentry",
@@ -2189,7 +2250,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "Covers the high-risk triple `hrt-up-image-single-feature-stale-config`. The second `up` runs against a configuration that has since changed (a different `containerEnv` generation), supplied as a command-line override because the runner materializes a fixture once and does not edit it mid-case — the observable situation is identical either way. RE-POINTED after the 024 live run. The case was an `invariant-metamorphic` asserting `first-create-vs-restart`, and that relationship simply is not deacon's contract: deacon's container identity includes a configHash, so a CHANGED document is a different identity and produces a NEW container. Reuse is the dangerous branch — the container would keep the Feature layer built from the OLD configuration while every reported value came from the NEW one — so recreating is the direction worth keeping, and the metamorphic oracle had no relationship kind that could express it (the closed set is idempotence / first-create-vs-restart / resume). Asserting the relationship anyway would have pinned a behavior deacon deliberately does not have. The reference does reattach, verified directly at oracle 0.87.0; that difference is recorded as bhv-up-changed-config-recreates-container and waived by wvr-up-changed-config-recreates. What the recreate does NOT license is leaving the superseded container running, which deacon currently does and which is tracked as a defect at https://github.com/get2knowio/deacon/issues/371 — when that lands, this case gains a container-count assertion."
+      "notes": "Covers the high-risk triple `hrt-up-image-single-feature-stale-config`. The second `up` runs against a configuration that has since changed (a different `containerEnv` generation), supplied as a command-line override because the runner materializes a fixture once and does not edit it mid-case \u2014 the observable situation is identical either way. RE-POINTED after the 024 live run. The case was an `invariant-metamorphic` asserting `first-create-vs-restart`, and that relationship simply is not deacon's contract: deacon's container identity includes a configHash, so a CHANGED document is a different identity and produces a NEW container. Reuse is the dangerous branch \u2014 the container would keep the Feature layer built from the OLD configuration while every reported value came from the NEW one \u2014 so recreating is the direction worth keeping, and the metamorphic oracle had no relationship kind that could express it (the closed set is idempotence / first-create-vs-restart / resume). Asserting the relationship anyway would have pinned a behavior deacon deliberately does not have. The reference does reattach, verified directly at oracle 0.87.0; that difference is recorded as bhv-up-changed-config-recreates-container and waived by wvr-up-changed-config-recreates. What the recreate does NOT license is leaving the superseded container running, which deacon currently does and which is tracked as a defect at https://github.com/get2knowio/deacon/issues/371 \u2014 when that lands, this case gains a container-count assertion."
     },
     {
       "id": "case-up-unsupported-image-reference",
@@ -2238,7 +2299,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-040 unsupported class for `up`: the configuration is well-formed and every field is valid, but it names an image reference that no registry serves. Nothing can reject this at configuration read — which is the point of the class, and the reason the failure phase is `container-create` rather than `config-resolution`."
+      "notes": "FR-040 unsupported class for `up`: the configuration is well-formed and every field is valid, but it names an image reference that no registry serves. Nothing can reject this at configuration read \u2014 which is the point of the class, and the reason the failure phase is `container-create` rather than `config-resolution`."
     },
     {
       "id": "case-up-user-created-by-feature",
@@ -2396,7 +2457,7 @@
         "volumes": true,
         "tempdir": true
       },
-      "notes": "FR-051, the image-created non-root user. Both halves are asserted: the DECLARATION (`userSpec`, parsed from the container's `Config.User`) and the EFFECT (`id -u`/`id -g`/`id -un` inside the container). The declaration alone would pass for a user that does not exist; the ids alone would not say which user was asked for. `uid`/`gid` are asserted as null because the declaration names a user rather than numeric ids — an unset id is not an id of 0."
+      "notes": "FR-051, the image-created non-root user. Both halves are asserted: the DECLARATION (`userSpec`, parsed from the container's `Config.User`) and the EFFECT (`id -u`/`id -g`/`id -un` inside the container). The declaration alone would pass for a user that does not exist; the ids alone would not say which user was asked for. `uid`/`gid` are asserted as null because the declaration names a user rather than numeric ids \u2014 an unset id is not an id of 0."
     }
   ]
 }

--- a/conformance/registry/obligation-dispositions/up.json
+++ b/conformance/registry/obligation-dispositions/up.json
@@ -247,6 +247,7 @@
       "obligation": "obl-cmb-2799eb8c",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-compose-project-resources",
         "case-up-compose-project-resources-differential",
         "case-up-compose-service-graph"
@@ -380,6 +381,7 @@
       "obligation": "obl-cmb-50abbf8e",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-compose-feature-restart"
       ]
     },
@@ -541,6 +543,7 @@
       "obligation": "obl-cmb-7b75c819",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-env-merge-differential",
         "case-up-env-merge-precedence",
         "case-up-path-construction"
@@ -563,6 +566,7 @@
       "obligation": "obl-cmb-7f53de5d",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-compose-feature-restart",
         "case-up-feature-single-differential",
         "case-up-feature-single-installed",
@@ -594,6 +598,7 @@
       "obligation": "obl-cmb-8440a94d",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-feature-single-differential",
         "case-up-feature-single-installed"
       ]
@@ -693,6 +698,7 @@
       "obligation": "obl-cmb-99575a20",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-compose-feature-restart"
       ]
     },
@@ -714,6 +720,7 @@
         "case-state-mount-variety",
         "case-state-single-container",
         "case-up-boundary-empty-collections",
+        "case-up-compose-env-merge-precedence",
         "case-up-container-identity-labels",
         "case-up-container-labels-stamped",
         "case-up-docker-channels",
@@ -859,8 +866,10 @@
     {
       "id": "odp-cmb-c6adecf0",
       "obligation": "obl-cmb-c6adecf0",
-      "disposition": "gap",
-      "gap": "gap-pairwise-up"
+      "disposition": "case",
+      "cases": [
+        "case-up-compose-env-merge-precedence"
+      ]
     },
     {
       "id": "odp-cmb-cf9650cb",
@@ -947,6 +956,7 @@
       "obligation": "obl-cmb-dfeff6c8",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-env-merge-differential",
         "case-up-env-merge-precedence",
         "case-up-path-construction"
@@ -1048,6 +1058,7 @@
       "obligation": "obl-cmb-fa8d7c4f",
       "disposition": "case",
       "cases": [
+        "case-up-compose-env-merge-precedence",
         "case-up-env-merge-differential",
         "case-up-env-merge-precedence",
         "case-up-path-construction"

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -76,7 +76,13 @@ const TODAY: &str = "2026-07-19";
 /// reattached process context, which the metamorphic relationship does not look at), and
 /// a multi-file `templates apply` (a scaffolded tree, the template manifest that must not
 /// be scaffolded, and a mode). No record was removed.
-const MIGRATED_CASE_COUNT: usize = 204;
+///
+/// **204 → 205** (#374): the compose half of `bhv-up-container-env-merge-precedence`. The
+/// behavior is stated over "the created container" and spans both container shapes, but
+/// every case covering it was single-container shaped, so nothing in the registry could
+/// have caught the compose path dropping a Feature's `containerEnv` — or proved the fix.
+/// No record was removed.
+const MIGRATED_CASE_COUNT: usize = 205;
 
 #[test]
 fn real_registry_is_structurally_valid() {


### PR DESCRIPTION
Closes #374.

## Why

`bhv-up-container-env-merge-precedence` is stated over **"the created container"**, so it spans both container shapes — but every case covering it was single-container shaped. Nothing in the registry could have caught the compose path dropping a Feature's `containerEnv`, and nothing proved the fix.

The compose defect was worse than the single-container one it mirrors: `commands/up/compose.rs` built the service's environment from `config.container_env` plus CLI `--remote-env` and **never read `feature_build.combined_env`**. A Feature's `containerEnv` was baked into the extended image and then dropped from the service's `environment:` block — so the configuration appeared to win the conflict only because the other layer was gone.

Production fix landed in `8772e7c`. This is the evidence.

## Why three variables

The same shape as the single-container twin, for the reason that twin documents: **a regression that makes the configuration win by dropping the Feature layer entirely passes a conflict-only assertion.**

| Variable | Declared by | Pins |
|---|---|---|
| `CONF_LAYER` | both | the configuration wins the conflict |
| `CONF_ONLY_CONFIG` | configuration | the configuration layer survives |
| `CONF_ONLY_FEATURE` | Feature | **the Feature layer survives** — the one that fails on the actual defect |

## Verification

Ran it. `up` on the new fixture exits 0 and the created container carries all three, observed both in `docker inspect` and in the process environment:

```
CONF_ONLY_FEATURE=feature
CONF_LAYER=config-wins
CONF_ONLY_CONFIG=config
```

Gates: `validate` ok · `coverage check` ok (797 obligations, 0 undispositioned) · `deacon-conformance` 778 passed · `dev-fast` 4157 passed · `clippy --all-targets --all-features -D warnings` clean · `fmt --check` clean.

## Registry bookkeeping

- Full `scenarioContext` (V26 rejects a partial one).
- The one combination it newly covers — **compose × image-metadata** — flipped off `gap` **in this commit**, rather than left reading as a hole a case already fills. The other nine pairs in its context credit it.
- `MIGRATED_CASE_COUNT` 204 → 205, with its reason recorded inline as that guard requires.
- `bhv-up-container-env-merge-precedence`'s notes now say the behavior spans both shapes and how each one failed it.

Pairwise coverage moves 402 → 403 covered, 395 → 394 gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)