### PR TITLE
fix(outdated): fail loudly on a present-but-invalid lockfile

### DIFF
--- a/conformance/fixtures/fx-outdated-malformed-lockfile/.devcontainer/devcontainer-lock.json
+++ b/conformance/fixtures/fx-outdated-malformed-lockfile/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git": {
+			"version": "1.3.0",
+			"resolved": "x",
+			"integrity": "sha256:aaaa"
+		}
+	}
+}

--- a/conformance/fixtures/fx-outdated-malformed-lockfile/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-malformed-lockfile/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "ConformanceOutdatedMalformedLockfile",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {}
+	}
+}

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -339,6 +339,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-c5b125aa",
+      "kind": "behavior",
+      "behavior": "bhv-outdated-malformed-lockfile-rejected",
+      "context": []
+    },
+    {
       "id": "obl-bhv-c658c572",
       "kind": "behavior",
       "behavior": "bhv-container-identity-labels",

--- a/conformance/registry/behaviors/outdated.json
+++ b/conformance/registry/behaviors/outdated.json
@@ -12,6 +12,16 @@
       "notes": "The pinned reference does not resolve `extends`, so it reports an EMPTY table and exits 0 for a workspace whose only Feature is declared one link up \u2014 a silent miss, not an error (observed 2026-07-26, src-obs-outdated-extends-chain). Backed by wvr-outdated-extends-chain-features; the difference is only visible on stdout, so that is the compared channel. The divergence is characterized by wvr-outdated-extends-chain-features and covered by the spec-expectation case-outdated-extends-chain-features, NOT by a live differential \u2014 the differential form is structurally unavailable here. The difference lands on `chan-stdout`, whose diverging path is deliberately the bare channel id because its evidence is arbitrary text, so no `observablePath` can tolerate it (FR-032). A companion differential case existed carrying a tolerance scoped to `chan-stdout.table`, a path no observation produces: it could never be consumed, the divergence could never be allowed, and the case was red by construction rather than by any deacon behavior. It was deleted, losing no coverage \u2014 the spec-expectation twin shares its `scenarioContext` and every obligation it appeared in. Comparing structured output instead is closed by a second fact: the runner sends ONE argv to both sides, deacon spells the flag `--output json` where the pinned reference spells it `--output-format json`, and deacon rejects `--output-format` outright (#389)."
     },
     {
+      "id": "bhv-outdated-malformed-lockfile-rejected",
+      "area": "outdated",
+      "statement": "`outdated` fails with a non-zero exit and a diagnostic naming the file when a `devcontainer-lock.json` is PRESENT but unreadable or invalid; an ABSENT lockfile remains silent and successful.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "divergent",
+      "decision": "intentional-divergence",
+      "notes": "Fixes #406. deacon swallowed the read/validation error at `debug!` and continued as though no lockfile existed. That is not equivalent: the lockfile supplies `current` (`derive_current_version`), so a typo silently changed the reported answer \u2014 `current: 1` instead of the locked `1.3.0`, exit 0, indistinguishable from having no lockfile. The reference CLI exits 0 on the same input because it never reads the lockfile for `outdated` at all (see #407 divergence 3), so this is deacon failing fast where the reference is silently unaffected \u2014 the same shape as the read-configuration strictness family, and waived as such by wvr-outdated-malformed-lockfile-rejected. The absent-vs-invalid distinction is load-bearing and is asserted alongside: `read_lockfile` already returns `Ok(None)` for absent, and most workspaces have no lockfile."
+    },
+    {
       "id": "bhv-outdated-reports-declared-reference-key",
       "area": "outdated",
       "statement": "`outdated` keys each report entry by the Feature reference the configuration DECLARED, tag included, so two Features differing only by tag are reported as two entries.",

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -716,6 +716,56 @@
       "notes": "FR-040 malformed class: the Feature set to report on comes from the configuration, so an unparseable document leaves nothing to resolve versions for."
     },
     {
+      "id": "case-outdated-malformed-lockfile-rejected",
+      "behaviors": [
+        "bhv-outdated-malformed-lockfile-rejected"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "outdated",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "lockfile",
+        "sdim-layering": "single",
+        "sdim-output-mode": "human"
+      },
+      "inputClass": "malformed",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-outdated",
+          "subcommand": "outdated",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-outdated-malformed-lockfile"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-outdated",
+          "assertion": {
+            "equals": 1
+          }
+        },
+        {
+          "channel": "chan-stderr",
+          "operation": "op-outdated",
+          "assertion": {
+            "contains": "devcontainer-lock.json"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Regression evidence for #406. The lockfile is present and fails validation (`resolved` is not an OCI digest reference). Before the fix the error was swallowed at `debug!` and the command reported `current` from the configuration instead of the lockfile, exit 0 \u2014 indistinguishable from having no lockfile at all, which is precisely the state it must NOT be confused with. Exit code and a stderr diagnostic naming the file are both asserted: exiting non-zero without saying which file is wrong leaves the user no better off than the silent version. Deliberately spec-expectation and waiver-backed rather than a live differential: the reference exits 0 on this same input because it never reads the lockfile for `outdated` at all (#407 divergence 3), so the difference is deacon consuming an input the reference does not, characterized by wvr-outdated-malformed-lockfile-rejected."
+    },
+    {
       "id": "case-outdated-no-features-empty-report",
       "behaviors": [
         "bhv-outdated-reports-feature-versions"

--- a/conformance/registry/obligation-dispositions/outdated.json
+++ b/conformance/registry/obligation-dispositions/outdated.json
@@ -21,6 +21,14 @@
       ]
     },
     {
+      "id": "odp-bhv-c5b125aa",
+      "obligation": "obl-bhv-c5b125aa",
+      "disposition": "case",
+      "cases": [
+        "case-outdated-malformed-lockfile-rejected"
+      ]
+    },
+    {
       "id": "odp-bhv-cd232792",
       "obligation": "obl-bhv-cd232792",
       "disposition": "case",

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -213,6 +213,16 @@
       ]
     },
     {
+      "id": "src-obs-outdated-malformed-lockfile",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "`outdated` against a workspace whose `devcontainer-lock.json` fails validation (`resolved` is not an OCI digest reference), compared with `devcontainer outdated` on the same workspace",
+      "summary": "Whether a present-but-invalid lockfile is an error or is silently ignored, given that the lockfile determines the reported `current` version.",
+      "behaviors": [
+        "bhv-outdated-malformed-lockfile-rejected"
+      ]
+    },
+    {
       "id": "src-obs-port-attributes-authored-keys",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",

--- a/conformance/registry/waivers/wvr-outdated-malformed-lockfile-rejected.json
+++ b/conformance/registry/waivers/wvr-outdated-malformed-lockfile-rejected.json
@@ -1,0 +1,20 @@
+{
+  "id": "wvr-outdated-malformed-lockfile-rejected",
+  "behaviors": [
+    "bhv-outdated-malformed-lockfile-rejected"
+  ],
+  "scope": {
+    "kind": "corpus_case",
+    "corpus": "us5",
+    "case": "outdated-malformed-lockfile"
+  },
+  "expect": {
+    "kind": "deacon-stricter",
+    "signal": [
+      "devcontainer-lock.json"
+    ]
+  },
+  "rationale": "deacon reads `devcontainer-lock.json` for `outdated` and lets it supply the reported `current` version; the reference CLI does not read it at all for this subcommand, so a malformed lockfile cannot affect its answer and it has nothing to reject. Measured at oracle 0.87.0 on the same workspace: deacon exits 1 naming the file and the precise validation failure, the reference exits 0 with a full report. The difference in exit code is therefore a consequence of deacon consuming an input the reference does not, not of the two disagreeing about how to treat that input. Deacon fails fast per constitution IV: silently ignoring a file the author wrote, which changes the reported answer, is the worse outcome \u2014 that swallow was #406. The absent-vs-invalid distinction is preserved and separately asserted: an absent lockfile stays silent and successful, because most workspaces have none. Revisit if #407 divergence 3 resolves toward deacon dropping lockfile support in `outdated`, at which point this waiver and its behavior both go away.",
+  "added": "2026-07-31",
+  "expires": "2027-01-31"
+}

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -411,6 +411,18 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      a fidelity loss on input both sides accept.",
     ),
     (
+        "bhv-outdated-malformed-lockfile-rejected",
+        "Whether a PRESENT but invalid `devcontainer-lock.json` is an error for `outdated` or \
+     is silently ignored. Unrecordable before #406 in either direction: deacon swallowed the \
+     validation failure at `debug!` and continued as though the file were absent, so the \
+     two states produced the same observation and no pre-migration unit could have \
+     distinguished them. Not a variant of the read-configuration strictness family, which \
+     rejects malformed CONFIGURATION documents both CLIs parse; here the reference never \
+     reads the file at all for this subcommand, so the difference comes from deacon \
+     consuming an input the reference does not, and it is waived on that ground by \
+     wvr-outdated-malformed-lockfile-rejected.",
+    ),
+    (
         "bhv-outdated-reports-declared-reference-key",
         "Whether the `outdated` report is keyed by the DECLARED Feature reference or by the \
      canonical untagged id, and therefore whether two Features declared at different tags \

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -123,7 +123,12 @@ const TODAY: &str = "2026-07-19";
 /// and dropped one silently with exit 0. No existing case could have caught it: every other
 /// fixture declares each Feature once, so canonical and declared keys coincide. No record was
 /// removed.
-const MIGRATED_CASE_COUNT: usize = 230;
+/// **230 → 231** (#406): a present-but-invalid `devcontainer-lock.json`. The failure was
+/// swallowed at `debug!` and the command continued as though the file were absent — which is
+/// exactly the state it must not be confused with, since the lockfile supplies the reported
+/// `current` version. Absent and invalid produced the same observation, so no existing case
+/// could have separated them. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 231;
 
 #[test]
 fn real_registry_is_structurally_valid() {

--- a/crates/deacon/src/commands/outdated.rs
+++ b/crates/deacon/src/commands/outdated.rs
@@ -2,7 +2,7 @@
 // This implements configuration discovery, feature extraction (preserving order),
 // computing wanted/current/latest using core helpers, and rendering a text table.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use deacon_core::config::{ConfigLoader, DiscoveryResult};
 use deacon_core::errors::{ConfigError, DeaconError};
 use deacon_core::lockfile as core_lockfile;
@@ -159,15 +159,29 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     }
     let features_map = features_map_opt.unwrap();
 
-    // Read lockfile if present
+    // Read the lockfile if present. `read_lockfile` already distinguishes the two
+    // states that matter: an ABSENT lockfile is `Ok(None)` and stays silent, because
+    // most workspaces have none. A PRESENT but unreadable or invalid one is an error
+    // and must stay one (#406).
+    //
+    // This used to swallow the error at `debug!` and continue as though no lockfile
+    // existed. That is not equivalent: the lockfile supplies `current` (see
+    // `derive_current_version`), so a typo in it silently changed the reported answer —
+    // a configuration declaring `git:1` reported `current: 1` instead of the locked
+    // `1.3.0`, exit 0, indistinguishable from having no lockfile at all. The validator's
+    // message is precise and was being discarded.
     let lockfile_path = core_lockfile::get_lockfile_path(&base_config_path);
-    let lockfile_opt = match core_lockfile::read_lockfile(&lockfile_path).await {
-        Ok(opt) => opt,
-        Err(e) => {
-            debug!(error = ?e, "Failed to read lockfile - proceeding without it");
-            None
-        }
-    };
+    let lockfile_opt = core_lockfile::read_lockfile(&lockfile_path)
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to read lockfile at '{}'. \
+                 The file may be corrupted or contain invalid JSON. \
+                 Remove it to report versions from the configuration alone, \
+                 or run `deacon upgrade` to regenerate it.",
+                lockfile_path.display()
+            )
+        })?;
 
     // Prepare results vector
     let mut results: Vec<core_outdated::FeatureVersionInfo> = Vec::new();

--- a/crates/deacon/tests/perf_outdated.rs
+++ b/crates/deacon/tests/perf_outdated.rs
@@ -158,16 +158,25 @@ fn test_outdated_performance_with_lockfile() -> Result<(), Box<dyn Error>> {
     );
     fs::write(devcontainer_dir.join("devcontainer.json"), &config)?;
 
-    // Create lockfile with entries for all features
+    // Create lockfile with entries for all features.
+    //
+    // The digests must be well-formed 64-hex and `integrity` must be a string. This
+    // fixture previously used `"resolved": "…@sha256:abc1"` and `"integrity": null`,
+    // both of which fail lockfile validation — and the test still passed, because
+    // `outdated` swallowed the validation error and continued as though no lockfile
+    // existed (#406). So a test named `..._with_lockfile` was measuring the WITHOUT
+    // path and never parsed a lockfile at all. Now that the error surfaces, the
+    // fixture has to be valid for the test to measure what it claims.
     let mut lockfile_features = Vec::new();
     for i in 1..=15 {
+        // Deterministic, well-formed 64-hex digest, distinct per feature.
+        let digest = format!("{i:02}").repeat(32);
         lockfile_features.push(format!(
-            r#"    "ghcr.io/devcontainers/features/feature{}": {{
+            r#"    "ghcr.io/devcontainers/features/feature{i}": {{
       "version": "1.0.0",
-      "resolved": "ghcr.io/devcontainers/features/feature{}@sha256:abc{}",
-      "integrity": null
-    }}"#,
-            i, i, i
+      "resolved": "ghcr.io/devcontainers/features/feature{i}@sha256:{digest}",
+      "integrity": "sha256:{digest}"
+    }}"#
         ));
     }
     let lockfile = format!(


### PR DESCRIPTION
Fixes #406. Third and last of the three fixes.

## The bug

`outdated` swallowed any lockfile read or validation error at `debug!` and continued as though
no lockfile existed. Not equivalent — the lockfile supplies the reported `current` version
(`derive_current_version`), so a typo silently changed the answer:

```
config declares git:1 ; lockfile pins 1.3.0
  valid lockfile     ->  current 1.3.0
  MALFORMED lockfile ->  current 1          <- silently, exit 0
  absent lockfile    ->  current 1
```

Malformed and absent were indistinguishable — exactly the confusion that must not happen, since
the user wrote the file and meant it used. The validator's message was already precise and was
being thrown away:

```
Invalid resolved field for feature '…/git': OCI reference 'x' must contain '@' separator
with digest (expected format: 'registry/path@sha256:...')
```

`read_lockfile` already draws the right line — `Ok(None)` for absent, `Err` for
present-and-invalid — so only the caller needed fixing. **Absent stays silent and successful**,
because most workspaces have no lockfile. `up` already propagates the same error with context;
`outdated` was the one production site that didn't.

## Conformance: intentional divergence, not parity

The reference exits 0 on this same input because it never reads the lockfile for `outdated` at
all (#407 divergence 3). So the difference comes from deacon consuming an input the reference
does not, not from the two disagreeing about how to treat it. Backed by
`wvr-outdated-malformed-lockfile-rejected`, which self-invalidates if #407 divergence 3
resolves toward dropping lockfile support here.

The case asserts the exit code **and** a stderr diagnostic naming the file — exiting non-zero
without saying which file is wrong leaves the user no better off than the silent version.

## It immediately caught a test that wasn't testing what it claimed

`perf_outdated::test_outdated_performance_with_lockfile` built its lockfile with
`"resolved": "…@sha256:abc1"` (a 4-character digest) and `"integrity": null` — **both fail
validation**. It passed anyway, because the error was swallowed. So a test named
`..._with_lockfile` was measuring the *without* path and never parsed a lockfile at all.

Its fixture is now well-formed, with deterministic 64-hex digests, so it measures what its name
says. That's the second time in this run of fixes that removing a silent fallback exposed a
test asserting a behavior the codebase didn't have — the other was #411.

## Verification

All three states measured against the built binary: absent → silent exit 0; valid → `current`
from the lockfile; malformed → exit 1 naming the file and the precise validation failure.

- `validate` ok; `coverage check` matches regeneration (743)
- `parity_conformance_runner` group `none`: **129** cases, only the pre-existing
  `case-merged-decl-*` cluster fails (#387)
- fmt, `clippy --all-targets --all-features`, `test-nextest-fast` (4171) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)