### PR TITLE
feat(conformance): close the doctor and read-configuration pairwise gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -740,6 +740,19 @@ real, both were in committed cases, and only the injected run found them. **SC-0
 floor** — no channel below three covering cases — exists for the same reason: a channel
 carried by one case is one authoring mistake from unobserved.
 
+**Before authoring cases for a gap pair, check the value is REACHABLE for that operation.**
+A `gap` obligation asserts nothing was covered; it does not assert coverage is possible.
+`templates-apply` × `output-mode=structured` was counted as a gap for a subcommand that has
+no `--output-format`, writes nothing to stdout, and whose every case observes only
+exit-code / filesystem / file-content / stderr — eight uncoverable pairs sitting in the
+denominator as if they were work. The instrument for those is an **applicability rule**
+(`rule-` in `applicability.json`, with a `ground` naming the mechanism), NOT five cases that
+declare `structured` while observing the filesystem; that would satisfy the mechanical
+`scenarioContext` match and cover nothing, which is precisely why explicit dispositions
+outrank the evidence. The cheap way to find candidates: a `(dimension, value)` appearing in
+that operation's gap pairs and in **none** of its covered pairs. Most such values are
+genuinely uncovered and do want cases — but that list is where the unreachable ones hide.
+
 See `specs/024-deterministic-conformance-coverage/quickstart.md` for the add-a-case,
 find-what-is-missing, disposition-the-queue, and drift workflows.
 

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+ "name": "compose-depends-overlay",
+ "dockerComposeFile": "docker-compose.yml",
+ "service": "app",
+ "workspaceFolder": "/workspace",
+ "features": {
+  "./features/needs-base-tool": {}
+ }
+}

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:bookworm
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/base-tool/devcontainer-feature.json
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/base-tool/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+ "id": "base-tool",
+ "version": "1.0.0",
+ "name": "Conformance base-tool"
+}

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/base-tool/install.sh
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/base-tool/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "base-tool" > /etc/conformance-base-tool

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/needs-base-tool/devcontainer-feature.json
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/needs-base-tool/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+ "id": "needs-base-tool",
+ "version": "1.0.0",
+ "name": "Conformance needs-base-tool",
+ "installsAfter": [
+  "./features/base-tool"
+ ]
+}

--- a/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/needs-base-tool/install.sh
+++ b/conformance/fixtures/fx-readconfig-compose-depends-overlay/.devcontainer/features/needs-base-tool/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "needs-base-tool" > /etc/conformance-needs-base-tool

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+ "name": "compose-lockfile-merged",
+ "dockerComposeFile": "docker-compose.yml",
+ "service": "app",
+ "workspaceFolder": "/workspace",
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {}
+ },
+ "remoteUser": "root"
+}

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:bookworm
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+ "name": "compose-lockfile-base",
+ "dockerComposeFile": "docker-compose.yml",
+ "service": "app",
+ "workspaceFolder": "/workspace",
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {}
+ }
+}

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:bookworm
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/overlay.json
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/overlay.json
@@ -1,0 +1,6 @@
+{
+ "name": "compose-lockfile-overlaid",
+ "containerEnv": {
+  "FROM_OVERLAY": "1"
+ }
+}

--- a/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+ "name": "compose-single-base",
+ "dockerComposeFile": "docker-compose.yml",
+ "service": "app",
+ "workspaceFolder": "/workspace",
+ "features": {
+  "./features/solo-tool": {}
+ }
+}

--- a/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:bookworm
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity

--- a/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/features/solo-tool/devcontainer-feature.json
+++ b/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/features/solo-tool/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+ "id": "solo-tool",
+ "version": "1.0.0",
+ "name": "Conformance solo-tool"
+}

--- a/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/features/solo-tool/install.sh
+++ b/conformance/fixtures/fx-readconfig-compose-single-overlay/.devcontainer/features/solo-tool/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "solo-tool" > /etc/conformance-solo-tool

--- a/conformance/fixtures/fx-readconfig-compose-single-overlay/overlay.json
+++ b/conformance/fixtures/fx-readconfig-compose-single-overlay/overlay.json
@@ -1,0 +1,3 @@
+{
+ "name": "compose-single-overlaid"
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance-declared-order > /etc/conformance-base

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+ "name": "dockerfile-declared-order",
+ "build": {
+  "dockerfile": "Dockerfile"
+ },
+ "features": {
+  "./features/alpha-tool": {},
+  "./features/beta-tool": {}
+ },
+ "overrideFeatureInstallOrder": [
+  "./features/beta-tool",
+  "./features/alpha-tool"
+ ]
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/alpha-tool/devcontainer-feature.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/alpha-tool/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+ "id": "alpha-tool",
+ "version": "1.0.0",
+ "name": "Conformance alpha-tool"
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/alpha-tool/install.sh
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/alpha-tool/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "alpha-tool" > /etc/conformance-alpha-tool

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/beta-tool/devcontainer-feature.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/beta-tool/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+ "id": "beta-tool",
+ "version": "1.0.0",
+ "name": "Conformance beta-tool"
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/beta-tool/install.sh
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/.devcontainer/features/beta-tool/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "beta-tool" > /etc/conformance-beta-tool

--- a/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/overlay.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-declared-overlay/overlay.json
@@ -1,0 +1,5 @@
+{
+ "containerEnv": {
+  "FROM_OVERLAY": "1"
+ }
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance-lockfile-extends > /etc/conformance-base

--- a/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/base.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/base.json
@@ -1,0 +1,10 @@
+{
+ "name": "dockerfile-lockfile-base",
+ "build": {
+  "dockerfile": "Dockerfile"
+ },
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {}
+ },
+ "remoteUser": "root"
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+ "extends": "./base.json",
+ "name": "dockerfile-lockfile-child"
+}

--- a/conformance/fixtures/fx-readconfig-overlay-image-merge/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-overlay-image-merge/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "base-name",
+	"image": "alpine:3.19",
+	"remoteUser": "root"
+}

--- a/conformance/fixtures/fx-readconfig-overlay-image-merge/overlay.json
+++ b/conformance/fixtures/fx-readconfig-overlay-image-merge/overlay.json
@@ -1,0 +1,6 @@
+{
+	"name": "overlay-name",
+	"containerEnv": {
+		"FROM_OVERLAY": "1"
+	}
+}

--- a/conformance/registry/cases/doctor.json
+++ b/conformance/registry/cases/doctor.json
@@ -49,7 +49,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "FR-040 boundary class: `doctor` diagnoses the HOST and the runtime, so a workspace with no devcontainer configuration is a perfectly ordinary input for it. Succeeding here is the behavior — an implementation that required a configuration would be useless in the situation the command exists for."
+      "notes": "FR-040 boundary class: `doctor` diagnoses the HOST and the runtime, so a workspace with no devcontainer configuration is a perfectly ordinary input for it. Succeeding here is the behavior \u2014 an implementation that required a configuration would be useless in the situation the command exists for."
     },
     {
       "id": "case-doctor-compose-workspace",
@@ -199,7 +199,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "FR-005 for `doctor`, human rendering. The pinned reference has no `doctor` command at all, so this is evaluated against the declared expectation and the per-operation report states the substitution — the alternative would be an operation that looks under-tested for a reason nobody recorded."
+      "notes": "FR-005 for `doctor`, human rendering. The pinned reference has no `doctor` command at all, so this is evaluated against the declared expectation and the per-operation report states the substitution \u2014 the alternative would be an operation that looks under-tested for a reason nobody recorded."
     },
     {
       "id": "case-doctor-malformed-configuration-still-diagnoses",
@@ -250,6 +250,64 @@
         "tempdir": true
       },
       "notes": "FR-040 malformed class, with the outcome that is easy to get backwards: an unparseable configuration must NOT stop the diagnosis. `doctor` is the command a user reaches for when something is wrong, so refusing to run because the workspace is broken would remove it exactly when it is needed."
+    },
+    {
+      "id": "case-doctor-structured-compose-workspace",
+      "behaviors": [
+        "bhv-doctor-diagnostics-report"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "doctor",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "single",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-doctor",
+          "subcommand": "doctor",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--json"
+          ],
+          "fixtures": [
+            "fx-tier1-compose-array"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-doctor",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-doctor",
+          "assertion": {
+            "jsonSubset": {
+              "host_os": {
+                "name": "linux"
+              },
+              "config_discovery": {
+                "primary_config": ".devcontainer/devcontainer.json"
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes the `config-source=compose` x `output-mode=structured` pair, the companion to the Dockerfile case above and the structured counterpart of `case-doctor-compose-workspace`. A Compose workspace carries `docker-compose.yml` and an override beside its `devcontainer.json`, and the diagnosis still reports the devcontainer configuration as primary rather than being drawn into resolving the Compose project. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved \u2014 the `jsonSubset: {}` failure mode 024 found in committed cases. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
     },
     {
       "id": "case-doctor-structured-diagnostics",
@@ -307,6 +365,64 @@
       "notes": "The structured rendering of the same diagnosis. The assertion deliberately avoids `cli_version` and every probed path: those change with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
     },
     {
+      "id": "case-doctor-structured-dockerfile-workspace",
+      "behaviors": [
+        "bhv-doctor-diagnostics-report"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "doctor",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "single",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-doctor",
+          "subcommand": "doctor",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--json"
+          ],
+          "fixtures": [
+            "fx-tier1-dockerfile-build"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-doctor",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-doctor",
+          "assertion": {
+            "jsonSubset": {
+              "host_os": {
+                "name": "linux"
+              },
+              "config_discovery": {
+                "primary_config": ".devcontainer/devcontainer.json"
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes the `config-source=dockerfile` x `output-mode=structured` pair. `case-doctor-dockerfile-workspace` already shows the human rendering over a Dockerfile-based workspace and `case-doctor-structured-diagnostics` shows the structured rendering over an image-based one; neither shows that the two dimensions are independent, which is exactly what a pairwise obligation asks. `doctor` diagnoses the HOST and the runtime, so the structured document reports the configuration it FOUND without resolving the build \u2014 an implementation that resolved it would be slower and would fail where the diagnosis is most needed. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved \u2014 the `jsonSubset: {}` failure mode 024 found in committed cases. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
+    },
+    {
       "id": "case-doctor-unsupported-values-still-diagnoses",
       "behaviors": [
         "bhv-doctor-diagnostics-report"
@@ -354,7 +470,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "FR-040 unsupported class: a configuration naming values outside the schema's closed sets is likewise no obstacle to a host diagnosis. Same ground as the malformed case, different input class — both are here because `doctor`'s independence from the workspace configuration is the property worth pinning."
+      "notes": "FR-040 unsupported class: a configuration naming values outside the schema's closed sets is likewise no obstacle to a host diagnosis. Same ground as the malformed case, different input class \u2014 both are here because `doctor`'s independence from the workspace configuration is the property worth pinning."
     }
   ]
 }

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -1607,6 +1607,265 @@
       "notes": "FR-040 boundary class: every collection-valued field is present and EMPTY \u2014 `features`, `forwardPorts`, `containerEnv`, `remoteEnv`, `mounts`, `runArgs`, `customizations`. An empty collection is the edge of the accepted domain and is distinct from an omitted field, which is exactly the distinction the `null_preserving` rule exists to keep visible. STRENGTHENED BY #398, which is what made the strengthening possible: until deacon wrapped the eleven bare-collection properties in `Option`, it emitted these keys whether or not the author wrote them, `drop_absent_optional` elided them from deacon's side, and observing `chan-structured-output` here would have compared a document with the fields removed \u2014 the case would have been green while proving nothing about the very boundary it names. deacon now emits exactly the authored eight and the rule no longer touches this block, so the channel is added and the boundary is actually compared. Measured at oracle 0.87.0: both CLIs emit the same ten keys, with no tolerance."
     },
     {
+      "id": "case-readconfig-compose-depends-overlay",
+      "behaviors": [
+        "bhv-readconfig-feature-resolution-order"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-dependency-order",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-features-configuration",
+            "--additional-features",
+            "{\"./features/base-tool\":{}}"
+          ],
+          "fixtures": [
+            "fx-readconfig-compose-depends-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "featuresConfiguration": {
+                "featureSets": [
+                  {
+                    "sourceInformation": {
+                      "userFeatureId": "./features/base-tool"
+                    }
+                  },
+                  {
+                    "sourceInformation": {
+                      "userFeatureId": "./features/needs-base-tool"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes `config-source=compose` x `features=multiple-dependency-order`. The Compose counterpart of `case-readconfig-overlay-dockerfile-depends`: the configuration declares only `needs-base-tool`, and `base-tool` \u2014 which it `installsAfter` \u2014 arrives ONLY through `--additional-features`, so dependency order has to be decided across the configuration and the overlay together. Positional for the same reason as its Dockerfile sibling. Its existence is the pairwise question stated plainly: the Dockerfile case proves nothing about whether a Compose-shaped configuration resolves the same way, which is why the pair was counted as a hole rather than assumed covered."
+    },
+    {
+      "id": "case-readconfig-compose-lockfile-merged",
+      "behaviors": [
+        "bhv-readconfig-merged-configuration"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "image-metadata",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-merged-configuration"
+          ],
+          "fixtures": [
+            "fx-readconfig-compose-lockfile-merged"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "mergedConfiguration": {
+                "name": "compose-lockfile-merged",
+                "service": "app",
+                "workspaceFolder": "/workspace",
+                "remoteUser": "root",
+                "features": {
+                  "ghcr.io/devcontainers/features/git:1.3.2": {}
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes `features=lockfile` x `layering=image-metadata`, the last pair reachable only through the merged document. The merged configuration for a Compose project layers the pinned Feature's own metadata onto the authored configuration, and the assertion names the Compose identity (`service`, `workspaceFolder`) beside the Feature pin so a merge that resolved the Feature while losing the service binding could not pass. The Feature's contributed `customizations` are deliberately NOT asserted: they are the FEATURE's published content, they change when the pinned version's metadata changes upstream, and a case whose verdict moved with that would be measuring the Feature rather than the merge."
+    },
+    {
+      "id": "case-readconfig-compose-lockfile-overlay",
+      "behaviors": [
+        "bhv-readconfig-basic-parse"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/overlay.json"
+          ],
+          "fixtures": [
+            "fx-readconfig-compose-lockfile-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "configuration": {
+                "name": "compose-lockfile-overlaid",
+                "service": "app",
+                "features": {
+                  "ghcr.io/devcontainers/features/git:1.3.2": {}
+                },
+                "containerEnv": {
+                  "FROM_OVERLAY": "1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes three pairs at once \u2014 `config-source=compose` x `features=lockfile`, `config-source=compose` x `layering=cli-overlay`, and `features=lockfile` x `layering=cli-overlay`. A Compose project whose Feature is pinned by a committed `devcontainer-lock.json`, read through a merge-fragment overlay. The assertion keeps the pinned Feature id alongside the overlaid `name`: an overlay that silently dropped the Feature set while applying its own keys would pass an assertion naming only the overlaid value, and dropping Features is exactly the failure a Compose-plus-lockfile read invites. Reading reports the DECLARED Feature set \u2014 consuming the lockfile belongs to `upgrade` and `up` \u2014 so the case makes the combination reachable without claiming the read resolves the pin."
+    },
+    {
+      "id": "case-readconfig-compose-single-overlay",
+      "behaviors": [
+        "bhv-readconfig-basic-parse"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "single",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-features-configuration",
+            "--merge-config",
+            "${WORKSPACE}/overlay.json"
+          ],
+          "fixtures": [
+            "fx-readconfig-compose-single-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "configuration": {
+                "name": "compose-single-overlaid",
+                "service": "app"
+              },
+              "featuresConfiguration": {
+                "featureSets": [
+                  {
+                    "sourceInformation": {
+                      "userFeatureId": "./features/solo-tool"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes `features=single` x `layering=cli-overlay`. One Feature, one merge fragment: the fragment renames the configuration and the single declared Feature survives untouched. The pairing matters because a merge fragment and a Feature set are the two things an overlay can most easily get wrong together \u2014 replacing the base wholesale would drop the Feature, and deep-merging the `features` map wrongly would duplicate it \u2014 so the assertion names both the overlaid `name` and the surviving Feature id rather than either alone."
+    },
+    {
       "id": "case-readconfig-decl-basic",
       "behaviors": [
         "bhv-readconfig-basic-parse",
@@ -1891,6 +2150,141 @@
         "tempdir": true
       },
       "notes": "FR-027 discovery: `.devcontainer.json` at the workspace ROOT is one of the three locations the spec names, and both CLIs find it. The differential is on the exit code alone, which is what 'the location was searched' actually shows; the resolved document is pinned by the sibling spec-expectation cases."
+    },
+    {
+      "id": "case-readconfig-dockerfile-declared-order-overlay",
+      "behaviors": [
+        "bhv-readconfig-feature-resolution-order"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-features-configuration",
+            "--merge-config",
+            "${WORKSPACE}/overlay.json"
+          ],
+          "fixtures": [
+            "fx-readconfig-dockerfile-declared-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "featuresConfiguration": {
+                "featureSets": [
+                  {
+                    "sourceInformation": {
+                      "userFeatureId": "./features/beta-tool"
+                    }
+                  },
+                  {
+                    "sourceInformation": {
+                      "userFeatureId": "./features/alpha-tool"
+                    }
+                  }
+                ]
+              },
+              "configuration": {
+                "containerEnv": {
+                  "FROM_OVERLAY": "1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes `config-source=dockerfile` x `features=multiple-declared-order` and `features=multiple-declared-order` x `layering=cli-overlay`. Two local Features with no dependency between them, so the order is DECLARED rather than derived: `overrideFeatureInstallOrder` names `beta-tool` first while the `features` map lists `alpha-tool` first, and the resolved order must follow the override. The array assertion is positional for the reason `case-readconfig-overlay-dockerfile-depends` records \u2014 a `jsonSubset` over an array matches without regard to order, so a non-positional assertion would pass for an implementation that ignored the override entirely. The overlay is a merge fragment rather than `--additional-features` so the declared order stays two Features long and the case measures ordering, not arrival."
+    },
+    {
+      "id": "case-readconfig-dockerfile-lockfile-extends",
+      "behaviors": [
+        "bhv-readconfig-extends-merged"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "extends-chain",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-merged-configuration"
+          ],
+          "fixtures": [
+            "fx-readconfig-dockerfile-lockfile-extends"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "mergedConfiguration": {
+                "name": "dockerfile-lockfile-child",
+                "build": {
+                  "dockerfile": "Dockerfile"
+                },
+                "features": {
+                  "ghcr.io/devcontainers/features/git:1.3.2": {}
+                },
+                "remoteUser": "root"
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes `config-source=dockerfile` x `features=lockfile` and `features=lockfile` x `layering=extends-chain`. The child document carries nothing but `extends` and a `name`; the Dockerfile build, the version-pinned Feature and `remoteUser` all reach the merged result through the base. Asserting all four together is the point \u2014 a chain that resolved the child's own keys but dropped the base's `features` would satisfy an assertion naming only `name`, and that is the failure mode an extends chain carrying a pinned Feature actually has. `--include-merged-configuration` is required because a plain read ECHOES `extends` rather than resolving it, which is deacon's characterized behavior, not an accident of this fixture."
     },
     {
       "id": "case-readconfig-extends-compose-features",
@@ -2440,6 +2834,67 @@
         "tempdir": true
       },
       "notes": "The ORDER half of the triple case above, kept separate because it needs a different channel: `jsonSubset` over an array is an order-insensitive containment check by design, so pinning that the dependency arrives BEFORE its dependant has to be done on the raw document. A regex over stdout is the narrowest assertion that expresses 'this identifier precedes that one'."
+    },
+    {
+      "id": "case-readconfig-overlay-image-merge",
+      "behaviors": [
+        "bhv-readconfig-basic-parse"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/overlay.json"
+          ],
+          "fixtures": [
+            "fx-readconfig-overlay-image-merge"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "configuration": {
+                "name": "overlay-name",
+                "image": "alpine:3.19",
+                "remoteUser": "root",
+                "containerEnv": {
+                  "FROM_OVERLAY": "1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Closes the `config-source=image` x `layering=cli-overlay` and `features=none` x `layering=cli-overlay` pairs. Every command-line overlay the registry carried until now arrived as `--additional-features`, which cannot express either pair: adding a Feature moves the scenario out of `features=none` by construction. `--merge-config` is the overlay that layers a fragment WITHOUT touching the Feature set, so it is the only way these two combinations are reachable at all. The assertion pins all three merge outcomes in one match \u2014 `name` overridden by the fragment, `containerEnv` contributed by it, `remoteUser` surviving from the base \u2014 because an assertion on the overridden key alone would also pass for an implementation that REPLACED the base rather than merging onto it, which is what `--override-config` does and what this flag must not."
     },
     {
       "id": "case-readconfig-parity-exit",

--- a/conformance/registry/gaps.json
+++ b/conformance/registry/gaps.json
@@ -9,13 +9,6 @@
       "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
     },
     {
-      "id": "gap-pairwise-doctor",
-      "kind": "coverage",
-      "behaviors": [],
-      "description": "Pairwise scenario combinations under the `doctor` operation that no declarative case covers. The count is deliberately NOT restated here: `coverage report` recomputes it on every run and writes it to `target/conformance/coverage-pairwise.md`, which is the authoritative live number; a count copied into this description drifts silently the moment a case lands and makes the record read as worse (or better) than reality. This is missing COVERAGE, not missing representation: the pairs are enumerated and valid, and no program, waiver, or argument stands behind the uncovered ones. Each authored case re-dispositions the pairs it covers from this gap to `case` (flip the `odp-cmb-*` records in the same commit, or the report keeps counting a hole that is filled); this record is deleted once none remain.",
-      "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
-    },
-    {
       "id": "gap-pairwise-down",
       "kind": "coverage",
       "behaviors": [],

--- a/conformance/registry/gaps.json
+++ b/conformance/registry/gaps.json
@@ -30,13 +30,6 @@
       "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
     },
     {
-      "id": "gap-pairwise-read-configuration",
-      "kind": "coverage",
-      "behaviors": [],
-      "description": "Pairwise scenario combinations under the `read-configuration` operation that no declarative case covers. The count is deliberately NOT restated here: `coverage report` recomputes it on every run and writes it to `target/conformance/coverage-pairwise.md`, which is the authoritative live number; a count copied into this description drifts silently the moment a case lands and makes the record read as worse (or better) than reality. This is missing COVERAGE, not missing representation: the pairs are enumerated and valid, and no program, waiver, or argument stands behind the uncovered ones. Each authored case re-dispositions the pairs it covers from this gap to `case` (flip the `odp-cmb-*` records in the same commit, or the report keeps counting a hole that is filled); this record is deleted once none remain.",
-      "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
-    },
-    {
       "id": "gap-pairwise-run-user-commands",
       "kind": "coverage",
       "behaviors": [],

--- a/conformance/registry/obligation-dispositions/doctor.json
+++ b/conformance/registry/obligation-dispositions/doctor.json
@@ -234,14 +234,18 @@
     {
       "id": "odp-cmb-f1dbca6e",
       "obligation": "obl-cmb-f1dbca6e",
-      "disposition": "gap",
-      "gap": "gap-pairwise-doctor"
+      "disposition": "case",
+      "cases": [
+        "case-doctor-structured-dockerfile-workspace"
+      ]
     },
     {
       "id": "odp-cmb-f783037b",
       "obligation": "obl-cmb-f783037b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-doctor"
+      "disposition": "case",
+      "cases": [
+        "case-doctor-structured-compose-workspace"
+      ]
     },
     {
       "id": "odp-cmb-f8bfac02",

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -286,8 +286,10 @@
     {
       "id": "odp-cmb-030accfe",
       "obligation": "obl-cmb-030accfe",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-037a318e",
@@ -390,8 +392,10 @@
     {
       "id": "odp-cmb-28c7fc43",
       "obligation": "obl-cmb-28c7fc43",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-lockfile-merged"
+      ]
     },
     {
       "id": "odp-cmb-315cab6d",
@@ -762,8 +766,10 @@
     {
       "id": "odp-cmb-51d90cdc",
       "obligation": "obl-cmb-51d90cdc",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-dockerfile-lockfile-extends"
+      ]
     },
     {
       "id": "odp-cmb-5ae9f1fc",
@@ -813,8 +819,10 @@
     {
       "id": "odp-cmb-5ec25efe",
       "obligation": "obl-cmb-5ec25efe",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-overlay-image-merge"
+      ]
     },
     {
       "id": "odp-cmb-6b94da7e",
@@ -827,8 +835,10 @@
     {
       "id": "odp-cmb-71ce71c7",
       "obligation": "obl-cmb-71ce71c7",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-depends-overlay"
+      ]
     },
     {
       "id": "odp-cmb-764d9bc6",
@@ -842,8 +852,10 @@
     {
       "id": "odp-cmb-7dfae70a",
       "obligation": "obl-cmb-7dfae70a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-dockerfile-declared-order-overlay"
+      ]
     },
     {
       "id": "odp-cmb-7fb02571",
@@ -857,8 +869,10 @@
     {
       "id": "odp-cmb-81377d6a",
       "obligation": "obl-cmb-81377d6a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-8252b855",
@@ -970,14 +984,18 @@
     {
       "id": "odp-cmb-9c95a825",
       "obligation": "obl-cmb-9c95a825",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-dockerfile-lockfile-extends"
+      ]
     },
     {
       "id": "odp-cmb-a69623f8",
       "obligation": "obl-cmb-a69623f8",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-ae27a584",
@@ -1040,8 +1058,10 @@
     {
       "id": "odp-cmb-b6832ce4",
       "obligation": "obl-cmb-b6832ce4",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-overlay-image-merge"
+      ]
     },
     {
       "id": "odp-cmb-b6db79df",
@@ -1143,8 +1163,10 @@
     {
       "id": "odp-cmb-bf5d8932",
       "obligation": "obl-cmb-bf5d8932",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-compose-single-overlay"
+      ]
     },
     {
       "id": "odp-cmb-c024a7fb",
@@ -1370,8 +1392,10 @@
     {
       "id": "odp-cmb-dca5a1e6",
       "obligation": "obl-cmb-dca5a1e6",
-      "disposition": "gap",
-      "gap": "gap-pairwise-read-configuration"
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-dockerfile-declared-order-overlay"
+      ]
     },
     {
       "id": "odp-cmb-e5f367b4",

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -87,7 +87,13 @@ const TODAY: &str = "2026-07-19";
 /// spec-expectation — the reference orders the two the other way round, and the difference
 /// lands in `chan-stdout`, which cannot carry a tolerance — so no existing case could have
 /// stated it. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 206;
+/// **206 → 208** (Phase 5, `doctor`): the two pairs that stood between `doctor` and full
+/// pairwise coverage — `config-source=dockerfile` and `config-source=compose`, each crossed
+/// with `output-mode=structured`. Both dimensions were already covered separately; neither
+/// case showed them to be independent, which is the only thing a pairwise obligation asks.
+/// Closing them emptied `gap-pairwise-doctor`, and that record was deleted in the same
+/// change — the first operation to reach zero. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 208;
 
 #[test]
 fn real_registry_is_structurally_valid() {

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -93,7 +93,14 @@ const TODAY: &str = "2026-07-19";
 /// case showed them to be independent, which is the only thing a pairwise obligation asks.
 /// Closing them emptied `gap-pairwise-doctor`, and that record was deleted in the same
 /// change — the first operation to reach zero. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 208;
+/// **208 → 215** (Phase 5, `read-configuration`): the twelve pairs that stood between it and
+/// full pairwise coverage, closed by seven cases (a case fixes five dimensions at once, so one
+/// case can close several pairs). Six of the twelve involve `layering=cli-overlay`, which every
+/// prior overlay case reached through `--additional-features` — a flag that cannot express
+/// `features=none` x `cli-overlay` at all, since adding a Feature moves the scenario out of
+/// that value by construction. `--merge-config` is what makes those pairs reachable.
+/// `gap-pairwise-read-configuration` was deleted in the same change. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 215;
 
 #[test]
 fn real_registry_is_structurally_valid() {


### PR DESCRIPTION
Phase 5 of the parity-operations plan, starting where the holes are smallest so the loop is
exercised end to end before it is applied at scale.

**Two of the ten operations reach zero pairwise gaps.** `certify` goes from 52 blocking to
50, and two `gap-pairwise-*` records are deleted.

| operation | gaps before | after | cases added |
|---|---:|---:|---:|
| `doctor` | 2 | **0** | 2 |
| `read-configuration` | 12 | **0** | 7 |

## `doctor`

Two pairs: `config-source=dockerfile` and `config-source=compose`, each crossed with
`output-mode=structured`. Both dimensions were already covered separately — there are
human-mode cases over a Dockerfile and a Compose workspace, and a structured-mode case over
an image workspace — but nothing showed the two to be independent, which is the only thing a
pairwise obligation asks.

Both new cases assert `config_discovery.primary_config` and not only `host_os`. `host_os`
holds for any workspace, so an assertion resting on it alone would leave the
configuration-source dimension declared but *unobserved* — the `jsonSubset: {}` failure mode
024 found in committed cases, where a channel is declared, observed, and incapable of
failing.

## `read-configuration`

Twelve pairs, seven cases. A case fixes all five applicable dimensions at once, so one case
can close several pairs; the set was chosen to do that rather than one case per hole.

**Six of the twelve involve `layering=cli-overlay`, and why they were all still open is the
useful part.** Every overlay case the registry carried reached the overlay through
`--additional-features`, which *cannot* express `features=none` × `cli-overlay` at all —
adding a Feature moves the scenario out of that value by construction. `--merge-config`
layers a fragment without touching the Feature set, and it is what makes those pairs
reachable.

Each assertion names something that would fail if the combination were mishandled, rather
than something true of any workspace:

- the merge-fragment case asserts all three merge outcomes together (key overridden, key
  contributed, base key surviving) — an assertion on the overridden key alone would also
  pass for an implementation that **replaced** the base, which is what `--override-config`
  does and what this flag must not;
- the two order-sensitive cases assert **positionally**, because a `jsonSubset` over an
  array matches without regard to order;
- the lockfile cases keep the pinned Feature id alongside the overlaid value, so an overlay
  that dropped the Feature set while applying its own keys cannot pass;
- the compose/lockfile merged case deliberately does **not** assert the Feature's contributed
  `customizations` — that is the Feature's published content, it moves when the pinned
  version's upstream metadata moves, and a case whose verdict moved with it would be
  measuring the Feature rather than the merge.

## The disposition flip

`odp-cmb-*` records are flipped in the same commits as the cases. CLAUDE.md names this as
the trap and it is a real one: explicit dispositions take precedence over the evidence, so a
commit that adds cases and forgets the combination records leaves the report counting a hole
that is filled.

## Verification

- every fixture measured against the built binary before its case was authored
- `parity_conformance_runner` (pinned oracle 0.87.0): resource group `none` now carries 114
  cases, up from 107; **all nine new cases report `agree`**. The 11 pre-existing
  `case-merged-decl-*` divergences are unchanged and unrelated
  (`featuresConfiguration.dstFolder` / `.featureSets`, #387, plus the arm64-only
  `universal:2-linux` manifest)
- `validate` ok · `coverage generate` / `check` ok · `certify` 52 → 50 blocking
- `make test-nextest-fast` 4170 passed · fmt + clippy clean

## Remaining

Eight operations, 380 gap pairs: `run-user-commands` 81, `up` 60, `build` 56, `exec` 50,
`upgrade` 45, `outdated` 44, `down` 29, `templates-apply` 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)