### PR TITLE
feat(conformance): generate the parity page instead of writing it

### DIFF
--- a/conformance/RULES.md
+++ b/conformance/RULES.md
@@ -79,6 +79,7 @@ checkable at a glance rather than by reading every section.
 | **V34** | lane integrity: a derived execution unit assigned to zero lanes; a lane naming an unknown class, program, or profile; case predicates that overlap or leave a remainder; a lane declaring `blocking: true` where FR-015/FR-019 forbid it; any lane declaring `mayWriteRecord: true`; a declared nextest profile whose filter does not select the lane's programs | [Lanes and execution units](#lanes-and-execution-units-v34) |
 | **V35** | execution-manifest integrity: absent, malformed, incomplete, produced for a different revision, stale against current hashes, or carrying an unaccounted outcome | [Execution manifest](#execution-manifest-v35) |
 | **V36** | drift-record integrity: an observation whose id is not derived from its substance; a duplicate; a `lastCompletedRun` omitting a probed kind; an upgrade-proposal section marked absent or unsorted | [Drift observations and upgrade proposals](#drift-observations-and-upgrade-proposals-v36) |
+| **V37** | an assertion that cannot fail: an empty `jsonSubset`, `contains`, or `matches` | [Assertions that cannot fail](#assertions-that-cannot-fail-v37) |
 
 **Three distinctions this file keeps apart**, because conflating any pair makes a status
 unfalsifiable:
@@ -1231,3 +1232,40 @@ or absent.
 **Only immutable revisions.** A branch name, moving tag, or distribution tag is rejected at
 load: a canary run against a moving target cannot be re-observed, so anything it finds can
 never be triaged into a durable record.
+
+## Assertions that cannot fail (V37)
+
+An assertion that constrains **nothing** is rejected. Three shapes qualify, from how the
+comparator evaluates them:
+
+- `jsonSubset: {}` — the matcher iterates the SUBSET's keys, so an empty object has
+  nothing to check and passes against any object.
+- `contains: ""` — every string contains the empty string.
+- `matches: ""` — the empty pattern matches everything.
+
+Such a case runs, evaluates, passes, and reports coverage on its channel while proving
+nothing. That is strictly worse than declaring no assertion at all, which at least shows
+up as an absence.
+
+**This is a cliff, not a slope, and the class is drawn narrowly on purpose.** A *weak*
+assertion still rules something out: `jsonSubset: {"features": {}}` requires a `features`
+key to exist, so a document omitting it fails. Only assertions that rule out nothing are
+rejected — widening V37 to "assertions that should be tighter" would make the validator a
+style critic on a judgement the case author is better placed to make.
+
+A nested empty object is likewise fine: in
+`{"features": {"ghcr.io/devcontainers/features/git:1.3.2": {}}}` the inner `{}` is a
+Feature's options map, and both enclosing keys must still be present.
+
+**What V37 cannot catch**, and does not pretend to: an assertion vacuous only in EFFECT.
+`equals: 0` on an exit code where both implementations always exit 0 on that input is
+structurally perfect and still proves nothing — three `live-differential` cases were in
+exactly that state (#407), leaving deacon's `outdated` report uncompared for the whole
+life of the registry. No validator decides that. The
+[injected-regression harness](#injected-regression-integrity-v30) does: it perturbs the
+evidence source and requires the case to go from clean to failing on that channel.
+
+The generated parity page applies the same rule from the other side — a case whose every
+assertion is vacuous does not colour a cell, because `·` ("not checked in this scenario")
+is what a check that cannot fail amounts to. V37 makes such a case unauthorable; the page
+rule keeps its claim true by construction rather than by that gate holding.

--- a/crates/conformance/src/bin/conformance.rs
+++ b/crates/conformance/src/bin/conformance.rs
@@ -105,6 +105,19 @@ enum Command {
         #[arg(long, value_name = "DIR")]
         out_dir: Option<PathBuf>,
     },
+    /// Generate the human-facing parity page (`docs/PARITY.md`) from the registry.
+    ///
+    /// Deterministic: the same registry renders the same bytes. Prints to stdout
+    /// unless `--write` is given, so a check can diff it without a temp file.
+    ParityPage {
+        /// Write to `docs/PARITY.md` instead of printing.
+        #[arg(long)]
+        write: bool,
+        /// Exit non-zero if the committed page differs from a fresh render, naming
+        /// the drift. This is the gate that keeps the page honest.
+        #[arg(long, conflicts_with = "write")]
+        check: bool,
+    },
     /// Strict certification for the active profile (release gate).
     Certify {
         /// Emit a single JSON document
@@ -589,6 +602,7 @@ fn run(cli: Cli) -> i32 {
     match cli.command {
         Command::Validate { json } => validate(&registry_dir, &today, json),
         Command::Report { out_dir } => report(&registry_dir, &today, out_dir),
+        Command::ParityPage { write, check } => parity_page_cmd(&registry_dir, write, check),
         Command::Certify {
             json,
             report_dir,
@@ -3688,6 +3702,56 @@ fn resolve_today(flag: Option<&str>) -> anyhow::Result<String> {
                 .date();
             Ok(date.to_string())
         }
+    }
+}
+
+/// `parity-page` — render the human-facing page, or verify the committed one matches.
+///
+/// Kept out of `docs/` generation-by-hand deliberately: this page drifted twice within
+/// an hour of first publication, both times because a count was typed rather than
+/// derived. `--check` is what makes that impossible to repeat.
+fn parity_page_cmd(registry_dir: &Path, write: bool, check: bool) -> i32 {
+    let registry = match Registry::load(registry_dir) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+    let rendered = deacon_conformance::parity_page::render(&registry);
+    let path = workspace_root().join("docs/PARITY.md");
+
+    if check {
+        let committed = std::fs::read_to_string(&path).unwrap_or_default();
+        if committed == rendered {
+            println!("ok: {} matches a fresh render", path.display());
+            return 0;
+        }
+        eprintln!(
+            "error: {} is stale — regenerate with `cargo run -p deacon-conformance -- \
+             parity-page --write`",
+            path.display()
+        );
+        return 1;
+    }
+
+    if write {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::write(&path, &rendered) {
+            Ok(()) => {
+                println!("wrote {}", path.display());
+                0
+            }
+            Err(e) => {
+                eprintln!("error: writing {}: {e}", path.display());
+                1
+            }
+        }
+    } else {
+        print!("{rendered}");
+        0
     }
 }
 

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -37,6 +37,7 @@ pub mod mapping;
 pub mod model;
 pub mod obligation;
 pub mod parity_corpus;
+pub mod parity_page;
 pub mod prose;
 pub mod regression;
 pub mod report;

--- a/crates/conformance/src/model.rs
+++ b/crates/conformance/src/model.rs
@@ -893,6 +893,39 @@ pub struct ExpectedObservable {
     pub assertion: Option<Value>,
 }
 
+/// Whether an assertion constrains **nothing** — a check that cannot fail.
+///
+/// This is a cliff, not a slope, and the distinction matters. A *weak* assertion still
+/// rules something out: `jsonSubset: {"features": {}}` requires a `features` key to
+/// exist, which a document omitting it would fail. A *vacuous* one rules out nothing at
+/// all, so declaring it is indistinguishable from declaring no expectation while looking
+/// like coverage on every report.
+///
+/// The three vacuous shapes, from how [`crate`]'s comparator evaluates them:
+///
+/// - `jsonSubset: {}` — the matcher iterates the SUBSET's keys, so an empty object has
+///   nothing to check and passes against any object.
+/// - `contains: ""` — every string contains the empty string.
+/// - `matches: ""` — the empty pattern matches everything.
+///
+/// Nested empties are NOT vacuous: in `{"features": {"…/git:1.3.2": {}}}` the inner `{}`
+/// is a Feature's options object, and both enclosing keys must still be present.
+///
+/// What this cannot catch is an assertion that is vacuous only in EFFECT — `equals: 0`
+/// on an exit code where both implementations always exit 0 is structurally perfect and
+/// still proves nothing (#407). That is the injected-regression harness's job, not a
+/// validator's.
+pub fn is_vacuous_assertion(assertion: &Value) -> bool {
+    let Some(map) = assertion.as_object() else {
+        return false;
+    };
+    map.iter().any(|(kind, value)| match kind.as_str() {
+        "jsonSubset" => value.as_object().is_some_and(serde_json::Map::is_empty),
+        "contains" | "matches" => value.as_str().is_some_and(str::is_empty),
+        _ => false,
+    })
+}
+
 /// Resources the runner reclaims after a case runs, on success AND failure (data-model
 /// §1, contract case-schema.md). `images` is `false` | `true` | `"case-built"`; typed
 /// precisely in US5 (T052), stored as raw JSON here.

--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -1,0 +1,407 @@
+//! Generate the human-facing parity page (`docs/PARITY.md`) from the registry.
+//!
+//! The page this replaces was hand-maintained, and it drifted twice within an hour of
+//! being published — once because the counts were taken from a working tree that had
+//! unmerged records in it, once because a PR merged behind it. A page whose stated
+//! premise is "every claim traces to a committed record" cannot be typed.
+//!
+//! ## What the page is, and what it deliberately is not
+//!
+//! It answers ONE question per cell, for a reader who wants to know whether deacon will
+//! behave like the reference CLI for their configuration. It does NOT expose the model
+//! we use to maintain conformance: the three-axis disposition, evidence tiers, waivers,
+//! residuals and obligations all stay in `conformance/RULES.md` and the generated
+//! coverage report. Publishing the maintenance vocabulary as if it were the status is
+//! what made the first version unreadable.
+//!
+//! ## The grid
+//!
+//! Rows are behaviors. Columns are the **cross product** of the scenario dimensions that
+//! apply to the area — for `up`, config-source × features, so fifteen columns. An earlier
+//! draft used the two dimensions as separate PROJECTIONS (three columns plus five), which
+//! is smaller and actively misleading: a behavior covered only as image×single and
+//! dockerfile×none projects to "img ✅ dkr ✅ / none ✅ 1 ✅" and reads as broad coverage.
+//! The cross product shows two cells of fifteen. The projection flatters; the product
+//! does not, so the product is what ships.
+//!
+//! Each cell carries the status **in that scenario**, from one vocabulary — an earlier
+//! draft used ✅ to mean "same as reference" in a status column and "checked against the
+//! reference" in the cells, so a deliberately-divergent row rendered as a line of green.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+use crate::load::Registry;
+use crate::model::{Decision, OracleType, ReferenceStatus, RevisionKind, TestCase};
+use crate::scenario::ScenarioModel;
+
+/// A cell's verdict: exactly one meaning per glyph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Cell {
+    /// Same as the reference, and verified against it in this scenario.
+    SameVerified,
+    /// Believed the same, but the only evidence here is deacon-side.
+    SameUnverified,
+    /// A deliberate difference, characterized.
+    DiffersOnPurpose,
+    /// A difference we intend to remove.
+    DiffersFixing,
+    /// deacon-only capability; the reference has no equivalent to compare against.
+    DeaconOnly,
+    /// No case exercises this scenario.
+    Unchecked,
+}
+
+impl Cell {
+    fn glyph(self) -> &'static str {
+        match self {
+            Cell::SameVerified => "✅",
+            Cell::SameUnverified => "◐",
+            Cell::DiffersOnPurpose => "⚠️",
+            Cell::DiffersFixing => "❌",
+            Cell::DeaconOnly => "🔵",
+            Cell::Unchecked => "·",
+        }
+    }
+}
+
+/// The per-scenario status a behavior takes wherever it IS covered, derived from its
+/// three-axis disposition. The axes are collapsed here and nowhere else.
+fn covered_verdict(b: &crate::model::BehaviorUnit, live: bool) -> Cell {
+    match (b.decision, b.reference) {
+        (Decision::DeaconExtension, _) | (_, ReferenceStatus::NotApplicable) => Cell::DeaconOnly,
+        (Decision::IntentionalDivergence, _) => Cell::DiffersOnPurpose,
+        // Divergent while intending to follow the spec or the reference means we are
+        // behind and mean to fix it — the only honest reading of R5/R6.
+        (_, ReferenceStatus::Divergent) => Cell::DiffersFixing,
+        _ if live => Cell::SameVerified,
+        _ => Cell::SameUnverified,
+    }
+}
+
+/// A scenario dimension rendered as a column group.
+///
+/// Which dimensions appear for an area comes from the applicability rules, not from
+/// this list: a dimension the rules pin to one value for an operation contributes no
+/// information and is dropped, so `doctor` carries no Feature columns.
+struct Dim {
+    /// The `sdim-` id in the scenario model.
+    key: &'static str,
+    /// `(scenario value, column heading)`, in the order they read best. The headings
+    /// are the group header; the dimension's own name is not rendered — a third
+    /// header row reading "config"/"features" adds a line and no information.
+    values: &'static [(&'static str, &'static str)],
+}
+
+const DIMS: &[Dim] = &[
+    Dim {
+        key: "sdim-config-source",
+        values: &[("image", "img"), ("dockerfile", "dkr"), ("compose", "cmp")],
+    },
+    Dim {
+        key: "sdim-features",
+        values: &[
+            ("none", "–"),
+            ("single", "1"),
+            ("multiple-declared-order", "many"),
+            ("multiple-dependency-order", "deps"),
+            ("lockfile", "lock"),
+        ],
+    },
+];
+
+fn area_title(area: &str) -> String {
+    area.replace('-', " ")
+}
+
+/// Render the page. Deterministic: same registry in, same bytes out.
+pub fn render(registry: &Registry) -> String {
+    // behavior -> set of (scenario key tuple, live?) drawn from its covering cases.
+    let mut coverage: BTreeMap<&str, Vec<(&TestCase, bool)>> = BTreeMap::new();
+    for case in &registry.cases {
+        let live = matches!(case.oracle_type, Some(OracleType::LiveDifferential));
+        for b in &case.behaviors {
+            coverage.entry(b.as_str()).or_default().push((case, live));
+        }
+    }
+
+    let mut areas: BTreeMap<&str, Vec<&crate::model::BehaviorUnit>> = BTreeMap::new();
+    for b in &registry.behaviors {
+        areas.entry(b.area.as_str()).or_default().push(b);
+    }
+
+    let model = ScenarioModel::new(&registry.scenario, &registry.applicability);
+
+    let mut out = String::new();
+    out.push_str(&header(registry));
+
+    for (area, behaviors) in &areas {
+        // Which dimensions can this area's operation actually VARY? Taken from the
+        // applicability rules, not from what the cases happen to use: a dimension the
+        // rules pin to a single value (Features for `doctor`, which resolves nothing)
+        // would otherwise render five columns that can never be anything but `·`, and
+        // an area with thin coverage would lose the columns that show it is thin.
+        let operations: BTreeSet<&str> = behaviors
+            .iter()
+            .filter_map(|b| coverage.get(b.id.as_str()))
+            .flatten()
+            .filter_map(|(case, _)| case.scenario_context.get("sdim-operation"))
+            .map(String::as_str)
+            .collect();
+        let mut permitted: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+        for op in &operations {
+            for (dim, values) in model.applicable_dimensions(op) {
+                permitted
+                    .entry(dim.id.as_str())
+                    .or_default()
+                    .extend(values.iter().copied());
+            }
+        }
+        let active: Vec<&Dim> = DIMS
+            .iter()
+            .filter(|d| permitted.get(d.key).is_some_and(|vs| vs.len() > 1))
+            .collect();
+
+        let _ = writeln!(out, "\n### {}\n", area_title(area));
+
+        if active.is_empty() {
+            // No scenario evidence to grid: a flat list is honest and smaller.
+            out.push_str("| | Behavior | Notes |\n|---|---|---|\n");
+            for b in behaviors {
+                let live = coverage
+                    .get(b.id.as_str())
+                    .is_some_and(|cs| cs.iter().any(|(_, l)| *l));
+                let _ = writeln!(
+                    out,
+                    "| {} | {} | {} |",
+                    covered_verdict(b, live).glyph(),
+                    first_sentence(&b.statement),
+                    notes_cell(b)
+                );
+            }
+            continue;
+        }
+
+        out.push_str(&grid(&active, behaviors, &coverage));
+    }
+
+    out.push_str(&footer());
+    out
+}
+
+fn grid(
+    active: &[&Dim],
+    behaviors: &[&crate::model::BehaviorUnit],
+    coverage: &BTreeMap<&str, Vec<(&TestCase, bool)>>,
+) -> String {
+    // Cross product of the active dimensions' values, in declared order.
+    let mut combos: Vec<Vec<(&str, &str)>> = vec![Vec::new()];
+    for dim in active {
+        let mut next = Vec::new();
+        for base in &combos {
+            for (value, _) in dim.values.iter() {
+                let mut c = base.clone();
+                c.push((dim.key, value));
+                next.push(c);
+            }
+        }
+        combos = next;
+    }
+
+    let mut s = String::new();
+    s.push_str("<table>\n<thead>\n");
+    if active.len() > 1 {
+        // Two header rows: the outer dimension spans the inner one's width.
+        let inner: usize = active[1..].iter().map(|d| d.values.len()).product();
+        s.push_str("<tr><th rowspan=\"2\"></th><th rowspan=\"2\">Behavior</th>");
+        for (_, label) in active[0].values.iter() {
+            let _ = write!(s, "<th colspan=\"{inner}\">{label}</th>");
+        }
+        s.push_str("<th rowspan=\"2\">Notes</th></tr>\n<tr>");
+        for _ in active[0].values.iter() {
+            for (_, short) in active[1].values.iter() {
+                let _ = write!(s, "<th>{short}</th>");
+            }
+        }
+        s.push_str("</tr>\n");
+    } else {
+        // One dimension: a single header row. Emitting the two-row form anyway left an
+        // empty second row of `<th></th>` under every column.
+        s.push_str("<tr><th></th><th>Behavior</th>");
+        for (_, label) in active[0].values.iter() {
+            let _ = write!(s, "<th>{label}</th>");
+        }
+        s.push_str("<th>Notes</th></tr>\n");
+    }
+    s.push_str("</thead>\n<tbody>\n");
+
+    for b in behaviors {
+        let cases = coverage.get(b.id.as_str());
+        let mut cells = Vec::with_capacity(combos.len());
+        for combo in &combos {
+            let hits: Vec<bool> = cases
+                .into_iter()
+                .flatten()
+                .filter(|(case, _)| {
+                    combo
+                        .iter()
+                        .all(|(k, v)| case.scenario_context.get(*k).map(String::as_str) == Some(*v))
+                })
+                .map(|(_, live)| *live)
+                .collect();
+            cells.push(match hits.iter().any(|l| *l) {
+                _ if hits.is_empty() => Cell::Unchecked,
+                live => covered_verdict(b, live),
+            });
+        }
+        let roll = cells
+            .iter()
+            .copied()
+            .find(|c| *c != Cell::Unchecked)
+            .unwrap_or(Cell::Unchecked);
+        let _ = write!(
+            s,
+            "<tr><td>{}</td><td>{}</td>",
+            roll.glyph(),
+            first_sentence(&b.statement)
+        );
+        for c in &cells {
+            let _ = write!(s, "<td>{}</td>", c.glyph());
+        }
+        let _ = writeln!(s, "<td>{}</td></tr>", notes_cell(b));
+    }
+    s.push_str("</tbody>\n</table>\n");
+    s
+}
+
+/// The statement's first sentence — the full text is the registry's job, not the page's.
+fn first_sentence(statement: &str) -> String {
+    const MAX: usize = 88;
+    let trimmed = statement.trim();
+    let cut = trimmed.find(". ").map(|i| i + 1).unwrap_or(trimmed.len());
+    let mut s = trimmed[..cut].trim_end_matches('.').trim().to_string();
+    if s.chars().count() > MAX {
+        // Cut on a word boundary; the full statement lives in the registry and the
+        // page is a scanning surface, not a substitute for it.
+        let mut end = 0;
+        for (i, _) in s.char_indices().take(MAX) {
+            end = i;
+        }
+        let boundary = s[..end].rfind(' ').unwrap_or(end);
+        s.truncate(boundary);
+        s.push('…');
+    }
+    html_escape(&s)
+}
+
+/// Issue links out of `notes`, so a reader can follow a divergence to its tracking
+/// without the page restating the rationale.
+fn notes_cell(b: &crate::model::BehaviorUnit) -> String {
+    let notes = b.notes.as_deref().unwrap_or("");
+    let mut refs: Vec<String> = Vec::new();
+    for (i, c) in notes.char_indices() {
+        if c != '#' {
+            continue;
+        }
+        let digits: String = notes[i + 1..]
+            .chars()
+            .take_while(|d| d.is_ascii_digit())
+            .collect();
+        if digits.len() >= 3 {
+            let r = format!("#{digits}");
+            if !refs.contains(&r) {
+                refs.push(r);
+            }
+        }
+    }
+    refs.truncate(3);
+    refs.join(" ")
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// The pin for a revision KIND. Selecting by id substring silently made the spec pin
+/// read `0.87.0` (the oracle's), because `rev-spec-…` does not contain "oracle" but
+/// neither does `rev-cli-surface-…`, which sorts first.
+fn pin_of(registry: &Registry, kind: RevisionKind) -> String {
+    registry
+        .revisions
+        .iter()
+        .find(|r| r.kind == kind)
+        .map(|r| r.pin.clone())
+        .unwrap_or_else(|| "(unpinned)".into())
+}
+
+fn header(registry: &Registry) -> String {
+    let total = registry.behaviors.len();
+    let deacon_only = registry
+        .behaviors
+        .iter()
+        .filter(|b| {
+            matches!(b.decision, Decision::DeaconExtension)
+                || matches!(b.reference, ReferenceStatus::NotApplicable)
+        })
+        .count();
+    let comparable = total - deacon_only;
+    let deliberate = registry
+        .behaviors
+        .iter()
+        .filter(|b| matches!(b.decision, Decision::IntentionalDivergence))
+        .count();
+    let behind = registry
+        .behaviors
+        .iter()
+        .filter(|b| {
+            matches!(b.reference, ReferenceStatus::Divergent)
+                && !matches!(b.decision, Decision::IntentionalDivergence)
+        })
+        .count();
+    let same = comparable.saturating_sub(deliberate + behind);
+
+    format!(
+        r#"# Does deacon behave like the DevContainers CLI?
+
+<!-- GENERATED FILE — do not edit.
+     Regenerate with: cargo run -q -p deacon-conformance -- parity-page --write -->
+
+Compared against **`@devcontainers/cli` {oracle}** and the [containers.dev spec]\
+(https://github.com/devcontainers/spec) at commit `{spec}`.
+
+**Of {comparable} behaviors that both tools implement, {same} match.**
+{deliberate} differ deliberately, {behind} are differences we intend to remove.
+A further {deacon_only} are deacon-only, with nothing to compare against.
+
+## How to read this
+
+| | Meaning |
+|---|---|
+| ✅ | Same as the CLI, and checked against it in this scenario |
+| ◐ | Believed the same, but only deacon-side evidence here — **never compared** |
+| ⚠️ | Differs on purpose |
+| ❌ | Differs, and we intend to fix it |
+| 🔵 | deacon-only; the CLI has no equivalent |
+| · | Not checked in this scenario |
+
+Columns are the scenarios a behavior was checked in: the configuration's shape
+(**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
+declares (**–** none / **1** one / **many** several / **deps** several with dependency
+ordering / **lock** with a lockfile). Areas only show the columns their evidence varies.
+
+A cell says a case exercised that scenario — not that the case's assertions were strong.
+The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
+"#,
+        oracle = pin_of(registry, RevisionKind::Oracle),
+        spec = pin_of(registry, RevisionKind::Spec),
+    )
+}
+
+fn footer() -> String {
+    "\n---\n\nThe full conformance record — the three-axis disposition behind each row, \
+     the waivers, and the scenario-coverage accounting — lives in `conformance/registry/` \
+     and `conformance/RULES.md`. This page is generated from it.\n"
+        .to_string()
+}

--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -119,6 +119,20 @@ pub fn render(registry: &Registry) -> String {
     // behavior -> set of (scenario key tuple, live?) drawn from its covering cases.
     let mut coverage: BTreeMap<&str, Vec<(&TestCase, bool)>> = BTreeMap::new();
     for case in &registry.cases {
+        // A case whose every declared assertion is vacuous checks nothing, so it must
+        // not colour a cell. `·` already means "not checked in this scenario", and a
+        // check that cannot fail IS not checking it — this is a correction to an
+        // existing cell, not a new tier. V37 makes such a case unauthorable; this keeps
+        // the page's claim true by construction rather than by that gate holding.
+        if !case.expected.is_empty()
+            && case.expected.iter().all(|e| {
+                e.assertion
+                    .as_ref()
+                    .is_some_and(crate::model::is_vacuous_assertion)
+            })
+        {
+            continue;
+        }
         let live = matches!(case.oracle_type, Some(OracleType::LiveDifferential));
         for b in &case.behaviors {
             coverage.entry(b.as_str()).or_default().push((case, live));
@@ -168,13 +182,17 @@ pub fn render(registry: &Registry) -> String {
             // No scenario evidence to grid: a flat list is honest and smaller.
             out.push_str("| | Behavior | Notes |\n|---|---|---|\n");
             for b in behaviors {
-                let live = coverage
-                    .get(b.id.as_str())
-                    .is_some_and(|cs| cs.iter().any(|(_, l)| *l));
+                // No covering case at all is `·`, not a verdict. Falling through to
+                // `covered_verdict` here rendered ◐ — "believed the same" — for a
+                // behavior nothing has ever exercised, which is a claim, not a gap.
+                let cell = match coverage.get(b.id.as_str()) {
+                    None => Cell::Unchecked,
+                    Some(cs) => covered_verdict(b, cs.iter().any(|(_, l)| *l)),
+                };
                 let _ = writeln!(
                     out,
                     "| {} | {} | {} |",
-                    covered_verdict(b, live).glyph(),
+                    cell.glyph(),
                     first_sentence(&b.statement),
                     notes_cell(b)
                 );
@@ -404,4 +422,90 @@ fn footer() -> String {
      the waivers, and the scenario-coverage accounting — lives in `conformance/registry/` \
      and `conformance/RULES.md`. This page is generated from it.\n"
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        BehaviorUnit, Decision, ExpectedObservable, ReferenceStatus, SpecStatus, TestCase,
+    };
+
+    fn behavior() -> BehaviorUnit {
+        BehaviorUnit {
+            id: "bhv-x".into(),
+            area: "up".into(),
+            statement: "does a thing".into(),
+            applicability: Vec::new(),
+            spec: SpecStatus::Conformant,
+            reference: ReferenceStatus::Aligned,
+            decision: Decision::FollowSpec,
+            notes: None,
+        }
+    }
+
+    fn case_with(assertion: serde_json::Value) -> TestCase {
+        let mut case = TestCase {
+            id: "case-x".into(),
+            behaviors: vec!["bhv-x".into()],
+            ..TestCase::default()
+        };
+        case.oracle_type = Some(OracleType::LiveDifferential);
+        case.scenario_context
+            .insert("sdim-operation".into(), "up".into());
+        case.scenario_context
+            .insert("sdim-config-source".into(), "image".into());
+        case.scenario_context
+            .insert("sdim-features".into(), "single".into());
+        case.expected = vec![ExpectedObservable {
+            channel: "chan-stdout".into(),
+            operation: None,
+            assertion: Some(assertion),
+        }];
+        case
+    }
+
+    /// The rendered rows only — the legend necessarily contains every glyph, so
+    /// asserting over the whole page is always true and tests nothing.
+    fn rows_of(page: &str) -> String {
+        page.lines()
+            .skip_while(|l| !l.starts_with("### "))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn render_with(assertion: serde_json::Value) -> String {
+        let mut reg = Registry {
+            behaviors: vec![behavior()],
+            cases: vec![case_with(assertion)],
+            ..Registry::default()
+        };
+        reg.cases[0].id = "case-x".into();
+        render(&reg)
+    }
+
+    /// A case whose only assertion cannot fail must not colour a cell — it reports
+    /// coverage while proving nothing, and `·` already means "not checked here".
+    #[test]
+    fn a_vacuous_case_does_not_colour_a_cell() {
+        let page = rows_of(&render_with(serde_json::json!({"jsonSubset": {}})));
+        assert!(
+            !page.contains("✅") && !page.contains("◐"),
+            "a vacuous assertion must leave the row unchecked:\n{page}"
+        );
+    }
+
+    /// A weak-but-real assertion still counts: `{"features": {}}` requires the key to
+    /// exist, so a document omitting it fails. Rejecting it here would make the page a
+    /// style critic rather than an honest report.
+    #[test]
+    fn a_presence_only_case_still_colours_a_cell() {
+        let page = rows_of(&render_with(
+            serde_json::json!({"jsonSubset": {"features": {}}}),
+        ));
+        assert!(
+            page.contains("✅"),
+            "a presence-only assertion is real coverage:\n{page}"
+        );
+    }
 }

--- a/crates/conformance/src/validate.rs
+++ b/crates/conformance/src/validate.rs
@@ -2603,6 +2603,27 @@ impl<'a> Checker<'a> {
             }
         }
 
+        // V37: an assertion that constrains nothing is not an assertion. Applies to
+        // EVERY oracle type, not just spec-expectation: a live-differential may omit an
+        // assertion entirely (the reference supplies the expectation), but if it declares
+        // one it must be capable of failing.
+        for exp in &case.expected {
+            if exp
+                .assertion
+                .as_ref()
+                .is_some_and(crate::model::is_vacuous_assertion)
+            {
+                self.push(
+                    "V37",
+                    &case.id,
+                    format!(
+                        "channel {:?} carries an assertion that cannot fail (an empty                          `jsonSubset`, `contains`, or `matches`). It passes against any                          output, so it reports coverage while proving nothing — worse                          than declaring no assertion, which is at least visible as such.                          Pin what the case is for, or drop the channel.",
+                        exp.channel
+                    ),
+                );
+            }
+        }
+
         self.check_case_fs_allowlist(case);
         self.check_case_observable_channels(case);
         self.check_case_resource_group(case);
@@ -4936,6 +4957,65 @@ mod tests {
             out.iter()
                 .any(|v| v.code == "V16" && v.record == "case-spec-no-assertion"),
             "spec-expectation without an assertion must be V16, got {out:?}"
+        );
+    }
+
+    // -- V37: an assertion that cannot fail -----------------------------------------
+
+    /// The three vacuous shapes are rejected. Each passes against ANY output, so it
+    /// reports coverage while proving nothing.
+    #[test]
+    fn v37_rejects_assertions_that_cannot_fail() {
+        for (label, assertion) in [
+            ("empty-subset", serde_json::json!({"jsonSubset": {}})),
+            ("empty-contains", serde_json::json!({"contains": ""})),
+            ("empty-matches", serde_json::json!({"matches": ""})),
+        ] {
+            let mut reg = Registry::default();
+            let id = format!("case-vacuous-{label}");
+            let mut case = declarative_case(&id);
+            case.expected[0].assertion = Some(assertion);
+            reg.cases.push(case);
+            let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+            assert!(
+                out.iter().any(|v| v.code == "V37" && v.record == id),
+                "{label} must be V37, got {out:?}"
+            );
+        }
+    }
+
+    /// A *weak* assertion is not a vacuous one and must be permitted. `{"features": {}}`
+    /// still requires a `features` key to exist, so a document omitting it fails. Only
+    /// an assertion that rules out NOTHING is rejected — otherwise V37 becomes a style
+    /// rule about how tightly cases should be written, which is a judgement call the
+    /// validator has no business making.
+    #[test]
+    fn v37_permits_a_weak_but_non_vacuous_assertion() {
+        let mut reg = Registry::default();
+        let mut case = declarative_case("case-presence-only");
+        case.expected[0].assertion = Some(serde_json::json!({"jsonSubset": {"features": {}}}));
+        reg.cases.push(case);
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            !out.iter().any(|v| v.code == "V37"),
+            "presence-only assertion must not be V37, got {out:?}"
+        );
+    }
+
+    /// A nested empty object is a Feature's OPTIONS map, not a vacuous assertion: both
+    /// enclosing keys must still be present for the case to pass.
+    #[test]
+    fn v37_permits_a_nested_empty_options_object() {
+        let mut reg = Registry::default();
+        let mut case = declarative_case("case-nested-empty-options");
+        case.expected[0].assertion = Some(serde_json::json!({
+            "jsonSubset": {"features": {"ghcr.io/devcontainers/features/git:1.3.2": {}}}
+        }));
+        reg.cases.push(case);
+        let out = run(&reg, "2026-07-19", Path::new("/nonexistent-root"));
+        assert!(
+            !out.iter().any(|v| v.code == "V37"),
+            "nested empty options must not be V37, got {out:?}"
         );
     }
 

--- a/crates/conformance/tests/parity_page_current.rs
+++ b/crates/conformance/tests/parity_page_current.rs
@@ -1,0 +1,46 @@
+//! The published parity page must match a fresh render of the registry.
+//!
+//! `docs/PARITY.md` drifted twice within an hour of first publication: once because its
+//! counts were taken from a working tree holding unmerged records, once because a PR
+//! merged behind it. Both times the page claimed numbers the registry did not have,
+//! while asserting in its own header that every claim traces to a committed record.
+//!
+//! Hand-maintenance cannot survive a repo where records land several times a day, so the
+//! page is generated and this test is the gate. Hermetic — no Docker, no network, no
+//! oracle — so it runs in the fast lane on every PR.
+
+use deacon_conformance::load::Registry;
+use deacon_conformance::{default_registry_dir, workspace_root};
+
+#[test]
+fn published_parity_page_matches_a_fresh_render() {
+    let registry = Registry::load(&default_registry_dir()).expect("registry loads");
+    let rendered = deacon_conformance::parity_page::render(&registry);
+
+    let path = workspace_root().join("docs/PARITY.md");
+    let committed = std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "{} is unreadable ({e}). It is generated: \
+             `cargo run -p deacon-conformance -- parity-page --write`",
+            path.display()
+        )
+    });
+
+    assert_eq!(
+        committed, rendered,
+        "docs/PARITY.md is stale — regenerate it with \
+         `cargo run -p deacon-conformance -- parity-page --write`. \
+         It is a GENERATED file: adding a behavior, a case, or a waiver changes it, and a \
+         page that disagrees with the registry is worse than no page, because its header \
+         promises that every claim traces to a committed record."
+    );
+}
+
+/// The render must not depend on anything outside the registry — same input, same bytes.
+#[test]
+fn rendering_is_deterministic() {
+    let registry = Registry::load(&default_registry_dir()).expect("registry loads");
+    let a = deacon_conformance::parity_page::render(&registry);
+    let b = deacon_conformance::parity_page::render(&registry);
+    assert_eq!(a, b, "the page render is not deterministic");
+}

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,225 +1,250 @@
-# Deacon Conformance & Parity Tracker
+# Does deacon behave like the DevContainers CLI?
 
-**Pins:** upstream [devcontainers/spec](https://github.com/devcontainers/spec) commit `113500f4` (schemas + normative prose) · reference oracle `@devcontainers/cli` **0.87.0** (exact-version verified before any live comparison).
+<!-- GENERATED FILE — do not edit.
+     Regenerate with: cargo run -q -p deacon-conformance -- parity-page --write -->
 
-**Source of this document:** the repository-owned conformance registry (`conformance/registry/`), live `deacon-conformance certify` / `coverage report` output, and open GitHub issues. Every claim traces to a committed record; nothing here is aspirational.
+Compared against **`@devcontainers/cli` 0.87.0** and the [containers.dev spec]\
+(https://github.com/devcontainers/spec) at commit `113500f4`.
 
-**Regenerate the counts:**
+**Of 57 behaviors that both tools implement, 33 match.**
+15 differ deliberately, 9 are differences we intend to remove.
+A further 16 are deacon-only, with nothing to compare against.
 
-```bash
-cargo run -q -p deacon-conformance -- certify
-cargo run -q -p deacon-conformance -- coverage report   # → target/conformance/
-```
+## How to read this
 
-## Legend
-
-Every behavior record carries **three independent axes** (`conformance/RULES.md`):
-
-| Axis | Values | Meaning |
-|---|---|---|
-| `spec` | conformant / nonconformant / unspecified / not-applicable | relation to the written spec |
-| `reference` | aligned / divergent / unknown / not-applicable | relation to the **observed** pinned reference CLI |
-| `decision` | follow-spec / align-with-reference / deacon-extension / intentional-divergence / unresolved-gap | what deacon decided to do |
-
-There is deliberately no combined "different but acceptable" state. Statuses are **evidence-backed claims**: a behavior may only claim `aligned`/`divergent` if a test case or waiver stands behind it (contradiction rules R1–R8; R8 in particular forces `reference: unknown` when neither exists).
-
-**Vocabulary**
-
-- **Divergence** — a *characterized* difference: we know what both sides do and why. Either fix-tracked (deacon behind) or accepted (`intentional-divergence` + waiver, or `deacon-extension`).
-- **Gap** (`gap-`) — an *admission of missing coverage*. No evidence stands behind it. **Always blocks release certification.**
-- **Waiver** (`wvr-`) — an accepted difference with a mandatory `expires`. The harness verifies it *keeps reproducing*: a difference that stops reproducing fails as **stale**. So a waiver is positive evidence, and it never blocks.
-- **Residual** (`res-`) — missing *representation*, not missing coverage: the coverage exists in a legacy program not yet retired. Never blocks certification; blocks deleting its carrier.
-- **Out of scope** — differences with no observable effect are recorded nowhere, by rule.
-
-**Evidence strength** (weakest → strongest)
-
-| Kind | Compares against the reference? |
+| | Meaning |
 |---|---|
-| `spec-expectation` | **No** — pins deacon's own behavior only |
-| `invariant-metamorphic` | **No** — relates ≥2 deacon runs (idempotence, restart) |
-| `snapshot` | Yes — vs a committed, provenance-checked recording |
-| legacy `parity_*` binary | Yes — live, but hand-written |
-| `live-differential` | Yes — deacon and the verified oracle side by side, per channel |
-| waiver | Yes — and self-invalidates when the difference stops reproducing |
+| ✅ | Same as the CLI, and checked against it in this scenario |
+| ◐ | Believed the same, but only deacon-side evidence here — **never compared** |
+| ⚠️ | Differs on purpose |
+| ❌ | Differs, and we intend to fix it |
+| 🔵 | deacon-only; the CLI has no equivalent |
+| · | Not checked in this scenario |
 
-## Summary
+Columns are the scenarios a behavior was checked in: the configuration's shape
+(**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
+declares (**–** none / **1** one / **many** several / **deps** several with dependency
+ordering / **lock** with a lockfile). Areas only show the columns their evidence varies.
 
-| Metric | Value |
-|---|---|
-| Behavior records | **73** across 16 areas |
-| — `follow-spec` / `align-with-reference` | 37 / 6 |
-| — `intentional-divergence` / `deacon-extension` | 15 / 15 |
-| — `unresolved-gap` | **0** |
-| Reference axis: aligned / divergent / not-applicable / unknown | 36 / 24 / 13 / **0** |
-| Test cases | **233** — 109 live-differential, 110 spec-expectation, 11 legacy, 2 metamorphic, 1 snapshot |
-| Waivers (all with expiry, self-invalidating) | 22 |
-| Extension records (`ext-`) | 10 |
-| Open gap records | **6** — `gap-pairwise-{build,down,exec,run-user-commands,up,upgrade}` |
-| Scenario obligations | 745 — covered 446, waived 1, gap 298, undispositioned **0** |
-| Residuals | 8 queued + 6 permanent (61 units, structurally outside the model) |
-| Certification verdict | **NOT certified — by design.** The 6 gap records block, as intended. |
+A cell says a case exercised that scenario — not that the case's assertions were strong.
+The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
 
-### Pairwise scenario coverage per operation
+### build
 
-| Operation | Covered | Operation | Covered |
-|---|---|---|---|
-| read-configuration | 66 / 66 ✅ | run-user-commands | 31 / 112 |
-| outdated | 66 / 66 ✅ | down | 26 / 55 |
-| templates-apply | 25 / 25 ✅ | exec | 26 / 76 |
-| doctor | 24 / 24 ✅ | upgrade | 25 / 47 |
-| up | 54 / 114 | build | 31 / 87 |
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>✅</td><td>A Dockerfile instruction that exits non-zero fails the build, and the failure is…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`build` reports and tags the FEATURE-EXTENDED image, so a user-supplied `--image-name`…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>build produces a container image and reports the build outcome, matching the reference</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
 
-## Per-area status
+### doctor
 
-**Source**: Spec = written spec text · Ref = reference-CLI contract with no spec text · Ext = deacon extension.
-**Permanent?**: waived divergences carry a re-review date; fix-tracked items do not.
+<table>
+<thead>
+<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+</thead>
+<tbody>
+<tr><td>🔵</td><td>`doctor` reports host, platform, and runtime diagnostics in both a human rendering and…</td><td>🔵</td><td>🔵</td><td>🔵</td><td></td></tr>
+</tbody>
+</table>
 
-### read-configuration (27 behaviors — the deepest-covered area)
+### down
 
-| Behavior | Source | Status | Permanent? | Evidence | Tracking |
-|---|---|---|---|---|---|
-| Basic parse & echo | Spec | Parity | — | live-diff + snapshot | — |
-| Config discovery incl. `.devcontainer/<folder>/` | Spec | **Reference behind spec** (0.87.0 skips the nested folder without `--config`) | Waived → 2027-07-26 | live-diff + waiver | — |
-| Missing config / bad `--config` rejected | Spec | Parity (both reject) | — | live-diff + waivers | — |
-| Unknown top-level fields preserved | Spec | Parity | — | live-diff + waiver | — |
-| Duplicate JSON keys: last wins | Spec | Parity | — | live-diff + waiver | — |
-| Tier-1 corpus (24 real-world shapes) | Spec | **Deacon behind** — residual `featuresConfiguration` shape; 5 of 6 original divergence families fixed | No — fix tracked | live-diff ×24 | **#387** |
-| `--include-merged-configuration` (24 variants) | Spec | **Deacon behind** — same family | No — fix tracked | live-diff ×24 | **#387** |
-| `featuresConfiguration` document shape | Spec | **Deacon behind** | No — fix tracked | spec-exp | **#387** |
-| `configFilePath` as VS Code URI object | Ref | Parity (fixed) | — | live-diff | — |
-| Merged lifecycle slots emit `[]` when empty | Ref | Parity (fixed) | — | live-diff | — |
-| `featuresConfiguration` omitted when none resolve | Ref | Parity (fixed) | — | live-diff | — |
-| `portsAttributes` authored keys only | Ref | Parity (fixed) | — | live-diff | — |
-| `workspace` section shape | Ref | Parity (fixed, #383) | — | live-diff | — |
-| `workspaceFolder` preserves git-root subdir | Spec | Parity (fixed, #383) | — | live-diff | — |
-| Substitution in object-shaped fields | Spec | Parity | — | ⚠️ spec-exp only | — |
-| Malformed JSONC rejected (reference: lenient) | Ref | Intentional divergence — fail fast | Yes → 2027-01-19 | live-diff + waiver | — |
-| Wrong-type `features` / `forwardPorts` rejected | Ref | Intentional divergence | Yes → 2027-01-19 | live-diff + twins + waivers | — |
-| Unsupported enum values rejected | Ref | Intentional divergence | Yes → 2027-07-26 | live-diff + waiver | — |
-| Authored-null vs omitted collapsed | Ref | Intentional divergence (residue; empty half fixed) | Waived → 2027-01-26 | live-diff + waiver | #398 |
-| Merged computed empties omitted | Ref | Intentional divergence | Waived → 2027-01-31 | live-diff + waiver | — |
-| `extends` resolved eagerly; missing/cycle rejected (3) | Ext | Deacon extension | Yes → 2027-01-19 | spec-exp + waivers | `ext-extends-resolution` |
-| `extends`: child's Feature version overrides the base's | Ext | Deacon extension | Yes | spec-exp | #411 |
-| Same Feature at two versions in one document rejected | Ref | Intentional divergence (reference installs both) | Yes → 2027-02-01 | spec-exp + waiver | floor under #411 |
+<table>
+<thead>
+<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+</thead>
+<tbody>
+<tr><td>🔵</td><td>`down --remove` on a Compose configuration removes the project it created, identifying…</td><td>·</td><td>·</td><td>🔵</td><td></td></tr>
+<tr><td>🔵</td><td>`down` over a workspace folder that has no devcontainer configuration reports that…</td><td>🔵</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>`down --remove` stops and removes the workspace's container, so a subsequent command…</td><td>🔵</td><td>🔵</td><td>·</td><td></td></tr>
+</tbody>
+</table>
 
-### up (12 behaviors)
+### exec
 
-| Behavior | Source | Status | Evidence | Tracking |
-|---|---|---|---|---|
-| `up` + `exec` end-to-end | Spec | Parity | live-diff + legacy + metamorphic | — |
-| containerEnv/remoteEnv precedence | Spec | Parity | live-diff + spec-exp | — |
-| Feature install order (dependency-sorted) | Spec | Parity | live-diff + metamorphic | — |
-| Feature install failure surfaces | Spec | Parity | live-diff | — |
-| Feature entrypoint chaining | Spec | Parity | live-diff + spec-exp | — |
-| Mount source and shape | Spec | Parity | live-diff + spec-exp | — |
-| Container PATH construction | Spec | Parity | live-diff + spec-exp | — |
-| Lifecycle command forms | Spec | Parity | live-diff + spec-exp | — |
-| Lifecycle cwd = workspace folder | Spec | Parity | ⚠️ spec-exp only | — |
-| Effective user uid/gid | Spec | Parity | ⚠️ spec-exp only | — |
-| Restart reuses container | Spec | Parity | ⚠️ metamorphic + spec-exp (deacon-only) | — |
-| Changed config recreates container (reference reattaches to stale) | Ref | Intentional divergence — safer branch | spec-exp + waiver → 2027-01-26 | adjacent #371 |
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
+<tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
+<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
+</tbody>
+</table>
 
-### build (3) · exec (4) · run-user-commands (2)
+### host ca
 
-| Behavior | Source | Status | Evidence | Tracking |
-|---|---|---|---|---|
-| build: image parity incl. compose | Spec | Parity | live-diff + legacy | — |
-| build: features layered into `--image-name` | Spec | Parity | live-diff + spec-exp | — |
-| build: failures reported | Spec | Parity | live-diff ×3 | — |
-| exec: command parity (tty, user, cwd, compose) | Spec | Parity | live-diff ×9 + legacy | — |
-| exec: image PATH preserved | Spec | Parity | live-diff | — |
-| exec: container-id metadata read-back | Spec | Parity | ⚠️ legacy binary is sole evidence | — |
-| exec: restored PATH ordering differs from reference | Ref | Intentional divergence | ⚠️ spec-exp only, **no waiver** | see weak spots |
-| run-user-commands: hook order | Spec | Parity | live-diff + spec-exp | — |
-| run-user-commands: hook failure propagates (reference exits 0) | Spec | **Reference behind spec** | live-diff + twins + waiver → 2027-01-26 | — |
-
-Not yet a behavior record: **#405** (run-user-commands ignores image/container `devcontainer.metadata` while `exec` honors it).
-
-### outdated (4) · upgrade (3)
-
-| Behavior | Source | Status | Evidence | Tracking |
-|---|---|---|---|---|
-| outdated: reports Feature versions (lockfile-aware) | Spec | Parity | live-diff ×4 + spec-exp | — |
-| outdated: keyed by declared reference (was: collision dropped a Feature) | Ref | Parity (fixed) | ⚠️ spec-exp only | #407 |
-| outdated: extends-chain Features reported | Spec | **Reference behind spec** (consequence of the extension) | spec-exp + waiver → 2027-07-26 | — |
-| outdated: malformed lockfile rejected | Ref | Intentional divergence (reference never reads it) | spec-exp + waiver → 2027-01-31 | #406 |
-| upgrade: regenerates lockfile | Spec | Parity | live-diff + spec-exp | — |
-| upgrade: empty Feature set → empty lockfile, exit 0 (reference errors) | Spec | Intentional divergence | live-diff + waiver → 2027-07-26 | — |
-| upgrade: honors `--override-config` / `--merge-config` | Ext | Deacon extension | spec-exp | #409 |
-
-Not yet a behavior record: **#389** (`--output` vs reference's `--output-format`).
-
-### observable-state (8 behaviors)
-
-| Behavior | Source | Status | Evidence | Tracking |
-|---|---|---|---|---|
-| Container state parity (labels, config, network) | Spec | Parity | legacy + spec-exp | — |
-| Normalized state diff parity | Spec | Parity | live-diff ×4 + legacy | — |
-| `devcontainer.metadata` content | Spec | Parity (fixed) | live-diff | #373 |
-| `devcontainer.metadata` byte serialization | Ref | Intentional divergence | live-diff + waiver → 2027-01-29 | **#394** (ordering nondeterminism is a bug within this row) |
-| Compose project file set (stdin `-` vs temp file) | Ref | Intentional divergence | live-diff + waiver → 2027-01-26 | — |
-| Compose project name always docker-valid | Ref | Intentional divergence — robustness | live-diff + legacy + spec-exp | #265 |
-| Keepalive command form (BusyBox-safe) | Ref | Intentional divergence | live-diff ×5 | — |
-| Five extra deacon identity labels | Ext | Deacon extension | live-diff (scoped per-label tolerances) | `ext-container-identity-labels` |
-
-Not yet a behavior record: **#399** (empty-string `dockerComposeFile` takes different provisioning paths).
-
-### Deacon extensions with no reference equivalent
-
-The reference has no surface at all for these, so `reference: not-applicable` is a classification, not an unverified claim. Evidence is deacon-only by necessity.
-
-| Capability | Evidence | Record |
+| | Behavior | Notes |
 |---|---|---|
-| `down` — teardown (3 behaviors) | spec-exp ×7 | `ext-teardown-command` |
-| `doctor` — diagnostics, human + JSON | spec-exp ×9 | `ext-doctor-diagnostics` |
-| Auto-forward ports daemon | legacy integration | `ext-auto-forward-ports` |
-| `.env`-format secrets file (superset) | legacy integration | `ext-secrets-file-env-format` |
-| Workspace-trust gate on host hooks | legacy integration | `ext-workspace-trust-gate` |
-| Host CA injection | legacy integration | `ext-host-ca-injection` |
-| User profiles from settings.json | legacy integration | `ext-user-profiles` |
-| `--merge-config` on config-consuming subcommands | spec-exp | `ext-cli-config-overlay` |
+| 🔵 | deacon can inject the host's CA certificates into the TLS trust store used for OCI… |  |
 
-### templates-apply (1 behavior)
+### observable state
 
-Scaffolds a template with option substitution — parity claimed against the spec, but **no reference comparison is structurally possible**: the reference's `--template-id` accepts only OCI refs while deacon takes the template positionally, so no shared argv exists. Evidence: spec-expectation ×8 over the scaffolded bytes.
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#265</td></tr>
+<tr><td>🔵</td><td>deacon stamps five identity/bookkeeping labels onto a created container that the…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>The `devcontainer.metadata` label records the image metadata the configuration and…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373</td></tr>
+<tr><td>⚠️</td><td>The BYTE FORM of the `devcontainer.metadata` label value — JSON whitespace and object…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373 #394</td></tr>
+<tr><td>◐</td><td>The observable container state after up (running status, labels, mounts, environment)…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>The normalized observable-state diff between deacon and the reference is empty for the…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
 
-## Known weak spots
+### outdated
 
-Called out deliberately — this section is the point of the document.
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
+<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
+<tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
+<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>·</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>·</td><td>◐</td><td></td></tr>
+</tbody>
+</table>
 
-1. **`aligned` claims resting on spec-expectation evidence only.** Nothing compares these against the reference on any run, so oracle drift would go undetected:
-   - `bhv-up-effective-user-uid-gid`, `bhv-up-lifecycle-command-cwd`
-   - `bhv-readconfig-substitution-object-fields`
-   - `bhv-outdated-reports-declared-reference-key`
-   - `bhv-up-restart-reuses-container` — evidence is a metamorphic relation across two *deacon* runs; the reference never enters it.
-2. **Single-carrier evidence.** `bhv-exec-container-id-metadata` is evidenced only by the legacy `parity_up_exec` binary (on record; blocks that binary's retirement).
-3. **An intentional divergence with no self-invalidating backing.** `bhv-exec-restored-path-ordering` is permitted by R8 (a case backs it), but its only case is `spec-expectation` — so if the reference changed to match, nothing would report the waiver-style *stale* signal. Its two unwaivered siblings are fine by contrast: `bhv-container-keepalive-command` has 5 live differentials and `bhv-compose-project-name-robust` has a live legacy carrier.
-4. **Thin or absent live-differential coverage.** `templates-apply` (zero, structurally impossible); `outdated` 4 of 20 cases live; `upgrade` 3 of 11. `down`/`doctor` have zero, but they are extensions with no reference side. The extension areas run on deacon-only integration tests.
-5. **Snapshot coverage is one case on one platform** (`case-readconfig-snapshot`, linux-x86_64). Other platforms report `no-reference-for-platform` — a declared coverage limit, not a silent skip.
-6. **The measured scenario hole.** 298 of 745 obligations are open gaps, concentrated in `run-user-commands` (81 uncovered pairs), `up` (60), `build` (56), `exec` (50), `down` (29), `upgrade` (22).
-7. **Corpus divergence history is fix-tracked, not hidden.** At migration time 51 of 71 read-configuration corpus cases diverged across six families. Five are fixed; the residual `featuresConfiguration` shape keeps `reference: divergent` on those records, tracked in #387.
+### ports
 
-## Open gaps (block release certification)
+| | Behavior | Notes |
+|---|---|---|
+| 🔵 | deacon can auto-forward container ports to the host via a host-side daemon backed by a… |  |
 
-`gap-pairwise-{build, down, exec, run-user-commands, up, upgrade}` — enumerated pairwise scenario combinations no declarative case covers. Live counts in `target/conformance/coverage-pairwise.md`. Each new case re-dispositions the pairs it covers; the record is deleted when none remain.
+### profiles
 
-`certify` reports **not certified** until these close. The model measures the hole rather than certifying around it.
+| | Behavior | Notes |
+|---|---|---|
+| 🔵 | deacon applies a user-defined profile from settings.json (selected via the global… |  |
 
-## Open issues
+### read configuration
 
-| Issue | Area | Summary | Registry status |
-|---|---|---|---|
-| #387 | read-configuration | `featuresConfiguration` structurally differs | characterized, fix pending |
-| #394 | observable-state | metadata label bytes nondeterministic | waiver covers whitespace; ordering fix pending |
-| #398 | read-configuration | authored-null vs omitted collapsed | record + waiver for the residue |
-| #399 | up/compose | empty-string `dockerComposeFile` | not yet a record — triage |
-| #405 | run-user-commands | ignores image/container metadata; `exec` honors it | not yet a record — triage |
-| #389 | outdated | `--output` vs `--output-format` | not yet a record — triage |
-| #376 | cross-area | triage umbrella for 024-surfaced divergences | in progress |
-| #371 / #372 | up / run-user-commands | stale container left running; markers with `config_hash: None` | bugs adjacent to characterized divergences |
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>🔵</td><td>When a link of an `extends` chain declares a Feature its base already declared at a…</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
+<tr><td>⚠️</td><td>A single configuration document whose `features` map contains two keys resolving to…</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
+<tr><td>⚠️</td><td>deacon's resolved-configuration output omits a property the author wrote as `null`,…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#398</td></tr>
+<tr><td>·</td><td>An explicit --config pointing at a file that does not exist is rejected (no silent…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Reading a well-formed devcontainer.json exits 0 and emits the resolved configuration…</td><td>✅</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`,…</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
+<tr><td>❌</td><td>Configuration discovery searches exactly the three locations the spec names —…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A JSON object with a duplicate top-level key is accepted with last-wins semantics,…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>A cyclic extends chain (a -&gt; b -&gt; a) is detected and rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>🔵</td><td>read-configuration --include-merged-configuration resolves the full extends chain…</td><td>🔵</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>🔵</td><td>An extends chain pointing at a nonexistent target file is rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>❌</td><td>`--include-features-configuration` reports the resolved Feature set in install order,…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`featuresConfiguration` is reported only when Feature resolution produced at least one…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#387</td></tr>
+<tr><td>⚠️</td><td>A devcontainer.json with a hard JSONC syntax error is rejected at parse rather than…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>deacon's `mergedConfiguration` omits the computed-empty properties the reference…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#398</td></tr>
+<tr><td>❌</td><td>read-configuration --include-merged-configuration over the tier1 corpus emits a merged…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
+<tr><td>✅</td><td>`mergedConfiguration` reports all five plural lifecycle hook arrays…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>A workspace folder with no devcontainer configuration at all is rejected rather than…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A `portsAttributes` / `otherPortsAttributes` entry reports the keys the author wrote…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>Variable substitution reaches the object-shaped fields that carry user templates —…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#312</td></tr>
+<tr><td>❌</td><td>Reading real-world devcontainer.json configurations from the tier1 corpus produces…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
+<tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>The reported `workspace.workspaceFolder` is the automatic source-code mount location…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#273 #383</td></tr>
+<tr><td>✅</td><td>The `workspace` section carries exactly `workspaceFolder` and the optional…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
+<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
 
-Recently closed: #406, #407, #409, #411, #370, #373, #383.
+### run user commands
+
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>❌</td><td>A lifecycle hook that exits non-zero fails the run rather than being reported as a…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Lifecycle hooks run in spec order — onCreate, updateContent, postCreate, postStart —…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
+
+### secrets
+
+| | Behavior | Notes |
+|---|---|---|
+| 🔵 | The --secrets-file flag auto-detects and accepts both a flat JSON object and a… |  |
+
+### templates apply
+
+<table>
+<thead>
+<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+</thead>
+<tbody>
+<tr><td>🔵</td><td>`templates apply` scaffolds the template's files into the target directory with…</td><td>🔵</td><td>🔵</td><td>🔵</td><td></td></tr>
+</tbody>
+</table>
+
+### trust
+
+| | Behavior | Notes |
+|---|---|---|
+| 🔵 | Host-side lifecycle hooks (initializeCommand and other workspace-resident host hooks)… |  |
+
+### up
+
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>⚠️</td><td>Re-entering a workspace whose configuration has CHANGED since its container was…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>A `containerEnv` variable declared by BOTH the configuration and a Feature takes the…</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>#374</td></tr>
+<tr><td>◐</td><td>`up` applies the declared container user so the container process runs as that user…</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>up creates a container from the resolved configuration such that a subsequent exec…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Entrypoints contributed by multiple Features are chained and all run, in the resolved…</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A Feature that cannot be installed — its install script exiting non-zero, or a…</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`up` installs the configuration's Features into the container it creates, in the…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>A lifecycle hook runs with its working directory set to the container workspace…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A lifecycle hook declared in the array (argv) form and one declared in the object…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Each declared mount is applied with both its declared source and its declared shape —…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A PATH segment contributed by a Feature's `containerEnv` is prepended to the image…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>Re-entering a workspace whose container already exists, with the SAME configuration,…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
+
+### upgrade
+
+<table>
+<thead>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+</thead>
+<tbody>
+<tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>#409</td></tr>
+<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+</tbody>
+</table>
 
 ---
 
-*Verification pipeline: hermetic registry validation (`registry_valid`, classes V1–V36) on every PR · the `parity / live-certification` lane (nightly + parity-path PRs) runs the 109 live differentials against the verified oracle · `certify` gates releases on gaps and uncovered behaviors · waivers self-invalidate when their difference stops reproducing · the nightly `discovery` lane searches for differences nobody curated and gates nothing.*
+The full conformance record — the three-axis disposition behind each row, the waivers, and the scenario-coverage accounting — lives in `conformance/registry/` and `conformance/RULES.md`. This page is generated from it.


### PR DESCRIPTION
`docs/PARITY.md` was confusing to read and drifted twice within an hour of publication. Both
problems had the same root: the page was **organized around our maintenance model** and
**typed by hand**.

## What changed

Rows are behaviors, columns are scenarios, one glyph per cell:

| | Meaning |
|---|---|
| ✅ | Same as the CLI, and checked against it in this scenario |
| ◐ | Believed the same, but only deacon-side evidence — **never compared** |
| ⚠️ | Differs on purpose |
| ❌ | Differs, and we intend to fix it |
| 🔵 | deacon-only; the CLI has no equivalent |
| · | Not checked in this scenario |

The three-axis disposition, evidence tiers, waivers, residuals and obligation counts are gone
from the page — they are how we *maintain* conformance, and publishing them as the status is
what made it unreadable. They stay in `conformance/RULES.md` and the coverage report.

Headline is now a sentence, not a metrics block: *"Of 57 behaviors that both tools implement,
33 match. 15 differ deliberately, 9 are differences we intend to remove."*

## Four design decisions worth reviewing

1. **Cells carry the status *in that scenario*, from one vocabulary.** An earlier draft had a
   status column plus evidence cells, so ✅ meant "same as reference" in one column and
   "checked against the reference" in the next — a deliberately-divergent row rendered as a
   line of green. Same confusion the original page was criticised for.

2. **Columns are the cross product, not projections.** Projecting config-source × features
   onto 3+5 columns is smaller and *flatters*. `bhv-up-feature-install-order`, covered only as
   image×single / dockerfile×none / dockerfile×single / compose×single, projects to
   `img ✅ dkr ✅ cmp ✅ / – ✅ 1 ✅` — broad-looking. The product shows **4 cells of 15**.
   15 columns render fine; my objection to them was wrong.

3. **Which columns appear comes from the applicability *rules*,** not from which values the
   cases happen to use. Otherwise `doctor` carries five Feature columns it can never vary, and
   a thinly-covered area loses exactly the columns that show it is thin.

4. **`◐` is first-class.** "Claims a match we never verified" used to be a numbered list at
   the bottom; it is now visible per scenario.

## It cannot drift again

`parity-page --write` renders it; `parity-page --check` and the hermetic
`parity_page_current` test fail the build if the committed page disagrees with a fresh render.
Determinism is asserted separately.

## Honesty the page states about itself

A cell means a case *exercised* that scenario, not that its assertions were strong — the
`jsonSubset: {}` class of defect still renders ✅. Saying so in the header rather than implying
otherwise is the point.

## Two bugs the generator caught in its own first render

The spec pin printed the oracle's version (revisions were selected by id substring rather than
by kind), and single-dimension areas emitted an empty second header row. Both fixed.

Related: #417, filed after the grid made `bhv-up-feature-install-order`'s missing multi-Feature
evidence undeniable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)