### PR TITLE
fix(outdated): key the report by the declared Feature reference, not the canonical id

### DIFF
--- a/conformance/fixtures/fx-outdated-same-feature-two-tags/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-same-feature-two-tags/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "ConformanceOutdatedSameFeatureTwoTags",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1.6.1": {},
+		"ghcr.io/devcontainers/features/node:2.1.0": {}
+	}
+}

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -255,6 +255,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-a09673dc",
+      "kind": "behavior",
+      "behavior": "bhv-outdated-reports-declared-reference-key",
+      "context": []
+    },
+    {
       "id": "obl-bhv-a21a70a1",
       "kind": "behavior",
       "behavior": "bhv-trust-host-hook-gate",

--- a/conformance/registry/behaviors/outdated.json
+++ b/conformance/registry/behaviors/outdated.json
@@ -12,6 +12,16 @@
       "notes": "The pinned reference does not resolve `extends`, so it reports an EMPTY table and exits 0 for a workspace whose only Feature is declared one link up \u2014 a silent miss, not an error (observed 2026-07-26, src-obs-outdated-extends-chain). Backed by wvr-outdated-extends-chain-features; the difference is only visible on stdout, so that is the compared channel. The divergence is characterized by wvr-outdated-extends-chain-features and covered by the spec-expectation case-outdated-extends-chain-features, NOT by a live differential \u2014 the differential form is structurally unavailable here. The difference lands on `chan-stdout`, whose diverging path is deliberately the bare channel id because its evidence is arbitrary text, so no `observablePath` can tolerate it (FR-032). A companion differential case existed carrying a tolerance scoped to `chan-stdout.table`, a path no observation produces: it could never be consumed, the divergence could never be allowed, and the case was red by construction rather than by any deacon behavior. It was deleted, losing no coverage \u2014 the spec-expectation twin shares its `scenarioContext` and every obligation it appeared in. Comparing structured output instead is closed by a second fact: the runner sends ONE argv to both sides, deacon spells the flag `--output json` where the pinned reference spells it `--output-format json`, and deacon rejects `--output-format` outright (#389)."
     },
     {
+      "id": "bhv-outdated-reports-declared-reference-key",
+      "area": "outdated",
+      "statement": "`outdated` keys each report entry by the Feature reference the configuration DECLARED, tag included, so two Features differing only by tag are reported as two entries.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "aligned",
+      "decision": "align-with-reference",
+      "notes": "Fixes #407 divergence 1. deacon previously keyed the report by the CANONICAL untagged id, which collapsed two Features declared at different tags into a single entry and silently dropped the other \u2014 exit 0, no warning, a user asking which Features are outdated told about one of two. The reference CLI echoes the declared reference, and after the fix the two agree byte-for-byte on this shape. The canonical id is still what the LOCKFILE is keyed by (`derive_current_version`); only the report changed. A residual difference remains on the same document and is NOT covered by this behavior: deacon reports `latest` as the raw registry tag (`2.1`) where the reference normalizes to full semver (`2.1.0`), tracked on #407."
+    },
+    {
       "id": "bhv-outdated-reports-feature-versions",
       "area": "outdated",
       "statement": "`outdated` reports each configured Feature's current, wanted, and latest version, and reports an empty result for a configuration that declares no Features.",

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -92,7 +92,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
           }
         }
       ],
@@ -148,11 +148,11 @@
           "assertion": {
             "jsonSubset": {
               "features": {
-                "ghcr.io/devcontainers/features/git": {
+                "ghcr.io/devcontainers/features/git:1": {
                   "current": "1.3.0",
                   "wanted": "1"
                 },
-                "ghcr.io/devcontainers/features/node": {
+                "ghcr.io/devcontainers/features/node:1.6.1": {
                   "current": "1.6.1",
                   "wanted": "1.6.1"
                 }
@@ -207,7 +207,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+            "matches": "git:1\\.3\\.2 \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
           }
         }
       ],
@@ -259,7 +259,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|"
+            "matches": "git:1\\.3\\.2 \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|"
           }
         }
       ],
@@ -353,11 +353,11 @@
           "assertion": {
             "jsonSubset": {
               "features": {
-                "ghcr.io/devcontainers/features/git": {
+                "ghcr.io/devcontainers/features/git:1.3.2": {
                   "current": "1.3.2",
                   "wanted": "1.3.2"
                 },
-                "ghcr.io/devcontainers/features/node": {
+                "ghcr.io/devcontainers/features/node:1.6.1": {
                   "current": "1.6.1",
                   "wanted": "1.6.1"
                 }
@@ -412,7 +412,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
           }
         }
       ],
@@ -558,7 +558,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "ghcr\\.io/devcontainers/features/git\\s*\\|\\s*1\\.3\\.2\\s*\\|\\s*1\\.3\\.2\\s*\\|"
+            "matches": "ghcr\\.io/devcontainers/features/git:1\\.3\\.2\\s*\\|\\s*1\\.3\\.2\\s*\\|\\s*1\\.3\\.2\\s*\\|"
           }
         }
       ],
@@ -610,7 +610,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.0 \\| 1 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
           }
         }
       ],
@@ -662,7 +662,7 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|[\\s\\S]*common-utils \\| 2\\.5\\.2 \\| 2\\.5\\.2 \\|"
+            "matches": "git:1\\.3\\.2 \\| 1\\.3\\.2 \\| 1\\.3\\.2 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|[\\s\\S]*common-utils:2\\.5\\.2 \\| 2\\.5\\.2 \\| 2\\.5\\.2 \\|"
           }
         }
       ],
@@ -805,6 +805,69 @@
       "notes": "The `reference-lenient` input class for `outdated` (FR-040): an input the reference accepts and deacon rejects, run through a subcommand other than `read-configuration` to show that deacon's type-strictness is a property of configuration loading rather than of one command's output path.\n\nThe divergence is deliberately observed on `chan-exit-code` rather than `chan-stdout`. An exit code is addressable as `chan-exit-code.exitCode`, so the tolerance above can actually be consumed; `chan-stdout`'s diverging path is the bare channel id by design (its evidence is arbitrary text, so a whole-channel tolerance would be a wildcard, FR-032), which is what made the previous `reference-lenient` case here unrunnable."
     },
     {
+      "id": "case-outdated-same-feature-two-tags",
+      "behaviors": [
+        "bhv-outdated-reports-declared-reference-key"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "single",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "boundary",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--output",
+            "json"
+          ],
+          "fixtures": [
+            "fx-outdated-same-feature-two-tags"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-outdated",
+          "assertion": {
+            "jsonSubset": {
+              "features": {
+                "ghcr.io/devcontainers/features/node:1.6.1": {
+                  "current": "1.6.1",
+                  "wanted": "1.6.1"
+                },
+                "ghcr.io/devcontainers/features/node:2.1.0": {
+                  "current": "2.1.0",
+                  "wanted": "2.1.0"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Regression evidence for #407 divergence 1, and the boundary the old implementation lost. The configuration declares the SAME Feature at two different tags \u2014 distinct keys in `devcontainer.json`, but one canonical id. Keying the report canonically collapsed them and dropped the `1.6.1` entry silently, exit 0. Both entries are asserted, each with its own `current`/`wanted`, so a report that keeps only one fails no matter which one survives. `latest` is deliberately not asserted: it is whatever the registry publishes next, and deacon and the reference additionally disagree on its FORM here \u2014 deacon emits the raw tag `2.1`, the reference normalizes to `2.1.0` \u2014 which is tracked separately on #407 and is why this case is spec-expectation rather than a live differential."
+    },
+    {
       "id": "case-outdated-structured-report",
       "behaviors": [
         "bhv-outdated-reports-feature-versions"
@@ -849,7 +912,7 @@
           "assertion": {
             "jsonSubset": {
               "features": {
-                "ghcr.io/devcontainers/features/git": {
+                "ghcr.io/devcontainers/features/git:1.3.2": {
                   "current": "1.3.2",
                   "wanted": "1.3.2"
                 }

--- a/conformance/registry/obligation-dispositions/outdated.json
+++ b/conformance/registry/obligation-dispositions/outdated.json
@@ -13,6 +13,14 @@
       ]
     },
     {
+      "id": "odp-bhv-a09673dc",
+      "obligation": "obl-bhv-a09673dc",
+      "disposition": "case",
+      "cases": [
+        "case-outdated-same-feature-two-tags"
+      ]
+    },
+    {
       "id": "odp-bhv-cd232792",
       "obligation": "obl-bhv-cd232792",
       "disposition": "case",

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -193,6 +193,16 @@
       ]
     },
     {
+      "id": "src-obs-outdated-declared-reference-key",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "`outdated --output json` against a configuration declaring `ghcr.io/devcontainers/features/node` at BOTH `:1.6.1` and `:2.1.0`, compared with `devcontainer outdated --output-format json`",
+      "summary": "Whether the report is keyed by the declared Feature reference or by the canonical untagged id, and therefore whether two Features differing only by tag both appear.",
+      "behaviors": [
+        "bhv-outdated-reports-declared-reference-key"
+      ]
+    },
+    {
       "id": "src-obs-outdated-extends-chain",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -411,6 +411,17 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      a fidelity loss on input both sides accept.",
     ),
     (
+        "bhv-outdated-reports-declared-reference-key",
+        "Whether the `outdated` report is keyed by the DECLARED Feature reference or by the \
+     canonical untagged id, and therefore whether two Features declared at different tags \
+     both appear. Unrecordable before #407: deacon collapsed them onto one key and every \
+     pre-migration fixture declared each Feature exactly once, so canonical and declared \
+     keys coincided and no unit could have distinguished them. Not a variant of \
+     bhv-outdated-reports-feature-versions, which claims each Feature's current/wanted/latest \
+     are correct; this claims WHICH entries exist at all, and its failure mode is a declared \
+     Feature silently absent from the report with a zero exit.",
+    ),
+    (
         "bhv-upgrade-cli-config-overlay-honored",
         "Whether `upgrade` regenerates its lockfile from the configuration AFTER the \
      command-line overlays apply. Unrecordable before #409 in either direction: deacon \

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -117,7 +117,13 @@ const TODAY: &str = "2026-07-19";
 /// use `jsonEquals` rather than `jsonSubset` deliberately: a subset assertion of
 /// `{"features": {}}` matches any features map and would have passed against the buggy
 /// output. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 229;
+/// **229 → 230** (#407 divergence 1): the boundary the old `outdated` implementation lost.
+/// A configuration declaring the same Feature at two different tags is two keys in
+/// `devcontainer.json` but one canonical id, and keying the report canonically collapsed them
+/// and dropped one silently with exit 0. No existing case could have caught it: every other
+/// fixture declares each Feature once, so canonical and declared keys coincide. No record was
+/// removed.
+const MIGRATED_CASE_COUNT: usize = 230;
 
 #[test]
 fn real_registry_is_structurally_valid() {

--- a/crates/core/src/outdated.rs
+++ b/crates/core/src/outdated.rs
@@ -12,7 +12,18 @@ use semver::Version;
 /// Per-feature version information reported by `outdated`
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FeatureVersionInfo {
-    /// Canonical fully-qualified feature id without version (e.g. "ghcr.io/devcontainers/features/node")
+    /// The feature identifier exactly as the configuration declared it, tag and
+    /// all (e.g. `"ghcr.io/devcontainers/features/node:1.6.1"`).
+    ///
+    /// This is the DECLARED reference, not the canonical untagged id, and the
+    /// distinction is load-bearing (#407). Two Features that differ only by tag
+    /// are distinct keys in `devcontainer.json` but collapse to one canonical
+    /// id, so reporting canonically dropped a declared Feature from the report
+    /// entirely — with a zero exit and no warning. It also matches the reference
+    /// CLI, which echoes the declared reference.
+    ///
+    /// The lockfile lookup still keys on the canonical id (see
+    /// [`derive_current_version`]); only what is REPORTED changed.
     pub id: String,
 
     /// Current version (lockfile or wanted fallback)

--- a/crates/deacon/src/commands/outdated.rs
+++ b/crates/deacon/src/commands/outdated.rs
@@ -270,7 +270,6 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     // Build results preserving original declaration order
     for (i, declared_ref) in declared_refs.iter().enumerate() {
         let declared_ref = declared_ref.as_str();
-        let canonical = core_outdated::canonical_feature_id(declared_ref);
         let wanted = core_outdated::compute_wanted_version(declared_ref);
         let current = core_outdated::derive_current_version(declared_ref, lockfile_opt.as_ref());
         let latest = latests.get(i).cloned().unwrap_or(None);
@@ -279,7 +278,13 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
         let latest_major = core_outdated::latest_major(&latest);
 
         results.push(core_outdated::FeatureVersionInfo {
-            id: canonical,
+            // The DECLARED reference, tag and all (#407). Reporting the
+            // CANONICAL untagged id collapsed two Features declared at
+            // different tags into one row and silently dropped the other.
+            // `canonical_feature_id` is still applied where it belongs —
+            // inside `derive_current_version`, to look the entry up in the
+            // lockfile, which IS keyed canonically.
+            id: declared_ref.to_string(),
             current: current.clone(),
             wanted: wanted.clone(),
             latest: latest.clone(),

--- a/crates/deacon/tests/integration_outdated_extends.rs
+++ b/crates/deacon/tests/integration_outdated_extends.rs
@@ -74,7 +74,7 @@ fn test_outdated_resolves_features_from_extends() -> Result<(), Box<dyn Error>> 
     );
 
     // Check node feature from extended config
-    let node = features.get("ghcr.io/devcontainers/features/node");
+    let node = features.get("ghcr.io/devcontainers/features/node:18");
     assert!(
         node.is_some(),
         "Feature 'node' from extended config should be present in outdated report"
@@ -84,7 +84,7 @@ fn test_outdated_resolves_features_from_extends() -> Result<(), Box<dyn Error>> 
     assert_eq!(node["wanted"], "18");
 
     // Check python feature from main config
-    let python = features.get("ghcr.io/devcontainers/features/python");
+    let python = features.get("ghcr.io/devcontainers/features/python:3.11");
     assert!(
         python.is_some(),
         "Feature 'python' from main config should be present in outdated report"
@@ -168,15 +168,15 @@ fn test_outdated_extends_chain_resolution() -> Result<(), Box<dyn Error>> {
 
     // Verify all three features
     assert!(
-        features.contains_key("ghcr.io/devcontainers/features/node"),
+        features.contains_key("ghcr.io/devcontainers/features/node:16"),
         "Feature 'node' from base should be present"
     );
     assert!(
-        features.contains_key("ghcr.io/devcontainers/features/python"),
+        features.contains_key("ghcr.io/devcontainers/features/python:3.10"),
         "Feature 'python' from intermediate should be present"
     );
     assert!(
-        features.contains_key("ghcr.io/devcontainers/features/docker-in-docker"),
+        features.contains_key("ghcr.io/devcontainers/features/docker-in-docker:2"),
         "Feature 'docker-in-docker' from main should be present"
     );
 
@@ -232,20 +232,37 @@ fn test_outdated_extends_feature_override() -> Result<(), Box<dyn Error>> {
 
     let features = parsed["features"].as_object().unwrap();
 
-    // Should only have one node feature entry
+    // BOTH node entries are reported, and that is what the merge actually produces.
+    //
+    // This assertion used to read "exactly one node feature (the override)", and it
+    // passed only because `outdated` keyed its report by the CANONICAL untagged id:
+    // `node:16` and `node:18` collapsed onto one key and the last one won, which LOOKED
+    // like override semantics. Keying by the declared reference (#407) removed the
+    // collapse and exposed the truth — `features` is a map, `node:16` and `node:18` are
+    // distinct keys, and `merge_two_configs` unions them. `upgrade` on the same chain
+    // tries to FETCH `node:16`, which shows the two-entry map is what feeds Feature
+    // resolution, not just reporting.
+    //
+    // Whether a child declaring a different tag of a Feature its base declares should
+    // OVERRIDE it is a real open question, tracked separately — it is a config-merge
+    // decision with blast radius through `up`/`build` Feature installation, not a
+    // reporting one. This test now records what the code does; it deliberately does not
+    // bless it.
     let node_features: Vec<_> = features.keys().filter(|k| k.contains("node")).collect();
     assert_eq!(
         node_features.len(),
-        1,
-        "Should have exactly one node feature (the override)"
+        2,
+        "both declared node tags are distinct map keys and both survive the merge; got {node_features:?}"
     );
 
-    // Verify it's the version from the main config (18, not 16)
-    let node = features.get("ghcr.io/devcontainers/features/node").unwrap();
-    assert_eq!(
-        node["current"], "18",
-        "Node version should be 18 (from main config override), not 16 (from base)"
-    );
+    let node18 = features
+        .get("ghcr.io/devcontainers/features/node:18")
+        .expect("the child's node:18 must be reported");
+    assert_eq!(node18["current"], "18");
+    let node16 = features
+        .get("ghcr.io/devcontainers/features/node:16")
+        .expect("the base's node:16 must be reported, not silently dropped");
+    assert_eq!(node16["current"], "16");
 
     Ok(())
 }
@@ -297,11 +314,11 @@ fn test_outdated_text_output_with_extends() -> Result<(), Box<dyn Error>> {
 
     // Verify both features appear in text output
     assert!(
-        text_output.contains("ghcr.io/devcontainers/features/node"),
+        text_output.contains("ghcr.io/devcontainers/features/node:18"),
         "Text output should include node feature from extends"
     );
     assert!(
-        text_output.contains("ghcr.io/devcontainers/features/python"),
+        text_output.contains("ghcr.io/devcontainers/features/python:3.11"),
         "Text output should include python feature from main config"
     );
 

--- a/crates/deacon/tests/integration_outdated_json.rs
+++ b/crates/deacon/tests/integration_outdated_json.rs
@@ -44,7 +44,9 @@ fn test_outdated_json_output_format() -> Result<(), Box<dyn Error>> {
     let json_str = String::from_utf8(output.stdout)?;
     let parsed: Value = serde_json::from_str(&json_str)?;
 
-    // Verify structure: { features: { "canonical-id": { current, wanted, latest, ... } } }
+    // Verify structure: { features: { "<declared ref>": { current, wanted, latest, ... } } }
+    // Keyed by the DECLARED reference, tag included (#407) — not the canonical untagged id,
+    // which collapsed two tags of one Feature into a single entry and dropped the other.
     assert!(parsed.is_object());
     assert!(parsed.get("features").is_some());
 
@@ -52,7 +54,9 @@ fn test_outdated_json_output_format() -> Result<(), Box<dyn Error>> {
     assert_eq!(features.len(), 2);
 
     // Check node feature
-    let node = features.get("ghcr.io/devcontainers/features/node").unwrap();
+    let node = features
+        .get("ghcr.io/devcontainers/features/node:18")
+        .unwrap();
     assert_eq!(node["current"], "18");
     assert_eq!(node["wanted"], "18");
     // latest should be null since we forced OCI failure
@@ -60,7 +64,7 @@ fn test_outdated_json_output_format() -> Result<(), Box<dyn Error>> {
 
     // Check python feature
     let python = features
-        .get("ghcr.io/devcontainers/features/python")
+        .get("ghcr.io/devcontainers/features/python:3.11")
         .unwrap();
     assert_eq!(python["current"], "3.11");
     assert_eq!(python["wanted"], "3.11");
@@ -139,9 +143,9 @@ fn test_outdated_json_preserves_declaration_order() -> Result<(), Box<dyn Error>
     // Verify declaration order is preserved (zzz, aaa, mmm), not alphabetical (aaa, mmm, zzz)
     let keys: Vec<&String> = features.keys().collect();
     assert_eq!(keys.len(), 3);
-    assert_eq!(keys[0], "ghcr.io/devcontainers/features/zzz");
-    assert_eq!(keys[1], "ghcr.io/devcontainers/features/aaa");
-    assert_eq!(keys[2], "ghcr.io/devcontainers/features/mmm");
+    assert_eq!(keys[0], "ghcr.io/devcontainers/features/zzz:1");
+    assert_eq!(keys[1], "ghcr.io/devcontainers/features/aaa:1");
+    assert_eq!(keys[2], "ghcr.io/devcontainers/features/mmm:1");
 
     Ok(())
 }
@@ -178,7 +182,7 @@ fn test_outdated_json_schema_stability() -> Result<(), Box<dyn Error>> {
     let json_str = String::from_utf8(output.stdout)?;
     let parsed: Value = serde_json::from_str(&json_str)?;
 
-    let node = &parsed["features"]["ghcr.io/devcontainers/features/node"];
+    let node = &parsed["features"]["ghcr.io/devcontainers/features/node:18"];
 
     // Verify expected fields exist
     assert!(node.get("current").is_some());

--- a/crates/deacon/tests/integration_outdated_local_features.rs
+++ b/crates/deacon/tests/integration_outdated_local_features.rs
@@ -60,8 +60,8 @@ fn test_outdated_skips_local_features() -> Result<(), Box<dyn Error>> {
     assert_eq!(features.len(), 2, "Only OCI features should be in output");
 
     // Check that OCI features are present
-    assert!(features.contains_key("ghcr.io/devcontainers/features/node"));
-    assert!(features.contains_key("ghcr.io/devcontainers/features/python"));
+    assert!(features.contains_key("ghcr.io/devcontainers/features/node:18"));
+    assert!(features.contains_key("ghcr.io/devcontainers/features/python:3.11"));
 
     // Check that local/non-OCI features are NOT present
     assert!(!features.contains_key("./local-feature"));
@@ -107,7 +107,7 @@ fn test_outdated_text_skips_local_features() -> Result<(), Box<dyn Error>> {
     let stdout = String::from_utf8(output.stdout)?;
 
     // Check that only the OCI feature appears in output
-    assert!(stdout.contains("ghcr.io/devcontainers/features/node"));
+    assert!(stdout.contains("ghcr.io/devcontainers/features/node:18"));
 
     // Check that local features don't appear
     assert!(!stdout.contains("./feature-a"));

--- a/crates/deacon/tests/integration_outdated_resilience.rs
+++ b/crates/deacon/tests/integration_outdated_resilience.rs
@@ -40,10 +40,10 @@ fn test_outdated_graceful_registry_failure() -> Result<(), Box<dyn Error>> {
             "Feature | Current | Wanted | Latest",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/node",
+            "ghcr.io/devcontainers/features/node:18",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/python",
+            "ghcr.io/devcontainers/features/python:3.11",
         ));
 
     Ok(())
@@ -82,7 +82,7 @@ fn test_outdated_graceful_registry_failure_json() -> Result<(), Box<dyn Error>> 
     let json_str = String::from_utf8(output.stdout)?;
     let parsed: serde_json::Value = serde_json::from_str(&json_str)?;
 
-    let node = &parsed["features"]["ghcr.io/devcontainers/features/node"];
+    let node = &parsed["features"]["ghcr.io/devcontainers/features/node:18"];
 
     // current and wanted should be present, latest should be null
     assert_eq!(node["current"], "18");
@@ -121,10 +121,10 @@ fn test_outdated_invalid_feature_reference() -> Result<(), Box<dyn Error>> {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/node",
+            "ghcr.io/devcontainers/features/node:18",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/python",
+            "ghcr.io/devcontainers/features/python@sha256:deadbeef",
         ));
 
     Ok(())
@@ -165,7 +165,7 @@ fn test_outdated_missing_lockfile_fallback() -> Result<(), Box<dyn Error>> {
     let json_str = String::from_utf8(output.stdout)?;
     let parsed: serde_json::Value = serde_json::from_str(&json_str)?;
 
-    let node = &parsed["features"]["ghcr.io/devcontainers/features/node"];
+    let node = &parsed["features"]["ghcr.io/devcontainers/features/node:18"];
 
     // Both current and wanted should be "18" (fallback)
     assert_eq!(node["current"], "18");

--- a/crates/deacon/tests/integration_outdated_text.rs
+++ b/crates/deacon/tests/integration_outdated_text.rs
@@ -258,9 +258,27 @@ fn test_outdated_text_strips_v_prefix() -> Result<(), Box<dyn Error>> {
 
     let stdout = String::from_utf8(output.stdout)?;
 
-    // Should show 18.0.0 without the v prefix
-    assert!(stdout.contains("18.0.0"));
-    assert!(!stdout.contains("v18"));
+    // The version COLUMNS strip the `v`; the identifier column does not, because it
+    // echoes the reference exactly as declared (#407) and the tag really is `v18.0.0`.
+    // Assert on the row's columns rather than on the whole line, which now contains the
+    // declared tag and would make a bare `!contains("v18")` fail for the wrong reason.
+    let row = stdout
+        .lines()
+        .find(|l| l.contains("features/node:v18.0.0"))
+        .expect("the node row must be present, keyed by its declared reference");
+    let cols: Vec<&str> = row.split('|').map(str::trim).collect();
+    assert_eq!(
+        cols[0], "ghcr.io/devcontainers/features/node:v18.0.0",
+        "identifier column echoes the declared reference verbatim"
+    );
+    for (i, c) in cols.iter().enumerate().skip(1) {
+        assert!(
+            !c.starts_with('v'),
+            "version column {i} must have the `v` prefix stripped, got {c:?}"
+        );
+    }
+    assert_eq!(cols[1], "18.0.0");
+    assert_eq!(cols[2], "18.0.0");
 
     Ok(())
 }

--- a/crates/deacon/tests/outdated_explicit_config.rs
+++ b/crates/deacon/tests/outdated_explicit_config.rs
@@ -40,10 +40,10 @@ fn test_outdated_respects_explicit_config_path() -> Result<(), Box<dyn Error>> {
             "Feature | Current | Wanted | Latest",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/node | 18 | 18 |",
+            "ghcr.io/devcontainers/features/node:18 | 18 | 18 |",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/python | 3.11 | 3.11 |",
+            "ghcr.io/devcontainers/features/python:3.11 | 3.11 | 3.11 |",
         ));
 
     Ok(())

--- a/crates/deacon/tests/outdated_text_render.rs
+++ b/crates/deacon/tests/outdated_text_render.rs
@@ -37,10 +37,10 @@ fn test_outdated_text_rendering_shows_features_table() -> Result<(), Box<dyn Err
             "Feature | Current | Wanted | Latest",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/node | 18 | 18 |",
+            "ghcr.io/devcontainers/features/node:18 | 18 | 18 |",
         ))
         .stdout(predicate::str::contains(
-            "ghcr.io/devcontainers/features/python | 3.11 | 3.11 |",
+            "ghcr.io/devcontainers/features/python:3.11 | 3.11 | 3.11 |",
         ));
 
     Ok(())


### PR DESCRIPTION
Fixes #407 divergence 1. **A declared Feature was being silently dropped from the report.**

## The bug

`outdated` keyed each entry by the canonical *untagged* feature id. Two Features differing
only by tag are distinct keys in `devcontainer.json` but collapse to one canonical id:

```jsonc
// declared: node:1.6.1 AND node:2.1.0
before: {"…/node": {"current": "2.1.0", …}}                    // <- 1.6.1 GONE, exit 0
after:  {"…/node:1.6.1": {…}, "…/node:2.1.0": {…}}             // <- matches the reference
```

A user asking which Features are outdated was told about one of two, with no indication the
other was dropped.

`canonical_feature_id` is still applied where it belongs — inside `derive_current_version`, to
look the entry up in the lockfile, which *is* keyed canonically. Only what is **reported**
changed.

## What this does NOT fix

Two #407 divergences remain: `current`/`wanted` for an unpinned reference, and lockfile
influence. A third surfaced while verifying: deacon reports `latest` as the raw registry tag
(`2.1`) where the reference normalizes to `2.1.0` — added to #407, and the reason the new case
is a spec-expectation rather than a live differential.

## It exposed a worse bug — #411, filed not fixed

`test_outdated_extends_feature_override` asserted *"exactly one node feature (the override)"*
for a chain where the base declares `node:16` and the child `node:18`. **It passed only because
of the collapse** — the two keys merged, last won, and that looked like override semantics.

Remove the collapse and the truth appears: `merge_two_configs` unions them, and `upgrade` on
the same chain tries to **fetch** `node:16`:

```
Caused by: Feature error: … manifests/16
```

So the two-entry map feeds Feature **resolution and installation**, not just reporting — a
child bumping a Feature version its base declares installs **both**. That is a config-merge
decision with blast radius through `up`/`build`, and `extends` is a deacon extension with no
reference answer, so it needs a deliberate call rather than a drive-by fix.

The test was verifying a behavior the codebase never had; a reporting bug was standing in for a
merge feature. It now records what the code actually does, with a comment saying explicitly
that it does not bless it.

## Test churn

Ten conformance cases and six integration tests pinned the canonical key — correct about the
values, wrong about the key. One needed more than a rename:
`test_outdated_text_strips_v_prefix` asserted `!stdout.contains("v18")`, which now fails for
the *wrong reason* since the identifier column legitimately contains `v18.0.0` — that IS the
declared tag. It now splits the row and asserts the `v` is stripped from the **version
columns**, which was always the claim under test.

## Verification

- Collision case measured against the pinned oracle: keys byte-identical
- `validate` ok; `coverage check` matches regeneration (742)
- `parity_conformance_runner`: only the pre-existing `case-merged-decl-*` cluster fails (#387)
- fmt, `clippy --all-targets --all-features`, `test-nextest-fast` (4171), doctests clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)