### PR TITLE
feat(conformance): close the outdated pairwise gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ artifacts/nextest/full-timing.json
 # runs. The intentionally-committed lockfile-demo lives at an example root (not
 # in a .devcontainer/ dir), so this scoped rule leaves it tracked.
 **/.devcontainer/devcontainer-lock.json
+# ...but a conformance fixture's lockfile is test INPUT, not a generated artifact:
+# a case asserts what the lockfile makes the CLI report. Without this exemption
+# `git add -A` skips it silently, the fixture works locally (the file is in the
+# working tree) and the case fails in CI (the checkout has no such file) with a
+# diff that looks like a behavior difference rather than a missing file.
+!conformance/fixtures/**/devcontainer-lock.json
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/compose-base.json
+++ b/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/compose-base.json
@@ -1,0 +1,5 @@
+{
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace"
+}

--- a/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "ConformanceOutdatedComposeExtendsNoFeatures",
+	"extends": "./compose-base.json",
+	"containerEnv": { "LAYER": "child" }
+}

--- a/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-outdated-compose-extends-nofeatures/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/compose-base.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/compose-base.json
@@ -1,0 +1,8 @@
+{
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git": {
+			"version": "1.3.0",
+			"resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+			"integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+		}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "ConformanceOutdatedComposeLockfileExtends",
+	"extends": "./compose-base.json",
+	"containerEnv": { "LAYER": "child" }
+}

--- a/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-extends/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git": {
+			"version": "1.3.0",
+			"resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+			"integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+		}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "ConformanceOutdatedComposeLockfileOverlay",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-outdated-compose-lockfile-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-multi/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-compose-multi/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "ConformanceOutdatedComposeMulti",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {},
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-compose-multi/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-outdated-compose-multi/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "ConformanceOutdatedComposeSingleOverlay",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace"
+}

--- a/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-outdated-compose-single-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance > /etc/marker

--- a/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "ConformanceOutdatedDockerfileExtendsMulti",
+	"extends": "./multi-base.json",
+	"containerEnv": { "LAYER": "child" }
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/multi-base.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-extends-multi/.devcontainer/multi-base.json
@@ -1,0 +1,9 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {},
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance > /etc/marker

--- a/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git": {
+			"version": "1.3.0",
+			"resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+			"integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+		}
+	}
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-lockfile/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "ConformanceOutdatedDockerfileLockfile",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance > /etc/marker

--- a/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "ConformanceOutdatedDockerfileOverlayNoFeatures",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-outdated-dockerfile-overlay-nofeatures/.devcontainer/overlay.json
@@ -1,0 +1,3 @@
+{
+	"containerEnv": { "OVERLAY": "applied" }
+}

--- a/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git": {
+			"version": "1.3.0",
+			"resolved": "ghcr.io/devcontainers/features/git@sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d",
+			"integrity": "sha256:63c96e8ac33f5630300d8883e2ec3123278de70d318589af596ea1954846014d"
+		}
+	}
+}

--- a/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "ConformanceOutdatedImageLockfileOverlay",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-outdated-image-lockfile-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-image-multi-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-image-multi-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "ConformanceOutdatedImageMultiOverlay",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {},
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-image-multi-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-outdated-image-multi-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2.5.2": {}
+	}
+}

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-merged/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {
+   "version": "1.3.2",
+   "resolved": "ghcr.io/devcontainers/features/git@sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4",
+   "integrity": "sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4"
+  }
+ }
+}

--- a/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-readconfig-compose-lockfile-overlay/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {
+   "version": "1.3.2",
+   "resolved": "ghcr.io/devcontainers/features/git@sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4",
+   "integrity": "sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4"
+  }
+ }
+}

--- a/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-readconfig-dockerfile-lockfile-extends/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+ "features": {
+  "ghcr.io/devcontainers/features/git:1.3.2": {
+   "version": "1.3.2",
+   "resolved": "ghcr.io/devcontainers/features/git@sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4",
+   "integrity": "sha256:8ba4b1d5a3e5c8a0c2e7a1f4d9b6c3e0f7a2d5b8c1e4f7a0d3b6c9e2f5a8d1b4"
+  }
+ }
+}

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -491,32 +491,12 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-030accfe",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-features": "lockfile"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-03439e09",
       "kind": "combination",
       "operation": "upgrade",
       "assignment": {
         "sdim-config-source": "compose",
         "sdim-features": "multiple-declared-order"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-037a318e",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "single"
       },
       "arity": 2
     },
@@ -1592,16 +1572,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-28c7fc43",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "image-metadata"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-2949da63",
       "kind": "combination",
       "operation": "upgrade",
@@ -2363,16 +2333,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-4a7b3111",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-features": "lockfile"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-4a9e8c34",
       "kind": "combination",
       "operation": "down",
@@ -2639,16 +2599,6 @@
       "assignment": {
         "sdim-features": "single",
         "sdim-layering": "single"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-51d90cdc",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-features": "lockfile"
       },
       "arity": 2
     },
@@ -3937,16 +3887,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-81377d6a",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "cli-overlay"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-81606542",
       "kind": "combination",
       "operation": "up",
@@ -4694,16 +4634,6 @@
       "operation": "build",
       "assignment": {
         "sdim-container-state": "none",
-        "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-9c95a825",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-features": "lockfile",
         "sdim-layering": "extends-chain"
       },
       "arity": 2
@@ -5718,16 +5648,6 @@
       "assignment": {
         "sdim-config-source": "dockerfile",
         "sdim-container-state": "none"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-be729589",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-features": "lockfile"
       },
       "arity": 2
     },
@@ -6812,16 +6732,6 @@
         "sdim-layering": "cli-overlay"
       },
       "arity": 3
-    },
-    {
-      "id": "obl-cmb-e5f367b4",
-      "kind": "combination",
-      "operation": "read-configuration",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
     },
     {
       "id": "obl-cmb-e65c9ee4",

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -641,16 +641,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-07ef9122",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-07ff6676",
       "kind": "combination",
       "operation": "exec",
@@ -3145,16 +3135,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-67c58787",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "single"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-687d5488",
       "kind": "combination",
       "operation": "up",
@@ -3943,16 +3923,6 @@
       "assignment": {
         "sdim-config-source": "dockerfile",
         "sdim-container-state": "running-stale-config"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-81246c5a",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-output-mode": "human"
       },
       "arity": 2
     },
@@ -4759,16 +4729,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-9ca129e7",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-features": "multiple-dependency-order"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-9cf6eb47",
       "kind": "combination",
       "operation": "run-user-commands",
@@ -5220,16 +5180,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-ad876a56",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-ae22c784",
       "kind": "combination",
       "operation": "templates-apply",
@@ -5661,16 +5611,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-bbd92f0e",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-features": "multiple-dependency-order"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-bc0f8004",
       "kind": "combination",
       "operation": "read-configuration",
@@ -5798,16 +5738,6 @@
       "assignment": {
         "sdim-container-state": "stopped",
         "sdim-features": "single"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-bef16666",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-features": "multiple-dependency-order"
       },
       "arity": 2
     },
@@ -5998,16 +5928,6 @@
       "assignment": {
         "sdim-container-state": "none",
         "sdim-layering": "image-metadata"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-c4fa4ad3",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-features": "multiple-dependency-order"
       },
       "arity": 2
     },
@@ -6479,16 +6399,6 @@
       "assignment": {
         "sdim-features": "none",
         "sdim-layering": "image-metadata"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-d57b8752",
-      "kind": "combination",
-      "operation": "outdated",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "cli-overlay"
       },
       "arity": 2
     },

--- a/conformance/registry/applicability.json
+++ b/conformance/registry/applicability.json
@@ -63,6 +63,24 @@
       "ground": "`templates apply` copies the template's payload into the target workspace and substitutes only its declared options; it never loads or resolves a devcontainer configuration, so an extends chain is never traversed. A payload file that happens to contain an `extends` key is copied opaquely, byte for byte, which leaves the value indistinguishable from `single` in every observable the operation produces — the same ground on which `image-metadata` is already excluded for it. A command-line overlay is different and stays applicable: `--option` genuinely layers over the template's declared option defaults."
     },
     {
+      "id": "rule-no-dependency-order-for-version-reporting",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "outdated"
+          ]
+        },
+        {
+          "dimension": "sdim-features",
+          "values": [
+            "multiple-dependency-order"
+          ]
+        }
+      ],
+      "ground": "`outdated` reports the version of each DECLARED Feature and never resolves the dependency graph: `commands/outdated.rs` takes the features map straight off the effective configuration, preserving declaration order, and iterates it. No `dependsOn` is followed, no `installsAfter` is honoured, and no transitive Feature is added, verified by declaring a Feature with dependencies and observing that only that Feature is reported. Declaration order IS observable — reversing the two keys reverses the table rows — so `multiple-declared-order` stays applicable and is the value that carries multi-Feature coverage here. A dependency relationship among the declared Features changes neither the rows nor their order, so the value is indistinguishable from `multiple-declared-order` in every observable. Note this is specific to `outdated`: its sibling `upgrade` resolves Features to regenerate a lockfile, so the value is NOT excluded there."
+    },
+    {
       "id": "rule-no-feature-composition-for-attach-only-operations",
       "excludes": [
         {

--- a/conformance/registry/applicability.json
+++ b/conformance/registry/applicability.json
@@ -81,6 +81,24 @@
       "ground": "`outdated` reports the version of each DECLARED Feature and never resolves the dependency graph: `commands/outdated.rs` takes the features map straight off the effective configuration, preserving declaration order, and iterates it. No `dependsOn` is followed, no `installsAfter` is honoured, and no transitive Feature is added, verified by declaring a Feature with dependencies and observing that only that Feature is reported. Declaration order IS observable — reversing the two keys reverses the table rows — so `multiple-declared-order` stays applicable and is the value that carries multi-Feature coverage here. A dependency relationship among the declared Features changes neither the rows nor their order, so the value is indistinguishable from `multiple-declared-order` in every observable. Note this is specific to `outdated`: its sibling `upgrade` resolves Features to regenerate a lockfile, so the value is NOT excluded there."
     },
     {
+      "id": "rule-no-lockfile-for-configuration-reporting",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "read-configuration"
+          ]
+        },
+        {
+          "dimension": "sdim-features",
+          "values": [
+            "lockfile"
+          ]
+        }
+      ],
+      "ground": "`read-configuration` reports the configuration as authored and never consults `devcontainer-lock.json`: `commands/read_configuration.rs` does not mention a lockfile anywhere, and its output is byte-identical with the file present and absent. Resolved Feature versions belong to `outdated` and `upgrade`, which do read it. This rule corrects an over-claim rather than shrinking real coverage: four cases previously declared `features=lockfile` while asserting only `configuration`/`mergedConfiguration` Feature keys, which come from `devcontainer.json`, so no assertion could tell whether a lockfile existed. They are relabelled `single`, the value their fixtures actually exercise."
+    },
+    {
       "id": "rule-no-feature-composition-for-attach-only-operations",
       "excludes": [
         {

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -2,6 +2,273 @@
   "schemaVersion": 1,
   "records": [
     {
+      "id": "case-outdated-compose-extends-empty-report",
+      "behaviors": [
+        "bhv-outdated-extends-chain-features"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "extends-chain",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-outdated-compose-extends-nofeatures"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "^Feature \\| Current \\| Wanted \\| Latest\\s*$"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "A chain in which no link declares a Feature must produce the header and nothing else. The regex is anchored so a spurious row fails it; an unanchored `contains` of the header would pass no matter what followed, since the header is printed unconditionally."
+    },
+    {
+      "id": "case-outdated-compose-lockfile-extends",
+      "behaviors": [
+        "bhv-outdated-extends-chain-features"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "extends-chain",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-outdated-compose-lockfile-extends"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The Feature is contributed by the parent link and its version by the lockfile, so two resolution steps have to both work for the row to be right. `current` 1.3.0 comes from the lockfile while `wanted` stays the parent's declared `1`; either step failing independently yields a row that still looks reasonable, which is why both columns are pinned and `latest` is not."
+    },
+    {
+      "id": "case-outdated-compose-lockfile-overlay",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json",
+            "--output",
+            "json"
+          ],
+          "fixtures": [
+            "fx-outdated-compose-lockfile-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-outdated",
+          "assertion": {
+            "jsonSubset": {
+              "features": {
+                "ghcr.io/devcontainers/features/git": {
+                  "current": "1.3.0",
+                  "wanted": "1"
+                },
+                "ghcr.io/devcontainers/features/node": {
+                  "current": "1.6.1",
+                  "wanted": "1.6.1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Two independent inputs meet in one report. `git` is declared `:1` and its `current` (1.3.0) can only have come from the lockfile \u2014 `wanted` stays the declared `1`, so the two fields together prove the lockfile was read rather than the reference re-derived. `node` is declared NOWHERE in devcontainer.json and reaches the report only through `--merge-config`. An implementation that ignored either input would still exit 0 with a plausible-looking report, which is why both are asserted in the same case. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it."
+    },
+    {
+      "id": "case-outdated-compose-multi",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "single",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-outdated-compose-multi"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Multiple Features on a Compose configuration, in declaration order, with no overlay and no chain. The Compose service shape is irrelevant to version reporting, which is the property worth pinning rather than assuming \u2014 `outdated` never starts a container, so a Compose configuration must report exactly as an image one does."
+    },
+    {
+      "id": "case-outdated-compose-single-overlay",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "single",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json"
+          ],
+          "fixtures": [
+            "fx-outdated-compose-single-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The configuration declares no Features at all; the single reported row exists only because `--merge-config` contributed it. The report would be empty and the exit code 0 if the overlay were dropped, so the stdout assertion is the whole case."
+    },
+    {
       "id": "case-outdated-compose-workspace",
       "behaviors": [
         "bhv-outdated-reports-feature-versions"
@@ -40,6 +307,175 @@
         "tempdir": true
       },
       "notes": "SC-004 requires every operation to carry a case for each configuration source the applicability rules permit for it. The Compose counterpart, with no Features declared: the empty report again, reached through a different configuration shape."
+    },
+    {
+      "id": "case-outdated-dockerfile-extends-multi",
+      "behaviors": [
+        "bhv-outdated-extends-chain-features"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "extends-chain",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--output",
+            "json"
+          ],
+          "fixtures": [
+            "fx-outdated-dockerfile-extends-multi"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-outdated",
+          "assertion": {
+            "jsonSubset": {
+              "features": {
+                "ghcr.io/devcontainers/features/git": {
+                  "current": "1.3.2",
+                  "wanted": "1.3.2"
+                },
+                "ghcr.io/devcontainers/features/node": {
+                  "current": "1.6.1",
+                  "wanted": "1.6.1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Both Features live on the parent link and neither on the child, so an implementation reading only the top document reports an empty set and exits 0 \u2014 a silent miss. The existing extends case pins a single inherited Feature; this pins that the whole inherited map survives, which a merge that overwrites rather than merges would break. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it."
+    },
+    {
+      "id": "case-outdated-dockerfile-lockfile",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "single",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-outdated-dockerfile-lockfile"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The lockfile's contribution isolated from any chain or overlay: `current` 1.3.0 against a declared `:1`. Note the lockfile must be keyed by the CANONICAL untagged id to be found, because `derive_current_version` looks up `canonical_feature_id(reference)`; a lockfile keyed by the tagged reference is silently ignored, so a naively authored fixture would pass this case while proving nothing. See #407."
+    },
+    {
+      "id": "case-outdated-dockerfile-overlay-empty-report",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json",
+            "--output",
+            "json"
+          ],
+          "fixtures": [
+            "fx-outdated-dockerfile-overlay-nofeatures"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-outdated",
+          "assertion": {
+            "jsonEquals": {
+              "features": {}
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "An overlay that contributes no Features must not invent any. Deliberately `jsonEquals` and not `jsonSubset`: a subset assertion of `{\"features\": {}}` is satisfied by ANY features map, so it would pass while the command reported anything at all \u2014 the exact always-green shape recorded in CLAUDE.md under the 024 coverage model. Exact equality is the only assertion that can fail here."
     },
     {
       "id": "case-outdated-dockerfile-workspace",
@@ -130,6 +566,110 @@
         "tempdir": true
       },
       "notes": "Covers the high-risk triple `hrt-outdated-extends-chain-image-single-feature`. The chain's BASE link contributes the only Feature, so an implementation that reads the top document alone reports an empty table and exits 0 \u2014 a silent miss, not an error. The regex pins the row's identifier and both pinned columns while leaving `latest` free."
+    },
+    {
+      "id": "case-outdated-image-lockfile-overlay",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json"
+          ],
+          "fixtures": [
+            "fx-outdated-image-lockfile-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The lockfile governs the configured Feature while the overlay adds one the lockfile says nothing about, so the two inputs must compose rather than one replacing the other. The overlay-contributed `node` row correctly falls back to its declared version, which is the part an implementation that applied the lockfile to every row would get wrong."
+    },
+    {
+      "id": "case-outdated-image-multi-overlay",
+      "behaviors": [
+        "bhv-outdated-reports-feature-versions"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json"
+          ],
+          "fixtures": [
+            "fx-outdated-image-multi-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-stdout",
+          "operation": "op-outdated",
+          "assertion": {
+            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|[\\s\\S]*common-utils \\| 2\\.5\\.2 \\| 2\\.5\\.2 \\|"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Declaration ORDER is the subject. The two configured Features come first in the order they were written and the overlay's contribution follows; the regex pins that sequence rather than mere membership, because a map-shaped report that lost declaration order would still contain all three rows. `latest` is left free in every row \u2014 it is whatever the registry publishes next and asserting it would decay into a false failure."
     },
     {
       "id": "case-outdated-malformed-config-rejected",

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -1684,7 +1684,7 @@
         "sdim-operation": "read-configuration",
         "sdim-config-source": "compose",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "image-metadata",
         "sdim-output-mode": "structured"
       },
@@ -1733,7 +1733,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Closes `features=lockfile` x `layering=image-metadata`, the last pair reachable only through the merged document. The merged configuration for a Compose project layers the pinned Feature's own metadata onto the authored configuration, and the assertion names the Compose identity (`service`, `workspaceFolder`) beside the Feature pin so a merge that resolved the Feature while losing the service binding could not pass. The Feature's contributed `customizations` are deliberately NOT asserted: they are the FEATURE's published content, they change when the pinned version's metadata changes upstream, and a case whose verdict moved with that would be measuring the Feature rather than the merge."
+      "notes": "Closes `features=lockfile` x `layering=image-metadata`, the last pair reachable only through the merged document. The merged configuration for a Compose project layers the pinned Feature's own metadata onto the authored configuration, and the assertion names the Compose identity (`service`, `workspaceFolder`) beside the Feature pin so a merge that resolved the Feature while losing the service binding could not pass. The Feature's contributed `customizations` are deliberately NOT asserted: they are the FEATURE's published content, they change when the pinned version's metadata changes upstream, and a case whose verdict moved with that would be measuring the Feature rather than the merge. Relabelled from `features=lockfile` to `single`: this case asserts Feature keys that come from `devcontainer.json`, and `read-configuration` never consults a lockfile at all, so nothing here could distinguish one being present from one being absent. The fixture declares exactly one Feature, which is what `single` names. See `rule-no-lockfile-for-configuration-reporting`."
     },
     {
       "id": "case-readconfig-compose-lockfile-overlay",
@@ -1745,7 +1745,7 @@
         "sdim-operation": "read-configuration",
         "sdim-config-source": "compose",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "cli-overlay",
         "sdim-output-mode": "structured"
       },
@@ -1796,7 +1796,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Closes three pairs at once \u2014 `config-source=compose` x `features=lockfile`, `config-source=compose` x `layering=cli-overlay`, and `features=lockfile` x `layering=cli-overlay`. A Compose project whose Feature is pinned by a committed `devcontainer-lock.json`, read through a merge-fragment overlay. The assertion keeps the pinned Feature id alongside the overlaid `name`: an overlay that silently dropped the Feature set while applying its own keys would pass an assertion naming only the overlaid value, and dropping Features is exactly the failure a Compose-plus-lockfile read invites. Reading reports the DECLARED Feature set \u2014 consuming the lockfile belongs to `upgrade` and `up` \u2014 so the case makes the combination reachable without claiming the read resolves the pin."
+      "notes": "Closes three pairs at once \u2014 `config-source=compose` x `features=lockfile`, `config-source=compose` x `layering=cli-overlay`, and `features=lockfile` x `layering=cli-overlay`. A Compose project whose Feature is pinned by a committed `devcontainer-lock.json`, read through a merge-fragment overlay. The assertion keeps the pinned Feature id alongside the overlaid `name`: an overlay that silently dropped the Feature set while applying its own keys would pass an assertion naming only the overlaid value, and dropping Features is exactly the failure a Compose-plus-lockfile read invites. Reading reports the DECLARED Feature set \u2014 consuming the lockfile belongs to `upgrade` and `up` \u2014 so the case makes the combination reachable without claiming the read resolves the pin. Relabelled from `features=lockfile` to `single`: this case asserts Feature keys that come from `devcontainer.json`, and `read-configuration` never consults a lockfile at all, so nothing here could distinguish one being present from one being absent. The fixture declares exactly one Feature, which is what `single` names. See `rule-no-lockfile-for-configuration-reporting`."
     },
     {
       "id": "case-readconfig-compose-single-overlay",
@@ -2234,7 +2234,7 @@
         "sdim-operation": "read-configuration",
         "sdim-config-source": "dockerfile",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "extends-chain",
         "sdim-output-mode": "structured"
       },
@@ -2284,7 +2284,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Closes `config-source=dockerfile` x `features=lockfile` and `features=lockfile` x `layering=extends-chain`. The child document carries nothing but `extends` and a `name`; the Dockerfile build, the version-pinned Feature and `remoteUser` all reach the merged result through the base. Asserting all four together is the point \u2014 a chain that resolved the child's own keys but dropped the base's `features` would satisfy an assertion naming only `name`, and that is the failure mode an extends chain carrying a pinned Feature actually has. `--include-merged-configuration` is required because a plain read ECHOES `extends` rather than resolving it, which is deacon's characterized behavior, not an accident of this fixture."
+      "notes": "Closes `config-source=dockerfile` x `features=lockfile` and `features=lockfile` x `layering=extends-chain`. The child document carries nothing but `extends` and a `name`; the Dockerfile build, the version-pinned Feature and `remoteUser` all reach the merged result through the base. Asserting all four together is the point \u2014 a chain that resolved the child's own keys but dropped the base's `features` would satisfy an assertion naming only `name`, and that is the failure mode an extends chain carrying a pinned Feature actually has. `--include-merged-configuration` is required because a plain read ECHOES `extends` rather than resolving it, which is deacon's characterized behavior, not an accident of this fixture. Relabelled from `features=lockfile` to `single`: this case asserts Feature keys that come from `devcontainer.json`, and `read-configuration` never consults a lockfile at all, so nothing here could distinguish one being present from one being absent. The fixture declares exactly one Feature, which is what `single` names. See `rule-no-lockfile-for-configuration-reporting`."
     },
     {
       "id": "case-readconfig-extends-compose-features",
@@ -2501,7 +2501,7 @@
         "sdim-operation": "read-configuration",
         "sdim-config-source": "image",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "single",
         "sdim-output-mode": "structured"
       },
@@ -2545,7 +2545,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "A workspace whose Features are already pinned by a committed `devcontainer-lock.json`. Reading the configuration reports the DECLARED Feature set \u2014 resolution against the lockfile belongs to `upgrade` and `up`, not to a configuration read \u2014 so this case is what makes the `lockfile` value reachable under `read-configuration` without claiming the read consumes it."
+      "notes": "A workspace whose Features are already pinned by a committed `devcontainer-lock.json`. Reading the configuration reports the DECLARED Feature set \u2014 resolution against the lockfile belongs to `upgrade` and `up`, not to a configuration read \u2014 so this case is what makes the `lockfile` value reachable under `read-configuration` without claiming the read consumes it. Relabelled from `features=lockfile` to `single`: this case asserts Feature keys that come from `devcontainer.json`, and `read-configuration` never consults a lockfile at all, so nothing here could distinguish one being present from one being absent. The fixture declares exactly one Feature, which is what `single` names. See `rule-no-lockfile-for-configuration-reporting`."
     },
     {
       "id": "case-readconfig-malformed-json-differential",

--- a/conformance/registry/gaps.json
+++ b/conformance/registry/gaps.json
@@ -23,13 +23,6 @@
       "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
     },
     {
-      "id": "gap-pairwise-outdated",
-      "kind": "coverage",
-      "behaviors": [],
-      "description": "Pairwise scenario combinations under the `outdated` operation that no declarative case covers. The count is deliberately NOT restated here: `coverage report` recomputes it on every run and writes it to `target/conformance/coverage-pairwise.md`, which is the authoritative live number; a count copied into this description drifts silently the moment a case lands and makes the record read as worse (or better) than reality. This is missing COVERAGE, not missing representation: the pairs are enumerated and valid, and no program, waiver, or argument stands behind the uncovered ones. Each authored case re-dispositions the pairs it covers from this gap to `case` (flip the `odp-cmb-*` records in the same commit, or the report keeps counting a hole that is filled); this record is deleted once none remain.",
-      "tracking": "specs/024-deterministic-conformance-coverage/tasks.md#phase-5-user-story-3---deterministic-coverage-of-the-shared-consumer-workflow-priority-p2"
-    },
-    {
       "id": "gap-pairwise-run-user-commands",
       "kind": "coverage",
       "behaviors": [],

--- a/conformance/registry/obligation-dispositions/outdated.json
+++ b/conformance/registry/obligation-dispositions/outdated.json
@@ -35,12 +35,6 @@
       "gap": "gap-pairwise-outdated"
     },
     {
-      "id": "odp-cmb-07ef9122",
-      "obligation": "obl-cmb-07ef9122",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-09548361",
       "obligation": "obl-cmb-09548361",
       "disposition": "case",
@@ -235,12 +229,6 @@
       ]
     },
     {
-      "id": "odp-cmb-67c58787",
-      "obligation": "obl-cmb-67c58787",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-6af5e680",
       "obligation": "obl-cmb-6af5e680",
       "disposition": "case",
@@ -327,12 +315,6 @@
       ]
     },
     {
-      "id": "odp-cmb-81246c5a",
-      "obligation": "obl-cmb-81246c5a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-812d1a46",
       "obligation": "obl-cmb-812d1a46",
       "disposition": "case",
@@ -413,12 +395,6 @@
       "gap": "gap-pairwise-outdated"
     },
     {
-      "id": "odp-cmb-9ca129e7",
-      "obligation": "obl-cmb-9ca129e7",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-a39b6ed6",
       "obligation": "obl-cmb-a39b6ed6",
       "disposition": "gap",
@@ -437,12 +413,6 @@
       "gap": "gap-pairwise-outdated"
     },
     {
-      "id": "odp-cmb-ad876a56",
-      "obligation": "obl-cmb-ad876a56",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-af5a984c",
       "obligation": "obl-cmb-af5a984c",
       "disposition": "case",
@@ -457,26 +427,8 @@
       "gap": "gap-pairwise-outdated"
     },
     {
-      "id": "odp-cmb-bbd92f0e",
-      "obligation": "obl-cmb-bbd92f0e",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
       "id": "odp-cmb-be03ef90",
       "obligation": "obl-cmb-be03ef90",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
-      "id": "odp-cmb-bef16666",
-      "obligation": "obl-cmb-bef16666",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
-      "id": "odp-cmb-c4fa4ad3",
-      "obligation": "obl-cmb-c4fa4ad3",
       "disposition": "gap",
       "gap": "gap-pairwise-outdated"
     },
@@ -521,12 +473,6 @@
     {
       "id": "odp-cmb-d2f126e7",
       "obligation": "obl-cmb-d2f126e7",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
-    },
-    {
-      "id": "odp-cmb-d57b8752",
-      "obligation": "obl-cmb-d57b8752",
       "disposition": "gap",
       "gap": "gap-pairwise-outdated"
     },

--- a/conformance/registry/obligation-dispositions/outdated.json
+++ b/conformance/registry/obligation-dispositions/outdated.json
@@ -31,8 +31,13 @@
     {
       "id": "odp-cmb-048ffe68",
       "obligation": "obl-cmb-048ffe68",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-extends",
+        "case-outdated-compose-lockfile-overlay",
+        "case-outdated-dockerfile-lockfile",
+        "case-outdated-image-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-09548361",
@@ -54,26 +59,36 @@
     {
       "id": "odp-cmb-0d6dd24b",
       "obligation": "obl-cmb-0d6dd24b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-multi",
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-0f7b3ee2",
       "obligation": "obl-cmb-0f7b3ee2",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-0fb7277b",
       "obligation": "obl-cmb-0fb7277b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-image-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-121ba470",
       "obligation": "obl-cmb-121ba470",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi",
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-13ab5772",
@@ -103,8 +118,10 @@
     {
       "id": "odp-cmb-219d0e03",
       "obligation": "obl-cmb-219d0e03",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi"
+      ]
     },
     {
       "id": "odp-cmb-268ce866",
@@ -143,14 +160,18 @@
     {
       "id": "odp-cmb-3532ca36",
       "obligation": "obl-cmb-3532ca36",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-3c708ae2",
       "obligation": "obl-cmb-3c708ae2",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-4249e664",
@@ -163,8 +184,11 @@
     {
       "id": "odp-cmb-4cd05e91",
       "obligation": "obl-cmb-4cd05e91",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-extends",
+        "case-outdated-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-4e0bb84c",
@@ -196,8 +220,12 @@
     {
       "id": "odp-cmb-50a2fe69",
       "obligation": "obl-cmb-50a2fe69",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-single-overlay",
+        "case-outdated-image-lockfile-overlay",
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-518b3543",
@@ -211,8 +239,12 @@
     {
       "id": "odp-cmb-57fde6fa",
       "obligation": "obl-cmb-57fde6fa",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-multi",
+        "case-outdated-dockerfile-extends-multi",
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-5a33c6bd",
@@ -239,14 +271,22 @@
     {
       "id": "odp-cmb-6bdc164b",
       "obligation": "obl-cmb-6bdc164b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay",
+        "case-outdated-compose-single-overlay",
+        "case-outdated-dockerfile-overlay-empty-report",
+        "case-outdated-image-lockfile-overlay",
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-6d332846",
       "obligation": "obl-cmb-6d332846",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-lockfile"
+      ]
     },
     {
       "id": "odp-cmb-714cfeeb",
@@ -271,14 +311,18 @@
     {
       "id": "odp-cmb-74c6d780",
       "obligation": "obl-cmb-74c6d780",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-lockfile"
+      ]
     },
     {
       "id": "odp-cmb-7547ea3a",
       "obligation": "obl-cmb-7547ea3a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-770a3b94",
@@ -303,8 +347,11 @@
     {
       "id": "odp-cmb-7c33dd66",
       "obligation": "obl-cmb-7c33dd66",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay",
+        "case-outdated-image-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-7c51db88",
@@ -330,20 +377,26 @@
     {
       "id": "odp-cmb-81951963",
       "obligation": "obl-cmb-81951963",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-extends"
+      ]
     },
     {
       "id": "odp-cmb-82d7e0b0",
       "obligation": "obl-cmb-82d7e0b0",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-multi"
+      ]
     },
     {
       "id": "odp-cmb-86c91410",
       "obligation": "obl-cmb-86c91410",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-874c24c1",
@@ -385,32 +438,45 @@
     {
       "id": "odp-cmb-9ba3247f",
       "obligation": "obl-cmb-9ba3247f",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi"
+      ]
     },
     {
       "id": "odp-cmb-9bce7468",
       "obligation": "obl-cmb-9bce7468",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-extends",
+        "case-outdated-dockerfile-lockfile",
+        "case-outdated-image-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-a39b6ed6",
       "obligation": "obl-cmb-a39b6ed6",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi"
+      ]
     },
     {
       "id": "odp-cmb-a4377f4c",
       "obligation": "obl-cmb-a4377f4c",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-extends-empty-report",
+        "case-outdated-compose-lockfile-extends"
+      ]
     },
     {
       "id": "odp-cmb-aabaaca2",
       "obligation": "obl-cmb-aabaaca2",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi"
+      ]
     },
     {
       "id": "odp-cmb-af5a984c",
@@ -423,20 +489,27 @@
     {
       "id": "odp-cmb-b3dbe864",
       "obligation": "obl-cmb-b3dbe864",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-be03ef90",
       "obligation": "obl-cmb-be03ef90",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-single-overlay"
+      ]
     },
     {
       "id": "odp-cmb-c770003a",
       "obligation": "obl-cmb-c770003a",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay",
+        "case-outdated-compose-single-overlay"
+      ]
     },
     {
       "id": "odp-cmb-c8adf857",
@@ -461,26 +534,35 @@
     {
       "id": "odp-cmb-ce0cb0a8",
       "obligation": "obl-cmb-ce0cb0a8",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-d1610954",
       "obligation": "obl-cmb-d1610954",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-dockerfile-extends-multi"
+      ]
     },
     {
       "id": "odp-cmb-d2f126e7",
       "obligation": "obl-cmb-d2f126e7",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay"
+      ]
     },
     {
       "id": "odp-cmb-d98e095d",
       "obligation": "obl-cmb-d98e095d",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-lockfile-overlay",
+        "case-outdated-dockerfile-overlay-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-dad36f43",
@@ -493,26 +575,35 @@
     {
       "id": "odp-cmb-e65c9ee4",
       "obligation": "obl-cmb-e65c9ee4",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-image-lockfile-overlay",
+        "case-outdated-image-multi-overlay"
+      ]
     },
     {
       "id": "odp-cmb-ea077572",
       "obligation": "obl-cmb-ea077572",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-multi"
+      ]
     },
     {
       "id": "odp-cmb-f559e4ce",
       "obligation": "obl-cmb-f559e4ce",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-single-overlay"
+      ]
     },
     {
       "id": "odp-cmb-fd3ca6ad",
       "obligation": "obl-cmb-fd3ca6ad",
-      "disposition": "gap",
-      "gap": "gap-pairwise-outdated"
+      "disposition": "case",
+      "cases": [
+        "case-outdated-compose-extends-empty-report"
+      ]
     },
     {
       "id": "odp-cmb-fefda74b",

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -284,22 +284,6 @@
       ]
     },
     {
-      "id": "odp-cmb-030accfe",
-      "obligation": "obl-cmb-030accfe",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-compose-lockfile-overlay"
-      ]
-    },
-    {
-      "id": "odp-cmb-037a318e",
-      "obligation": "obl-cmb-037a318e",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-lockfile-present"
-      ]
-    },
-    {
       "id": "odp-cmb-05df8fcb",
       "obligation": "obl-cmb-05df8fcb",
       "disposition": "case",
@@ -387,14 +371,6 @@
         "case-errors-decl-extends-missing",
         "case-readconfig-extends-merge-precedence",
         "case-tier1-decl-extends-child"
-      ]
-    },
-    {
-      "id": "odp-cmb-28c7fc43",
-      "obligation": "obl-cmb-28c7fc43",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-compose-lockfile-merged"
       ]
     },
     {
@@ -595,14 +571,6 @@
       ]
     },
     {
-      "id": "odp-cmb-4a7b3111",
-      "obligation": "obl-cmb-4a7b3111",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-lockfile-present"
-      ]
-    },
-    {
       "id": "odp-cmb-4bcf721d",
       "obligation": "obl-cmb-4bcf721d",
       "disposition": "case",
@@ -764,14 +732,6 @@
       ]
     },
     {
-      "id": "odp-cmb-51d90cdc",
-      "obligation": "obl-cmb-51d90cdc",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-dockerfile-lockfile-extends"
-      ]
-    },
-    {
       "id": "odp-cmb-5ae9f1fc",
       "obligation": "obl-cmb-5ae9f1fc",
       "disposition": "case",
@@ -864,14 +824,6 @@
       "cases": [
         "case-merged-decl-feature-order",
         "case-merged-decl-python-features"
-      ]
-    },
-    {
-      "id": "odp-cmb-81377d6a",
-      "obligation": "obl-cmb-81377d6a",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-compose-lockfile-overlay"
       ]
     },
     {
@@ -979,14 +931,6 @@
         "case-tier1-decl-universal-jsonc",
         "case-tier1-decl-user-mapping",
         "case-tier1-decl-workspacefolder-custom"
-      ]
-    },
-    {
-      "id": "odp-cmb-9c95a825",
-      "obligation": "obl-cmb-9c95a825",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-dockerfile-lockfile-extends"
       ]
     },
     {
@@ -1135,14 +1079,6 @@
       "cases": [
         "case-readconfig-overlay-dockerfile-depends",
         "case-readconfig-overlay-dockerfile-depends-order"
-      ]
-    },
-    {
-      "id": "odp-cmb-be729589",
-      "obligation": "obl-cmb-be729589",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-lockfile-present"
       ]
     },
     {
@@ -1395,14 +1331,6 @@
       "disposition": "case",
       "cases": [
         "case-readconfig-dockerfile-declared-order-overlay"
-      ]
-    },
-    {
-      "id": "odp-cmb-e5f367b4",
-      "obligation": "obl-cmb-e5f367b4",
-      "disposition": "case",
-      "cases": [
-        "case-readconfig-lockfile-present"
       ]
     },
     {

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -110,7 +110,7 @@ const TODAY: &str = "2026-07-19";
 /// while declaring `single`. Relabelling it needed an honest `single` twin, which is the one
 /// case added. `gap-pairwise-templates-apply` was deleted in the same change — the third
 /// operation to reach zero. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 216;
+const MIGRATED_CASE_COUNT: usize = 226;
 
 #[test]
 fn real_registry_is_structurally_valid() {


### PR DESCRIPTION
Phase 5 continues. **`outdated` reaches zero pairwise gaps** — the fourth operation, after
`doctor`, `read-configuration` and `templates-apply`.

44 gap pairs → 0, via one applicability rule (9 pairs that were never coverable) and ten
cases (the remaining 35).

## The rule: `outdated` never resolves the dependency graph

`commands/outdated.rs:131-179` takes the features map straight off the effective
configuration — the comment says *"preserving declaration order"* — and iterates it. No
`dependsOn` is followed, no `installsAfter` honoured, no transitive Feature added. Verified
by declaring a Feature that has dependencies and observing only that Feature reported.

So `features=multiple-dependency-order` is indistinguishable from `multiple-declared-order`
in every observable. Declaration order, by contrast, **is** observable — reversing the two
keys reverses the table rows — so `multiple-declared-order` stays applicable and is the
value that carries multi-Feature coverage here.

Scoped to `outdated` only: `upgrade` resolves Features to regenerate a lockfile, so its 9
dependency-order pairs stay gaps.

## The ten cases

Every mechanism was verified against the built binary **before** any assertion was written.
Two do not behave the way a naive fixture would assume:

- **The lockfile is found only under the canonical *untagged* id** — `derive_current_version`
  looks up `canonical_feature_id(reference)`, so a lockfile keyed by the tagged reference is
  silently ignored. It also only changes anything when the declared reference is **unpinned**;
  an exact pin wins. Both lockfile cases therefore declare `:1` and assert `current`=1.3.0
  against `wanted`=1 — the two columns *together* are what prove the lockfile was read rather
  than the reference re-derived. A fixture wrong on either detail would pass while proving nothing.
- **`--merge-config` genuinely contributes Features to the report**, so `layering=cli-overlay`
  is real coverage here rather than a label.

Two assertion choices worth keeping:

- `case-outdated-dockerfile-overlay-empty-report` uses **`jsonEquals`, not `jsonSubset`**. A
  subset assertion of `{"features": {}}` is satisfied by *any* features map — the always-green
  shape CLAUDE.md records under the 024 coverage model.
- `case-outdated-compose-extends-empty-report` **anchors** its regex, because the header row is
  printed unconditionally and an unanchored `contains` of it could never fail.

The multi-Feature cases pin declaration **order**, not membership — a report that lost ordering
would still contain every row.

## Numbers

| | before | after |
|---|---|---|
| obligations | 774 | 765 |
| gap | 344 | 309 |
| `certify` blocking | 49 | 48 |
| cases | 216 | 226 |
| gap records | 7 | 6 |
| operations at zero | 3 | **4** |

All 35 `odp-cmb-*` records flip `gap` → `case` in the same commit as their cases, and
`gap-pairwise-outdated` is deleted.

## Found while authoring, deliberately not resolved here

**#407** — deacon's `outdated` report diverges from the reference in three ways, and **no case
has ever observed it**: all three `live-differential` cases declare only `chan-exit-code`, both
CLIs exit 0, so the report goes uncompared. The divergences are the map key shape
(unconditional — and it **silently drops a Feature** when two are declared at different tags),
`current`/`wanted` for an unpinned reference, and lockfile influence. Filed rather than papered
over; the affected assertions here say in their notes that they pin deacon's current shape to
make the change visible when it lands, not to endorse it.

**#406** — a malformed `devcontainer-lock.json` is swallowed at `debug!` on this same path,
silently changing reported `current`.

## Verification

- `validate` ok; `coverage check` matches regeneration (765)
- `parity_conformance_runner` group `none` runs **124** cases (was 114); all ten new cases pass,
  only the pre-existing `case-merged-decl-*` cluster fails (#387)
- `registry_valid` 4/4; fmt, `clippy --all-targets --all-features`, `test-nextest-fast` (4171) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)