### PR TITLE
fix(conformance): drop parity-page columns for scenarios that cannot exist

### DIFF
--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -93,6 +93,12 @@ struct Dim {
     values: &'static [(&'static str, &'static str)],
 }
 
+/// A dimension narrowed to the values its operations actually permit.
+struct ActiveDim<'a> {
+    key: &'a str,
+    values: Vec<(&'a str, &'a str)>,
+}
+
 const DIMS: &[Dim] = &[
     Dim {
         key: "sdim-config-source",
@@ -171,9 +177,24 @@ pub fn render(registry: &Registry) -> String {
                     .extend(values.iter().copied());
             }
         }
-        let active: Vec<&Dim> = DIMS
+        // Render only the values the applicability rules PERMIT for this area's
+        // operations. Filtering the dimension but not its values rendered columns that
+        // can never be anything but `·` — `outdated` never resolves a dependency graph,
+        // so a `deps` column there reads as an untested hole where the truth is that the
+        // scenario cannot exist. That is the inverse of the projection problem: it makes
+        // coverage look WORSE than it is, and is just as dishonest.
+        let active: Vec<ActiveDim<'_>> = DIMS
             .iter()
-            .filter(|d| permitted.get(d.key).is_some_and(|vs| vs.len() > 1))
+            .filter_map(|d| {
+                let allowed = permitted.get(d.key)?;
+                let values: Vec<(&str, &str)> = d
+                    .values
+                    .iter()
+                    .filter(|(value, _)| allowed.contains(value))
+                    .copied()
+                    .collect();
+                (values.len() > 1).then_some(ActiveDim { key: d.key, values })
+            })
             .collect();
 
         let _ = writeln!(out, "\n### {}\n", area_title(area));
@@ -208,7 +229,7 @@ pub fn render(registry: &Registry) -> String {
 }
 
 fn grid(
-    active: &[&Dim],
+    active: &[ActiveDim<'_>],
     behaviors: &[&crate::model::BehaviorUnit],
     coverage: &BTreeMap<&str, Vec<(&TestCase, bool)>>,
 ) -> String {
@@ -407,10 +428,19 @@ A further {deacon_only} are deacon-only, with nothing to compare against.
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
 declares (**–** none / **1** one / **many** several / **deps** several with dependency
-ordering / **lock** with a lockfile). Areas only show the columns their evidence varies.
+ordering / **lock** with a lockfile).
+
+**A column only appears where that scenario is possible.** `outdated` never resolves a
+dependency graph, so it has no **deps** column at all rather than a column of `·` implying
+an untested hole. So a `·` means genuinely not yet checked — with one caveat below.
 
 A cell says a case exercised that scenario — not that the case's assertions were strong.
 The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
+
+The caveat: columns are dropped per AREA, not per behavior. A behavior that is inherently
+about one configuration shape — deriving a Compose project name, say — still shows `·`
+under **img** and **dkr**, where the truth is that the question does not arise. Reading
+down a column is reliable; reading along a row needs that in mind.
 "#,
         oracle = pin_of(registry, RevisionKind::Oracle),
         spec = pin_of(registry, RevisionKind::Spec),
@@ -492,6 +522,60 @@ mod tests {
         assert!(
             !page.contains("✅") && !page.contains("◐"),
             "a vacuous assertion must leave the row unchecked:\n{page}"
+        );
+    }
+
+    /// A scenario value the applicability RULES exclude for an operation must not render
+    /// a column. Such a column can only ever be `·`, which reads as "we have not tested
+    /// this" when the truth is "this cannot happen" — making coverage look worse than it
+    /// is, exactly as damaging as making it look better.
+    #[test]
+    fn a_rule_excluded_value_renders_no_column() {
+        use crate::model::Condition;
+        use crate::scenario::{ApplicabilityRule, ScenarioDimension, ScenarioDimensionKind};
+
+        let mut reg = Registry {
+            behaviors: vec![behavior()],
+            cases: vec![case_with(serde_json::json!({"equals": 0}))],
+            ..Registry::default()
+        };
+        reg.scenario = vec![
+            ScenarioDimension {
+                id: "sdim-operation".into(),
+                kind: ScenarioDimensionKind::Scenario,
+                description: "operation".into(),
+                values: vec!["up".into()],
+            },
+            ScenarioDimension {
+                id: "sdim-features".into(),
+                kind: ScenarioDimensionKind::Scenario,
+                description: "features".into(),
+                values: vec!["none".into(), "single".into(), "lockfile".into()],
+            },
+        ];
+        reg.applicability = vec![ApplicabilityRule {
+            id: "rule-x".into(),
+            excludes: vec![
+                Condition {
+                    dimension: "sdim-operation".into(),
+                    values: vec!["up".into()],
+                },
+                Condition {
+                    dimension: "sdim-features".into(),
+                    values: vec!["lockfile".into()],
+                },
+            ],
+            ground: "the operation never reads a lockfile".into(),
+        }];
+
+        let page = render(&reg);
+        assert!(
+            page.contains("<th>1</th>"),
+            "a permitted value must still render:\n{page}"
+        );
+        assert!(
+            !page.contains("<th>lock</th>"),
+            "a rule-excluded value must render no column:\n{page}"
         );
     }
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -24,10 +24,19 @@ A further 16 are deacon-only, with nothing to compare against.
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
 declares (**–** none / **1** one / **many** several / **deps** several with dependency
-ordering / **lock** with a lockfile). Areas only show the columns their evidence varies.
+ordering / **lock** with a lockfile).
+
+**A column only appears where that scenario is possible.** `outdated` never resolves a
+dependency graph, so it has no **deps** column at all rather than a column of `·` implying
+an untested hole. So a `·` means genuinely not yet checked — with one caveat below.
 
 A cell says a case exercised that scenario — not that the case's assertions were strong.
 The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
+
+The caveat: columns are dropped per AREA, not per behavior. A behavior that is inherently
+about one configuration shape — deriving a Compose project name, say — still shows `·`
+under **img** and **dkr**, where the truth is that the question does not arise. Reading
+down a column is reliable; reading along a row needs that in mind.
 
 ### build
 
@@ -71,14 +80,14 @@ The leading glyph rolls the row up; where a row is mostly `·`, that is the hone
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
-<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="2">img</th><th colspan="2">dkr</th><th colspan="2">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>–</th><th>1</th><th>–</th><th>1</th></tr>
 </thead>
 <tbody>
-<tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
-<tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
-<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
+<tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
+<tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
+<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>#370</td></tr>
 </tbody>
 </table>
 
@@ -111,14 +120,14 @@ The leading glyph rolls the row up; where a row is mostly `·`, that is the hone
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
-<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="4">img</th><th colspan="4">dkr</th><th colspan="4">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
-<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
-<tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
-<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>·</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>·</td><td>◐</td><td></td></tr>
+<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
+<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
+<tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
+<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td></td></tr>
 </tbody>
 </table>
 
@@ -235,13 +244,13 @@ The leading glyph rolls the row up; where a row is mostly `·`, that is the hone
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
-<tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="3">img</th><th colspan="3">dkr</th><th colspan="3">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th>–</th><th>1</th><th>many</th><th>–</th><th>1</th><th>many</th><th>–</th><th>1</th><th>many</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>#409</td></tr>
-<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>·</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>#409</td></tr>
+<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Asked whether every `·` on the page means "not tested yet", the answer was **no** — and the
reason was a bug in the generator.

Columns were filtered per **dimension** but not per **value**. A dimension was dropped only
when the applicability rules left it fewer than two permitted values, so an individually
excluded value still rendered a column that could never be anything but `·`:

| | excluded because |
|---|---|
| `outdated` × **deps** | `outdated` never resolves a dependency graph |
| `upgrade` × **deps**, **lock** | regenerates from the configuration; an existing lockfile is not an input |
| `exec` × **many**, **deps**, **lock** | `exec` resolves no Features at all |

Every one of those read as an untested hole where the truth is *this scenario cannot happen*.
That's the inverse of the projection problem the cross product was chosen to avoid — it makes
coverage look **worse** than it is, and is exactly as dishonest.

Columns are now the values the rules permit: `outdated` loses `deps`, `upgrade` loses `deps`
and `lock`, `exec` drops from 15 columns to 6. **A `·` now means genuinely not yet checked.**

## One caveat the page now states

Columns are dropped per **area**, not per **behavior**. A behavior inherently about one
configuration shape — deriving a Compose project name — still shows `·` under `img`/`dkr`,
where the question doesn't arise. Fixing that needs per-behavior applicability, which the
registry models against *context* dimensions rather than *scenario* ones, so it isn't a filter
this generator can apply today.

The header says so outright: reading down a column is reliable; reading along a row needs that
in mind.

Covered by a test asserting a rule-excluded value renders no column, so this can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)