### PR TITLE
fix(upgrade): honor --override-config, --merge-config and profile fragments

### DIFF
--- a/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "ConformanceUpgradeComposeMultiOverlay",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {}
+	}
+}

--- a/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/docker-compose.yml
+++ b/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.19
+    command: sleep infinity

--- a/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-upgrade-compose-multi-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/Dockerfile
+++ b/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.19
+RUN echo conformance > /etc/marker

--- a/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "ConformanceUpgradeDockerfileOverlayEmpty",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {}
+	}
+}

--- a/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/replacement.json
+++ b/conformance/fixtures/fx-upgrade-dockerfile-overlay-empty/.devcontainer/replacement.json
@@ -1,0 +1,6 @@
+{
+	"name": "ConformanceUpgradeDockerfileReplaced",
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+}

--- a/conformance/fixtures/fx-upgrade-image-single-overlay/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-upgrade-image-single-overlay/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+	"name": "ConformanceUpgradeImageSingleOverlay",
+	"image": "alpine:3.19"
+}

--- a/conformance/fixtures/fx-upgrade-image-single-overlay/.devcontainer/overlay.json
+++ b/conformance/fixtures/fx-upgrade-image-single-overlay/.devcontainer/overlay.json
@@ -1,0 +1,5 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {}
+	}
+}

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -111,6 +111,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-45551f67",
+      "kind": "behavior",
+      "behavior": "bhv-upgrade-cli-config-overlay-honored",
+      "context": []
+    },
+    {
       "id": "obl-bhv-495a30ef",
       "kind": "behavior",
       "behavior": "bhv-readconfig-merged-configuration",
@@ -721,16 +727,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-0b194953",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-features": "lockfile"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-0b7267a0",
       "kind": "combination",
       "operation": "build",
@@ -790,16 +786,6 @@
         "sdim-features": "single"
       },
       "arity": 3
-    },
-    {
-      "id": "obl-cmb-0cfe1f76",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-features": "multiple-dependency-order"
-      },
-      "arity": 2
     },
     {
       "id": "obl-cmb-0d0d89d2",
@@ -1782,16 +1768,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-30357cd3",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-3043811a",
       "kind": "combination",
       "operation": "doctor",
@@ -1800,6 +1776,17 @@
         "sdim-output-mode": "structured"
       },
       "arity": 2
+    },
+    {
+      "id": "obl-cmb-3073e0a2",
+      "kind": "combination",
+      "operation": "upgrade",
+      "assignment": {
+        "sdim-layering": "extends-chain",
+        "sdim-config-source": "image",
+        "sdim-features": "single"
+      },
+      "arity": 3
     },
     {
       "id": "obl-cmb-315cab6d",
@@ -2289,16 +2276,6 @@
       "assignment": {
         "sdim-layering": "extends-chain",
         "sdim-output-mode": "human"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-48a3d9eb",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "single"
       },
       "arity": 2
     },
@@ -2915,16 +2892,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-5e00fbe8",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-features": "multiple-dependency-order"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-5ec25efe",
       "kind": "combination",
       "operation": "read-configuration",
@@ -3245,16 +3212,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-6ca77f90",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-container-state": "none",
-        "sdim-features": "multiple-dependency-order"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-6d28294c",
       "kind": "combination",
       "operation": "upgrade",
@@ -3516,16 +3473,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-76286197",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-764d9bc6",
       "kind": "combination",
       "operation": "read-configuration",
@@ -3777,16 +3724,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-7dd34b50",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-features": "lockfile"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-7dd616cd",
       "kind": "combination",
       "operation": "exec",
@@ -3937,16 +3874,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-835fa8aa",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "single"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-83a58b7f",
       "kind": "combination",
       "operation": "up",
@@ -3983,16 +3910,6 @@
       "assignment": {
         "sdim-container-state": "none",
         "sdim-features": "multiple-declared-order"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-84b01b94",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "cli-overlay"
       },
       "arity": 2
     },
@@ -4063,16 +3980,6 @@
       "assignment": {
         "sdim-features": "lockfile",
         "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-883530a6",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "image",
-        "sdim-features": "multiple-dependency-order"
       },
       "arity": 2
     },
@@ -4709,17 +4616,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-9d8f9594",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-layering": "extends-chain",
-        "sdim-config-source": "image",
-        "sdim-features": "lockfile"
-      },
-      "arity": 3
-    },
-    {
       "id": "obl-cmb-9ec2a4dd",
       "kind": "combination",
       "operation": "build",
@@ -5331,16 +5227,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-b3f4795c",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-b4540ff2",
       "kind": "combination",
       "operation": "build",
@@ -5477,16 +5363,6 @@
       "assignment": {
         "sdim-container-state": "stopped",
         "sdim-output-mode": "structured"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-ba2615ba",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "lockfile",
-        "sdim-layering": "cli-overlay"
       },
       "arity": 2
     },
@@ -5792,16 +5668,6 @@
       "arity": 2
     },
     {
-      "id": "obl-cmb-c21c09c0",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "dockerfile",
-        "sdim-features": "lockfile"
-      },
-      "arity": 2
-    },
-    {
       "id": "obl-cmb-c23a19a1",
       "kind": "combination",
       "operation": "up",
@@ -5918,16 +5784,6 @@
       "assignment": {
         "sdim-container-state": "running-stale-config",
         "sdim-layering": "cli-overlay"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-c71b7d4f",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-features": "multiple-dependency-order",
-        "sdim-layering": "extends-chain"
       },
       "arity": 2
     },
@@ -6569,16 +6425,6 @@
       "assignment": {
         "sdim-features": "single",
         "sdim-layering": "extends-chain"
-      },
-      "arity": 2
-    },
-    {
-      "id": "obl-cmb-de50e6b0",
-      "kind": "combination",
-      "operation": "upgrade",
-      "assignment": {
-        "sdim-config-source": "compose",
-        "sdim-features": "lockfile"
       },
       "arity": 2
     },

--- a/conformance/registry/applicability.json
+++ b/conformance/registry/applicability.json
@@ -45,6 +45,25 @@
       "ground": "These operations neither create nor attach to a container: they resolve configuration, build an image, resolve Feature versions, scaffold files, or probe the host. A pre-existing container is therefore not a condition they can observe or act on, and only the degenerate `none` state remains meaningful."
     },
     {
+      "id": "rule-no-dependency-order-for-feature-version-resolution",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "outdated",
+            "upgrade"
+          ]
+        },
+        {
+          "dimension": "sdim-features",
+          "values": [
+            "multiple-dependency-order"
+          ]
+        }
+      ],
+      "ground": "`outdated` and `upgrade` both read the DECLARED Feature map and neither resolves the dependency graph. `commands/outdated.rs` takes the map straight off the effective configuration, preserving declaration order, and iterates it; `commands/upgrade.rs::resolve_lockfile_from_config` iterates the same map to fetch each declared Feature's digest. No `dependsOn` is followed, no `installsAfter` is honoured, no transitive Feature is added, and `upgrade` never populates the lockfile's `dependsOn` field. Verified by declaring a Feature that has dependencies and observing that only that Feature appears in either output. Declaration order IS observable in `outdated` — reversing the two keys reverses the table rows — so `multiple-declared-order` stays applicable for both and is the value that carries multi-Feature coverage. A dependency relationship among the declared Features changes neither output, so the value is indistinguishable from `multiple-declared-order`. Install ordering is decided by `up`/`build`, which do resolve it, and a case pinning that decision is a case for those operations."
+    },
+    {
       "id": "rule-no-extends-chain-for-scaffolding",
       "excludes": [
         {
@@ -61,42 +80,6 @@
         }
       ],
       "ground": "`templates apply` copies the template's payload into the target workspace and substitutes only its declared options; it never loads or resolves a devcontainer configuration, so an extends chain is never traversed. A payload file that happens to contain an `extends` key is copied opaquely, byte for byte, which leaves the value indistinguishable from `single` in every observable the operation produces — the same ground on which `image-metadata` is already excluded for it. A command-line overlay is different and stays applicable: `--option` genuinely layers over the template's declared option defaults."
-    },
-    {
-      "id": "rule-no-dependency-order-for-version-reporting",
-      "excludes": [
-        {
-          "dimension": "sdim-operation",
-          "values": [
-            "outdated"
-          ]
-        },
-        {
-          "dimension": "sdim-features",
-          "values": [
-            "multiple-dependency-order"
-          ]
-        }
-      ],
-      "ground": "`outdated` reports the version of each DECLARED Feature and never resolves the dependency graph: `commands/outdated.rs` takes the features map straight off the effective configuration, preserving declaration order, and iterates it. No `dependsOn` is followed, no `installsAfter` is honoured, and no transitive Feature is added, verified by declaring a Feature with dependencies and observing that only that Feature is reported. Declaration order IS observable — reversing the two keys reverses the table rows — so `multiple-declared-order` stays applicable and is the value that carries multi-Feature coverage here. A dependency relationship among the declared Features changes neither the rows nor their order, so the value is indistinguishable from `multiple-declared-order` in every observable. Note this is specific to `outdated`: its sibling `upgrade` resolves Features to regenerate a lockfile, so the value is NOT excluded there."
-    },
-    {
-      "id": "rule-no-lockfile-for-configuration-reporting",
-      "excludes": [
-        {
-          "dimension": "sdim-operation",
-          "values": [
-            "read-configuration"
-          ]
-        },
-        {
-          "dimension": "sdim-features",
-          "values": [
-            "lockfile"
-          ]
-        }
-      ],
-      "ground": "`read-configuration` reports the configuration as authored and never consults `devcontainer-lock.json`: `commands/read_configuration.rs` does not mention a lockfile anywhere, and its output is byte-identical with the file present and absent. Resolved Feature versions belong to `outdated` and `upgrade`, which do read it. This rule corrects an over-claim rather than shrinking real coverage: four cases previously declared `features=lockfile` while asserting only `configuration`/`mergedConfiguration` Feature keys, which come from `devcontainer.json`, so no assertion could tell whether a lockfile existed. They are relabelled `single`, the value their fixtures actually exercise."
     },
     {
       "id": "rule-no-feature-composition-for-attach-only-operations",
@@ -183,6 +166,25 @@
       "ground": "`doctor` reports host, runtime, and environment diagnostics rather than a merged configuration; it never resolves an extends chain or applies a command-line overlay, so how a configuration would have been layered cannot affect the diagnosis it prints."
     },
     {
+      "id": "rule-no-lockfile-input-for-reporting-and-regeneration",
+      "excludes": [
+        {
+          "dimension": "sdim-operation",
+          "values": [
+            "read-configuration",
+            "upgrade"
+          ]
+        },
+        {
+          "dimension": "sdim-features",
+          "values": [
+            "lockfile"
+          ]
+        }
+      ],
+      "ground": "Neither operation takes an existing lockfile as INPUT. `read-configuration` reports the configuration as authored and never consults `devcontainer-lock.json` — `commands/read_configuration.rs` does not mention a lockfile anywhere, and its output is byte-identical with the file present and absent. `upgrade` REGENERATES the lockfile from the configuration and overwrites it, which is its whole job: a stale committed lockfile pinning 1.3.0 does not change the regenerated 1.3.8 by so much as a byte. In both cases the value is indistinguishable from `single`. `outdated` is the operation for which an existing lockfile IS an input — it supplies `current` — and the value stays applicable there. This rule corrects over-claims rather than shrinking real coverage: four `read-configuration` cases declared the value while asserting only Feature keys that come from `devcontainer.json`, so no assertion could tell whether a lockfile existed; they are relabelled `single`, which is what their fixtures exercise."
+    },
+    {
       "id": "rule-no-result-document-for-scaffolding",
       "excludes": [
         {
@@ -242,6 +244,66 @@
   ],
   "triples": [
     {
+      "id": "hrt-build-compose-no-features-structured",
+      "assignment": {
+        "sdim-operation": "build",
+        "sdim-config-source": "compose",
+        "sdim-features": "none",
+        "sdim-output-mode": "structured"
+      },
+      "reason": "Building a Compose configuration has to resolve the SERVICE's build shape rather than the top-level one, and then report the image it produced in its structured result. A build that reads the top-level shape still succeeds when the service happens to declare an image, so the mistake is only visible in what the result document names."
+    },
+    {
+      "id": "hrt-build-dockerfile-cli-overlay-single-feature",
+      "assignment": {
+        "sdim-operation": "build",
+        "sdim-config-source": "dockerfile",
+        "sdim-layering": "cli-overlay",
+        "sdim-features": "single"
+      },
+      "reason": "`--image-name` must resolve to the FEATURE-EXTENDED image, not to the base the Dockerfile produced. This project has already shipped the defect once: the post-build Feature pass layered correctly and the user's tag still pointed at the pre-Feature base, which every outcome-only assertion reported as success. Only the combination of a Dockerfile build, a command-line tag overlay and an installed Feature exposes it."
+    },
+    {
+      "id": "hrt-down-compose-running-cli-overlay",
+      "assignment": {
+        "sdim-operation": "down",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "running",
+        "sdim-layering": "cli-overlay"
+      },
+      "reason": "Teardown identifies what to remove from the Compose project name and the workspace labels, both derived from the resolved configuration. A command-line overlay changes that configuration, so if the derivation is not identical to the one `up` used, `down` reports success and leaves the project running — a failure that is silent on every channel except the container graph."
+    },
+    {
+      "id": "hrt-exec-dockerfile-running-cli-overlay",
+      "assignment": {
+        "sdim-operation": "exec",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "running",
+        "sdim-layering": "cli-overlay"
+      },
+      "reason": "A command-line overlay on `exec` (a user, extra remote environment) is applied on top of whatever the image's own metadata already established for the running container. A Dockerfile base is where the image contributes a real user and a real PATH, so the overlay has something to win against — and PATH is the field a careless overlay replaces instead of extending."
+    },
+    {
+      "id": "hrt-outdated-extends-chain-image-single-feature",
+      "assignment": {
+        "sdim-operation": "outdated",
+        "sdim-layering": "extends-chain",
+        "sdim-config-source": "image",
+        "sdim-features": "single"
+      },
+      "reason": "Version reporting has to read the Feature set from the FULL extends chain before comparing it against the registry. Reading only the top document is the easy mistake and produces an empty report rather than an error, so a chain link that contributes the only Feature is exactly the shape in which `outdated` quietly reports that nothing is out of date."
+    },
+    {
+      "id": "hrt-readconfig-cli-overlay-dockerfile-dependency-order",
+      "assignment": {
+        "sdim-operation": "read-configuration",
+        "sdim-layering": "cli-overlay",
+        "sdim-config-source": "dockerfile",
+        "sdim-features": "multiple-dependency-order"
+      },
+      "reason": "A Feature set supplied on the command line has to JOIN the dependency resolution the configuration's own Features are already subject to, not be appended after it. Appending is the natural implementation and is wrong whenever an overlaid Feature is a dependency of a declared one. The Dockerfile source matters because the build is what consumes the resulting order, so an order computed only for the declared set is invisible until the image is built."
+    },
+    {
       "id": "hrt-readconfig-extends-chain-compose-declared-order",
       "assignment": {
         "sdim-operation": "read-configuration",
@@ -262,14 +324,24 @@
       "reason": "`build.dockerfile` resolves relative to the directory of the configuration that DECLARED it, and an extends chain moves that directory at every link, so a Dockerfile inherited from a parent is where the build path is computed from the wrong base. Layer on Features whose install order comes from dependency resolution rather than from declaration order and a second computation joins in: the merged Feature map has to be assembled across the chain BEFORE the dependency sort runs, or the sort orders a set that is missing the parent's contribution."
     },
     {
-      "id": "hrt-readconfig-cli-overlay-dockerfile-dependency-order",
+      "id": "hrt-run-user-commands-image-single-feature-running",
       "assignment": {
-        "sdim-operation": "read-configuration",
-        "sdim-layering": "cli-overlay",
-        "sdim-config-source": "dockerfile",
-        "sdim-features": "multiple-dependency-order"
+        "sdim-operation": "run-user-commands",
+        "sdim-config-source": "image",
+        "sdim-features": "single",
+        "sdim-container-state": "running"
       },
-      "reason": "A Feature set supplied on the command line has to JOIN the dependency resolution the configuration's own Features are already subject to, not be appended after it. Appending is the natural implementation and is wrong whenever an overlaid Feature is a dependency of a declared one. The Dockerfile source matters because the build is what consumes the resulting order, so an order computed only for the declared set is invisible until the image is built."
+      "reason": "Lifecycle hooks contributed by a Feature must run in the same ordered sequence as the ones the configuration declares, against a container that already exists. Hook ordering and Feature-contributed hooks are separately covered; the interaction is where a hook the Feature added runs before the Feature's own installation is visible, or is dropped entirely because the container was not created by this invocation."
+    },
+    {
+      "id": "hrt-templates-apply-cli-overlay-image-human",
+      "assignment": {
+        "sdim-operation": "templates-apply",
+        "sdim-layering": "cli-overlay",
+        "sdim-config-source": "image",
+        "sdim-output-mode": "human"
+      },
+      "reason": "Template options given on the command line are substituted into the files the template scaffolds, and the only evidence that they arrived is the scaffolded bytes: the operation emits no result document to inspect. An option that is parsed but never substituted therefore produces a successful, human-readable run and a configuration containing the unsubstituted placeholder."
     },
     {
       "id": "hrt-up-compose-single-feature-running",
@@ -302,84 +374,14 @@
       "reason": "Re-running `up` after the configuration changed must decide between reusing the existing container and recreating it. With a Feature installed, reuse is the dangerous branch: the container keeps the layer built from the OLD configuration while every observable the CLI reports comes from the NEW one, so the two agree and the container is wrong."
     },
     {
-      "id": "hrt-exec-dockerfile-running-cli-overlay",
-      "assignment": {
-        "sdim-operation": "exec",
-        "sdim-config-source": "dockerfile",
-        "sdim-container-state": "running",
-        "sdim-layering": "cli-overlay"
-      },
-      "reason": "A command-line overlay on `exec` (a user, extra remote environment) is applied on top of whatever the image's own metadata already established for the running container. A Dockerfile base is where the image contributes a real user and a real PATH, so the overlay has something to win against — and PATH is the field a careless overlay replaces instead of extending."
-    },
-    {
-      "id": "hrt-build-dockerfile-cli-overlay-single-feature",
-      "assignment": {
-        "sdim-operation": "build",
-        "sdim-config-source": "dockerfile",
-        "sdim-layering": "cli-overlay",
-        "sdim-features": "single"
-      },
-      "reason": "`--image-name` must resolve to the FEATURE-EXTENDED image, not to the base the Dockerfile produced. This project has already shipped the defect once: the post-build Feature pass layered correctly and the user's tag still pointed at the pre-Feature base, which every outcome-only assertion reported as success. Only the combination of a Dockerfile build, a command-line tag overlay and an installed Feature exposes it."
-    },
-    {
-      "id": "hrt-build-compose-no-features-structured",
-      "assignment": {
-        "sdim-operation": "build",
-        "sdim-config-source": "compose",
-        "sdim-features": "none",
-        "sdim-output-mode": "structured"
-      },
-      "reason": "Building a Compose configuration has to resolve the SERVICE's build shape rather than the top-level one, and then report the image it produced in its structured result. A build that reads the top-level shape still succeeds when the service happens to declare an image, so the mistake is only visible in what the result document names."
-    },
-    {
-      "id": "hrt-run-user-commands-image-single-feature-running",
-      "assignment": {
-        "sdim-operation": "run-user-commands",
-        "sdim-config-source": "image",
-        "sdim-features": "single",
-        "sdim-container-state": "running"
-      },
-      "reason": "Lifecycle hooks contributed by a Feature must run in the same ordered sequence as the ones the configuration declares, against a container that already exists. Hook ordering and Feature-contributed hooks are separately covered; the interaction is where a hook the Feature added runs before the Feature's own installation is visible, or is dropped entirely because the container was not created by this invocation."
-    },
-    {
-      "id": "hrt-down-compose-running-cli-overlay",
-      "assignment": {
-        "sdim-operation": "down",
-        "sdim-config-source": "compose",
-        "sdim-container-state": "running",
-        "sdim-layering": "cli-overlay"
-      },
-      "reason": "Teardown identifies what to remove from the Compose project name and the workspace labels, both derived from the resolved configuration. A command-line overlay changes that configuration, so if the derivation is not identical to the one `up` used, `down` reports success and leaves the project running — a failure that is silent on every channel except the container graph."
-    },
-    {
-      "id": "hrt-outdated-extends-chain-image-single-feature",
-      "assignment": {
-        "sdim-operation": "outdated",
-        "sdim-layering": "extends-chain",
-        "sdim-config-source": "image",
-        "sdim-features": "single"
-      },
-      "reason": "Version reporting has to read the Feature set from the FULL extends chain before comparing it against the registry. Reading only the top document is the easy mistake and produces an empty report rather than an error, so a chain link that contributes the only Feature is exactly the shape in which `outdated` quietly reports that nothing is out of date."
-    },
-    {
-      "id": "hrt-upgrade-extends-chain-image-lockfile",
+      "id": "hrt-upgrade-extends-chain-image-single",
       "assignment": {
         "sdim-operation": "upgrade",
         "sdim-layering": "extends-chain",
         "sdim-config-source": "image",
-        "sdim-features": "lockfile"
+        "sdim-features": "single"
       },
-      "reason": "Regenerating the lockfile must write the set the EFFECTIVE configuration resolves to, assembled across the whole extends chain, and must not simply refresh the entries the existing lockfile already contains. Refreshing what is already pinned is the implementation that passes every single-document case and silently drops a Feature a parent link contributed — and it drops it into an EMPTY lockfile with a zero exit, so nothing downstream notices. Selected over the command-line-overlay form of the same risk because `upgrade` exposes no overlay flag that reaches Feature resolution, so that combination has no invocable case to evidence it."
-    },
-    {
-      "id": "hrt-templates-apply-cli-overlay-image-human",
-      "assignment": {
-        "sdim-operation": "templates-apply",
-        "sdim-layering": "cli-overlay",
-        "sdim-config-source": "image",
-        "sdim-output-mode": "human"
-      },
-      "reason": "Template options given on the command line are substituted into the files the template scaffolds, and the only evidence that they arrived is the scaffolded bytes: the operation emits no result document to inspect. An option that is parsed but never substituted therefore produces a successful, human-readable run and a configuration containing the unsubstituted placeholder."
+      "reason": "Regenerating the lockfile must write the set the EFFECTIVE configuration resolves to, assembled across the whole extends chain, and must not simply refresh the entries an existing lockfile already contains. Refreshing what is already pinned is the implementation that passes every single-document case and silently drops a Feature a parent link contributed — into an EMPTY lockfile with a zero exit, so nothing downstream notices. Retargeted from `features=lockfile` to `single` in the #409 work: an existing lockfile is not an input to `upgrade` at all, so the old assignment named a scenario no case could exercise, and the evidencing case's fixture never contained one. The risk is unchanged — it lives in the extends chain crossing Feature resolution, not in the lockfile being read. The original reason also recorded that `upgrade` \"exposes no overlay flag that reaches Feature resolution\", which was #409 (the flags were advertised and silently discarded) observed and designed around rather than filed; that is now fixed, so the command-line-overlay form of this risk is invocable and carries its own cases."
     }
   ]
 }

--- a/conformance/registry/behaviors/upgrade.json
+++ b/conformance/registry/behaviors/upgrade.json
@@ -2,6 +2,16 @@
   "schemaVersion": 1,
   "records": [
     {
+      "id": "bhv-upgrade-cli-config-overlay-honored",
+      "area": "upgrade",
+      "statement": "`upgrade` regenerates the lockfile from the configuration AFTER the command-line overlays are applied: `--override-config` replaces the base document and `--merge-config` fragments deep-overlay on top, so a Feature contributed or removed by an overlay is reflected in the regenerated lockfile.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "not-applicable",
+      "decision": "deacon-extension",
+      "notes": "The reference CLI's `upgrade` accepts NEITHER flag \u2014 `--merge-config` does not exist anywhere in its surface, and its `upgrade` has no `--override-config` even though its `up` and `read-configuration` do. There is therefore no reference surface to compare against, which is why `reference` is `not-applicable` rather than `divergent`. Recorded by ext-cli-config-overlay. Fixes #409: deacon ADVERTISED both flags on `upgrade` and silently discarded them (`UpgradeArgs` had no field for either and both `load_config` sites passed `override_config_path: None` hard-coded), so a user pinning a configuration got a lockfile regenerated from a different one, exit 0, no warning. The profile-sourced `mergeConfig` fragments were dropped the same way."
+    },
+    {
       "id": "bhv-upgrade-empty-feature-set",
       "area": "upgrade",
       "statement": "`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile and exits 0.",

--- a/conformance/registry/cases/upgrade.json
+++ b/conformance/registry/cases/upgrade.json
@@ -2,6 +2,68 @@
   "schemaVersion": 1,
   "records": [
     {
+      "id": "case-upgrade-compose-merge-config-adds-feature",
+      "behaviors": [
+        "bhv-upgrade-cli-config-overlay-honored"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "upgrade",
+        "sdim-config-source": "compose",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-upgrade",
+          "subcommand": "upgrade",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json",
+            "--dry-run"
+          ],
+          "fixtures": [
+            "fx-upgrade-compose-multi-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-upgrade",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-upgrade",
+          "assertion": {
+            "jsonSubset": {
+              "features": {
+                "ghcr.io/devcontainers/features/git:1.3.2": {
+                  "version": "1.3.2"
+                },
+                "ghcr.io/devcontainers/features/node:1.6.1": {
+                  "version": "1.6.1"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Regression evidence for #409. `--merge-config` was advertised on `upgrade` and silently discarded, so the regenerated lockfile came from the base configuration alone. `node` is declared NOWHERE in devcontainer.json and can only reach the lockfile through the overlay; `git` must survive it, because a merge that replaced rather than layered would also produce a plausible one-entry lockfile with exit 0. Both entries are asserted for that reason."
+    },
+    {
       "id": "case-upgrade-compose-workspace",
       "behaviors": [
         "bhv-upgrade-empty-feature-set"
@@ -53,6 +115,61 @@
         "tempdir": true
       },
       "notes": "SC-004 requires every operation to carry a case for each configuration source the applicability rules permit for it. A Compose workspace with no Features regenerates to the empty lockfile. Spec-expectation rather than differential because the pinned reference treats the empty Feature set as a failure — the divergence characterized by wvr-upgrade-empty-feature-set, reached here through a third configuration shape."
+    },
+    {
+      "id": "case-upgrade-dockerfile-override-config-removes-features",
+      "behaviors": [
+        "bhv-upgrade-cli-config-overlay-honored"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "upgrade",
+        "sdim-config-source": "dockerfile",
+        "sdim-container-state": "none",
+        "sdim-features": "none",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-upgrade",
+          "subcommand": "upgrade",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--override-config",
+            "${WORKSPACE}/.devcontainer/replacement.json",
+            "--dry-run"
+          ],
+          "fixtures": [
+            "fx-upgrade-dockerfile-overlay-empty"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-upgrade",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-upgrade",
+          "assertion": {
+            "jsonEquals": {
+              "features": {}
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The sharpest form of #409, and the one that proves the flag is honored rather than merely accepted. `--override-config` REPLACES the base document, and the replacement declares no Features, so the correct lockfile is empty even though the workspace's own devcontainer.json declares `git`. An implementation that ignores the flag emits a one-entry lockfile and exits 0 — which is exactly what deacon did before the fix. Deliberately `jsonEquals`, not `jsonSubset`: a subset assertion of `{\"features\": {}}` is satisfied by ANY features map, so it would pass against the buggy output. Only exact equality can fail here."
     },
     {
       "id": "case-upgrade-dockerfile-workspace",
@@ -109,7 +226,7 @@
         "sdim-operation": "upgrade",
         "sdim-config-source": "image",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "extends-chain",
         "sdim-output-mode": "structured"
       },
@@ -154,7 +271,66 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Covers the high-risk triple `hrt-upgrade-extends-chain-image-lockfile`: the effective Feature set is assembled across the extends chain BEFORE the lockfile is regenerated, so a Feature contributed by a parent link appears in the written lockfile. An implementation that refreshed only the entries an existing lockfile already contained would emit an empty document here and still exit 0."
+      "notes": "Covers the high-risk triple `hrt-upgrade-extends-chain-image-lockfile`: the effective Feature set is assembled across the extends chain BEFORE the lockfile is regenerated, so a Feature contributed by a parent link appears in the written lockfile. An implementation that refreshed only the entries an existing lockfile already contained would emit an empty document here and still exit 0. Relabelled `features=lockfile` to `single` (#409 work): the fixture contains no lockfile at all, and `upgrade` does not take one as input — it regenerates from the configuration and overwrites, so a stale pin cannot change the result. The label claimed a scenario nothing here could exercise. See `rule-no-lockfile-input-for-reporting-and-regeneration`."
+    },
+    {
+      "id": "case-upgrade-image-merge-config-contributes-only-feature",
+      "behaviors": [
+        "bhv-upgrade-cli-config-overlay-honored"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "upgrade",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "single",
+        "sdim-layering": "cli-overlay",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-upgrade",
+          "subcommand": "upgrade",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--merge-config",
+            "${WORKSPACE}/.devcontainer/overlay.json",
+            "--dry-run"
+          ],
+          "fixtures": [
+            "fx-upgrade-image-single-overlay"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-upgrade",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-upgrade",
+          "assertion": {
+            "jsonSubset": {
+              "features": {
+                "ghcr.io/devcontainers/features/git:1.3.2": {
+                  "version": "1.3.2"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The base configuration declares no Features at all, so the single lockfile entry exists only because the overlay contributed it: before #409 was fixed this produced an empty lockfile and exit 0. The `resolved` digest and `integrity` are deliberately NOT pinned. An earlier draft did pin them, arguing a lockfile is consumed for its digests — and `every_case_pins_only_run_invariant_evidence` rejected it for embedding a 64-character hex run. The guard is right: an OCI tag is mutable, so the digest behind `git:1.3.2` is not a run-invariant fact this case may assert. The sibling `case-upgrade-regenerates-lockfile` covers digest agreement the way it can be covered, by comparing both CLIs live rather than against a literal."
     },
     {
       "id": "case-upgrade-malformed-config-rejected",
@@ -314,7 +490,7 @@
         "sdim-operation": "upgrade",
         "sdim-config-source": "image",
         "sdim-container-state": "none",
-        "sdim-features": "lockfile",
+        "sdim-features": "single",
         "sdim-layering": "single",
         "sdim-output-mode": "structured"
       },
@@ -347,7 +523,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "FR-033 lockfile production. `--dry-run` writes the regenerated lockfile to stdout instead of to disk, which is what makes this comparable AND keeps the case from mutating its own fixture. Both CLIs resolve the pinned `git:1.3.2` to the same digest and integrity, so the structured comparison is on the document itself rather than on the exit code alone."
+      "notes": "FR-033 lockfile production. `--dry-run` writes the regenerated lockfile to stdout instead of to disk, which is what makes this comparable AND keeps the case from mutating its own fixture. Both CLIs resolve the pinned `git:1.3.2` to the same digest and integrity, so the structured comparison is on the document itself rather than on the exit code alone. Relabelled `features=lockfile` to `single` (#409 work): the fixture contains no lockfile at all, and `upgrade` does not take one as input — it regenerates from the configuration and overwrites, so a stale pin cannot change the result. The label claimed a scenario nothing here could exercise. See `rule-no-lockfile-input-for-reporting-and-regeneration`."
     },
     {
       "id": "case-upgrade-unsupported-values-rejected",

--- a/conformance/registry/extensions.json
+++ b/conformance/registry/extensions.json
@@ -10,6 +10,14 @@
       "docs": "specs/015-auto-forward-ports/spec.md"
     },
     {
+      "id": "ext-cli-config-overlay",
+      "behaviors": [
+        "bhv-upgrade-cli-config-overlay-honored"
+      ],
+      "description": "deacon accepts `--merge-config <PATH>` (deep-overlay fragments, later wins) on every configuration-consuming subcommand, and extends `--override-config` to subcommands where the reference CLI does not offer it, including `upgrade`. The reference has no `--merge-config` anywhere in its surface, and its `upgrade` takes neither flag.",
+      "docs": "docs/DIFFERENTIATORS.md"
+    },
+    {
       "id": "ext-container-identity-labels",
       "behaviors": [
         "bhv-container-identity-labels"

--- a/conformance/registry/obligation-dispositions/upgrade.json
+++ b/conformance/registry/obligation-dispositions/upgrade.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "id": "odp-bhv-45551f67",
+      "obligation": "obl-bhv-45551f67",
+      "disposition": "case",
+      "cases": [
+        "case-upgrade-compose-merge-config-adds-feature",
+        "case-upgrade-dockerfile-override-config-removes-features",
+        "case-upgrade-image-merge-config-contributes-only-feature"
+      ]
+    },
+    {
       "id": "odp-bhv-6a2d5301",
       "obligation": "obl-bhv-6a2d5301",
       "disposition": "case",
@@ -48,27 +58,12 @@
       ]
     },
     {
-      "id": "odp-cmb-0b194953",
-      "obligation": "obl-cmb-0b194953",
-      "disposition": "case",
-      "cases": [
-        "case-upgrade-extends-chain-lockfile",
-        "case-upgrade-regenerates-lockfile"
-      ]
-    },
-    {
       "id": "odp-cmb-0cb4effa",
       "obligation": "obl-cmb-0cb4effa",
       "disposition": "case",
       "cases": [
         "case-upgrade-compose-workspace"
       ]
-    },
-    {
-      "id": "odp-cmb-0cfe1f76",
-      "obligation": "obl-cmb-0cfe1f76",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     },
     {
       "id": "odp-cmb-15cfc44a",
@@ -124,8 +119,8 @@
       ]
     },
     {
-      "id": "odp-cmb-30357cd3",
-      "obligation": "obl-cmb-30357cd3",
+      "id": "odp-cmb-3073e0a2",
+      "obligation": "obl-cmb-3073e0a2",
       "disposition": "case",
       "cases": [
         "case-upgrade-extends-chain-lockfile"
@@ -146,14 +141,6 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-48a3d9eb",
-      "obligation": "obl-cmb-48a3d9eb",
-      "disposition": "case",
-      "cases": [
-        "case-upgrade-regenerates-lockfile"
-      ]
-    },
-    {
       "id": "odp-cmb-53668210",
       "obligation": "obl-cmb-53668210",
       "disposition": "gap",
@@ -172,12 +159,6 @@
       ]
     },
     {
-      "id": "odp-cmb-5e00fbe8",
-      "obligation": "obl-cmb-5e00fbe8",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-68fa56a9",
       "obligation": "obl-cmb-68fa56a9",
       "disposition": "case",
@@ -188,12 +169,6 @@
         "case-upgrade-no-features-empty-lockfile",
         "case-upgrade-unsupported-values-rejected"
       ]
-    },
-    {
-      "id": "odp-cmb-6ca77f90",
-      "obligation": "obl-cmb-6ca77f90",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     },
     {
       "id": "odp-cmb-6d28294c",
@@ -210,12 +185,6 @@
       "cases": [
         "case-upgrade-dockerfile-workspace"
       ]
-    },
-    {
-      "id": "odp-cmb-76286197",
-      "obligation": "obl-cmb-76286197",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     },
     {
       "id": "odp-cmb-7693352b",
@@ -247,29 +216,8 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-7dd34b50",
-      "obligation": "obl-cmb-7dd34b50",
-      "disposition": "case",
-      "cases": [
-        "case-upgrade-extends-chain-lockfile",
-        "case-upgrade-regenerates-lockfile"
-      ]
-    },
-    {
       "id": "odp-cmb-8004dcb5",
       "obligation": "obl-cmb-8004dcb5",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-835fa8aa",
-      "obligation": "obl-cmb-835fa8aa",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-84b01b94",
-      "obligation": "obl-cmb-84b01b94",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
@@ -280,12 +228,6 @@
       "cases": [
         "case-upgrade-extends-chain-lockfile"
       ]
-    },
-    {
-      "id": "odp-cmb-883530a6",
-      "obligation": "obl-cmb-883530a6",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
     },
     {
       "id": "odp-cmb-89498bda",
@@ -355,14 +297,6 @@
       ]
     },
     {
-      "id": "odp-cmb-9d8f9594",
-      "obligation": "obl-cmb-9d8f9594",
-      "disposition": "case",
-      "cases": [
-        "case-upgrade-extends-chain-lockfile"
-      ]
-    },
-    {
       "id": "odp-cmb-9f83485f",
       "obligation": "obl-cmb-9f83485f",
       "disposition": "gap",
@@ -381,15 +315,6 @@
       ]
     },
     {
-      "id": "odp-cmb-b3f4795c",
-      "obligation": "obl-cmb-b3f4795c",
-      "disposition": "case",
-      "cases": [
-        "case-upgrade-extends-chain-lockfile",
-        "case-upgrade-regenerates-lockfile"
-      ]
-    },
-    {
       "id": "odp-cmb-b5573eb6",
       "obligation": "obl-cmb-b5573eb6",
       "disposition": "case",
@@ -404,26 +329,8 @@
       "gap": "gap-pairwise-upgrade"
     },
     {
-      "id": "odp-cmb-ba2615ba",
-      "obligation": "obl-cmb-ba2615ba",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-c21c09c0",
-      "obligation": "obl-cmb-c21c09c0",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
       "id": "odp-cmb-c5083a84",
       "obligation": "obl-cmb-c5083a84",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-c71b7d4f",
-      "obligation": "obl-cmb-c71b7d4f",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },
@@ -442,12 +349,6 @@
     {
       "id": "odp-cmb-d123620b",
       "obligation": "obl-cmb-d123620b",
-      "disposition": "gap",
-      "gap": "gap-pairwise-upgrade"
-    },
-    {
-      "id": "odp-cmb-de50e6b0",
-      "obligation": "obl-cmb-de50e6b0",
       "disposition": "gap",
       "gap": "gap-pairwise-upgrade"
     },

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -243,6 +243,16 @@
       ]
     },
     {
+      "id": "src-obs-upgrade-cli-config-overlay",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "`deacon upgrade --dry-run` with `--merge-config` and with `--override-config`, compared against the same run without them; and `devcontainer upgrade --help`, which lists neither flag",
+      "summary": "Whether the regenerated lockfile reflects the command-line configuration overlays, and whether the reference offers any comparable surface on this subcommand.",
+      "behaviors": [
+        "bhv-upgrade-cli-config-overlay-honored"
+      ]
+    },
+    {
       "id": "src-obs-upgrade-empty-feature-set",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -411,6 +411,18 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      a fidelity loss on input both sides accept.",
     ),
     (
+        "bhv-upgrade-cli-config-overlay-honored",
+        "Whether `upgrade` regenerates its lockfile from the configuration AFTER the \
+     command-line overlays apply. Unrecordable before #409 in either direction: deacon \
+     ADVERTISED `--override-config` and `--merge-config` on the subcommand and silently \
+     discarded both (`UpgradeArgs` carried no field for either and both `load_config` \
+     sites passed `override_config_path: None` hard-coded), so no pre-migration unit \
+     could invoke the surface it names. Not a variant of any pre-migration claim: the \
+     reference CLI has no `--merge-config` anywhere and its `upgrade` takes neither \
+     flag, so there is no reference behavior this could be a variant OF. A deacon \
+     extension recorded by ext-cli-config-overlay.",
+    ),
+    (
         "bhv-readconfig-merged-computed-empties-omitted",
         "Which computed-empty properties the reference synthesizes into `mergedConfiguration` for a \
      configuration that authors none. Unobservable before #398 in either direction: deacon emitted \

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -110,7 +110,14 @@ const TODAY: &str = "2026-07-19";
 /// while declaring `single`. Relabelling it needed an honest `single` twin, which is the one
 /// case added. `gap-pairwise-templates-apply` was deleted in the same change — the third
 /// operation to reach zero. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 226;
+/// **226 → 229** (#409): `upgrade` advertised `--override-config` and `--merge-config` and
+/// silently discarded both, so the overlay surface it names could not be exercised at all.
+/// Three cases arrive with the fix — a `--merge-config` that ADDS a Feature, an
+/// `--override-config` that REMOVES one, and an overlay contributing the only Feature. Two
+/// use `jsonEquals` rather than `jsonSubset` deliberately: a subset assertion of
+/// `{"features": {}}` matches any features map and would have passed against the buggy
+/// output. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 229;
 
 #[test]
 fn real_registry_is_structurally_valid() {

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -1780,9 +1780,19 @@ impl Cli {
             }) => {
                 use crate::commands::upgrade::{UpgradeArgs, execute_upgrade};
 
+                // Resolve the selected profile (017): ordered override fragments
+                // to layer beneath any `--override-config`. Mirrors `outdated`.
+                let resolved_profile = crate::commands::shared::profile::resolve_active_profile(
+                    self.user_data_folder.as_deref(),
+                    self.profile.as_deref(),
+                )?;
+
                 let args = UpgradeArgs {
                     workspace_folder: self.workspace_folder,
                     config_path: self.config,
+                    override_config: self.override_config,
+                    settings_merge_paths: resolved_profile.merge_paths,
+                    cli_merge_paths: self.merge_config,
                     docker_path,
                     docker_compose_path,
                     dry_run,

--- a/crates/deacon/src/commands/upgrade.rs
+++ b/crates/deacon/src/commands/upgrade.rs
@@ -43,6 +43,17 @@ pub struct UpgradeArgs {
     pub workspace_folder: Option<PathBuf>,
     /// Optional `--config <PATH>`.
     pub config_path: Option<PathBuf>,
+    /// REPLACE base (`--override-config`). Threaded through in #409: these
+    /// three inputs were previously hard-coded away here, so a user pinning a
+    /// configuration got a lockfile regenerated from a DIFFERENT configuration
+    /// with exit 0 and no warning. The sibling `outdated` honored them all
+    /// along, which is what made the omission visible.
+    pub override_config: Option<PathBuf>,
+    /// Settings/profile-sourced merge fragments (root `mergeConfig` then the
+    /// selected profile's), lowest→highest precedence.
+    pub settings_merge_paths: Vec<PathBuf>,
+    /// CLI `--merge-config` fragments, in given order (later wins).
+    pub cli_merge_paths: Vec<PathBuf>,
     /// Docker CLI path; default `"docker"`. Spec §2 surface parity only —
     /// upgrade itself does not invoke docker (the OCI fetcher uses HTTP).
     #[allow(dead_code)]
@@ -80,9 +91,9 @@ pub async fn execute_upgrade(args: UpgradeArgs) -> Result<()> {
     let initial = load_config(ConfigLoadArgs {
         workspace_folder: args.workspace_folder.as_deref(),
         config_path: args.config_path.as_deref(),
-        settings_merge_paths: &[],
-        cli_merge_paths: &[],
-        override_config_path: None,
+        settings_merge_paths: &args.settings_merge_paths,
+        cli_merge_paths: &args.cli_merge_paths,
+        override_config_path: args.override_config.as_deref(),
         secrets_files: &[],
         resolve_devcontainer_id: true,
     })
@@ -108,9 +119,9 @@ pub async fn execute_upgrade(args: UpgradeArgs) -> Result<()> {
         load_config(ConfigLoadArgs {
             workspace_folder: args.workspace_folder.as_deref(),
             config_path: args.config_path.as_deref(),
-            settings_merge_paths: &[],
-            cli_merge_paths: &[],
-            override_config_path: None,
+            settings_merge_paths: &args.settings_merge_paths,
+            cli_merge_paths: &args.cli_merge_paths,
+            override_config_path: args.override_config.as_deref(),
             secrets_files: &[],
             resolve_devcontainer_id: true,
         })
@@ -801,6 +812,9 @@ mod tests {
         let args = UpgradeArgs {
             workspace_folder: None,
             config_path: None,
+            override_config: None,
+            settings_merge_paths: Vec::new(),
+            cli_merge_paths: Vec::new(),
             docker_path: "docker".to_string(),
             docker_compose_path: "docker-compose".to_string(),
             dry_run: false,
@@ -810,5 +824,13 @@ mod tests {
         assert!(!args.dry_run);
         assert!(args.feature.is_none());
         assert!(args.target_version.is_none());
+        // #409: these three were hard-coded away at the load sites, so the
+        // struct could not even express an overlay. A default-constructed
+        // args value carrying none of them is the *absence* case, not proof
+        // the wiring works — that lives in the conformance cases, which run
+        // the real binary with the flags set.
+        assert!(args.override_config.is_none());
+        assert!(args.cli_merge_paths.is_empty());
+        assert!(args.settings_merge_paths.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #409.

## The bug

`deacon upgrade --help` advertised `--override-config` and `--merge-config`. **Neither did
anything.** The profile-sourced `mergeConfig` fragments were dropped the same way.

They're global `Cli` flags, so every subcommand's help lists them and each dispatch site has
to read them. `upgrade`'s never did — `UpgradeArgs` had no field for either, and both
`load_config` sites passed `override_config_path: None` hard-coded. The flags parsed, were
accepted, and were discarded.

`--override-config` is the decisive demonstration: it *replaces* the base document, so a
replacement declaring no Features must yield an empty lockfile. Before this change it yielded
the base configuration's lockfile instead — a user pinning a config got one regenerated from a
**different** config, exit 0, no warning. Silent-wrong-answer, worse than a rejection.

```
before:  --override-config <no features>   ->  {"features": {"…/git:1.3.2": {…}}}
after:   --override-config <no features>   ->  {"features": {}}
```

Fixed by threading all three into `UpgradeArgs` and both load sites, and resolving the active
profile at the dispatch site — mirroring `outdated`, which honored them all along, which is
what made the omission visible.

**Audited the same axis** across every dispatch site: `up`, `build`, `exec`,
`read-configuration`, `config`, `run-user-commands`, `outdated` honor them; `templates`,
`doctor`, `forward-daemon` legitimately don't. `down` and `set-up` also don't — plausible
oversights of the same shape, but less clear-cut, so they're left alone here and called out in
#409 for a separate decision.

## Conformance: extension, not parity

The reference CLI has **no `--merge-config` anywhere**, and its `upgrade` takes neither flag
even though its `up` and `read-configuration` take `--override-config`. So
`bhv-upgrade-cli-config-overlay-honored` is `reference: not-applicable` /
`decision: deacon-extension`, recorded by the new `ext-cli-config-overlay`.

Three cases, each of which fails against the old binary: a `--merge-config` that **adds** a
Feature (both entries asserted — a replace-instead-of-layer bug also yields a plausible
one-entry lockfile), an `--override-config` that **removes** one, and an overlay contributing
the only Feature. The removal case uses **`jsonEquals`, not `jsonSubset`**: a subset assertion
of `{"features": {}}` matches any features map and would have passed against the buggy output.

## Two model corrections from verifying rather than assuming

- **`features=multiple-dependency-order` is unreachable for `upgrade` too.**
  `resolve_lockfile_from_config` iterates the declared map to fetch digests — no `dependsOn`
  followed, no transitive Feature added, lockfile `dependsOn` never populated. This **corrects
  the ground I wrote on the `outdated` rule one commit earlier**, which asserted without
  checking that "upgrade resolves Features to regenerate a lockfile, so the value is NOT
  excluded there". The rule now covers both.

- **`features=lockfile` is unreachable for `upgrade`.** It regenerates from config and
  overwrites: a stale lockfile pinning 1.3.0 doesn't change the regenerated 1.3.8 by a byte.
  Same shape as `read-configuration`, so both join one rule. Two existing cases and a high-risk
  triple declared the value — their fixtures contain no lockfile at all — and are relabelled
  `single`.

**Worth noting:** the retargeted triple's original reason recorded that *"`upgrade` exposes no
overlay flag that reaches Feature resolution, so that combination has no invocable case to
evidence it."* That was this bug, observed in an earlier session and **designed around rather
than filed**.

One assertion was walked back by a guard: an earlier draft pinned the `resolved` digest, and
`every_case_pins_only_run_invariant_evidence` rejected it for embedding a 64-hex run. The guard
is right — an OCI tag is mutable, so the digest behind `git:1.3.2` isn't a run-invariant fact a
case may assert.

## Numbers

obligations 749 → 741 · `upgrade` gap pairs 33 → 22 · cases 226 → 229

## Verification

- Empirically before/after on all three flags (add / replace / profile)
- `validate` ok; `coverage check` matches regeneration (741)
- `parity_conformance_runner` group `none`: **127** cases (was 124), all three new pass, only
  the pre-existing `case-merged-decl-*` cluster fails (#387)
- fmt, `clippy --all-targets --all-features`, `test-nextest-fast` (4171), doctests clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)