### PR TITLE
fix(outdated): resolve a partial version pin instead of echoing its text

### DIFF
--- a/conformance/registry/behaviors/outdated.json
+++ b/conformance/registry/behaviors/outdated.json
@@ -39,7 +39,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Assertions pin `current` and `wanted`, which the configuration's exact version reference fixes; `latest` is deliberately unpinned because it is whatever the registry publishes next and an assertion on it would decay into a false failure."
+      "notes": "Assertions pin `current` and `wanted`, which the configuration's exact version reference fixes; `latest` is deliberately unpinned because it is whatever the registry publishes next and an assertion on it would decay into a false failure. The `reference: aligned` claim was only made true by #407 divergence 2. Until then deacon reported the DECLARED TEXT of a partial pin as both `current` and `wanted` \u2014 `\"wanted\": \"1\"`, which is not a version and cannot answer whether an upgrade is available \u2014 while the reference resolved the pin to the newest published version satisfying it. The two agreed only on exactly-pinned references, which is what every case happened to use. deacon's own `upgrade` already resolved ranges correctly, so the two subcommands disagreed with each other as well as with the reference; that settled the direction without needing a spec reading."
     }
   ]
 }

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -92,14 +92,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The Feature is contributed by the parent link and its version by the lockfile, so two resolution steps have to both work for the row to be right. `current` 1.3.0 comes from the lockfile while `wanted` stays the parent's declared `1`; either step failing independently yields a row that still looks reasonable, which is why both columns are pinned and `latest` is not."
+      "notes": "The Feature is contributed by the parent link and its version by the lockfile, so two resolution steps have to both work for the row to be right. `current` 1.3.0 comes from the lockfile while `wanted` stays the parent's declared `1`; either step failing independently yields a row that still looks reasonable, which is why both columns are pinned and `latest` is not. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-compose-lockfile-overlay",
@@ -149,8 +149,7 @@
             "jsonSubset": {
               "features": {
                 "ghcr.io/devcontainers/features/git:1": {
-                  "current": "1.3.0",
-                  "wanted": "1"
+                  "current": "1.3.0"
                 },
                 "ghcr.io/devcontainers/features/node:1.6.1": {
                   "current": "1.6.1",
@@ -164,7 +163,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Two independent inputs meet in one report. `git` is declared `:1` and its `current` (1.3.0) can only have come from the lockfile \u2014 `wanted` stays the declared `1`, so the two fields together prove the lockfile was read rather than the reference re-derived. `node` is declared NOWHERE in devcontainer.json and reaches the report only through `--merge-config`. An implementation that ignored either input would still exit 0 with a plausible-looking report, which is why both are asserted in the same case. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it."
+      "notes": "Two independent inputs meet in one report. `git` is declared `:1` and its `current` (1.3.0) can only have come from the lockfile \u2014 `wanted` stays the declared `1`, so the two fields together prove the lockfile was read rather than the reference re-derived. `node` is declared NOWHERE in devcontainer.json and reaches the report only through `--merge-config`. An implementation that ignored either input would still exit 0 with a plausible-looking report, which is why both are asserted in the same case. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-compose-multi",
@@ -412,14 +411,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The lockfile's contribution isolated from any chain or overlay: `current` 1.3.0 against a declared `:1`. Note the lockfile must be keyed by the CANONICAL untagged id to be found, because `derive_current_version` looks up `canonical_feature_id(reference)`; a lockfile keyed by the tagged reference is silently ignored, so a naively authored fixture would pass this case while proving nothing. See #407."
+      "notes": "The lockfile's contribution isolated from any chain or overlay: `current` 1.3.0 against a declared `:1`. Note the lockfile must be keyed by the CANONICAL untagged id to be found, because `derive_current_version` looks up `canonical_feature_id(reference)`; a lockfile keyed by the tagged reference is silently ignored, so a naively authored fixture would pass this case while proving nothing. See #407. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-dockerfile-overlay-empty-report",
@@ -610,14 +609,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The lockfile governs the configured Feature while the overlay adds one the lockfile says nothing about, so the two inputs must compose rather than one replacing the other. The overlay-contributed `node` row correctly falls back to its declared version, which is the part an implementation that applied the lockfile to every row would get wrong."
+      "notes": "The lockfile governs the configured Feature while the overlay adds one the lockfile says nothing about, so the two inputs must compose rather than one replacing the other. The overlay-contributed `node` row correctly falls back to its declared version, which is the part an implementation that applied the lockfile to every row would get wrong. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-image-multi-overlay",

--- a/crates/core/src/outdated.rs
+++ b/crates/core/src/outdated.rs
@@ -207,7 +207,7 @@ pub fn wanted_major(version: &Option<String>) -> Option<String> {
 ///
 /// // Without lockfile, falls back to wanted version
 /// let reference = "ghcr.io/devcontainers/features/node:18";
-/// assert_eq!(derive_current_version(reference, None), Some("18".to_string()));
+/// assert_eq!(derive_current_version(reference, None, &[]), Some("18".to_string()));
 ///
 /// // With lockfile entry
 /// let mut features = HashMap::new();
@@ -221,11 +221,12 @@ pub fn wanted_major(version: &Option<String>) -> Option<String> {
 ///     }
 /// );
 /// let lockfile = Lockfile { features };
-/// assert_eq!(derive_current_version(reference, Some(&lockfile)), Some("16.0.0".to_string()));
+/// assert_eq!(derive_current_version(reference, Some(&lockfile), &[]), Some("16.0.0".to_string()));
 /// ```
 pub fn derive_current_version(
     reference: &str,
     lockfile_opt: Option<&lockfile::Lockfile>,
+    stable_tags: &[String],
 ) -> Option<String> {
     let canonical = canonical_feature_id(reference);
     if let Some(ld) = lockfile_opt {
@@ -234,8 +235,11 @@ pub fn derive_current_version(
         }
     }
 
-    // Fallback
-    compute_wanted_version(reference)
+    // No lockfile entry: what is installed is whatever the declared reference resolves
+    // to, which for a partial pin is the newest published version satisfying it — the
+    // same resolution `wanted` performs (#407). Returning the pin's literal text here
+    // reported `"current": "1"`, which is not a version.
+    resolve_wanted_version(reference, stable_tags)
 }
 
 /// Fetch the latest stable semver tag for the given declared feature reference.
@@ -243,7 +247,7 @@ pub fn derive_current_version(
 /// This performs a registry `list_tags` via the core `FeatureFetcher` and uses
 /// `semver_utils` to filter and sort tags. Returns `None` on any error or if
 /// no stable semver tags are present.
-pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
+pub async fn fetch_stable_tags_descending(reference: &str) -> Option<Vec<String>> {
     // Build a FeatureRef for listing tags. We make a best-effort parse: registry is the
     // first path segment, repository is the remainder. For nested namespaces we keep them.
     let canonical = canonical_feature_id(reference);
@@ -289,9 +293,63 @@ pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
         return None;
     }
     semver_utils::sort_tags_descending(&mut semver_tags);
+    Some(semver_tags)
+}
 
-    // First element is the highest stable semver
-    semver_tags.into_iter().next()
+/// The highest stable published version, i.e. the first of
+/// [`fetch_stable_tags_descending`].
+pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
+    fetch_stable_tags_descending(reference)
+        .await?
+        .into_iter()
+        .next()
+}
+
+/// Resolve the version the declared reference ASKS FOR, given the published stable tags
+/// in descending order.
+///
+/// `wanted` means "the newest published version satisfying what the configuration
+/// declared" — which is what the neighbouring `latest` and `wantedMajor` fields imply,
+/// and what the reference CLI reports. deacon used to return the declared tag STRING
+/// verbatim, so a configuration pinning `git:1` reported `"wanted": "1"` — not a version
+/// at all, and unusable for deciding whether an upgrade is available (#407 divergence 2).
+///
+/// An exactly-pinned reference resolves to itself and needs no tag list; only a partial
+/// pin (`1`, `1.3`) has to consult the registry. Non-numeric tags (`latest`, a named
+/// channel) are returned as declared: they name a moving target the registry alone
+/// resolves, and guessing would be worse than echoing.
+///
+/// deacon's own `upgrade` already resolved ranges this way, so the two subcommands
+/// disagreed with each other as well as with the reference — which is what settled the
+/// direction.
+pub fn resolve_wanted_version(reference: &str, stable_tags: &[String]) -> Option<String> {
+    let declared = compute_wanted_version(reference)?;
+
+    // A full `major.minor.patch` pin is already the answer.
+    let parts: Vec<&str> = declared.split('.').collect();
+    if parts.len() >= 3 || !parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit())) {
+        return Some(declared);
+    }
+    if parts.iter().any(|p| p.is_empty()) {
+        return Some(declared);
+    }
+
+    // A partial pin selects the highest published version sharing its prefix. Tags are
+    // already sorted descending, so the first match wins.
+    let prefix: Vec<&str> = parts;
+    let matched = stable_tags.iter().find(|tag| {
+        let tag_parts: Vec<&str> = tag.trim_start_matches('v').split('.').collect();
+        tag_parts.len() >= prefix.len()
+            && prefix
+                .iter()
+                .zip(tag_parts.iter())
+                .all(|(want, have)| want == have)
+    });
+
+    // No published tag satisfies the pin (or the registry was unreachable): echo what was
+    // declared rather than reporting nothing. Degrading to today's answer is better than
+    // turning a transient lookup failure into a missing field.
+    Some(matched.cloned().unwrap_or(declared))
 }
 
 /// Return the major portion of the latest stable version string.
@@ -441,6 +499,96 @@ mod tests {
     }
 
     // wanted_major tests
+    // -- resolve_wanted_version (#407 divergence 2) ---------------------------------
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A partial pin resolves to the newest published version satisfying it — NOT the
+    /// pin's literal text, which is what deacon used to report.
+    #[test]
+    fn wanted_resolves_a_major_only_pin_to_the_newest_matching_version() {
+        let published = tags(&["2.1.0", "1.7.1", "1.6.0", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/node:1", &published),
+            Some("1.7.1".to_string())
+        );
+    }
+
+    #[test]
+    fn wanted_resolves_a_minor_pin_within_that_minor() {
+        let published = tags(&["1.7.1", "1.3.8", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/git:1.3", &published),
+            Some("1.3.8".to_string())
+        );
+    }
+
+    /// An exact pin is already the answer and must not drift to a newer patch.
+    #[test]
+    fn wanted_leaves_an_exact_pin_alone() {
+        let published = tags(&["1.3.8", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/git:1.3.2", &published),
+            Some("1.3.2".to_string())
+        );
+    }
+
+    /// `1` must not match `10.x`: the comparison is per component, not textual prefix.
+    #[test]
+    fn wanted_does_not_match_a_longer_major() {
+        let published = tags(&["10.0.0", "1.2.0"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:1", &published),
+            Some("1.2.0".to_string())
+        );
+    }
+
+    /// An unreachable registry (or a pin nothing published satisfies) degrades to the
+    /// declared text rather than reporting nothing — a transient lookup failure must not
+    /// turn into a missing field.
+    #[test]
+    fn wanted_falls_back_to_the_declared_pin_when_nothing_matches() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:9", &tags(&["1.0.0"])),
+            Some("9".to_string())
+        );
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:1", &[]),
+            Some("1".to_string())
+        );
+    }
+
+    /// A non-numeric tag names a moving target only the registry resolves; echoing it is
+    /// better than guessing which published version it points at.
+    #[test]
+    fn wanted_echoes_a_non_numeric_tag() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:latest", &tags(&["2.0.0"])),
+            Some("latest".to_string())
+        );
+    }
+
+    /// A digest reference carries no version to want.
+    #[test]
+    fn wanted_is_none_for_a_digest_reference() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z@sha256:abc", &tags(&["2.0.0"])),
+            None
+        );
+    }
+
+    /// Without a lockfile, `current` resolves the same way `wanted` does — reporting the
+    /// pin's literal text said `"current": "1"`, which is not a version.
+    #[test]
+    fn current_without_a_lockfile_resolves_the_pin() {
+        assert_eq!(
+            derive_current_version("ghcr.io/x/y/node:1", None, &tags(&["1.7.1", "1.6.0"])),
+            Some("1.7.1".to_string())
+        );
+    }
+
     #[test]
     fn test_wanted_major_valid() {
         assert_eq!(
@@ -492,7 +640,7 @@ mod tests {
     fn test_derive_current_version_no_lockfile() {
         let reference = "ghcr.io/devcontainers/features/node:18";
         assert_eq!(
-            derive_current_version(reference, None),
+            derive_current_version(reference, None, &[]),
             Some("18".to_string())
         );
     }
@@ -514,7 +662,7 @@ mod tests {
 
         // Should return lockfile version, not wanted version
         assert_eq!(
-            derive_current_version(reference, Some(&lockfile)),
+            derive_current_version(reference, Some(&lockfile), &[]),
             Some("18.5.0".to_string())
         );
     }
@@ -536,7 +684,7 @@ mod tests {
 
         // No match in lockfile, should fall back to wanted
         assert_eq!(
-            derive_current_version(reference, Some(&lockfile)),
+            derive_current_version(reference, Some(&lockfile), &[]),
             Some("3.11".to_string())
         );
     }
@@ -545,7 +693,7 @@ mod tests {
     fn test_derive_current_version_digest_no_lockfile() {
         let reference = "ghcr.io/devcontainers/features/node@sha256:abcdef";
         // Digest with no lockfile should return None (can't derive version)
-        assert_eq!(derive_current_version(reference, None), None);
+        assert_eq!(derive_current_version(reference, None, &[]), None);
     }
 
     // FeatureVersionInfo serialization tests

--- a/crates/core/tests/outdated_helpers.rs
+++ b/crates/core/tests/outdated_helpers.rs
@@ -40,17 +40,18 @@ fn test_derive_current_version_from_lockfile() {
     );
 
     // When lockfile has entry, derive_current_version should return the locked version
-    let current = derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", Some(&lf));
+    let current =
+        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", Some(&lf), &[]);
     assert_eq!(current.as_deref(), Some("7.8.9"));
 
     // When lockfile is absent, it should fall back to the wanted tag
     let current_no_lock =
-        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", None);
+        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", None, &[]);
     assert_eq!(current_no_lock.as_deref(), Some("10.0.0"));
 
     // Digest-based reference with no lockfile should yield None
     let digest_ref = "ghcr.io/devcontainers/features/node@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let current_digest = derive_current_version(digest_ref, None);
+    let current_digest = derive_current_version(digest_ref, None, &[]);
     assert!(current_digest.is_none());
 }
 

--- a/crates/core/tests/outdated_helpers_additional.rs
+++ b/crates/core/tests/outdated_helpers_additional.rs
@@ -56,11 +56,15 @@ fn test_derive_current_version_lockfile_behavior() {
     );
 
     // Derive from lockfile
-    let current = derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", Some(&lf));
+    let current = derive_current_version(
+        "ghcr.io/devcontainers/features/sample:9.9.9",
+        Some(&lf),
+        &[],
+    );
     assert_eq!(current.as_deref(), Some("0.1.2"));
 
     // No lockfile -> fallback to wanted
     let current_no_lock =
-        derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", None);
+        derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", None, &[]);
     assert_eq!(current_no_lock.as_deref(), Some("9.9.9"));
 }

--- a/crates/deacon/src/commands/outdated.rs
+++ b/crates/deacon/src/commands/outdated.rs
@@ -199,7 +199,10 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
         declared_refs.push(feature_key.clone());
     }
 
-    // Bounded parallel fetching of latest versions with timeout and deterministic ordering
+    // Bounded parallel fetching of the published tag list, with timeout and deterministic
+    // ordering. The list serves BOTH `latest` (its first element) and `wanted` (the
+    // highest entry satisfying the declared pin), so resolving ranges costs no extra
+    // request — the tags were already being fetched for `latest` alone (#407).
     let concurrency_limit = std::env::var("DEACON_OUTDATED_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -239,19 +242,19 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
                 // Use core helper; enforce timeout per attempt
                 let attempt_result = tokio::time::timeout(
                     timeout_dur,
-                    core_outdated::fetch_latest_stable_version(&dr_clone),
+                    core_outdated::fetch_stable_tags_descending(&dr_clone),
                 )
                 .await;
 
                 match attempt_result {
-                    Ok(latest_opt) => {
+                    Ok(tags_opt) => {
                         // Either Some or None returned by fetcher; treat as final
-                        break latest_opt;
+                        break tags_opt;
                     }
                     Err(_) => {
                         // Timeout during fetch
                         let canonical = core_outdated::canonical_feature_id(&dr_clone);
-                        debug!(feature = %canonical, attempt, "Timeout fetching latest version (attempt {})", attempt);
+                        debug!(feature = %canonical, attempt, "Timeout fetching published tags (attempt {})", attempt);
 
                         if attempt >= max_retries {
                             // Give up after max retries
@@ -270,13 +273,13 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     }
 
     // Await handles in order to preserve deterministic output ordering
-    let mut latests: Vec<Option<String>> = Vec::with_capacity(handles.len());
+    let mut tag_lists: Vec<Option<Vec<String>>> = Vec::with_capacity(handles.len());
     for h in handles {
         match h.await {
-            Ok(latest_opt) => latests.push(latest_opt),
+            Ok(tags_opt) => tag_lists.push(tags_opt),
             Err(e) => {
-                debug!(error = ?e, "Task join error when fetching latest");
-                latests.push(None);
+                debug!(error = ?e, "Task join error when fetching published tags");
+                tag_lists.push(None);
             }
         }
     }
@@ -284,9 +287,13 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     // Build results preserving original declaration order
     for (i, declared_ref) in declared_refs.iter().enumerate() {
         let declared_ref = declared_ref.as_str();
-        let wanted = core_outdated::compute_wanted_version(declared_ref);
-        let current = core_outdated::derive_current_version(declared_ref, lockfile_opt.as_ref());
-        let latest = latests.get(i).cloned().unwrap_or(None);
+        // `wanted` is the newest published version satisfying the declared pin, not the
+        // pin's literal text (#407 divergence 2). Both fields come from one tag list.
+        let tags: &[String] = tag_lists.get(i).and_then(|o| o.as_deref()).unwrap_or(&[]);
+        let wanted = core_outdated::resolve_wanted_version(declared_ref, tags);
+        let current =
+            core_outdated::derive_current_version(declared_ref, lockfile_opt.as_ref(), tags);
+        let latest = tags.first().cloned();
 
         let wanted_major = core_outdated::wanted_major(&wanted);
         let latest_major = core_outdated::latest_major(&latest);

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -127,7 +127,7 @@ down a column is reliable; reading along a row needs that in mind.
 <tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
 <tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
 <tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
-<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td></td></tr>
+<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>#407</td></tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Fixes #407 divergence 2.

`outdated` reported the **declared text** of a partial pin as both `current` and `wanted`. A
configuration pinning `git:1` produced `"wanted": "1"` — not a version, and useless for the
question the subcommand exists to answer, since nothing can be compared against `latest`.

```
declared git:1        before      after / reference
current               "1"         "1.3.8"
wanted                "1"         "1.3.8"
```

Measured **byte-identical to the reference** across all three pin shapes (`:1`, `:1.3`,
`:1.3.2`) and on an old-major pin where `wanted` and `latest` genuinely differ (`node:1` →
wanted `1.7.1`, latest `2.x`).

**No extra network request.** The published tag list was already fetched for `latest`; it now
serves both — `latest` is its first element, `wanted` the highest entry satisfying the pin.
`derive_current_version` takes the same list, since without a lockfile entry what is installed
is whatever the reference resolves to, and its fallback had the identical defect.

## Direction needed no spec reading

deacon's own `upgrade` already resolved ranges this way, so the two subcommands disagreed with
**each other** as well as with the reference.

## Four deliberate details, each tested

- **An exact pin never drifts** — `:1.3.2` stays `1.3.2` even when 1.3.8 exists, and needs no
  tag list at all.
- **Matching is per component, not textual** — `:1` must not match `10.x`.
- **A failed lookup degrades to the declared text**, not to `null`: a transient registry
  failure must not become a missing field.
- **A non-numeric tag is echoed** — `latest` names a moving target only the registry resolves.

## A trap this created and closed

Four conformance cases stopped pinning `wanted` on their unpinned `:1` reference. That value is
now whatever the registry publishes next, so asserting it would decay into a false failure
exactly as an assertion on `latest` would — the same trap those cases already avoid for
`latest`. `current` is their subject and still comes from the lockfile.

`bhv-outdated-reports-feature-versions` carried `reference: aligned` before this change, and
that claim was **aspirational**: the two agreed only on exactly-pinned references, which is what
every case happened to use. Its notes now say so.

## Still open on #407

`latest` reported as the raw registry tag (`2.1`) where the reference normalizes to `2.1.0`
(divergence 4), and lockfile influence (divergence 3, characterized and waived). Neither is
touched here.

Verified: `validate` ok; `parity_conformance_runner` shows only the pre-existing
`case-merged-decl-*` cluster (#387); fmt, clippy `--all-features`, and 4190 tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)