### PR TITLE
feat(conformance): close the templates-apply pairwise gap and correct two unreachable denominators

### DIFF
--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -671,16 +671,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-0806ebda",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-0887f993",
       "kind": "combination",
       "operation": "exec",
@@ -1072,16 +1062,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-131ad79f",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-layering": "single",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-13ab5772",
       "kind": "combination",
       "operation": "outdated",
@@ -1168,16 +1148,6 @@
       "assignment": {
         "sdim-config-source": "compose",
         "sdim-features": "single"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-16edd486",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-layering": "extends-chain"
       },
       "arity": 2
     },
@@ -1298,16 +1268,6 @@
       "assignment": {
         "sdim-features": "multiple-dependency-order",
         "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-1bae26a2",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-layering": "extends-chain",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -1913,16 +1873,6 @@
       "arity": 3
     },
     {
-      "id": "obl-cmb-31670959",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-316cc1b7",
       "kind": "combination",
       "operation": "build",
@@ -2139,16 +2089,6 @@
       "assignment": {
         "sdim-config-source": "compose",
         "sdim-container-state": "running"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-3d890f23",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-features": "none",
-        "sdim-layering": "extends-chain"
       },
       "arity": 2
     },
@@ -3161,16 +3101,6 @@
       "assignment": {
         "sdim-features": "none",
         "sdim-layering": "cli-overlay"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-62966e8d",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-layering": "extends-chain"
       },
       "arity": 2
     },
@@ -4607,16 +4537,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-9342e98c",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-93c0b0a3",
       "kind": "combination",
       "operation": "build",
@@ -4693,16 +4613,6 @@
       "operation": "outdated",
       "assignment": {
         "sdim-features": "single",
-        "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-95e84e7b",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-container-state": "none",
         "sdim-layering": "extends-chain"
       },
       "arity": 2
@@ -5781,16 +5691,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-bae3303e",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-layering": "extends-chain",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-bb536130",
       "kind": "combination",
       "operation": "exec",
@@ -6318,16 +6218,6 @@
       "assignment": {
         "sdim-container-state": "running-stale-config",
         "sdim-features": "single"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-c846b04a",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-layering": "extends-chain"
       },
       "arity": 2
     },
@@ -6883,16 +6773,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-dbe96618",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-features": "none",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-dc346367",
       "kind": "combination",
       "operation": "up",
@@ -6959,16 +6839,6 @@
       "assignment": {
         "sdim-features": "single",
         "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-de19fbe2",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-layering": "cli-overlay",
-        "sdim-output-mode": "structured"
       },
       "arity": 2
     },
@@ -7129,16 +6999,6 @@
       "assignment": {
         "sdim-features": "lockfile",
         "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-e5638543",
-      "kind": "combination",
-      "operation": "templates-apply",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-output-mode": "structured"
       },
       "arity": 2
     },

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -541,16 +541,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-0412e436",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-042be3b8",
       "kind": "combination",
       "operation": "upgrade",
@@ -1672,16 +1662,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-2a2e5b40",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "none",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-2a744af0",
       "kind": "combination",
       "operation": "up",
@@ -2123,16 +2103,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-3e60d85c",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-layering": "cli-overlay",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-3e915ab8",
       "kind": "combination",
       "operation": "exec",
@@ -2279,16 +2249,6 @@
       "assignment": {
         "sdim-container-state": "none",
         "sdim-layering": "single"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-44d5dd3c",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-layering": "single",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -2841,16 +2801,6 @@
       "assignment": {
         "sdim-features": "multiple-dependency-order",
         "sdim-layering": "cli-overlay"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-584d6440",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -5752,16 +5702,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-bc986d3a",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-bcca0d67",
       "kind": "combination",
       "operation": "doctor",
@@ -6302,26 +6242,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-cc08481e",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-cc12fdd0",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-declared-order",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-cca3eefd",
       "kind": "combination",
       "operation": "run-user-commands",
@@ -6408,16 +6328,6 @@
       "assignment": {
         "sdim-container-state": "running",
         "sdim-features": "none"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-cf98d7c3",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "single",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -6638,16 +6548,6 @@
       "operation": "down",
       "assignment": {
         "sdim-container-state": "running-stale-config",
-        "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-d85553f9",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
         "sdim-output-mode": "human"
       },
       "arity": 2
@@ -6989,16 +6889,6 @@
       "assignment": {
         "sdim-layering": "single",
         "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-e5530e73",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -7480,16 +7370,6 @@
       "assignment": {
         "sdim-config-source": "compose",
         "sdim-layering": "cli-overlay"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-fcbbce91",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-layering": "extends-chain",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },

--- a/conformance/registry/applicability.json
+++ b/conformance/registry/applicability.json
@@ -190,7 +190,8 @@
           "dimension": "sdim-operation",
           "values": [
             "read-configuration",
-            "up"
+            "up",
+            "upgrade"
           ]
         },
         {
@@ -200,7 +201,7 @@
           ]
         }
       ],
-      "ground": "`read-configuration` and `up` emit their result exclusively as a single JSON document on stdout; neither carries an output-format flag, so a human-readable rendering of the result does not exist and cannot be exercised."
+      "ground": "`read-configuration`, `up`, and `upgrade` emit their result exclusively as a single JSON document on stdout; none carries an output-format flag, so a human-readable rendering of the result does not exist and cannot be exercised. `upgrade` is the one to check rather than assume, because its sibling `outdated` does carry `--output text|json` and both of its modes are reachable; `upgrade` prints the regenerated lockfile document and nothing else, and every case already declares `structured` and observes `chan-structured-output`."
     }
   ],
   "triples": [

--- a/conformance/registry/applicability.json
+++ b/conformance/registry/applicability.json
@@ -45,6 +45,24 @@
       "ground": "These operations neither create nor attach to a container: they resolve configuration, build an image, resolve Feature versions, scaffold files, or probe the host. A pre-existing container is therefore not a condition they can observe or act on, and only the degenerate `none` state remains meaningful."
     },
     {
+      "id": "rule-no-extends-chain-for-scaffolding",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "templates-apply"
+          ]
+        },
+        {
+          "dimension": "sdim-layering",
+          "values": [
+            "extends-chain"
+          ]
+        }
+      ],
+      "ground": "`templates apply` copies the template's payload into the target workspace and substitutes only its declared options; it never loads or resolves a devcontainer configuration, so an extends chain is never traversed. A payload file that happens to contain an `extends` key is copied opaquely, byte for byte, which leaves the value indistinguishable from `single` in every observable the operation produces — the same ground on which `image-metadata` is already excluded for it. A command-line overlay is different and stays applicable: `--option` genuinely layers over the template's declared option defaults."
+    },
+    {
       "id": "rule-no-feature-composition-for-attach-only-operations",
       "excludes": [
         {
@@ -127,6 +145,24 @@
         }
       ],
       "ground": "`doctor` reports host, runtime, and environment diagnostics rather than a merged configuration; it never resolves an extends chain or applies a command-line overlay, so how a configuration would have been layered cannot affect the diagnosis it prints."
+    },
+    {
+      "id": "rule-no-result-document-for-scaffolding",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "templates-apply"
+          ]
+        },
+        {
+          "dimension": "sdim-output-mode",
+          "values": [
+            "structured"
+          ]
+        }
+      ],
+      "ground": "`templates apply` delivers its result by writing files into the target workspace. It carries no output-format flag — `--output` names a destination directory, not a rendering — and it writes nothing at all to stdout on success, so there is no result document whose rendering a case could choose between. Its observables are exit code, filesystem, file content, and stderr; declaring `structured` would satisfy the scenario match while observing none of it."
     },
     {
       "id": "rule-no-result-document-for-teardown-and-hook-execution",

--- a/conformance/registry/cases/templates.json
+++ b/conformance/registry/cases/templates.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "records": [
     {
-      "id": "case-templates-apply-compose-target",
+      "id": "case-templates-apply-compose-default-option",
       "behaviors": [
         "bhv-templates-apply-scaffolds-options"
       ],
@@ -13,6 +13,63 @@
         "sdim-container-state": "none",
         "sdim-features": "none",
         "sdim-layering": "single",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "resourceGroup": "fs-heavy",
+      "operations": [
+        {
+          "id": "op-apply",
+          "subcommand": "templates-apply",
+          "argv": [
+            "${WORKSPACE}/template",
+            "--output",
+            "${WORKSPACE}/applied"
+          ],
+          "fixtures": [
+            "fx-templates-target-compose"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-apply",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-file-content",
+          "operation": "op-apply",
+          "assertion": {
+            "jsonSubset": {
+              "applied/.devcontainer/devcontainer.json": "{\n\t\"name\": \"conformance-minimal\",\n\t\"image\": \"alpine:3.19\"\n}\n"
+            }
+          }
+        }
+      ],
+      "fsAllowlist": [
+        "applied/.devcontainer/devcontainer.json"
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The unoverlaid twin of `case-templates-apply-compose-target`, which supplies `--option` and is therefore `cli-overlay`. No option is supplied here, so the declared default (`3.19`) must reach the scaffolded bytes. The distinction matters because the two failure modes are indistinguishable from the outside: a template engine that ignores defaults and one that ignores the command line both exit 0 and write a file. Pinning the default separately is the only way the overlay case proves the overlay did anything."
+    },
+    {
+      "id": "case-templates-apply-compose-target",
+      "behaviors": [
+        "bhv-templates-apply-scaffolds-options"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "templates-apply",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "cli-overlay",
         "sdim-output-mode": "human"
       },
       "inputClass": "valid",
@@ -58,7 +115,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "SC-004 requires every operation to carry a case for each configuration source the applicability rules permit for it. The Compose counterpart, with an option supplied: the target workspace's own configuration shape is irrelevant to the substitution, which is the property worth pinning rather than assuming."
+      "notes": "SC-004 requires every operation to carry a case for each configuration source the applicability rules permit for it. The Compose counterpart, with an option supplied: the target workspace's own configuration shape is irrelevant to the substitution, which is the property worth pinning rather than assuming. Relabelled `single` to `cli-overlay`: the argv supplies `--option imageVariant=3.20` and the assertion pins the overlaid `3.20`, so the case has always exercised the overlay. It was the sole violator of the convention every other case follows, and the mislabel made `compose x cli-overlay` read as an uncovered gap while `compose x single` read as covered by evidence that did not show it. `case-templates-apply-compose-default-option` now carries `single` honestly."
     },
     {
       "id": "case-templates-apply-default-option",

--- a/conformance/registry/gaps.json
+++ b/conformance/registry/gaps.json
@@ -37,13 +37,6 @@
       "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
     },
     {
-      "id": "gap-pairwise-templates-apply",
-      "kind": "coverage",
-      "behaviors": [],
-      "description": "Pairwise scenario combinations under the `templates-apply` operation that no declarative case covers. The count is deliberately NOT restated here: `coverage report` recomputes it on every run and writes it to `target/conformance/coverage-pairwise.md`, which is the authoritative live number; a count copied into this description drifts silently the moment a case lands and makes the record read as worse (or better) than reality. This is missing COVERAGE, not missing representation: the pairs are enumerated and valid, and no program, waiver, or argument stands behind the uncovered ones. Each authored case re-dispositions the pairs it covers from this gap to `case` (flip the `odp-cmb-*` records in the same commit, or the report keeps counting a hole that is filled); this record is deleted once none remain.",
-      "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
-    },
-    {
       "id": "gap-pairwise-up",
       "kind": "coverage",
       "behaviors": [],

--- a/conformance/registry/obligation-dispositions/templates-apply.json
+++ b/conformance/registry/obligation-dispositions/templates-apply.json
@@ -6,19 +6,15 @@
       "obligation": "obl-bhv-a36e5ed6",
       "disposition": "case",
       "cases": [
+        "case-templates-apply-compose-default-option",
         "case-templates-apply-compose-target",
         "case-templates-apply-default-option",
         "case-templates-apply-dockerfile-target",
         "case-templates-apply-missing-template",
+        "case-templates-apply-multifile-tree",
         "case-templates-apply-option-substituted",
         "case-templates-apply-unsupported-option"
       ]
-    },
-    {
-      "id": "odp-cmb-0806ebda",
-      "obligation": "obl-cmb-0806ebda",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
     },
     {
       "id": "odp-cmb-0a4ac00f",
@@ -34,26 +30,10 @@
     {
       "id": "odp-cmb-0c025991",
       "obligation": "obl-cmb-0c025991",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-131ad79f",
-      "obligation": "obl-cmb-131ad79f",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-16edd486",
-      "obligation": "obl-cmb-16edd486",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-1bae26a2",
-      "obligation": "obl-cmb-1bae26a2",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
+      "disposition": "case",
+      "cases": [
+        "case-templates-apply-compose-target"
+      ]
     },
     {
       "id": "odp-cmb-1fa28d7f",
@@ -91,24 +71,12 @@
       ]
     },
     {
-      "id": "odp-cmb-31670959",
-      "obligation": "obl-cmb-31670959",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
       "id": "odp-cmb-3455e73b",
       "obligation": "obl-cmb-3455e73b",
       "disposition": "case",
       "cases": [
         "case-templates-apply-compose-target"
       ]
-    },
-    {
-      "id": "odp-cmb-3d890f23",
-      "obligation": "obl-cmb-3d890f23",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
     },
     {
       "id": "odp-cmb-40c6c014",
@@ -170,12 +138,6 @@
       ]
     },
     {
-      "id": "odp-cmb-62966e8d",
-      "obligation": "obl-cmb-62966e8d",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
       "id": "odp-cmb-70ece2c5",
       "obligation": "obl-cmb-70ece2c5",
       "disposition": "case",
@@ -220,12 +182,6 @@
       ]
     },
     {
-      "id": "odp-cmb-9342e98c",
-      "obligation": "obl-cmb-9342e98c",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
       "id": "odp-cmb-9416e353",
       "obligation": "obl-cmb-9416e353",
       "disposition": "case",
@@ -233,12 +189,6 @@
         "case-templates-apply-option-substituted",
         "case-templates-apply-unsupported-option"
       ]
-    },
-    {
-      "id": "odp-cmb-95e84e7b",
-      "obligation": "obl-cmb-95e84e7b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
     },
     {
       "id": "odp-cmb-a540f875",
@@ -284,12 +234,6 @@
       ]
     },
     {
-      "id": "odp-cmb-bae3303e",
-      "obligation": "obl-cmb-bae3303e",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
       "id": "odp-cmb-c0ad0da9",
       "obligation": "obl-cmb-c0ad0da9",
       "disposition": "case",
@@ -297,30 +241,6 @@
         "case-templates-apply-default-option",
         "case-templates-apply-missing-template"
       ]
-    },
-    {
-      "id": "odp-cmb-c846b04a",
-      "obligation": "obl-cmb-c846b04a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-dbe96618",
-      "obligation": "obl-cmb-dbe96618",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-de19fbe2",
-      "obligation": "obl-cmb-de19fbe2",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
-    },
-    {
-      "id": "odp-cmb-e5638543",
-      "obligation": "obl-cmb-e5638543",
-      "disposition": "gap",
-      "gap": "gap-pairwise-templates-apply"
     },
     {
       "id": "odp-cmb-f4b1ab8d",

--- a/conformance/registry/obligation-dispositions/upgrade.json
+++ b/conformance/registry/obligation-dispositions/upgrade.json
@@ -34,12 +34,6 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-0412e436",
-      "obligation": "obl-cmb-0412e436",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-042be3b8",
       "obligation": "obl-cmb-042be3b8",
       "disposition": "gap",
@@ -117,12 +111,6 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-2a2e5b40",
-      "obligation": "obl-cmb-2a2e5b40",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-2bb41234",
       "obligation": "obl-cmb-2bb41234",
       "disposition": "case",
@@ -152,20 +140,8 @@
       ]
     },
     {
-      "id": "odp-cmb-3e60d85c",
-      "obligation": "obl-cmb-3e60d85c",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-3f125c4d",
       "obligation": "obl-cmb-3f125c4d",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-44d5dd3c",
-      "obligation": "obl-cmb-44d5dd3c",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
@@ -180,12 +156,6 @@
     {
       "id": "odp-cmb-53668210",
       "obligation": "obl-cmb-53668210",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-584d6440",
-      "obligation": "obl-cmb-584d6440",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
@@ -440,12 +410,6 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-bc986d3a",
-      "obligation": "obl-cmb-bc986d3a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-c21c09c0",
       "obligation": "obl-cmb-c21c09c0",
       "disposition": "gap",
@@ -470,38 +434,14 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-cc08481e",
-      "obligation": "obl-cmb-cc08481e",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-cc12fdd0",
-      "obligation": "obl-cmb-cc12fdd0",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-cebf08fb",
       "obligation": "obl-cmb-cebf08fb",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-cf98d7c3",
-      "obligation": "obl-cmb-cf98d7c3",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-d123620b",
       "obligation": "obl-cmb-d123620b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-d85553f9",
-      "obligation": "obl-cmb-d85553f9",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
@@ -528,12 +468,6 @@
         "case-upgrade-regenerates-lockfile",
         "case-upgrade-unsupported-values-rejected"
       ]
-    },
-    {
-      "id": "odp-cmb-e5530e73",
-      "obligation": "obl-cmb-e5530e73",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     },
     {
       "id": "odp-cmb-e873981b",
@@ -575,12 +509,6 @@
         "case-upgrade-regenerates-lockfile",
         "case-upgrade-unsupported-values-rejected"
       ]
-    },
-    {
-      "id": "odp-cmb-fcbbce91",
-      "obligation": "obl-cmb-fcbbce91",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     }
   ]
 }

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -100,7 +100,17 @@ const TODAY: &str = "2026-07-19";
 /// `features=none` x `cli-overlay` at all, since adding a Feature moves the scenario out of
 /// that value by construction. `--merge-config` is what makes those pairs reachable.
 /// `gap-pairwise-read-configuration` was deleted in the same change. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 215;
+/// **215 → 216** (Phase 5, `templates-apply`): fifteen gap pairs, but only one wanted a case.
+/// Fourteen were unreachable rather than uncovered — `output-mode=structured` for a subcommand
+/// that has no output-format flag and writes nothing to stdout, and `layering=extends-chain`
+/// for one that never loads a configuration — and those went to two applicability rules, which
+/// is what shrinks a denominator honestly. The fifteenth, `config-source=compose` x
+/// `layering=cli-overlay`, turned out to be a mislabel: `case-templates-apply-compose-target`
+/// supplies `--option` and asserts the overlaid value, so it had always exercised the overlay
+/// while declaring `single`. Relabelling it needed an honest `single` twin, which is the one
+/// case added. `gap-pairwise-templates-apply` was deleted in the same change — the third
+/// operation to reach zero. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 216;
 
 #[test]
 fn real_registry_is_structurally_valid() {


### PR DESCRIPTION
Phase 5 continues. This one is mostly about the **denominator**: of the 27 gap
pairs it removes, 26 were never coverable and one was a mislabel.

## `templates-apply` reaches zero (third operation, after `doctor` and `read-configuration`)

Fifteen gap pairs stood in the way. **Fourteen were unreachable, not uncovered**, and
two applicability rules say so with a mechanism:

- **`rule-no-result-document-for-scaffolding`** — `templates apply` delivers its result
  by *writing files*. It has no output-format flag (`--output` names a destination
  directory, not a rendering) and writes nothing at all to stdout on success, verified
  against the built binary. Its observables are exit code, filesystem, file content and
  stderr. Same mechanism `rule-exec-emits-no-result-document` and
  `rule-no-result-document-for-teardown-and-hook-execution` already record for `exec`,
  `down` and `run-user-commands`.
- **`rule-no-extends-chain-for-scaffolding`** — the operation copies the template payload
  and substitutes only its declared options; it never loads or resolves a devcontainer
  configuration. A payload containing an `extends` key is copied opaquely, byte for byte,
  leaving the value indistinguishable from `single` in every observable. That is the same
  ground on which `image-metadata` is *already* excluded for it. `cli-overlay` stays
  applicable — `--option` genuinely layers over the template's declared defaults.

Authoring cases for those fourteen would have satisfied the mechanical `scenarioContext`
match and covered nothing.

**The fifteenth was a mislabel.** `case-templates-apply-compose-target` supplies
`--option imageVariant=3.20` and asserts the overlaid `3.20`, so it had always exercised
the overlay while declaring `single` — the sole violator of the convention the other six
cases follow. It made `compose x cli-overlay` read as an uncovered gap while
`compose x single` read as covered by evidence that never showed it. Relabelling it needed
an honest `single` twin, and that is the one case added:
`case-templates-apply-compose-default-option` supplies no option and pins that the declared
default (`3.19`) reaches the scaffolded bytes. The two failure modes are otherwise
indistinguishable — a template engine that ignores defaults and one that ignores the command
line both exit 0 and write a file.

## `upgrade`: 45 → 33 gap pairs

`upgrade` carries no output-format flag and prints the regenerated lockfile document to
stdout and nothing else (verified on `fx-upgrade-overlay-lockfile`). All eight of its
existing cases already declare `structured`. So `output-mode=human` is unreachable and
`upgrade` joins `rule-structured-only-result-documents`.

Worth checking rather than assuming: its sibling **`outdated` DOES carry
`--output text|json`** and both of its modes are reachable and already covered. The two
look alike and differ here, so the ground now says so.

The neighbouring never-covered values on `upgrade` are deliberately left as gaps for real
cases: `layering=cli-overlay` is reachable through `--merge-config` / `--override-config`
(both flags exist), and the multi-Feature ordering values are the operation's whole subject.

## Numbers

| | before | after |
|---|---|---|
| obligations | 800 | 774 |
| gap | 380 | 353 |
| `certify` blocking | 50 | 49 |
| cases | 215 | 216 |
| gap records | 8 | 7 |

All 26 removed obligations' dispositions were `gap` and are deleted in the same commits
(asserted in the edit, not assumed). `odp-cmb-0c025991` flips `gap` → `case` in the same
commit as its covering case, and `odp-bhv-a36e5ed6` now lists all eight covering cases
rather than six.

## What this PR deliberately does NOT do

The same reachability screen flags `layering=image-metadata` on `run-user-commands`
(13 pairs). Tracing it shows `run_user_commands.rs:65-79` loads config purely from the
workspace and never reads the image or container `devcontainer.metadata` label, while
`exec.rs:634-651` explicitly does (added for #223). **That asymmetry is a candidate bug,
not grounds for an exclusion** — a rule must name a mechanism that makes the value
meaningless for the operation, never deacon's current omission, or it enshrines the bug as
"not applicable". Filed separately for investigation against the reference.

## Verification

- `validate` ok; `coverage check` matches regeneration (774)
- `parity_conformance_runner` resource group `fs-heavy` runs **8** cases (was 7) and passes
- `registry_valid` 4/4; `fmt`, `clippy --all-targets --all-features`, `test-nextest-fast` (4171) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)