### PR TITLE
fix(discovery): derive drift witness ids from the candidate, not the signature

### DIFF
--- a/conformance/discovery/campaigns.json
+++ b/conformance/discovery/campaigns.json
@@ -1,4 +1,97 @@
 {
   "schemaVersion": 1,
-  "records": []
+  "records": [
+    {
+      "id": "cmp-db91349f",
+      "seed": "0d15c0",
+      "lane": "invoked",
+      "tier": "metamorphic",
+      "profile": "prof-linux-amd64-docker-0870",
+      "pinnedInputSet": {
+        "schemaPin": "113500f4",
+        "prosePin": "113500f4",
+        "oracleVersion": "0.87.0",
+        "normalizerVersion": "6",
+        "grammarVersion": "rev-schema-113500f4",
+        "mutationCatalogVersion": "mutation-catalogue/v1",
+        "generatorVersion": "splitmix64-seed+xoshiro256starstar/v1+reduce[drop-optional-key,un-apply-mutation,empty-collection,collapse-extends-level,drop-compose-service,minimize-scalar,drop-feature]/v1+generator/v1"
+      },
+      "budget": {
+        "wallClockSeconds": 1800,
+        "perCandidateSeconds": 60,
+        "shrinkStepsPerFinding": 64,
+        "admissionCap": 25
+      },
+      "outcome": {
+        "candidatesGenerated": 7,
+        "candidatesExecuted": 7,
+        "candidatesDiscardedUnsafe": 0,
+        "parseStageFailures": 0,
+        "budgetExhausted": false,
+        "spaceCoveredFraction": 1.0,
+        "mutationApplications": {
+          "unknown-field": 0,
+          "wrong-type": 0,
+          "null-value": 0,
+          "empty-value": 0,
+          "conflicting-source": 0,
+          "invalid-feature-id": 0,
+          "extends-cycle": 0,
+          "substitution-edge": 0,
+          "lifecycle-shape": 0,
+          "compose-combination": 0,
+          "ordering-change": 0
+        },
+        "signaturesObserved": 0,
+        "signaturesAdmitted": 0,
+        "signaturesSuppressed": 0
+      }
+    },
+    {
+      "id": "cmp-978ec2cf",
+      "seed": "0d15c0",
+      "lane": "invoked",
+      "tier": "config-differential",
+      "profile": "prof-linux-amd64-docker-0870",
+      "pinnedInputSet": {
+        "schemaPin": "113500f4",
+        "prosePin": "113500f4",
+        "oracleVersion": "0.87.0",
+        "normalizerVersion": "6",
+        "grammarVersion": "rev-schema-113500f4",
+        "mutationCatalogVersion": "mutation-catalogue/v1",
+        "generatorVersion": "splitmix64-seed+xoshiro256starstar/v1+reduce[drop-optional-key,un-apply-mutation,empty-collection,collapse-extends-level,drop-compose-service,minimize-scalar,drop-feature]/v1+generator/v1"
+      },
+      "budget": {
+        "wallClockSeconds": 900,
+        "perCandidateSeconds": 60,
+        "shrinkStepsPerFinding": 64,
+        "admissionCap": 25
+      },
+      "outcome": {
+        "candidatesGenerated": 150,
+        "candidatesExecuted": 149,
+        "candidatesDiscardedUnsafe": 1,
+        "parseStageFailures": 3,
+        "budgetExhausted": false,
+        "spaceCoveredFraction": 1.0,
+        "mutationApplications": {
+          "unknown-field": 20,
+          "wrong-type": 23,
+          "null-value": 16,
+          "empty-value": 18,
+          "conflicting-source": 22,
+          "invalid-feature-id": 21,
+          "extends-cycle": 22,
+          "substitution-edge": 20,
+          "lifecycle-shape": 22,
+          "compose-combination": 18,
+          "ordering-change": 16
+        },
+        "signaturesObserved": 25,
+        "signaturesAdmitted": 23,
+        "signaturesSuppressed": 0
+      }
+    }
+  ]
 }

--- a/conformance/discovery/findings.json
+++ b/conformance/discovery/findings.json
@@ -296,8 +296,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -563,8 +563,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -616,8 +616,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -667,8 +667,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -1049,8 +1049,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -1543,8 +1543,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -2130,8 +2130,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -2717,8 +2717,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3081,8 +3081,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "spec-ambiguity",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3158,8 +3158,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "spec-ambiguity",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3206,8 +3206,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3303,8 +3303,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3464,8 +3464,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3599,8 +3599,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -3677,8 +3677,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -4147,8 +4147,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -4324,8 +4324,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -4477,8 +4477,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -4597,8 +4597,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -5072,8 +5072,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -5119,8 +5119,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -5216,8 +5216,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,
@@ -5267,8 +5267,8 @@
           ]
         }
       ],
-      "classification": null,
-      "state": "untriaged",
+      "classification": "deacon-regression",
+      "state": "triaged",
       "firstObserved": "cmp-978ec2cf",
       "lastObserved": "cmp-978ec2cf",
       "promotedTo": null,

--- a/conformance/discovery/findings.json
+++ b/conformance/discovery/findings.json
@@ -1,4 +1,5279 @@
 {
   "schemaVersion": 1,
-  "records": []
+  "records": [
+    {
+      "id": "fnd-03ca9a7c",
+      "signature": {
+        "id": "sig-8a3899f6",
+        "channel": "chan-structured-output",
+        "path": "configuration.customizations",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "customizations": {},
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "empty-collection"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-808426d7",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f3f20a7b",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [
+              "docker-compose.yml",
+              "docker-compose.override.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "containerUser": "vscode",
+            "customizations": {},
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": "echo discovery",
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ]
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-92cca6ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f431c019",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "vscode",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postStartCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteUser": "root",
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "userEnvProbe": "none",
+            "workspaceFolder": "${containerWorkspaceFolder",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-ordering-change",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-d7d668b9",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-da08200e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "postCreateCommand": null,
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {},
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "waitFor": "postCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [],
+            "service": "app",
+            "workspaceFolder": "/workspaces/project",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "root",
+            "customizations": {},
+            "init": true,
+            "onCreateCommand": {},
+            "shutdownAction": "none"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-da489434",
+      "signature": {
+        "id": "sig-3cf94604",
+        "channel": "chan-structured-output",
+        "path": "configuration.name",
+        "kind": "deacon-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-22fb22ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-2ee56f86",
+          "minimalInput": {},
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7600bd8f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1578de93",
+          "minimalInput": {
+            "remoteUser": "vscode",
+            "dockerComposeFile": [
+              "docker-compose.override.yml",
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "privileged": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "runServices": [],
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000
+            ],
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "otherPortsAttributes": null,
+            "privileged": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-92fd09ba",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d9409d47",
+          "minimalInput": {
+            "onCreateCommand": [
+              "discovery",
+              "echo"
+            ],
+            "image": "alpine:3.19",
+            "capAdd": [
+              "SYS_PTRACE"
+            ]
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-0afae60a",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-42d408fc",
+          "minimalInput": {
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "image": "alpine:3.19",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "init": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-fbbf448e",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-30c7df92",
+          "minimalInput": {
+            "remoteEnv": {
+              "TEST_ENV": "single-container"
+            },
+            "image": "ubuntu:22.04",
+            "remoteUser": "root",
+            "workspaceFolder": "/workspace",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-wrong-type",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "init": true,
+            "dockerComposeFile": [],
+            "service": "app",
+            "workspaceFolder": "/workspaces/project",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "root",
+            "customizations": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-7a847ae3",
+      "signature": {
+        "id": "sig-915021bc",
+        "channel": "chan-structured-output",
+        "path": "configuration.build",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "build": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "build": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-4c192adb",
+      "signature": {
+        "id": "sig-65bcc818",
+        "channel": "chan-structured-output",
+        "path": "configuration.features",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "features": {},
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "empty-collection"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-1ce42f08",
+      "signature": {
+        "id": "sig-72d8f619",
+        "channel": "chan-structured-output",
+        "path": "configuration.otherPortsAttributes",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "otherPortsAttributes": {},
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "empty-collection"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000
+            ],
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "otherPortsAttributes": null,
+            "privileged": true,
+            "runServices": [],
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": null,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "vscode",
+            "otherPortsAttributes": {},
+            "overrideFeatureInstallOrder": [],
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-77b3efc1",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b5f55e2e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [],
+            "postAttachCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--rm",
+              "--init"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b2ecc8ac",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-7e4b9c1e",
+          "minimalInput": {
+            "name": "${localWorkspaceFolder}${localWorkspaceFolder}",
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopCompose",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-83cdf60d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-388e888b",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "alpine:3.19",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "hostRequirements": {},
+            "init": true,
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "postStartCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "userEnvProbe": "none",
+            "features": {
+              "not a feature id": {}
+            },
+            "notASchemaProperty": null
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id",
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-b50aa394",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eaab0a54",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "hostRequirements": {},
+            "init": true,
+            "onCreateCommand": "echo discovery",
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "updateRemoteUserUID": true,
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-daf2cea2",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-3eccbea1",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "otherPortsAttributes": {},
+            "postAttachCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "shutdownAction": "stopCompose",
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-77d33f38",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d283d30c",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": "3000:3000",
+            "containerUser": "root",
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "init": true,
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "privileged": true,
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "shutdownAction": "stopContainer",
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "waitFor": "updateContentCommand",
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-b7137943",
+      "signature": {
+        "id": "sig-4b529d30",
+        "channel": "chan-structured-output",
+        "path": "configuration.hostRequirements.cpus",
+        "kind": "deacon-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {},
+            "hostRequirements": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-4ec2967f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-a9274738",
+          "minimalInput": {
+            "name": "",
+            "image": "alpine:3.19",
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "overrideCommand": true,
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {},
+            "waitFor": "postStartCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-fc889de5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f434211b",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": [
+              3000,
+              8080
+            ],
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "updateRemoteUserUID": true,
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "notASchemaProperty": 7
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-f364f484",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-976765fe",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "${containerWorkspaceFolder",
+            "workspaceFolder": "/workspaces/project",
+            "containerUser": "root",
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "overrideCommand": true,
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "userEnvProbe": "interactiveShell",
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-83cdf60d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-388e888b",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "alpine:3.19",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "hostRequirements": {},
+            "init": true,
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "postStartCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "userEnvProbe": "none",
+            "features": {
+              "not a feature id": {}
+            },
+            "notASchemaProperty": null
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id",
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-b50aa394",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eaab0a54",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "hostRequirements": {},
+            "init": true,
+            "onCreateCommand": "echo discovery",
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "updateRemoteUserUID": true,
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-ac065cea",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5530d77e",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "${containerWorkspaceFolder",
+            "service": "",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "postStartCommand": {
+              "step": "echo discovery"
+            },
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "waitFor": "updateContentCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-daf2cea2",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-3eccbea1",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "otherPortsAttributes": {},
+            "postAttachCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "shutdownAction": "stopCompose",
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-53988ab6",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b0c5d569",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "workspaceFolder": "${localEnv:${localEnv:DEACON_DISCOVERY}}",
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "containerUser": "root",
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-b1fa087c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-0b0df6b1",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+            "appPort": "3000:3000",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "hostRequirements": {},
+            "onCreateCommand": "echo discovery",
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "remoteUser": "root",
+            "updateContentCommand": [
+              "discovery",
+              "echo"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-d0569901",
+      "signature": {
+        "id": "sig-84964fab",
+        "channel": "chan-structured-output",
+        "path": "configuration.hostRequirements.memory",
+        "kind": "deacon-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {},
+            "hostRequirements": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-22fb22ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-2ee56f86",
+          "minimalInput": {
+            "name": "discovery-image",
+            "capAdd": [],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "onCreateCommand": "${}",
+            "overrideCommand": true,
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-4ec2967f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-a9274738",
+          "minimalInput": {
+            "name": "",
+            "image": "alpine:3.19",
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "overrideCommand": true,
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {},
+            "waitFor": "postStartCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-fc889de5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f434211b",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": [
+              3000,
+              8080
+            ],
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "updateRemoteUserUID": true,
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "notASchemaProperty": 7
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-4a1a9054",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-15ef7acd",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "forwardPorts": [
+              3000
+            ],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "updateRemoteUserUID": true,
+            "userEnvProbe": "loginInteractiveShell",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "runServices": [
+              "db",
+              "cache"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-f364f484",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-976765fe",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "${containerWorkspaceFolder",
+            "workspaceFolder": "/workspaces/project",
+            "containerUser": "root",
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "overrideCommand": true,
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "userEnvProbe": "interactiveShell",
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-83cdf60d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-388e888b",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "alpine:3.19",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "hostRequirements": {},
+            "init": true,
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "postStartCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "userEnvProbe": "none",
+            "features": {
+              "not a feature id": {}
+            },
+            "notASchemaProperty": null
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id",
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-b50aa394",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eaab0a54",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "hostRequirements": {},
+            "init": true,
+            "onCreateCommand": "echo discovery",
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "updateRemoteUserUID": true,
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-ac065cea",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5530d77e",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "${containerWorkspaceFolder",
+            "service": "",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "postStartCommand": {
+              "step": "echo discovery"
+            },
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "waitFor": "updateContentCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-daf2cea2",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-3eccbea1",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "otherPortsAttributes": {},
+            "postAttachCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "shutdownAction": "stopCompose",
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-53988ab6",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b0c5d569",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "workspaceFolder": "${localEnv:${localEnv:DEACON_DISCOVERY}}",
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "containerUser": "root",
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-b1fa087c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-0b0df6b1",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+            "appPort": "3000:3000",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "hostRequirements": {},
+            "onCreateCommand": "echo discovery",
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "remoteUser": "root",
+            "updateContentCommand": [
+              "discovery",
+              "echo"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-de38ae6c",
+      "signature": {
+        "id": "sig-c8f8feca",
+        "channel": "chan-structured-output",
+        "path": "configuration.hostRequirements.storage",
+        "kind": "deacon-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {},
+            "hostRequirements": {}
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-22fb22ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-2ee56f86",
+          "minimalInput": {
+            "name": "discovery-image",
+            "capAdd": [],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "onCreateCommand": "${}",
+            "overrideCommand": true,
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-4ec2967f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-a9274738",
+          "minimalInput": {
+            "name": "",
+            "image": "alpine:3.19",
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "overrideCommand": true,
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {},
+            "waitFor": "postStartCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-fc889de5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f434211b",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": [
+              3000,
+              8080
+            ],
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "updateRemoteUserUID": true,
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "notASchemaProperty": 7
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-4a1a9054",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-15ef7acd",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "forwardPorts": [
+              3000
+            ],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "updateRemoteUserUID": true,
+            "userEnvProbe": "loginInteractiveShell",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "runServices": [
+              "db",
+              "cache"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-f364f484",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-976765fe",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "${containerWorkspaceFolder",
+            "workspaceFolder": "/workspaces/project",
+            "containerUser": "root",
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "overrideCommand": true,
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "userEnvProbe": "interactiveShell",
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-83cdf60d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-388e888b",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "alpine:3.19",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "hostRequirements": {},
+            "init": true,
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "postStartCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "userEnvProbe": "none",
+            "features": {
+              "not a feature id": {}
+            },
+            "notASchemaProperty": null
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id",
+            "mop-unknown-field"
+          ]
+        },
+        {
+          "id": "wit-b50aa394",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eaab0a54",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "hostRequirements": {},
+            "init": true,
+            "onCreateCommand": "echo discovery",
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "updateRemoteUserUID": true,
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-ac065cea",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5530d77e",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "${containerWorkspaceFolder",
+            "service": "",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "postStartCommand": {
+              "step": "echo discovery"
+            },
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "waitFor": "updateContentCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-daf2cea2",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-3eccbea1",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "otherPortsAttributes": {},
+            "postAttachCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteEnv": {
+              "DISCOVERY": "1"
+            },
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "shutdownAction": "stopCompose",
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-53988ab6",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b0c5d569",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "workspaceFolder": "${localEnv:${localEnv:DEACON_DISCOVERY}}",
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "containerUser": "root",
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-b1fa087c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-0b0df6b1",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+            "appPort": "3000:3000",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "hostRequirements": {},
+            "onCreateCommand": "echo discovery",
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "remoteUser": "root",
+            "updateContentCommand": [
+              "discovery",
+              "echo"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-ea78c581",
+      "signature": {
+        "id": "sig-4bcdc7bd",
+        "channel": "chan-structured-output",
+        "path": "workspace.workspaceMount",
+        "kind": "deacon-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "dockerComposeFile": "",
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "empty-collection",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-AdGBe1",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-2d879f7f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-4bb0e61b",
+          "minimalInput": {
+            "name": "Compose Test Fixture",
+            "dockerComposeFile": "",
+            "workspaceFolder": "/workspace",
+            "dockerFile": "Dockerfile"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-G3jKLH",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-fcc7dc57",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-603ef8db",
+          "minimalInput": {
+            "name": "Multi-service Compose Test",
+            "dockerComposeFile": [
+              "../docker-compose.yml",
+              "docker-compose.override.yml"
+            ],
+            "runServices": [
+              "db",
+              "redis"
+            ],
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000,
+              5432,
+              6379
+            ],
+            "portsAttributes": {
+              "3000": {
+                "label": "Web App",
+                "onAutoForward": "notify"
+              },
+              "5432": {
+                "label": "PostgreSQL",
+                "onAutoForward": "silent"
+              },
+              "6379": {
+                "label": "Redis",
+                "onAutoForward": "ignore"
+              }
+            },
+            "privileged": true,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "securityOpt": [
+              "seccomp=unconfined"
+            ]
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-jWuck7",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-0ba40b12",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-3c15f00f",
+          "minimalInput": {
+            "name": "Multi-service Compose Test",
+            "dockerComposeFile": "../docker-compose.yml",
+            "runServices": [
+              "db",
+              "redis"
+            ],
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000,
+              5432,
+              6379
+            ],
+            "portsAttributes": {
+              "3000": {
+                "label": "Web App",
+                "onAutoForward": "notify"
+              },
+              "5432": {
+                "label": "PostgreSQL",
+                "onAutoForward": "silent"
+              },
+              "6379": {
+                "label": "Redis",
+                "onAutoForward": "ignore"
+              }
+            },
+            "privileged": true,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "dockerFile": "Dockerfile"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-EsvJDQ",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-564f59fd",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-18a15d88",
+          "minimalInput": {
+            "name": "Multi-service Compose Test",
+            "dockerComposeFile": "${localWorkspaceFolder}${localWorkspaceFolder}",
+            "runServices": [
+              "db",
+              "redis"
+            ],
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000,
+              5432,
+              6379
+            ],
+            "portsAttributes": {
+              "3000": {
+                "label": "Web App",
+                "onAutoForward": "notify"
+              },
+              "5432": {
+                "label": "PostgreSQL",
+                "onAutoForward": "silent"
+              },
+              "6379": {
+                "label": "Redis",
+                "onAutoForward": "ignore"
+              }
+            },
+            "privileged": true,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-Xv70Bd",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-53988ab6",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b0c5d569",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "docker-compose.yml",
+            "workspaceFolder": "${localEnv:${localEnv:DEACON_DISCOVERY}}",
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "containerUser": "root",
+            "forwardPorts": [
+              "db:5432"
+            ],
+            "hostRequirements": {},
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-arp0Rl",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-e5259f9a",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-7dc98d7f",
+          "minimalInput": {
+            "name": "Compose Test Fixture",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": null,
+            "workspaceFolder": "/workspace"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-1Q1pcF",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-fb0fd4af",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1b40ca6d",
+          "minimalInput": {
+            "name": "discovery-image",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "updateContentCommand": {
+              "step": "echo discovery"
+            },
+            "userEnvProbe": "interactiveShell",
+            "waitFor": "onCreateCommand",
+            "workspaceFolder": "/workspaces/project",
+            "dockerComposeFile": "docker-compose.yml"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-Mz9OtC",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-a8143436",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b51c280e",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "onCreateCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "privileged": true,
+            "remoteUser": "root",
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "waitFor": "onCreateCommand",
+            "workspaceFolder": "/workspace",
+            "dockerComposeFile": "docker-compose.yml"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "type=bind,source=<WORKSPACE>,target=/workspaces/deacon-discovery-WU0z41",
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-d59b7cbd",
+      "signature": {
+        "id": "sig-fc2832df",
+        "channel": "chan-structured-output",
+        "path": "workspace.workspaceFolder",
+        "kind": "value",
+        "valueShapeClass": "value-changed"
+      },
+      "witnesses": [
+        {
+          "id": "wit-f7d549a4",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-79be0dc6",
+          "minimalInput": {
+            "dockerComposeFile": "",
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "empty-collection",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": "/workspaces/deacon-discovery-AdGBe1",
+            "reference": "/"
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-4e80b7ed",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-771ad525",
+          "minimalInput": {
+            "name": "Feature and Dotfiles Test",
+            "image": "ubuntu:22.04",
+            "remoteUser": "root",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "remoteEnv": {
+              "FIXTURE_TYPE": "feature-and-dotfiles"
+            },
+            "updateContentCommand": "apt-get update && apt-get install -y git && echo 'Update content command'",
+            "postCreateCommand": "echo 'Post-create command'",
+            "dockerComposeFile": "docker-compose.yml"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": "/workspaces/deacon-discovery-iUDFiG",
+            "reference": "/"
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-ff31f170",
+      "signature": {
+        "id": "sig-cd5e5823",
+        "channel": "chan-structured-output",
+        "path": "configuration.capAdd",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-22fb22ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-2ee56f86",
+          "minimalInput": {
+            "capAdd": []
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "drop-optional-key"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-e8e0abb2",
+      "signature": {
+        "id": "sig-210b7985",
+        "channel": "chan-structured-output",
+        "path": "configuration.runServices",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-7600bd8f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1578de93",
+          "minimalInput": {
+            "runServices": [],
+            "dockerComposeFile": [],
+            "service": "",
+            "workspaceFolder": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "un-apply-mutation",
+            "empty-collection",
+            "minimize-scalar",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "forwardPorts": [
+              3000
+            ],
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "onCreateCommand": [
+              "echo",
+              "discovery"
+            ],
+            "otherPortsAttributes": null,
+            "privileged": true,
+            "runServices": [],
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-28386f3a",
+      "signature": {
+        "id": "sig-c101fb87",
+        "channel": "chan-structured-output",
+        "path": "configuration.dockerComposeFile",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-7600bd8f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1578de93",
+          "minimalInput": {
+            "workspaceFolder": "/workspace",
+            "dockerComposeFile": [],
+            "service": "app"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "workspaceFolder": "/workspace",
+            "dockerComposeFile": [],
+            "service": "app"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-2d879f7f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-4bb0e61b",
+          "minimalInput": {
+            "name": "Compose Test Fixture",
+            "dockerComposeFile": "",
+            "workspaceFolder": "/workspace",
+            "dockerFile": "Dockerfile"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-d631954e",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-02141b1a",
+          "minimalInput": {
+            "name": "Multi-service Compose Test",
+            "dockerComposeFile": "",
+            "service": "app",
+            "runServices": [
+              "db",
+              "redis"
+            ],
+            "forwardPorts": [
+              3000,
+              5432,
+              6379
+            ],
+            "portsAttributes": {
+              "3000": {
+                "label": "Web App",
+                "onAutoForward": "notify"
+              },
+              "5432": {
+                "label": "PostgreSQL",
+                "onAutoForward": "silent"
+              },
+              "6379": {
+                "label": "Redis",
+                "onAutoForward": "ignore"
+              }
+            },
+            "privileged": true,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [],
+            "service": "app",
+            "workspaceFolder": "/workspaces/project",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "root",
+            "customizations": {},
+            "init": true,
+            "onCreateCommand": {},
+            "shutdownAction": "none"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-4b3d44b3",
+      "signature": {
+        "id": "sig-2074514d",
+        "channel": "chan-structured-output",
+        "path": "configuration.service",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-7600bd8f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1578de93",
+          "minimalInput": {
+            "workspaceFolder": "/workspace",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "workspaceFolder": "/workspace",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-ac065cea",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5530d77e",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "${containerWorkspaceFolder",
+            "service": "",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "postStartCommand": {
+              "step": "echo discovery"
+            },
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "waitFor": "updateContentCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-e5259f9a",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-7dc98d7f",
+          "minimalInput": {
+            "name": "Compose Test Fixture",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": null,
+            "workspaceFolder": "/workspace"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "workspaceFolder": "/workspaces/project",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-27ef0855",
+      "signature": {
+        "id": "sig-4c4cd99c",
+        "channel": "chan-structured-output",
+        "path": "configuration.workspaceFolder",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-7600bd8f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1578de93",
+          "minimalInput": {
+            "workspaceFolder": "",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-compose-combination"
+          ]
+        },
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "workspaceFolder": "",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "workspaceFolder": "",
+            "dockerComposeFile": [],
+            "service": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-9ce4a834",
+      "signature": {
+        "id": "sig-dc73d777",
+        "channel": "chan-structured-output",
+        "path": "configuration.secrets",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-7bf341c0",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5f56dd46",
+          "minimalInput": {
+            "secrets": {},
+            "dockerComposeFile": [],
+            "service": "",
+            "workspaceFolder": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "drop-optional-key",
+            "empty-collection",
+            "minimize-scalar",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-4ec2967f",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-a9274738",
+          "minimalInput": {
+            "name": "",
+            "image": "alpine:3.19",
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "overrideCommand": true,
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {},
+            "waitFor": "postStartCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-808426d7",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f3f20a7b",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [
+              "docker-compose.yml",
+              "docker-compose.override.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "containerUser": "vscode",
+            "customizations": {},
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [
+              "ghcr.io/devcontainers/features/common-utils"
+            ],
+            "postCreateCommand": "echo discovery",
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ]
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-b2ecc8ac",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-7e4b9c1e",
+          "minimalInput": {
+            "name": "${localWorkspaceFolder}${localWorkspaceFolder}",
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopCompose",
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-4a1a9054",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-15ef7acd",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "forwardPorts": [
+              3000
+            ],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "updateRemoteUserUID": true,
+            "userEnvProbe": "loginInteractiveShell",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "runServices": [
+              "db",
+              "cache"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-32afc49d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-c8ca5667",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "init": true,
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [],
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "root",
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "userEnvProbe": "none",
+            "waitFor": "onCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        },
+        {
+          "id": "wit-cf2089c5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d3822325",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": [
+              "docker-compose.yml"
+            ],
+            "service": "app",
+            "workspaceFolder": "/workspaces/project",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY": "1"
+            },
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "postStartCommand": {
+              "step0": "echo",
+              "step1": "discovery"
+            },
+            "privileged": true,
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "userEnvProbe": "none"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-d7d668b9",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-da08200e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "postCreateCommand": null,
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {},
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "waitFor": "postCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-ac065cea",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-5530d77e",
+          "minimalInput": {
+            "name": "discovery-compose",
+            "dockerComposeFile": "${containerWorkspaceFolder",
+            "service": "",
+            "workspaceFolder": "/workspace",
+            "hostRequirements": {},
+            "portsAttributes": {
+              "3000": {
+                "label": "web",
+                "onAutoForward": "notify"
+              }
+            },
+            "postStartCommand": {
+              "step": "echo discovery"
+            },
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "waitFor": "updateContentCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-fa666dd8",
+      "signature": {
+        "id": "sig-3976b160",
+        "channel": "chan-structured-output",
+        "path": "configuration.overrideFeatureInstallOrder",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-92fd09ba",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d9409d47",
+          "minimalInput": {
+            "overrideFeatureInstallOrder": [],
+            "image": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "un-apply-mutation",
+            "drop-optional-key",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-unknown-field",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": null,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "vscode",
+            "otherPortsAttributes": {},
+            "overrideFeatureInstallOrder": [],
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-77b3efc1",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-b5f55e2e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [],
+            "postAttachCommand": "echo discovery",
+            "remoteEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "runArgs": [
+              "--rm",
+              "--init"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-32afc49d",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-c8ca5667",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "init": true,
+            "mounts": [
+              {
+                "source": "${localWorkspaceFolder}/.cache",
+                "target": "/cache",
+                "type": "bind"
+              }
+            ],
+            "overrideCommand": true,
+            "overrideFeatureInstallOrder": [],
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "root",
+            "secrets": {},
+            "updateContentCommand": [
+              "echo",
+              "discovery"
+            ],
+            "userEnvProbe": "none",
+            "waitFor": "onCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "build": {
+              "dockerfile": "Dockerfile"
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": []
+          },
+          "mutationOperators": [
+            "mop-conflicting-source"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-e39c5344",
+      "signature": {
+        "id": "sig-46ab26e0",
+        "channel": "chan-structured-output",
+        "path": "configuration.image",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-92fd09ba",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d9409d47",
+          "minimalInput": {
+            "image": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-unknown-field",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-0afae60a",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-42d408fc",
+          "minimalInput": {
+            "image": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-6512b396",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-49f4f5df",
+          "minimalInput": {
+            "name": "Image Reference Test Fixture",
+            "image": ""
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-07406c78",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-0961f162",
+          "minimalInput": {
+            "name": "Single Container Test",
+            "image": "",
+            "remoteUser": "root",
+            "workspaceFolder": "${}",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "remoteEnv": {
+              "TEST_ENV": "single-container"
+            },
+            "postCreateCommand": "echo 'Post-create command executed'",
+            "updateContentCommand": "apt-get update && apt-get install -y git && echo 'Update content command executed'"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-substitution-edge",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-2404f573",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-1e137b12",
+          "minimalInput": {
+            "name": "Image Reference Test Fixture",
+            "image": null
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-3d2379fa",
+      "signature": {
+        "id": "sig-069ea5e4",
+        "channel": "chan-structured-output",
+        "path": "configuration.remoteEnv",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-92fd09ba",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d9409d47",
+          "minimalInput": {
+            "remoteEnv": {},
+            "image": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "un-apply-mutation",
+            "drop-optional-key",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-unknown-field",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-65300525",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eadf7a33",
+          "minimalInput": {
+            "name": "Single Container Test",
+            "remoteUser": "root",
+            "workspaceFolder": "/workspace",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "remoteEnv": {},
+            "postCreateCommand": "echo 'Post-create command executed'",
+            "updateContentCommand": "apt-get update && apt-get install -y git && echo 'Update content command executed'"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-20e22286",
+      "signature": {
+        "id": "sig-f750e12b",
+        "channel": "chan-structured-output",
+        "path": "configuration.portsAttributes",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-0afae60a",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-42d408fc",
+          "minimalInput": {
+            "portsAttributes": {},
+            "image": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "drop-optional-key",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "appPort": null,
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "vscode",
+            "otherPortsAttributes": {},
+            "overrideFeatureInstallOrder": [],
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "remoteUser": "root"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-4a1a9054",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-15ef7acd",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerEnv": {},
+            "forwardPorts": [
+              3000
+            ],
+            "hostRequirements": {
+              "cpus": 2
+            },
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "remoteUser": "vscode",
+            "secrets": {},
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "updateRemoteUserUID": true,
+            "userEnvProbe": "loginInteractiveShell",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "runServices": [
+              "db",
+              "cache"
+            ],
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-b99a25f8",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-9a1dc5d2",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postCreateCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "updateContentCommand": "echo discovery",
+            "updateRemoteUserUID": true,
+            "dockerComposeFile": "docker-compose.yml",
+            "service": "app",
+            "workspaceFolder": "/workspace",
+            "runServices": [
+              "db"
+            ]
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-compose-combination",
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-b50aa394",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-eaab0a54",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "debian:bookworm-slim",
+            "containerUser": "vscode",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "hostRequirements": {},
+            "init": true,
+            "onCreateCommand": "echo discovery",
+            "otherPortsAttributes": {},
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postAttachCommand": "echo discovery",
+            "postStartCommand": "echo discovery",
+            "remoteUser": "root",
+            "updateRemoteUserUID": true,
+            "waitFor": "postStartCommand"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape"
+          ]
+        },
+        {
+          "id": "wit-92cca6ad",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-f431c019",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerUser": "vscode",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "postStartCommand": [
+              "discovery",
+              "echo"
+            ],
+            "remoteUser": "root",
+            "runArgs": [
+              "--init"
+            ],
+            "secrets": {
+              "TOKEN": {
+                "description": "a token"
+              }
+            },
+            "userEnvProbe": "none",
+            "workspaceFolder": "${containerWorkspaceFolder",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-ordering-change",
+            "mop-substitution-edge"
+          ]
+        },
+        {
+          "id": "wit-ff14febe",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-a2352da3",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "containerUser": "vscode",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "shutdownAction": "stopContainer",
+            "workspaceFolder": "/workspace",
+            "features": {
+              "not a feature id": {}
+            }
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-invalid-feature-id"
+          ]
+        },
+        {
+          "id": "wit-d7d668b9",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-da08200e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "postCreateCommand": null,
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {},
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "waitFor": "postCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        },
+        {
+          "id": "wit-b1fa087c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-0b0df6b1",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+            "appPort": "3000:3000",
+            "customizations": {
+              "vscode": {
+                "extensions": [
+                  "rust-lang.rust-analyzer"
+                ]
+              }
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "hostRequirements": {},
+            "onCreateCommand": "echo discovery",
+            "overrideCommand": true,
+            "portsAttributes": {},
+            "remoteUser": "root",
+            "updateContentCommand": [
+              "discovery",
+              "echo"
+            ],
+            "updateRemoteUserUID": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-lifecycle-shape",
+            "mop-ordering-change"
+          ]
+        },
+        {
+          "id": "wit-b292c80c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-e64c8da9",
+          "minimalInput": {
+            "name": "discovery-image",
+            "image": "",
+            "containerUser": "root",
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": false
+              }
+            },
+            "hostRequirements": {},
+            "onCreateCommand": {
+              "step": "echo discovery"
+            },
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "secrets": {},
+            "workspaceFolder": "/workspaces/project"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-7585c0cc",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-d983329a",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "appPort": [
+              3000,
+              8080
+            ],
+            "containerEnv": {
+              "DISCOVERY_PATH": "${containerEnv:PATH}"
+            },
+            "customizations": {},
+            "hostRequirements": {},
+            "mounts": [
+              "source=${localWorkspaceFolder}/.cache,target=/cache,type=bind"
+            ],
+            "onCreateCommand": "echo discovery",
+            "portsAttributes": {},
+            "postAttachCommand": {
+              "step": "echo discovery"
+            },
+            "privileged": true,
+            "remoteEnv": {},
+            "remoteUser": "root",
+            "securityOpt": [
+              "seccomp=unconfined"
+            ],
+            "shutdownAction": "stopContainer",
+            "updateRemoteUserUID": true,
+            "workspaceFolder": "/workspaces/project",
+            "xUnrecognizedSetting": true
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-unknown-field"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-b77b8a5e",
+      "signature": {
+        "id": "sig-2c681fc6",
+        "channel": "chan-structured-output",
+        "path": "configuration.appPort",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-b9d97c8c",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-df101038",
+          "minimalInput": {
+            "appPort": null,
+            "build": {}
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "empty-collection"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-5fbfcace",
+      "signature": {
+        "id": "sig-1bd9dd8d",
+        "channel": "chan-structured-output",
+        "path": "configuration.postCreateCommand",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-fbbf448e",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-30c7df92",
+          "minimalInput": {
+            "postCreateCommand": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "drop-optional-key"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": ""
+          },
+          "mutationOperators": [
+            "mop-wrong-type",
+            "mop-empty-value"
+          ]
+        },
+        {
+          "id": "wit-d7d668b9",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-da08200e",
+          "minimalInput": {
+            "name": "discovery-dockerfile",
+            "build": {
+              "dockerfile": "Dockerfile"
+            },
+            "capAdd": [
+              "SYS_PTRACE"
+            ],
+            "customizations": {},
+            "features": {
+              "ghcr.io/devcontainers/features/git:1": {}
+            },
+            "forwardPorts": [
+              3000,
+              8080
+            ],
+            "portsAttributes": {},
+            "postAttachCommand": [
+              "echo",
+              "discovery"
+            ],
+            "postCreateCommand": null,
+            "postStartCommand": [
+              "echo",
+              "discovery"
+            ],
+            "runArgs": [
+              "--init",
+              "--rm"
+            ],
+            "secrets": {},
+            "shutdownAction": "none",
+            "updateContentCommand": "echo discovery",
+            "waitFor": "postCreateCommand",
+            "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+          },
+          "isMinimal": false,
+          "reductionSteps": [],
+          "observedValues": {
+            "deacon": null,
+            "reference": null
+          },
+          "mutationOperators": [
+            "mop-null-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    },
+    {
+      "id": "fnd-e2510ffc",
+      "signature": {
+        "id": "sig-0c1885f8",
+        "channel": "chan-structured-output",
+        "path": "configuration.onCreateCommand",
+        "kind": "ref-only",
+        "valueShapeClass": "present-absent"
+      },
+      "witnesses": [
+        {
+          "id": "wit-3e51d9e5",
+          "campaignId": "cmp-978ec2cf",
+          "candidateId": "cnd-de59e96a",
+          "minimalInput": {
+            "onCreateCommand": {},
+            "dockerComposeFile": [],
+            "service": "",
+            "workspaceFolder": ""
+          },
+          "isMinimal": true,
+          "reductionSteps": [
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "drop-optional-key",
+            "un-apply-mutation",
+            "empty-collection",
+            "minimize-scalar",
+            "minimize-scalar"
+          ],
+          "observedValues": {
+            "deacon": null,
+            "reference": {}
+          },
+          "mutationOperators": [
+            "mop-empty-value",
+            "mop-empty-value"
+          ]
+        }
+      ],
+      "classification": null,
+      "state": "untriaged",
+      "firstObserved": "cmp-978ec2cf",
+      "lastObserved": "cmp-978ec2cf",
+      "promotedTo": null,
+      "splitFrom": null,
+      "notes": ""
+    }
+  ]
 }

--- a/crates/conformance/src/discovery/queue.rs
+++ b/crates/conformance/src/discovery/queue.rs
@@ -2362,11 +2362,35 @@ mod tests {
 
     // --- T018 loader -------------------------------------------------------
 
+    /// The committed root loads and every finding in it is anchored to a campaign that
+    /// actually ran.
+    ///
+    /// This used to assert the root was EMPTY, which was true only because no campaign had
+    /// ever produced a committable queue — the drift path wrote witness ids the loader
+    /// rejected, so `discovery check` failed on anything a shrink touched. With that fixed
+    /// the queue is populated, and an emptiness assertion would forbid the very thing this
+    /// feature exists to do. What is worth pinning is the invariant that survives
+    /// population: a finding is only as good as the run that witnessed it, so a witness
+    /// naming a campaign the history does not contain is a record nobody can re-examine.
     #[test]
-    fn the_committed_data_root_loads_and_is_empty() {
+    fn every_committed_finding_is_anchored_to_a_campaign_that_ran() {
         let data = DiscoveryData::load_default().expect("the committed discovery root must load");
-        assert!(data.findings.is_empty());
-        assert!(data.campaigns.is_empty());
+        for finding in &data.findings {
+            assert!(
+                !finding.witnesses.is_empty(),
+                "{} claims a difference with nothing to show for it",
+                finding.id
+            );
+            for witness in &finding.witnesses {
+                assert!(
+                    data.campaign(&witness.campaign_id).is_some(),
+                    "{}/{} names campaign {}, which is absent from campaigns.json",
+                    finding.id,
+                    witness.id,
+                    witness.campaign_id
+                );
+            }
+        }
     }
 
     #[test]
@@ -2432,18 +2456,43 @@ mod tests {
 
     #[test]
     fn the_rendered_empty_file_matches_the_committed_data_root() {
-        // The T003 seed files were hand-written; assert the writer reproduces them
-        // byte-for-byte, so the first campaign's write is a content diff and not a
-        // whole-file reformat.
-        let rendered = render_findings(&FindingsFile::default());
-        for name in ["findings.json", "campaigns.json"] {
-            let committed =
-                std::fs::read_to_string(crate::default_discovery_dir().join(name)).expect(name);
-            assert_eq!(
-                committed, rendered,
-                "{name} must match the canonical rendering"
-            );
-        }
+        // `findings.json` and `campaigns.json` are no longer empty — the first campaign
+        // whose output the loader accepted populated them — so the claim takes the same
+        // form it already took for `corpus.json` below: the committed file IS the canonical
+        // rendering of its own records. That is what keeps the NEXT campaign's write a
+        // content diff rather than a whole-file reformat, which is the property this test
+        // exists for, restated over content rather than over emptiness.
+        let discovery_dir = crate::default_discovery_dir();
+
+        let committed = std::fs::read_to_string(discovery_dir.join("findings.json"))
+            .expect("findings.json is readable");
+        let parsed: FindingsFile =
+            serde_json::from_str(&committed).expect("findings.json parses as strict JSON");
+        assert!(
+            !parsed.records.is_empty(),
+            "the queue is populated; an empty one would make this assertion vacuous rather \
+             than satisfied"
+        );
+        assert_eq!(
+            committed,
+            render_findings(&parsed),
+            "findings.json must match the canonical rendering"
+        );
+
+        let committed = std::fs::read_to_string(discovery_dir.join("campaigns.json"))
+            .expect("campaigns.json is readable");
+        let parsed: CampaignsFile =
+            serde_json::from_str(&committed).expect("campaigns.json parses as strict JSON");
+        assert!(
+            !parsed.records.is_empty(),
+            "a populated queue implies at least one campaign ran; findings with no campaign \
+             history would be unanchored"
+        );
+        assert_eq!(
+            committed,
+            render_campaigns(&parsed),
+            "campaigns.json must match the canonical rendering"
+        );
 
         // `corpus.json` is no longer empty (US7 T106 populated it with the 33 pinned
         // entries), so the claim is the same one in the form it can still take: the

--- a/crates/parity-harness/src/discovery/campaign.rs
+++ b/crates/parity-harness/src/discovery/campaign.rs
@@ -494,7 +494,22 @@ pub async fn run(request: &CampaignRequest) -> Result<CampaignRun, HarnessError>
             for drifted in &reduction.drifted {
                 observed.insert(drifted.signature.id.clone());
                 let drift_witness = Witness {
-                    id: Witness::derived_id(&campaign_id, &drifted.signature.id),
+                    // Derived from the CANDIDATE, like every other witness this crate
+                    // writes — never from the drifted signature. A witness id is
+                    // substance-anchored over `campaignId ‖ candidateId` (D1 recomputes it
+                    // from those two stored fields), so hashing anything else produces a
+                    // record the discovery loader rejects as malformed. It did: the first
+                    // real config-differential campaign wrote 14 such witnesses, and every
+                    // one of them failed `discovery check`, which is why no finding had
+                    // ever been committed to the queue.
+                    //
+                    // Two drifts from ONE candidate into ONE finding therefore collapse to
+                    // a single witness (`upsert_finding` returns `AlreadyWitnessed`). That
+                    // is the intended reading, not a loss: the id says an observation is
+                    // identified by the campaign and the input that produced it, and both
+                    // drifts came from the same input. The drifted signature still gets its
+                    // own FINDING — which is what FR-023 is about.
+                    id: Witness::derived_id(&campaign_id, &candidate.id),
                     campaign_id: campaign_id.clone(),
                     candidate_id: candidate.id.clone(),
                     // The rejected proposal the drift was SEEN on — not the candidate's
@@ -1144,6 +1159,8 @@ fn complete(
         },
     };
 
+    reject_underived_witness(&queue.findings)?;
+
     if request.persist {
         let mut campaigns = existing_campaigns.to_vec();
         // Append-only: a campaign record is never rewritten, because a finding names the
@@ -1175,6 +1192,39 @@ fn complete(
         // Filled in by the corpus driver after this returns; every other tier has none.
         corpus_statuses: Vec::new(),
     })
+}
+
+/// Refuse to hand back a queue whose witness ids the discovery loader would reject.
+///
+/// A witness id is substance-anchored over `campaignId ‖ candidateId`, and **D1** recomputes
+/// it from those two stored fields. Each of the four witness-construction sites in this
+/// crate derives its own id, and one of them hashed the drifted SIGNATURE while storing the
+/// candidate — so the first real config-differential campaign wrote 14 records that
+/// `discovery check` refused, and the queue could not be committed at all. A convention four
+/// call sites must independently honour is one call site away from breaking again; this
+/// makes it structural.
+///
+/// Fail-loud rather than repair-in-place: a mismatch means the writer and the identity rule
+/// disagree about what a witness IS, and quietly rewriting the id would bury that.
+fn reject_underived_witness(findings: &[Finding]) -> Result<(), HarnessError> {
+    for finding in findings {
+        for witness in &finding.witnesses {
+            let derived = Witness::derived_id(&witness.campaign_id, &witness.candidate_id);
+            if witness.id != derived {
+                return Err(HarnessError::Report {
+                    cause: format!(
+                        "refusing to write a findings queue the loader would reject: witness \
+                         `{}` on finding `{}` has an id that is not derived from its own \
+                         `campaignId ‖ candidateId` (expected `{derived}`). A witness id is \
+                         substance-anchored; whichever construction site produced this one is \
+                         hashing something other than the two fields it stores.",
+                        witness.id, finding.id
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// The findings queue plus one campaign's admission bookkeeping (FR-030/FR-034/FR-034b).
@@ -1495,6 +1545,35 @@ mod tests {
         assert_eq!(queue.findings.len(), 1);
         assert_eq!(queue.findings[0].witnesses.len(), 2);
         assert!(queue.suppressed.is_empty());
+    }
+
+    /// The regression this guard exists for. The drift path used to hash the drifted
+    /// SIGNATURE into the witness id while storing the candidate id beside it, so every
+    /// drift witness failed **D1** the moment `discovery check` looked at it — and a
+    /// campaign that shrank anything produced a queue nobody could commit.
+    #[test]
+    fn a_witness_id_hashed_from_anything_but_its_own_fields_is_refused_before_writing() {
+        let mut queue = AdmissionQueue::new(&[], "cmp-11111111", 25);
+        queue.offer(
+            signature("structuredOutput.configuration.name"),
+            witness("cmp-11111111", "cnd-a"),
+        );
+        assert!(
+            reject_underived_witness(&queue.findings).is_ok(),
+            "a queue whose witnesses derive their own ids must pass"
+        );
+
+        // Exactly the old drift-path mistake: a real campaign id, a real candidate id, and
+        // an id hashed over something else entirely.
+        queue.findings[0].witnesses[0].id = Witness::derived_id("cmp-11111111", "sig-deadbeef");
+        let err = reject_underived_witness(&queue.findings)
+            .expect_err("an id that is not derived from the stored fields must be refused");
+        let message = err.to_string();
+        assert!(
+            message.contains(&Witness::derived_id("cmp-11111111", "cnd-a")),
+            "the error must name the id the loader WILL derive, so the fix is mechanical: \
+             {message}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Activates discovery (plan Phase 4) — and the first real campaign immediately found a defect
in the discovery machinery itself.

## The queue could never have been committed

`discovery check` rejected **14 of the campaign's own witnesses**:

```
D1 fnd-4b3d44b3/wit-84b326f9: witness id does not match `campaignId ‖ candidateId`
   (expected `wit-7600bd8f`)
```

A witness id is substance-anchored over `campaignId ‖ candidateId`, and D1 recomputes it
from those two stored fields. Three of the four witness-construction sites hash exactly what
they store — the metamorphic and corpus tiers even carry comments explaining that the
relation/entry id *is* the candidate id for their tier. The shrink-drift path did not: it
hashed the **drifted signature** while storing the candidate beside it. So any campaign that
shrank anything wrote records its own loader refused, which is why `findings.json` has been
empty since the feature landed.

Fixed at the one inconsistent site. Two drifts from one candidate into one finding now
collapse to a single witness (`upsert_finding` reports `AlreadyWitnessed`) — the intended
reading rather than a loss, since the id says an observation is identified by the campaign
and the input that produced it, and both drifts came from the same input. The drifted
signature still gets its own **finding**, which is what FR-023 is about.

## Making it structural

Added `reject_underived_witness`, run before the queue is written at all. A convention four
independent call sites must honour is one call site away from breaking again, and the
failure mode is invisible until someone happens to run the checker. It fails loud and names
the id the loader *will* derive, so the fix is mechanical.

## Two tests asserted the queue would stay empty

`the_committed_data_root_loads_and_is_empty` and the emptiness half of
`the_rendered_empty_file_matches_the_committed_data_root` were true only because no campaign
could populate the root. Keeping them would forbid the one thing this feature exists to do.

Both are restated over content, which is the same treatment `corpus.json` already received
when US7 populated it:
- every committed finding is anchored to a campaign that actually ran;
- the committed files **are** the canonical rendering of their own records, so the next
  campaign's write stays a content diff rather than a whole-file reformat.

## What the campaigns found

- **metamorphic** (no oracle, no Docker, no network): 7 relations, 7 executed, **0 findings**
  — deacon holds all seven declared relations. A real negative result.
- **config-differential**: 150 generated, 149 executed, **23 findings admitted**, 42 further
  observations filtered out as already characterized by an existing case or waiver.

All 23 are now triaged (second commit). A sample of the evidence, with
the shrinker's minimal input:

| finding | path | deacon | reference | minimal input |
|---|---|---|---|---|
| `fnd-d59b7cbd` | `workspace.workspaceFolder` | `/workspaces/…` | `/` | `{"dockerComposeFile": "", "build": {}}` |
| `fnd-ea78c581` | `workspace.workspaceMount` | emitted | absent | same |
| `fnd-03ca9a7c` | `configuration.customizations` | absent | `{}` | `{"customizations": {}, "build": {}}` |

An empty `dockerComposeFile` is enough to make the two CLIs disagree about the workspace
folder — that one reduced to a two-key document.

## Gating

None, by design. `certify` is byte-identical with 23 findings in the queue and with zero
(`52 blocking, 19 waived` either way): no registry loader path reaches the discovery root.
`discovery check` is clean, and the hermetic discovery guards run in the `default` and
`dev-fast` lanes. `make test-nextest-fast` 4162/4162.

Findings are **candidates for assertions, never assertions** — promotion into the registry
stays a human act. Triage of these 23 is the next step and deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Triage (second commit)

Every finding's minimal input was re-materialized and both CLIs re-run against it, so each
classification rests on a measurement. That mattered — the raw outputs disagree far less
often than the queue's shapes suggest, and the reason they still count is not the reason the
shapes imply.

**21 × `deacon-regression`** → **#398**, one root cause reached by 21 paths. deacon
serializes every modeled optional unconditionally, so it cannot distinguish an authored
`"customizations": {}` from an omitted property; the reference can. Seventeen are
byte-identical in the raw documents and surface only because `drop_absent_optional` strips
deacon's copy — that rule runs on deacon's side alone precisely because deacon cannot prove
authorship, its own doc comment says it *"compensates for a deacon defect and is deleted when
that defect is fixed"*, and 024 US5 narrowed it so that authoring an empty property **would**
surface. This is that narrowing paying out. The other four (`name`,
`hostRequirements.{cpus,memory,storage}`) are the same defect on keys the compensation list
does not name, so they differ in the raw bytes too.

**2 × `spec-ambiguity`** → **#399**. An empty-string `dockerComposeFile` sends the two CLIs
down different provisioning paths: the reference reads the key's *presence* as "Compose",
deacon reads the empty *value* as "no Compose", so they disagree about `workspaceFolder` and
about whether a workspace bind mount exists at all. The schema does not define the empty
case. Structural rather than cosmetic, which is why it is recorded rather than shrugged at.

Nothing is promoted — promotion is a human act with no code path into the registry, and the
two issues are the reviewable output. `certify` remains byte-identical.
