### PR TITLE
fix(config): a child's Feature version overrides its base's across a merge

### DIFF
--- a/conformance/fixtures/fx-outdated-declared-reference-keys/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-declared-reference-keys/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "ConformanceOutdatedDeclaredReferenceKeys",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": {},
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-outdated-same-feature-two-tags/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-outdated-same-feature-two-tags/.devcontainer/devcontainer.json
@@ -1,8 +1,0 @@
-{
-	"name": "ConformanceOutdatedSameFeatureTwoTags",
-	"image": "alpine:3.19",
-	"features": {
-		"ghcr.io/devcontainers/features/node:1.6.1": {},
-		"ghcr.io/devcontainers/features/node:2.1.0": {}
-	}
-}

--- a/conformance/fixtures/fx-readconfig-duplicate-feature-one-document/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-duplicate-feature-one-document/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "ConformanceDuplicateFeatureOneDocument",
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/node:16": {},
+		"ghcr.io/devcontainers/features/node:18": {}
+	}
+}

--- a/conformance/fixtures/fx-readconfig-extends-feature-version-override/.devcontainer/base.json
+++ b/conformance/fixtures/fx-readconfig-extends-feature-version-override/.devcontainer/base.json
@@ -1,0 +1,7 @@
+{
+	"image": "alpine:3.19",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.2": { "ppa": true },
+		"ghcr.io/devcontainers/features/node:1.6.1": {}
+	}
+}

--- a/conformance/fixtures/fx-readconfig-extends-feature-version-override/.devcontainer/devcontainer.json
+++ b/conformance/fixtures/fx-readconfig-extends-feature-version-override/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+	"name": "ConformanceExtendsFeatureVersionOverride",
+	"extends": "./base.json",
+	"features": {
+		"ghcr.io/devcontainers/features/git:1.3.8": {}
+	}
+}

--- a/conformance/obligations/obligations.json
+++ b/conformance/obligations/obligations.json
@@ -333,6 +333,12 @@
       "context": []
     },
     {
+      "id": "obl-bhv-c5445b00",
+      "kind": "behavior",
+      "behavior": "bhv-features-duplicate-in-one-document-rejected",
+      "context": []
+    },
+    {
       "id": "obl-bhv-c5668b84",
       "kind": "behavior",
       "behavior": "bhv-up-effective-user-uid-gid",
@@ -384,6 +390,12 @@
       "id": "obl-bhv-d8b2b5e7",
       "kind": "behavior",
       "behavior": "bhv-readconfig-bad-config-path",
+      "context": []
+    },
+    {
+      "id": "obl-bhv-dc7cc488",
+      "kind": "behavior",
+      "behavior": "bhv-extends-feature-version-override",
       "context": []
     },
     {

--- a/conformance/registry/behaviors/outdated.json
+++ b/conformance/registry/behaviors/outdated.json
@@ -24,12 +24,12 @@
     {
       "id": "bhv-outdated-reports-declared-reference-key",
       "area": "outdated",
-      "statement": "`outdated` keys each report entry by the Feature reference the configuration DECLARED, tag included, so two Features differing only by tag are reported as two entries.",
+      "statement": "`outdated` keys each report entry by the Feature reference the configuration DECLARED, tag included, rather than by the canonical untagged id.",
       "applicability": [],
       "spec": "unspecified",
       "reference": "aligned",
       "decision": "align-with-reference",
-      "notes": "Fixes #407 divergence 1. deacon previously keyed the report by the CANONICAL untagged id, which collapsed two Features declared at different tags into a single entry and silently dropped the other \u2014 exit 0, no warning, a user asking which Features are outdated told about one of two. The reference CLI echoes the declared reference, and after the fix the two agree byte-for-byte on this shape. The canonical id is still what the LOCKFILE is keyed by (`derive_current_version`); only the report changed. A residual difference remains on the same document and is NOT covered by this behavior: deacon reports `latest` as the raw registry tag (`2.1`) where the reference normalizes to full semver (`2.1.0`), tracked on #407."
+      "notes": "Fixes #407 divergence 1. deacon previously keyed the report by the CANONICAL untagged id. The concrete harm was a collision: two Features declared at different tags are distinct keys in `devcontainer.json` but one canonical id, so one was silently dropped from the report with a zero exit. That input is no longer authorable \u2014 #411 rejects a document declaring one Feature at two versions, because installing both has no coherent meaning \u2014 so the collision is now unreachable BY CONSTRUCTION rather than merely reported correctly. What remains observable, and what this behavior claims, is the key SHAPE: the declared reference with its tag, matching the reference CLI, which a canonical-id implementation would strip. A residual difference on the same document is NOT covered here: deacon reports `latest` as the raw registry tag (`2.1`) where the reference normalizes to full semver (`2.1.0`), tracked on #407."
     },
     {
       "id": "bhv-outdated-reports-feature-versions",

--- a/conformance/registry/behaviors/read-configuration.json
+++ b/conformance/registry/behaviors/read-configuration.json
@@ -2,6 +2,26 @@
   "schemaVersion": 1,
   "records": [
     {
+      "id": "bhv-extends-feature-version-override",
+      "area": "read-configuration",
+      "statement": "When a link of an `extends` chain declares a Feature its base already declared at a different version, the later link's version REPLACES the base's entry rather than adding a second one; the base's position in declaration order and its configured options are kept.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "not-applicable",
+      "decision": "deacon-extension",
+      "notes": "Fixes #411. A Feature's map key carries its version, so a child bumping an inherited version writes a DIFFERENT key; under the previous key-wise merge both survived and everything downstream treated them as two Features \u2014 `up` ran the same install script twice with the last one winning the binary, and three reporting paths each named a different winner. Bumping an inherited version is the central reason to use `extends`, so the later link wins. The reference CLI has no `extends`, so there is no reference behavior to compare against; recorded by ext-extends-resolution. Position is kept because declaration order drives install order and the overlay changed WHICH version to install, not where; options are deep-merged so a base that configured the Feature keeps that configuration through a bare version bump."
+    },
+    {
+      "id": "bhv-features-duplicate-in-one-document-rejected",
+      "area": "read-configuration",
+      "statement": "A single configuration document whose `features` map contains two keys resolving to the same canonical Feature id is rejected with a diagnostic naming both keys and the id they collide on.",
+      "applicability": [],
+      "spec": "unspecified",
+      "reference": "divergent",
+      "decision": "intentional-divergence",
+      "notes": "The floor under bhv-extends-feature-version-override (#411). Across merge layers a version bump has a later layer to win; within ONE document there is no later layer, nothing to break the tie, and no reading under which installing two versions of one Feature is what the author meant \u2014 so it is rejected rather than guessed at, and the merge never has to invent a winner. The reference CLI accepts such a document and reports both entries, measured at oracle 0.87.0, so deacon is stricter here in the same way it is over malformed JSONC and wrong-typed properties (constitution IV). Waived by wvr-features-duplicate-in-one-document."
+    },
+    {
       "id": "bhv-readconfig-authored-null-omitted-collapsed",
       "area": "read-configuration",
       "statement": "deacon's resolved-configuration output omits a property the author wrote as `null`, reporting it identically to one the author left out, while the reference echoes the authored `null` and omits only what was not written.",

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -855,7 +855,7 @@
       "notes": "The `reference-lenient` input class for `outdated` (FR-040): an input the reference accepts and deacon rejects, run through a subcommand other than `read-configuration` to show that deacon's type-strictness is a property of configuration loading rather than of one command's output path.\n\nThe divergence is deliberately observed on `chan-exit-code` rather than `chan-stdout`. An exit code is addressable as `chan-exit-code.exitCode`, so the tolerance above can actually be consumed; `chan-stdout`'s diverging path is the bare channel id by design (its evidence is arbitrary text, so a whole-channel tolerance would be a wildcard, FR-032), which is what made the previous `reference-lenient` case here unrunnable."
     },
     {
-      "id": "case-outdated-same-feature-two-tags",
+      "id": "case-outdated-declared-reference-keys",
       "behaviors": [
         "bhv-outdated-reports-declared-reference-key"
       ],
@@ -868,7 +868,7 @@
         "sdim-layering": "single",
         "sdim-output-mode": "structured"
       },
-      "inputClass": "boundary",
+      "inputClass": "valid",
       "oracleType": "spec-expectation",
       "operations": [
         {
@@ -881,7 +881,7 @@
             "json"
           ],
           "fixtures": [
-            "fx-outdated-same-feature-two-tags"
+            "fx-outdated-declared-reference-keys"
           ]
         }
       ],
@@ -899,13 +899,13 @@
           "assertion": {
             "jsonSubset": {
               "features": {
+                "ghcr.io/devcontainers/features/git:1.3.2": {
+                  "current": "1.3.2",
+                  "wanted": "1.3.2"
+                },
                 "ghcr.io/devcontainers/features/node:1.6.1": {
                   "current": "1.6.1",
                   "wanted": "1.6.1"
-                },
-                "ghcr.io/devcontainers/features/node:2.1.0": {
-                  "current": "2.1.0",
-                  "wanted": "2.1.0"
                 }
               }
             }
@@ -915,7 +915,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Regression evidence for #407 divergence 1, and the boundary the old implementation lost. The configuration declares the SAME Feature at two different tags \u2014 distinct keys in `devcontainer.json`, but one canonical id. Keying the report canonically collapsed them and dropped the `1.6.1` entry silently, exit 0. Both entries are asserted, each with its own `current`/`wanted`, so a report that keeps only one fails no matter which one survives. `latest` is deliberately not asserted: it is whatever the registry publishes next, and deacon and the reference additionally disagree on its FORM here \u2014 deacon emits the raw tag `2.1`, the reference normalizes to `2.1.0` \u2014 which is tracked separately on #407 and is why this case is spec-expectation rather than a live differential."
+      "notes": "Evidence for #407 divergence 1: every report key carries the tag the configuration declared. A canonical-id implementation strips it, which is what deacon did and what silently dropped a Feature when two tags of one Feature collided onto a single key. This case was originally that collision \u2014 the same Feature at `:1.6.1` and `:2.1.0` \u2014 and it can no longer be written: #411 rejects a document declaring one Feature at two versions, so the bug's triggering input is now unauthorable rather than merely handled. Two DISTINCT tagged Features are what remains observable, and they still separate the two implementations: canonical keying would report `\u2026/git` and `\u2026/node`, declared keying reports `\u2026/git:1.3.2` and `\u2026/node:1.6.1`. `latest` is not asserted \u2014 it is whatever the registry publishes next."
     },
     {
       "id": "case-outdated-structured-report",

--- a/conformance/registry/cases/read-configuration.json
+++ b/conformance/registry/cases/read-configuration.json
@@ -2287,6 +2287,56 @@
       "notes": "Closes `config-source=dockerfile` x `features=lockfile` and `features=lockfile` x `layering=extends-chain`. The child document carries nothing but `extends` and a `name`; the Dockerfile build, the version-pinned Feature and `remoteUser` all reach the merged result through the base. Asserting all four together is the point \u2014 a chain that resolved the child's own keys but dropped the base's `features` would satisfy an assertion naming only `name`, and that is the failure mode an extends chain carrying a pinned Feature actually has. `--include-merged-configuration` is required because a plain read ECHOES `extends` rather than resolving it, which is deacon's characterized behavior, not an accident of this fixture. Relabelled from `features=lockfile` to `single`: this case asserts Feature keys that come from `devcontainer.json`, and `read-configuration` never consults a lockfile at all, so nothing here could distinguish one being present from one being absent. The fixture declares exactly one Feature, which is what `single` names. See `rule-no-lockfile-for-configuration-reporting`."
     },
     {
+      "id": "case-readconfig-duplicate-feature-one-document-rejected",
+      "behaviors": [
+        "bhv-features-duplicate-in-one-document-rejected"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "single",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "malformed",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ],
+          "fixtures": [
+            "fx-readconfig-duplicate-feature-one-document"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 1
+          }
+        },
+        {
+          "channel": "chan-stderr",
+          "operation": "op-read",
+          "assertion": {
+            "contains": "declares the same Feature twice"
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "The floor under the override rule (#411): within one document there is no later layer to win, so the collision is rejected rather than guessed at. Both the exit code and the diagnostic are asserted \u2014 a rejection that does not say WHICH two keys collided, and on what id, leaves the author hunting through a Feature map. The reference CLI accepts this document and reports both entries, so this is a characterized intentional divergence backed by wvr-features-duplicate-in-one-document, not a parity claim."
+    },
+    {
       "id": "case-readconfig-extends-compose-features",
       "behaviors": [
         "bhv-readconfig-extends-merged"
@@ -2422,6 +2472,66 @@
         "tempdir": true
       },
       "notes": "Covers the high-risk triple `hrt-readconfig-extends-chain-dockerfile-dependency-order`. The parent link declares the Dockerfile build AND one Feature; the child declares a second Feature that `installsAfter` the parent's. The assertion pins that the merged Feature map is assembled across the WHOLE chain before any ordering question is asked \u2014 an implementation that sorted the child's map alone would produce a set missing the parent's contribution and still look ordered."
+    },
+    {
+      "id": "case-readconfig-extends-feature-version-override",
+      "behaviors": [
+        "bhv-extends-feature-version-override"
+      ],
+      "context": [],
+      "scenarioContext": {
+        "sdim-operation": "read-configuration",
+        "sdim-config-source": "image",
+        "sdim-container-state": "none",
+        "sdim-features": "multiple-declared-order",
+        "sdim-layering": "extends-chain",
+        "sdim-output-mode": "structured"
+      },
+      "inputClass": "valid",
+      "oracleType": "spec-expectation",
+      "operations": [
+        {
+          "id": "op-read",
+          "subcommand": "read-configuration",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--include-merged-configuration"
+          ],
+          "fixtures": [
+            "fx-readconfig-extends-feature-version-override"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-read",
+          "assertion": {
+            "equals": 0
+          }
+        },
+        {
+          "channel": "chan-structured-output",
+          "operation": "op-read",
+          "assertion": {
+            "jsonSubset": {
+              "mergedConfiguration": {
+                "features": {
+                  "ghcr.io/devcontainers/features/git:1.3.8": {
+                    "ppa": true
+                  },
+                  "ghcr.io/devcontainers/features/node:1.6.1": {}
+                }
+              }
+            }
+          }
+        }
+      ],
+      "cleanup": {
+        "tempdir": true
+      },
+      "notes": "Regression evidence for #411, and it pins three things one assertion at a time. The child's `git:1.3.8` is present, so the version bump took effect. The base's `ppa: true` is still on it, so a bare version bump does not discard the options the base configured. The base's unrelated `node:1.6.1` survives, so overriding is not confused with replacing the whole map. What CANNOT be asserted by a subset is the absence of the base's `git:1.3.2` \u2014 a jsonSubset match ignores extra keys \u2014 which is exactly the failure this case exists to catch, so the unit tests in `config.rs` assert the key SET and the ordering; this case pins the end-to-end shape those tests cannot reach."
     },
     {
       "id": "case-readconfig-extends-merge-precedence",

--- a/conformance/registry/obligation-dispositions/outdated.json
+++ b/conformance/registry/obligation-dispositions/outdated.json
@@ -17,7 +17,7 @@
       "obligation": "obl-bhv-a09673dc",
       "disposition": "case",
       "cases": [
-        "case-outdated-same-feature-two-tags"
+        "case-outdated-declared-reference-keys"
       ]
     },
     {

--- a/conformance/registry/obligation-dispositions/read-configuration.json
+++ b/conformance/registry/obligation-dispositions/read-configuration.json
@@ -223,6 +223,14 @@
       ]
     },
     {
+      "id": "odp-bhv-c5445b00",
+      "obligation": "obl-bhv-c5445b00",
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-duplicate-feature-one-document-rejected"
+      ]
+    },
+    {
       "id": "odp-bhv-c87a30ad",
       "obligation": "obl-bhv-c87a30ad",
       "disposition": "case",
@@ -255,6 +263,14 @@
       "cases": [
         "case-errors-decl-bad-config-path",
         "case-errors-decl-bad-config-path-decision"
+      ]
+    },
+    {
+      "id": "odp-bhv-dc7cc488",
+      "obligation": "obl-bhv-dc7cc488",
+      "disposition": "case",
+      "cases": [
+        "case-readconfig-extends-feature-version-override"
       ]
     },
     {

--- a/conformance/registry/sources/observed.json
+++ b/conformance/registry/sources/observed.json
@@ -123,6 +123,16 @@
       ]
     },
     {
+      "id": "src-obs-extends-feature-version-override",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "`read-configuration --include-merged-configuration` and `up` over an extends chain whose base declares `git:1.3.2` with options and whose child declares `git:1.3.8`",
+      "summary": "Whether a child's Feature version replaces the base's entry or adds a second one, and what the resulting container installs.",
+      "behaviors": [
+        "bhv-extends-feature-version-override"
+      ]
+    },
+    {
       "id": "src-obs-extends-missing",
       "inventory": "observed",
       "revision": "rev-oracle-0-87-0",
@@ -150,6 +160,16 @@
       "summary": "With no Features declared the reference emits no `featuresConfiguration` key under either flag; with Features declared it emits the block under `--include-merged-configuration` alone, so the flags are not exclusive on either side. Observed 2026-07-28.",
       "behaviors": [
         "bhv-readconfig-features-configuration-omitted-when-none"
+      ]
+    },
+    {
+      "id": "src-obs-features-duplicate-one-document",
+      "inventory": "observed",
+      "revision": "rev-oracle-0-87-0",
+      "locator": "a single `devcontainer.json` declaring `ghcr.io/devcontainers/features/node` at both `:16` and `:18`, loaded by deacon and by the reference CLI",
+      "summary": "Whether two keys naming one Feature at different versions in the same document are rejected or accepted.",
+      "behaviors": [
+        "bhv-features-duplicate-in-one-document-rejected"
       ]
     },
     {

--- a/conformance/registry/waivers/wvr-features-duplicate-in-one-document.json
+++ b/conformance/registry/waivers/wvr-features-duplicate-in-one-document.json
@@ -1,0 +1,20 @@
+{
+  "id": "wvr-features-duplicate-in-one-document",
+  "behaviors": [
+    "bhv-features-duplicate-in-one-document-rejected"
+  ],
+  "scope": {
+    "kind": "corpus_case",
+    "corpus": "us5",
+    "case": "features-duplicate-one-document"
+  },
+  "expect": {
+    "kind": "deacon-stricter",
+    "signal": [
+      "features"
+    ]
+  },
+  "rationale": "A `features` map with two keys resolving to one canonical Feature id has no coherent meaning: the two entries name one Feature at two versions, and installing both runs the same install script twice with the last one winning. The reference CLI accepts the document and reports both entries, measured at oracle 0.87.0 \u2014 it has no `extends`, so it never had to decide what a version bump across layers means and never grew a rule for the degenerate single-document case either. deacon rejects per constitution IV, the same strictness it applies to malformed JSONC and wrong-typed properties. This is deliberately the FLOOR under bhv-extends-feature-version-override: across merge layers the later link wins, and rejecting the tie-less case is what lets the merge rule never invent a winner. Revisit if the spec ever defines duplicate Feature entries, at which point deacon should follow it.",
+  "added": "2026-08-01",
+  "expires": "2027-02-01"
+}

--- a/crates/conformance/src/conservation.rs
+++ b/crates/conformance/src/conservation.rs
@@ -411,6 +411,26 @@ pub const POST_BRANCH_BEHAVIORS: &[(&str, &str)] = &[
      a fidelity loss on input both sides accept.",
     ),
     (
+        "bhv-extends-feature-version-override",
+        "Whether a child link of an `extends` chain that declares a Feature its base already \
+     declared at a different version REPLACES that entry or adds a second one. Unrecordable \
+     before #411: the key-wise merge produced both, `outdated` collapsed them onto one \
+     canonical key in its report, and the collapse LOOKED like override semantics, so no \
+     pre-migration unit could distinguish a real override from a reporting artifact. Not a \
+     variant of any pre-migration claim: `extends` is a deacon extension the reference has \
+     no equivalent for, recorded by ext-extends-resolution.",
+    ),
+    (
+        "bhv-features-duplicate-in-one-document-rejected",
+        "Whether a single document declaring one Feature at two versions is rejected. \
+     Unrecordable before #411: deacon accepted it and installed both, and the report \
+     collapsed them, so acceptance and rejection produced indistinguishable observations. \
+     Not a variant of the read-configuration strictness family, which rejects MALFORMED \
+     documents both CLIs parse; this document is well-formed JSON and schema-valid, and is \
+     rejected for a semantic collision the spec does not address — waived on that ground by \
+     wvr-features-duplicate-in-one-document.",
+    ),
+    (
         "bhv-outdated-malformed-lockfile-rejected",
         "Whether a PRESENT but invalid `devcontainer-lock.json` is an error for `outdated` or \
      is silently ignored. Unrecordable before #406 in either direction: deacon swallowed the \

--- a/crates/conformance/tests/registry_valid.rs
+++ b/crates/conformance/tests/registry_valid.rs
@@ -128,7 +128,13 @@ const TODAY: &str = "2026-07-19";
 /// exactly the state it must not be confused with, since the lockfile supplies the reported
 /// `current` version. Absent and invalid produced the same observation, so no existing case
 /// could have separated them. No record was removed.
-const MIGRATED_CASE_COUNT: usize = 231;
+/// **231 → 233** (#411): the extends Feature-version override and its floor. A child bumping
+/// a version its base pinned used to add a SECOND entry, so `up` ran the same install script
+/// twice and three reporting paths each named a different winner. One case pins the override
+/// end to end; the other pins that the tie-less single-document form is rejected rather than
+/// guessed at. Neither could have existed before: the old `outdated` key collapse made a real
+/// override and a reporting artifact indistinguishable. No record was removed.
+const MIGRATED_CASE_COUNT: usize = 233;
 
 #[test]
 fn real_registry_is_structurally_valid() {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -24,6 +24,7 @@
 
 use crate::container_env_probe::ContainerProbeMode;
 use crate::errors::{ConfigError, DeaconError, Result};
+use crate::features::canonical_feature_id;
 use crate::variable::{SubstitutionContext, SubstitutionReport, VariableSubstitution};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{HashMap, HashSet};
@@ -97,6 +98,44 @@ where
             json_type_name(&value)
         )))
     }
+}
+
+/// Deserialize the `features` map: an object, like every other object-shaped field,
+/// and additionally one in which no two keys may name the SAME Feature (#411).
+///
+/// A Feature's key carries its version, so `…/node:16` and `…/node:18` are distinct
+/// map keys naming one Feature at two versions. Across an `extends` chain or a CLI
+/// overlay that is a version bump and the later layer wins
+/// ([`ConfigLoader::merge_feature_maps`]). Within a single document there is no later
+/// layer, nothing to break the tie, and no reading under which installing both is what
+/// the author meant — so it is rejected here rather than guessed at.
+///
+/// This is the floor under the merge rule: the merge never has to invent a winner,
+/// because a document that would force it to cannot be loaded.
+fn deserialize_features_value<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = deserialize_optional_object_value(deserializer)?;
+
+    if let Some(serde_json::Value::Object(map)) = &value {
+        let mut seen: HashMap<String, &String> = HashMap::new();
+        for key in map.keys() {
+            let canonical = canonical_feature_id(key);
+            if let Some(first) = seen.insert(canonical.clone(), key) {
+                return Err(serde::de::Error::custom(format!(
+                    "`features` declares the same Feature twice: \"{first}\" and \"{key}\" \
+                     both resolve to \"{canonical}\". Two versions of one Feature cannot both \
+                     be installed; keep the one you want. (A parent and child in an `extends` \
+                     chain MAY differ here — the child's version wins.)"
+                )));
+            }
+        }
+    }
+
+    Ok(value)
 }
 
 /// Combine two optional collection properties, staying `None` when neither side
@@ -675,7 +714,7 @@ pub struct DevContainerConfig {
     /// empty object. Read it through [`Self::features`].
     #[serde(
         default,
-        deserialize_with = "deserialize_optional_object_value",
+        deserialize_with = "deserialize_features_value",
         skip_serializing_if = "Option::is_none"
     )]
     pub features: Option<serde_json::Value>,
@@ -1745,9 +1784,9 @@ impl ConfigMerger {
                     overlay.run_services().to_vec()
                 }
             }),
-            // Features: deep merge as objects
+            // Features: merged by CANONICAL Feature id, not by literal map key (#411).
             features: combine_if_authored(&base.features, &overlay.features, || {
-                Self::merge_json_objects(base.features(), overlay.features())
+                Self::merge_feature_maps(base.features(), overlay.features())
             }),
 
             // Override feature install order: last writer wins
@@ -1916,6 +1955,76 @@ impl ConfigMerger {
             }
             (_, overlay) => overlay.clone(),
         }
+    }
+
+    /// Merge two `features` maps, keyed by CANONICAL Feature id rather than by the
+    /// literal map key (#411).
+    ///
+    /// A Feature's map key carries its version (`ghcr.io/…/node:18`), so a child that
+    /// bumps a version its base pinned writes a DIFFERENT key. Under a plain key-wise
+    /// merge both keys survive, and everything downstream then treats them as two
+    /// Features: `up` runs the same install script twice, whichever ran last winning the
+    /// binary, and three reporting paths each named a different winner. Since bumping an
+    /// inherited version is the central reason to use `extends` at all, the overlay's
+    /// entry REPLACES the base's entry for the same canonical id.
+    ///
+    /// Two deliberate details:
+    ///
+    /// - The base's POSITION is kept. Declaration order drives Feature install order, and
+    ///   the overlay is changing which version to install, not where in the sequence it
+    ///   belongs. Moving it to the overlay's position would silently reorder installs.
+    /// - The options object is deep-merged, exactly as it is for an identical key. A base
+    ///   that configured the Feature keeps that configuration when a child only bumps the
+    ///   version; the child can still override any individual option.
+    ///
+    /// Within a SINGLE document two keys sharing a canonical id is a different situation —
+    /// there is no "later" layer to win — and is rejected at parse time instead; see
+    /// [`deserialize_features_value`].
+    fn merge_feature_maps(
+        base: &serde_json::Value,
+        overlay: &serde_json::Value,
+    ) -> serde_json::Value {
+        let (base_obj, overlay_obj) = match (base, overlay) {
+            (serde_json::Value::Object(b), serde_json::Value::Object(o)) => (b, o),
+            // Not both objects: fall back to the generic rule (overlay replaces).
+            _ => return Self::merge_json_objects(base, overlay),
+        };
+
+        let mut result = base_obj.clone();
+        for (overlay_key, overlay_value) in overlay_obj {
+            let canonical = canonical_feature_id(overlay_key);
+            // Does some base key name the same Feature at a (possibly) different version?
+            let existing_key = result
+                .keys()
+                .find(|k| canonical_feature_id(k) == canonical)
+                .cloned();
+
+            match existing_key {
+                Some(existing_key) if existing_key == *overlay_key => {
+                    // Same key: the pre-existing deep-merge of the options object.
+                    let merged = Self::merge_json_objects(&result[&existing_key], overlay_value);
+                    result.insert(existing_key, merged);
+                }
+                Some(existing_key) => {
+                    // Same Feature, different version: the overlay's version wins, the
+                    // base's position and configured options are kept.
+                    let merged = Self::merge_json_objects(&result[&existing_key], overlay_value);
+                    let mut rebuilt = serde_json::Map::with_capacity(result.len());
+                    for (k, v) in &result {
+                        if k == &existing_key {
+                            rebuilt.insert(overlay_key.clone(), merged.clone());
+                        } else {
+                            rebuilt.insert(k.clone(), v.clone());
+                        }
+                    }
+                    result = rebuilt;
+                }
+                None => {
+                    result.insert(overlay_key.clone(), overlay_value.clone());
+                }
+            }
+        }
+        serde_json::Value::Object(result)
     }
 
     /// Merge string maps with overlay taking precedence
@@ -5287,6 +5396,120 @@ mod tests {
     /// End-to-end fold through `merge_configs`: a 3-layer chain must collapse all
     /// `Number(N)` / `String("localhost:N")` pairs to a single `Number(N)` regardless of
     /// which layer contributed each form.
+    /// #411: a child bumping a Feature version its base pinned OVERRIDES it rather than
+    /// adding a second entry. Two tags of one Feature are two map keys but one Feature,
+    /// and installing both runs the same install script twice with the last one winning.
+    #[test]
+    fn test_merge_features_child_version_overrides_base() {
+        let base = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/git:1.3.2": {"ppa": true},
+                "ghcr.io/devcontainers/features/node:1.6.1": {}
+            })),
+            ..Default::default()
+        };
+        let overlay = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/git:1.3.8": {}
+            })),
+            ..Default::default()
+        };
+
+        let merged = ConfigMerger::merge_configs(&[base, overlay]);
+        let features = merged.features().as_object().unwrap();
+
+        let keys: Vec<&String> = features.keys().collect();
+        assert_eq!(
+            keys,
+            vec![
+                "ghcr.io/devcontainers/features/git:1.3.8",
+                "ghcr.io/devcontainers/features/node:1.6.1"
+            ],
+            "the child's version replaces the base's IN PLACE — declaration order drives \
+             install order, and the overlay changed which version to install, not where"
+        );
+        assert_eq!(
+            features["ghcr.io/devcontainers/features/git:1.3.8"],
+            serde_json::json!({"ppa": true}),
+            "the base's configured options survive a bare version bump"
+        );
+    }
+
+    /// #411: the child can still override an individual option while bumping the version.
+    #[test]
+    fn test_merge_features_child_overrides_option_while_bumping_version() {
+        let base = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/git:1.3.2": {"ppa": true, "version": "latest"}
+            })),
+            ..Default::default()
+        };
+        let overlay = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/git:1.3.8": {"ppa": false}
+            })),
+            ..Default::default()
+        };
+
+        let merged = ConfigMerger::merge_configs(&[base, overlay]);
+        let features = merged.features().as_object().unwrap();
+        assert_eq!(
+            features["ghcr.io/devcontainers/features/git:1.3.8"],
+            serde_json::json!({"ppa": false, "version": "latest"})
+        );
+    }
+
+    /// #411: a DIFFERENT Feature is still added, not confused with an override.
+    #[test]
+    fn test_merge_features_distinct_features_both_survive() {
+        let base = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/git:1.3.2": {}
+            })),
+            ..Default::default()
+        };
+        let overlay = DevContainerConfig {
+            features: Some(serde_json::json!({
+                "ghcr.io/devcontainers/features/node:1.6.1": {}
+            })),
+            ..Default::default()
+        };
+
+        let merged = ConfigMerger::merge_configs(&[base, overlay]);
+        let features = merged.features().as_object().unwrap();
+        assert_eq!(features.len(), 2);
+    }
+
+    /// #411 (option B, the floor): within ONE document there is no later layer to win,
+    /// so a canonical-id collision is rejected at parse time rather than guessed at.
+    #[test]
+    fn test_features_same_feature_twice_in_one_document_is_rejected() {
+        let err = serde_json::from_str::<DevContainerConfig>(
+            r#"{"features": {
+                "ghcr.io/devcontainers/features/node:16": {},
+                "ghcr.io/devcontainers/features/node:18": {}
+            }}"#,
+        )
+        .expect_err("two tags of one Feature in one document must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("declares the same Feature twice"), "{msg}");
+        assert!(msg.contains("node:16") && msg.contains("node:18"), "{msg}");
+        assert!(
+            msg.contains("ghcr.io/devcontainers/features/node"),
+            "the message must name the canonical id the two collide on: {msg}"
+        );
+    }
+
+    /// A local Feature path carries no tag and must not be canonicalized into a collision
+    /// with an unrelated one.
+    #[test]
+    fn test_features_local_paths_are_not_treated_as_versions() {
+        let cfg: DevContainerConfig =
+            serde_json::from_str(r#"{"features": {"./features/a": {}, "./features/b": {}}}"#)
+                .expect("distinct local Feature paths must load");
+        assert_eq!(cfg.features().as_object().unwrap().len(), 2);
+    }
+
     #[test]
     fn test_merge_configs_forward_ports_dedupes_through_full_chain() {
         let layer_a = DevContainerConfig {

--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -4290,3 +4290,46 @@ mod entrypoint_tests {
         assert!(script.contains("exec \"$@\""));
     }
 }
+
+/// Compute a canonical feature id with no version information.
+///
+/// Strips version tags (`:version`) and digest references (`@sha256:...`) from feature references.
+///
+/// # Examples
+///
+/// ```
+/// use deacon_core::features::canonical_feature_id;
+///
+/// // Tag reference
+/// let ref_with_tag = "ghcr.io/devcontainers/features/node:1.2.3";
+/// assert_eq!(canonical_feature_id(ref_with_tag), "ghcr.io/devcontainers/features/node");
+///
+/// // Digest reference
+/// let ref_with_digest = "ghcr.io/devcontainers/features/node@sha256:abcd1234";
+/// assert_eq!(canonical_feature_id(ref_with_digest), "ghcr.io/devcontainers/features/node");
+///
+/// // No version
+/// let ref_no_version = "ghcr.io/devcontainers/features/node";
+/// assert_eq!(canonical_feature_id(ref_no_version), "ghcr.io/devcontainers/features/node");
+/// ```
+pub fn canonical_feature_id(reference: &str) -> String {
+    // If contains '@', split there first
+    if let Some(idx) = reference.find('@') {
+        return reference[..idx].to_string();
+    }
+
+    // Otherwise, we need to strip a tag if present. Tags are separated by ':' but registry hostnames
+    // may contain ':' for ports. We decide based on the position of the last '/' vs last ':'
+    let last_slash = reference.rfind('/');
+    let last_colon = reference.rfind(':');
+
+    if let (Some(slash_idx), Some(colon_idx)) = (last_slash, last_colon) {
+        if colon_idx > slash_idx {
+            // colon after last slash -> this is a tag separator
+            return reference[..colon_idx].to_string();
+        }
+    }
+
+    // No digest or tag detected; return as-is
+    reference.to_string()
+}

--- a/crates/core/src/outdated.rs
+++ b/crates/core/src/outdated.rs
@@ -118,48 +118,7 @@ pub fn is_oci_feature_ref(reference: &str) -> bool {
     true
 }
 
-/// Compute a canonical feature id with no version information.
-///
-/// Strips version tags (`:version`) and digest references (`@sha256:...`) from feature references.
-///
-/// # Examples
-///
-/// ```
-/// use deacon_core::outdated::canonical_feature_id;
-///
-/// // Tag reference
-/// let ref_with_tag = "ghcr.io/devcontainers/features/node:1.2.3";
-/// assert_eq!(canonical_feature_id(ref_with_tag), "ghcr.io/devcontainers/features/node");
-///
-/// // Digest reference
-/// let ref_with_digest = "ghcr.io/devcontainers/features/node@sha256:abcd1234";
-/// assert_eq!(canonical_feature_id(ref_with_digest), "ghcr.io/devcontainers/features/node");
-///
-/// // No version
-/// let ref_no_version = "ghcr.io/devcontainers/features/node";
-/// assert_eq!(canonical_feature_id(ref_no_version), "ghcr.io/devcontainers/features/node");
-/// ```
-pub fn canonical_feature_id(reference: &str) -> String {
-    // If contains '@', split there first
-    if let Some(idx) = reference.find('@') {
-        return reference[..idx].to_string();
-    }
-
-    // Otherwise, we need to strip a tag if present. Tags are separated by ':' but registry hostnames
-    // may contain ':' for ports. We decide based on the position of the last '/' vs last ':'
-    let last_slash = reference.rfind('/');
-    let last_colon = reference.rfind(':');
-
-    if let (Some(slash_idx), Some(colon_idx)) = (last_slash, last_colon) {
-        if colon_idx > slash_idx {
-            // colon after last slash -> this is a tag separator
-            return reference[..colon_idx].to_string();
-        }
-    }
-
-    // No digest or tag detected; return as-is
-    reference.to_string()
-}
+pub use crate::features::canonical_feature_id;
 
 /// Compute the "wanted" version for a declared feature reference.
 ///

--- a/crates/deacon/tests/integration_outdated_extends.rs
+++ b/crates/deacon/tests/integration_outdated_extends.rs
@@ -232,37 +232,36 @@ fn test_outdated_extends_feature_override() -> Result<(), Box<dyn Error>> {
 
     let features = parsed["features"].as_object().unwrap();
 
-    // BOTH node entries are reported, and that is what the merge actually produces.
+    // The child's tag overrides the base's: exactly one node entry, at the child's version.
     //
-    // This assertion used to read "exactly one node feature (the override)", and it
-    // passed only because `outdated` keyed its report by the CANONICAL untagged id:
-    // `node:16` and `node:18` collapsed onto one key and the last one won, which LOOKED
-    // like override semantics. Keying by the declared reference (#407) removed the
-    // collapse and exposed the truth — `features` is a map, `node:16` and `node:18` are
-    // distinct keys, and `merge_two_configs` unions them. `upgrade` on the same chain
-    // tries to FETCH `node:16`, which shows the two-entry map is what feeds Feature
-    // resolution, not just reporting.
-    //
-    // Whether a child declaring a different tag of a Feature its base declares should
-    // OVERRIDE it is a real open question, tracked separately — it is a config-merge
-    // decision with blast radius through `up`/`build` Feature installation, not a
-    // reporting one. This test now records what the code does; it deliberately does not
-    // bless it.
+    // This assertion has been round the houses and the history is worth keeping. It
+    // originally read "exactly one node feature (the override)" and passed — but only
+    // because `outdated` keyed its report by the CANONICAL untagged id, so `node:16` and
+    // `node:18` collapsed onto one key and the last won. That LOOKED like override
+    // semantics while the merge was actually producing both. Fixing the report key (#407)
+    // removed the collapse and exposed the truth, and this test was rewritten to record
+    // it: two entries, both installed, which is what #411 filed. Merging `features` by
+    // canonical Feature id (#411) makes the override real, so the original expectation is
+    // correct again — this time because the merge does it, not because a reporting bug
+    // hid it.
     let node_features: Vec<_> = features.keys().filter(|k| k.contains("node")).collect();
     assert_eq!(
         node_features.len(),
-        2,
-        "both declared node tags are distinct map keys and both survive the merge; got {node_features:?}"
+        1,
+        "the child's node tag must override the base's; got {node_features:?}"
     );
 
-    let node18 = features
+    let node = features
         .get("ghcr.io/devcontainers/features/node:18")
-        .expect("the child's node:18 must be reported");
-    assert_eq!(node18["current"], "18");
-    let node16 = features
-        .get("ghcr.io/devcontainers/features/node:16")
-        .expect("the base's node:16 must be reported, not silently dropped");
-    assert_eq!(node16["current"], "16");
+        .expect("the surviving entry must be the CHILD's version, keyed by its declared ref");
+    assert_eq!(
+        node["current"], "18",
+        "node version should be 18 (from the main config override), not 16 (from the base)"
+    );
+    assert!(
+        !features.contains_key("ghcr.io/devcontainers/features/node:16"),
+        "the base's superseded node:16 must not survive the merge"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #411. **Option A (child overrides) with option B (reject the tie-less case) as its
floor**, per the decision on the issue.

## The bug, measured

A Feature's map key carries its version, so a child bumping a version its base pinned writes a
*different* key. Under the key-wise merge both survived. With Docker, before the fix:

```
$ docker history --no-trunc deacon-devcontainer-features:<tag> | grep -oE 'git_[01]'
git_0     <- git:1.3.2 (base)
git_1     <- git:1.3.8 (child)
```

The same install script ran **twice**, whichever ran last winning the binary — while three
reporting paths each named a different winner:

| Path | Reported |
|---|---|
| `mergedConfiguration.features` | both |
| `featuresConfiguration.featureSets` | `git:1.3.2` (first) |
| container `devcontainer.metadata` | `git:1.3.8` (second) |
| actually installed | **both** |

After the fix, on a base image carrying no metadata of its own: a single `git_0`, and all four
paths agree.

## The rule

`merge_feature_maps` merges by **canonical Feature id**; the later layer's entry replaces the
base's. Two deliberate details, both unit-tested:

- **The base's position is kept.** Declaration order drives install order, and the overlay is
  changing *which version* to install, not where in the sequence it belongs.
- **Options are deep-merged**, exactly as for an identical key — a base that configured the
  Feature keeps that configuration through a bare version bump, and the child can still
  override any single option.

**Option B is the floor, not a separate feature.** Within one document there is no later layer
and nothing to break the tie, so it's rejected at parse time — which is precisely what lets the
merge rule never invent a winner. The diagnostic names both keys and the canonical id:

```
`features` declares the same Feature twice: "…/node:16" and "…/node:18" both resolve to
"…/node". Two versions of one Feature cannot both be installed; keep the one you want.
(A parent and child in an `extends` chain MAY differ here — the child's version wins.)
```

## Conformance

The reference has no `extends`, so there's no reference answer for the merge rule — a deacon
extension under `ext-extends-resolution`. It *does* accept a single document declaring one
Feature twice and reports both, so the rejection is a characterized intentional divergence
(constitution IV), waived by `wvr-features-duplicate-in-one-document`.

## It invalidated #412's own regression fixture — which is the strongest form this fix could take

`case-outdated-same-feature-two-tags` declared one Feature at two tags to prove the report no
longer collapses them. **That document can no longer be authored.** The collision that silently
dropped a Feature is now unreachable *by construction* rather than merely reported correctly.

The case is re-targeted to two distinct tagged Features — still enough to separate
declared-reference keying from canonical keying — and the behavior statement drops its
now-unreachable two-entry clause.

`test_outdated_extends_feature_override` also comes full circle: it originally asserted "exactly
one node feature (the override)" and passed only because the old report collapsed the keys (a
reporting bug standing in for a merge feature); #412 rewrote it to record the exposed two-entry
truth; it now asserts the override again, this time because the merge performs it.

`canonical_feature_id` moves from `outdated` to `features`, re-exported so no call site changes
— it's now a core config-merge concept, not a reporting helper.

## Verification

- Docker end-to-end before *and* after, on a base image with no metadata of its own (the first
  attempt was confounded by `mcr…/base:bookworm` contributing its own `git:1`)
- 5 new unit tests: override, option-override-while-bumping, distinct Features both survive,
  within-document rejection, local Feature paths not mistaken for versions
- `validate` ok; `coverage check` matches regeneration (745)
- `parity_conformance_runner`: only the pre-existing `case-merged-decl-*` cluster fails (#387)
- fmt, `clippy --all-targets --all-features`, `test-nextest-fast` (4176), doctests clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)