### PR TITLE
feat(conformance): make the parity matrix a work queue

### DIFF
--- a/conformance/registry/behaviors/down.json
+++ b/conformance/registry/behaviors/down.json
@@ -9,7 +9,12 @@
       "spec": "unspecified",
       "reference": "not-applicable",
       "decision": "deacon-extension",
-      "notes": "Same extension as bhv-down-removes-container. The risk this record exists for is a derivation that does not reproduce what `up` used — teardown then reports success and leaves the project running, silent on every channel except the container graph."
+      "notes": "Same extension as bhv-down-removes-container. The risk this record exists for is a derivation that does not reproduce what `up` used — teardown then reports success and leaves the project running, silent on every channel except the container graph.",
+      "scenarioApplicability": {
+        "sdim-config-source": [
+          "compose"
+        ]
+      }
     },
     {
       "id": "bhv-down-missing-config-idempotent",

--- a/conformance/registry/behaviors/observable-state.json
+++ b/conformance/registry/behaviors/observable-state.json
@@ -9,6 +9,11 @@
       "spec": "unspecified",
       "reference": "divergent",
       "decision": "intentional-divergence",
+      "scenarioApplicability": {
+        "sdim-config-source": [
+          "compose"
+        ]
+      },
       "notes": "Measured at oracle 0.87.0: both CLIs layer an override on top of the workspace's Compose file, and each delivers it differently — deacon passes it on stdin (recorded as `-`), the reference writes a temporary `docker-compose.devcontainer.containerFeatures-*.yml` under its own cache directory and names that path. `config-hash` differs as a consequence, since Compose hashes the merged file set. The spec does not say how a consumer must deliver its override, and neither delivery is observable in the resulting container beyond these two bookkeeping labels — the SERVICE, the project-relative network and volume, and every mount are compared and agree. Distinct from `bhv-compose-project-name-robust`, which is about the project NAME: an implementation could adopt either CLI's naming and still deliver its override the other way. Characterized by `wvr-compose-project-file-set`."
     },
     {
@@ -19,6 +24,11 @@
       "spec": "unspecified",
       "reference": "divergent",
       "decision": "intentional-divergence",
+      "scenarioApplicability": {
+        "sdim-config-source": [
+          "compose"
+        ]
+      },
       "notes": "Robustness differentiator (issue #265; docs/DIFFERENTIATORS.md). The reference derives <folder>_devcontainer verbatim, so a folder like `-myproj` yields an invalid --project-name docker compose rejects. deacon's derived name is always valid and isolated. Backed by case-compose-project-name (parity_observable_state, which observes com.docker.compose.project)."
     },
     {

--- a/conformance/registry/behaviors/outdated.json
+++ b/conformance/registry/behaviors/outdated.json
@@ -39,7 +39,7 @@
       "spec": "conformant",
       "reference": "aligned",
       "decision": "follow-spec",
-      "notes": "Assertions pin `current` and `wanted`, which the configuration's exact version reference fixes; `latest` is deliberately unpinned because it is whatever the registry publishes next and an assertion on it would decay into a false failure."
+      "notes": "Assertions pin `current` and `wanted`, which the configuration's exact version reference fixes; `latest` is deliberately unpinned because it is whatever the registry publishes next and an assertion on it would decay into a false failure. The `reference: aligned` claim was only made true by #407 divergence 2. Until then deacon reported the DECLARED TEXT of a partial pin as both `current` and `wanted` \u2014 `\"wanted\": \"1\"`, which is not a version and cannot answer whether an upgrade is available \u2014 while the reference resolved the pin to the newest published version satisfying it. The two agreed only on exactly-pinned references, which is what every case happened to use. deacon's own `upgrade` already resolved ranges correctly, so the two subcommands disagreed with each other as well as with the reference; that settled the direction without needing a spec reading."
     }
   ]
 }

--- a/conformance/registry/cases/outdated.json
+++ b/conformance/registry/cases/outdated.json
@@ -92,14 +92,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The Feature is contributed by the parent link and its version by the lockfile, so two resolution steps have to both work for the row to be right. `current` 1.3.0 comes from the lockfile while `wanted` stays the parent's declared `1`; either step failing independently yields a row that still looks reasonable, which is why both columns are pinned and `latest` is not."
+      "notes": "The Feature is contributed by the parent link and its version by the lockfile, so two resolution steps have to both work for the row to be right. `current` 1.3.0 comes from the lockfile while `wanted` stays the parent's declared `1`; either step failing independently yields a row that still looks reasonable, which is why both columns are pinned and `latest` is not. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-compose-lockfile-overlay",
@@ -149,8 +149,7 @@
             "jsonSubset": {
               "features": {
                 "ghcr.io/devcontainers/features/git:1": {
-                  "current": "1.3.0",
-                  "wanted": "1"
+                  "current": "1.3.0"
                 },
                 "ghcr.io/devcontainers/features/node:1.6.1": {
                   "current": "1.6.1",
@@ -164,7 +163,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Two independent inputs meet in one report. `git` is declared `:1` and its `current` (1.3.0) can only have come from the lockfile \u2014 `wanted` stays the declared `1`, so the two fields together prove the lockfile was read rather than the reference re-derived. `node` is declared NOWHERE in devcontainer.json and reaches the report only through `--merge-config`. An implementation that ignored either input would still exit 0 with a plausible-looking report, which is why both are asserted in the same case. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it."
+      "notes": "Two independent inputs meet in one report. `git` is declared `:1` and its `current` (1.3.0) can only have come from the lockfile \u2014 `wanted` stays the declared `1`, so the two fields together prove the lockfile was read rather than the reference re-derived. `node` is declared NOWHERE in devcontainer.json and reaches the report only through `--merge-config`. An implementation that ignored either input would still exit 0 with a plausible-looking report, which is why both are asserted in the same case. The map key is deacon's canonical untagged id; the reference echoes the declared reference with its tag. That divergence is filed as #407 and this assertion pins deacon's current shape to make the change visible when it lands, not to endorse it. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-compose-multi",
@@ -412,14 +411,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The lockfile's contribution isolated from any chain or overlay: `current` 1.3.0 against a declared `:1`. Note the lockfile must be keyed by the CANONICAL untagged id to be found, because `derive_current_version` looks up `canonical_feature_id(reference)`; a lockfile keyed by the tagged reference is silently ignored, so a naively authored fixture would pass this case while proving nothing. See #407."
+      "notes": "The lockfile's contribution isolated from any chain or overlay: `current` 1.3.0 against a declared `:1`. Note the lockfile must be keyed by the CANONICAL untagged id to be found, because `derive_current_version` looks up `canonical_feature_id(reference)`; a lockfile keyed by the tagged reference is silently ignored, so a naively authored fixture would pass this case while proving nothing. See #407. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-dockerfile-overlay-empty-report",
@@ -610,14 +609,14 @@
           "channel": "chan-stdout",
           "operation": "op-outdated",
           "assertion": {
-            "matches": "git:1 \\| 1\\.3\\.0 \\| 1 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
+            "matches": "git:1 \\| 1\\.3\\.0 \\|[\\s\\S]*node:1\\.6\\.1 \\| 1\\.6\\.1 \\| 1\\.6\\.1 \\|"
           }
         }
       ],
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The lockfile governs the configured Feature while the overlay adds one the lockfile says nothing about, so the two inputs must compose rather than one replacing the other. The overlay-contributed `node` row correctly falls back to its declared version, which is the part an implementation that applied the lockfile to every row would get wrong."
+      "notes": "The lockfile governs the configured Feature while the overlay adds one the lockfile says nothing about, so the two inputs must compose rather than one replacing the other. The overlay-contributed `node` row correctly falls back to its declared version, which is the part an implementation that applied the lockfile to every row would get wrong. `wanted` is deliberately NOT asserted for the unpinned `:1` reference. Since #407 divergence 2 it resolves to the newest published version satisfying the pin, which is whatever the registry publishes next \u2014 pinning it would decay into a false failure the way an assertion on `latest` would. `current` is the subject here and comes from the lockfile."
     },
     {
       "id": "case-outdated-image-multi-overlay",

--- a/crates/conformance/src/bin/conformance.rs
+++ b/crates/conformance/src/bin/conformance.rs
@@ -110,6 +110,14 @@ enum Command {
     /// Deterministic: the same registry renders the same bytes. Prints to stdout
     /// unless `--write` is given, so a check can diff it without a temp file.
     ParityPage {
+        /// Instead of the page, list every `·` — the untested (behavior, scenario)
+        /// cells — as a work queue, most-neglected first. Each line is a thing to go
+        /// and test, unlike a coverage count.
+        #[arg(long, conflicts_with_all = ["write", "check"])]
+        open: bool,
+        /// With `--open`: emit JSON instead of the human listing.
+        #[arg(long, requires = "open")]
+        json: bool,
         /// Write to `docs/PARITY.md` instead of printing.
         #[arg(long)]
         write: bool,
@@ -602,7 +610,12 @@ fn run(cli: Cli) -> i32 {
     match cli.command {
         Command::Validate { json } => validate(&registry_dir, &today, json),
         Command::Report { out_dir } => report(&registry_dir, &today, out_dir),
-        Command::ParityPage { write, check } => parity_page_cmd(&registry_dir, write, check),
+        Command::ParityPage {
+            open,
+            json,
+            write,
+            check,
+        } => parity_page_cmd(&registry_dir, open, json, write, check),
         Command::Certify {
             json,
             report_dir,
@@ -3710,7 +3723,7 @@ fn resolve_today(flag: Option<&str>) -> anyhow::Result<String> {
 /// Kept out of `docs/` generation-by-hand deliberately: this page drifted twice within
 /// an hour of first publication, both times because a count was typed rather than
 /// derived. `--check` is what makes that impossible to repeat.
-fn parity_page_cmd(registry_dir: &Path, write: bool, check: bool) -> i32 {
+fn parity_page_cmd(registry_dir: &Path, open: bool, json: bool, write: bool, check: bool) -> i32 {
     let registry = match Registry::load(registry_dir) {
         Ok(r) => r,
         Err(e) => {
@@ -3718,6 +3731,53 @@ fn parity_page_cmd(registry_dir: &Path, write: bool, check: bool) -> i32 {
             return 1;
         }
     };
+    if open {
+        let cells = deacon_conformance::parity_page::open_cells(&registry);
+        if json {
+            match serde_json::to_string_pretty(&cells) {
+                Ok(s) => println!("{s}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    return 1;
+                }
+            }
+            return 0;
+        }
+        // Most-neglected first: a behavior with no evidence anywhere outranks one already
+        // covered in a neighbouring scenario, and deacon-only evidence outranks
+        // differentially-tested. Ties keep page order so the listing is stable.
+        let mut sorted = cells.clone();
+        sorted.sort_by_key(|c| {
+            (
+                c.covered_elsewhere == 0 && !c.waiver_backed,
+                c.covered_elsewhere,
+                c.differentially_tested,
+                c.area.clone(),
+                c.behavior.clone(),
+            )
+        });
+        for c in &sorted {
+            let scenario = c
+                .scenario
+                .iter()
+                .map(|(k, v)| format!("{}={v}", k.trim_start_matches("sdim-")))
+                .collect::<Vec<_>>()
+                .join(" ");
+            let flag = if c.covered_elsewhere == 0 && !c.waiver_backed {
+                " [no evidence anywhere]"
+            } else if c.covered_elsewhere == 0 {
+                " [waiver-backed, no case]"
+            } else if !c.differentially_tested {
+                " [never compared to the CLI]"
+            } else {
+                ""
+            };
+            println!("{:<44} {scenario}{flag}", c.behavior);
+        }
+        println!("\n{} open cells", sorted.len());
+        return 0;
+    }
+
     let rendered = deacon_conformance::parity_page::render(&registry);
     let path = workspace_root().join("docs/PARITY.md");
 

--- a/crates/conformance/src/coverage.rs
+++ b/crates/conformance/src/coverage.rs
@@ -565,6 +565,7 @@ mod tests {
             reference,
             decision,
             notes: None,
+            scenario_applicability: Default::default(),
         }
     }
 

--- a/crates/conformance/src/discovery/promote.rs
+++ b/crates/conformance/src/discovery/promote.rs
@@ -637,6 +637,7 @@ mod tests {
             reference: ReferenceStatus::Aligned,
             decision: Decision::FollowSpec,
             notes: None,
+            scenario_applicability: Default::default(),
         };
         let rendered = serde_json::to_value(&unit).expect("a behavior serializes");
         for axis in BEHAVIOR_DISPOSITION_AXES {

--- a/crates/conformance/src/model.rs
+++ b/crates/conformance/src/model.rs
@@ -373,6 +373,20 @@ pub struct BehaviorUnit {
     /// Rationale, issue links.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
+    /// SCENARIO applicability: the `sdim-` values this behavior can be exercised under
+    /// at all. Absent (the usual case) means every value the operation permits.
+    ///
+    /// Distinct from [`Self::applicability`], which conditions on ENVIRONMENT dimensions
+    /// (os, arch, runtime, oracle) — "where does this evidence hold". This answers
+    /// "where does the question even arise". A behavior about deriving a Compose project
+    /// name has no meaning under an image configuration, and rendering it as untested
+    /// invents a gap.
+    ///
+    /// The applicability RULES already exclude values per operation; this is the finer
+    /// grain the rules cannot express, because they are keyed by operation and several
+    /// behaviors of one operation may differ.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub scenario_applicability: IndexMap<String, Vec<String>>,
 }
 
 /// The executable-test reference of a [`TestCase`] (research Decision 9). `binary`

--- a/crates/conformance/src/obligation.rs
+++ b/crates/conformance/src/obligation.rs
@@ -1141,6 +1141,7 @@ mod tests {
             reference: ReferenceStatus::Aligned,
             decision: Decision::FollowSpec,
             notes: None,
+            scenario_applicability: Default::default(),
         }
     }
 

--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -50,6 +50,10 @@ enum Cell {
     DeaconOnly,
     /// No case exercises this scenario.
     Unchecked,
+    /// The behavior does not arise in this scenario — not a gap. Rendered blank rather
+    /// than with a glyph: there is no question here to answer, so any mark would invite
+    /// one.
+    NotApplicable,
 }
 
 impl Cell {
@@ -61,6 +65,7 @@ impl Cell {
             Cell::DiffersFixing => "❌",
             Cell::DeaconOnly => "🔵",
             Cell::Unchecked => "·",
+            Cell::NotApplicable => "",
         }
     }
 }
@@ -278,6 +283,17 @@ fn grid(
         let cases = coverage.get(b.id.as_str());
         let mut cells = Vec::with_capacity(combos.len());
         for combo in &combos {
+            // A behavior can declare the scenario values it arises under at all. Without
+            // this, a Compose-only behavior showed `·` under `img`/`dkr` — indistinguishable
+            // from an untested gap, when the question does not arise.
+            if combo.iter().any(|(dim, value)| {
+                b.scenario_applicability
+                    .get(*dim)
+                    .is_some_and(|allowed| !allowed.iter().any(|a| a == value))
+            }) {
+                cells.push(Cell::NotApplicable);
+                continue;
+            }
             let hits: Vec<bool> = cases
                 .into_iter()
                 .flatten()
@@ -296,7 +312,7 @@ fn grid(
         let roll = cells
             .iter()
             .copied()
-            .find(|c| *c != Cell::Unchecked)
+            .find(|c| !matches!(c, Cell::Unchecked | Cell::NotApplicable))
             .unwrap_or(Cell::Unchecked);
         let _ = write!(
             s,
@@ -423,7 +439,8 @@ A further {deacon_only} are deacon-only, with nothing to compare against.
 | ⚠️ | Differs on purpose |
 | ❌ | Differs, and we intend to fix it |
 | 🔵 | deacon-only; the CLI has no equivalent |
-| · | Not checked in this scenario |
+| · | **Not checked yet** — a real gap |
+| *(blank)* | Does not arise in this scenario |
 
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
@@ -432,15 +449,16 @@ ordering / **lock** with a lockfile).
 
 **A column only appears where that scenario is possible.** `outdated` never resolves a
 dependency graph, so it has no **deps** column at all rather than a column of `·` implying
-an untested hole. So a `·` means genuinely not yet checked — with one caveat below.
+an untested hole. So a `·` means genuinely not yet checked.
 
 A cell says a case exercised that scenario — not that the case's assertions were strong.
 The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
 
-The caveat: columns are dropped per AREA, not per behavior. A behavior that is inherently
-about one configuration shape — deriving a Compose project name, say — still shows `·`
-under **img** and **dkr**, where the truth is that the question does not arise. Reading
-down a column is reliable; reading along a row needs that in mind.
+A **blank** cell means the behavior does not arise in that scenario at all — deriving a
+Compose project name has no meaning under an image configuration. Blank rather than a
+glyph, because there is no question there to answer.
+
+So every `·` is a real gap: a scenario this behavior COULD be checked in and has not been.
 "#,
         oracle = pin_of(registry, RevisionKind::Oracle),
         spec = pin_of(registry, RevisionKind::Spec),
@@ -471,6 +489,7 @@ mod tests {
             reference: ReferenceStatus::Aligned,
             decision: Decision::FollowSpec,
             notes: None,
+            scenario_applicability: Default::default(),
         }
     }
 
@@ -592,4 +611,151 @@ mod tests {
             "a presence-only assertion is real coverage:\n{page}"
         );
     }
+}
+
+/// One untested `(behavior, scenario)` cell — a `·` on the page, and a unit of work.
+///
+/// The parity matrix doubles as a queue. A dot names something concrete to go and do:
+/// author a case for this behavior in this scenario, run it, and learn whether deacon
+/// matches. That is a better driver than the pairwise obligation counts, which say how
+/// many abstract value-pairs remain uncovered but never what to test.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenCell {
+    pub area: String,
+    pub behavior: String,
+    /// The scenario assignment, e.g. `{"sdim-config-source": "compose"}`.
+    pub scenario: std::collections::BTreeMap<String, String>,
+    /// This behavior's other scenarios that ARE covered. An empty list means the
+    /// behavior has no evidence at all anywhere, which is a different and larger
+    /// problem than one uncovered scenario.
+    pub covered_elsewhere: usize,
+    /// Whether any covering case anywhere compares against the reference. A behavior
+    /// evidenced only deacon-side is worth more attention than one already differentially
+    /// tested in a neighbouring scenario.
+    pub differentially_tested: bool,
+    /// Whether a waiver stands behind this behavior. A waiver IS evidence — it is
+    /// verified to keep reproducing and fails as stale when it stops — but it is scoped
+    /// to a difference, not to a scenario, so it never fills a cell. Without this the
+    /// queue reported a waiver-backed behavior as having no evidence at all.
+    pub waiver_backed: bool,
+}
+
+/// Enumerate every `·` on the page, in the order the page renders them.
+///
+/// Deliberately excludes blanks (the behavior does not arise there) and every non-dot
+/// cell, so the result is exactly the open work.
+pub fn open_cells(registry: &Registry) -> Vec<OpenCell> {
+    let mut coverage: BTreeMap<&str, Vec<(&TestCase, bool)>> = BTreeMap::new();
+    for case in &registry.cases {
+        if !case.expected.is_empty()
+            && case.expected.iter().all(|e| {
+                e.assertion
+                    .as_ref()
+                    .is_some_and(crate::model::is_vacuous_assertion)
+            })
+        {
+            continue;
+        }
+        let live = matches!(case.oracle_type, Some(OracleType::LiveDifferential));
+        for b in &case.behaviors {
+            coverage.entry(b.as_str()).or_default().push((case, live));
+        }
+    }
+
+    let waived: BTreeSet<&str> = registry
+        .waivers
+        .iter()
+        .flat_map(|w| w.behaviors.iter().map(String::as_str))
+        .collect();
+
+    let model = ScenarioModel::new(&registry.scenario, &registry.applicability);
+    let mut areas: BTreeMap<&str, Vec<&crate::model::BehaviorUnit>> = BTreeMap::new();
+    for b in &registry.behaviors {
+        areas.entry(b.area.as_str()).or_default().push(b);
+    }
+
+    let mut out = Vec::new();
+    for behaviors in areas.values() {
+        let operations: BTreeSet<&str> = behaviors
+            .iter()
+            .filter_map(|b| coverage.get(b.id.as_str()))
+            .flatten()
+            .filter_map(|(case, _)| case.scenario_context.get("sdim-operation"))
+            .map(String::as_str)
+            .collect();
+        let mut permitted: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+        for op in &operations {
+            for (dim, values) in model.applicable_dimensions(op) {
+                permitted
+                    .entry(dim.id.as_str())
+                    .or_default()
+                    .extend(values.iter().copied());
+            }
+        }
+        let active: Vec<ActiveDim<'_>> = DIMS
+            .iter()
+            .filter_map(|d| {
+                let allowed = permitted.get(d.key)?;
+                let values: Vec<(&str, &str)> = d
+                    .values
+                    .iter()
+                    .filter(|(value, _)| allowed.contains(value))
+                    .copied()
+                    .collect();
+                (values.len() > 1).then_some(ActiveDim { key: d.key, values })
+            })
+            .collect();
+        if active.is_empty() {
+            continue;
+        }
+
+        let mut combos: Vec<Vec<(&str, &str)>> = vec![Vec::new()];
+        for dim in &active {
+            let mut next = Vec::new();
+            for base in &combos {
+                for (value, _) in dim.values.iter() {
+                    let mut c = base.clone();
+                    c.push((dim.key, value));
+                    next.push(c);
+                }
+            }
+            combos = next;
+        }
+
+        for b in behaviors {
+            let cases = coverage.get(b.id.as_str());
+            let covered = cases.map_or(0, |c| c.len());
+            let differential = cases.is_some_and(|c| c.iter().any(|(_, live)| *live));
+            for combo in &combos {
+                if combo.iter().any(|(dim, value)| {
+                    b.scenario_applicability
+                        .get(*dim)
+                        .is_some_and(|allowed| !allowed.iter().any(|a| a == value))
+                }) {
+                    continue; // does not arise
+                }
+                let exercised = cases.into_iter().flatten().any(|(case, _)| {
+                    combo
+                        .iter()
+                        .all(|(k, v)| case.scenario_context.get(*k).map(String::as_str) == Some(*v))
+                });
+                if exercised {
+                    continue;
+                }
+                out.push(OpenCell {
+                    area: b.area.clone(),
+                    behavior: b.id.clone(),
+                    scenario: combo
+                        .iter()
+                        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                        .collect(),
+                    covered_elsewhere: covered,
+                    differentially_tested: differential,
+                    waiver_backed: waived.contains(b.id.as_str()),
+                });
+            }
+        }
+    }
+    out
 }

--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -157,6 +157,12 @@ pub fn render(registry: &Registry) -> String {
 
     let model = ScenarioModel::new(&registry.scenario, &registry.applicability);
 
+    let waivers: BTreeMap<&str, &str> = registry
+        .waivers
+        .iter()
+        .flat_map(|w| w.behaviors.iter().map(|b| (b.as_str(), w.id.as_str())))
+        .collect();
+
     let mut out = String::new();
     out.push_str(&header(registry));
 
@@ -220,13 +226,13 @@ pub fn render(registry: &Registry) -> String {
                     "| {} | {} | {} |",
                     cell.glyph(),
                     first_sentence(&b.statement),
-                    notes_cell(b)
+                    notes_cell(b, &waivers)
                 );
             }
             continue;
         }
 
-        out.push_str(&grid(&active, behaviors, &coverage));
+        out.push_str(&grid(&active, behaviors, &coverage, &waivers));
     }
 
     out.push_str(&footer());
@@ -237,6 +243,7 @@ fn grid(
     active: &[ActiveDim<'_>],
     behaviors: &[&crate::model::BehaviorUnit],
     coverage: &BTreeMap<&str, Vec<(&TestCase, bool)>>,
+    waivers: &BTreeMap<&str, &str>,
 ) -> String {
     // Cross product of the active dimensions' values, in declared order.
     let mut combos: Vec<Vec<(&str, &str)>> = vec![Vec::new()];
@@ -323,7 +330,7 @@ fn grid(
         for c in &cells {
             let _ = write!(s, "<td>{}</td>", c.glyph());
         }
-        let _ = writeln!(s, "<td>{}</td></tr>", notes_cell(b));
+        let _ = writeln!(s, "<td>{}</td></tr>", notes_cell(b, waivers));
     }
     s.push_str("</tbody>\n</table>\n");
     s
@@ -351,7 +358,7 @@ fn first_sentence(statement: &str) -> String {
 
 /// Issue links out of `notes`, so a reader can follow a divergence to its tracking
 /// without the page restating the rationale.
-fn notes_cell(b: &crate::model::BehaviorUnit) -> String {
+fn notes_cell(b: &crate::model::BehaviorUnit, waivers: &BTreeMap<&str, &str>) -> String {
     let notes = b.notes.as_deref().unwrap_or("");
     let mut refs: Vec<String> = Vec::new();
     for (i, c) in notes.char_indices() {
@@ -369,8 +376,23 @@ fn notes_cell(b: &crate::model::BehaviorUnit) -> String {
             }
         }
     }
-    refs.truncate(3);
-    refs.join(" ")
+    refs.truncate(2);
+
+    // A deliberate difference should be backed by a waiver: a waiver is verified to keep
+    // reproducing and fails as STALE when the difference stops, so it is what stops a
+    // characterization outliving the thing it characterized. Showing which waiver — and
+    // flagging a deliberate difference that has none — is what makes the row auditable
+    // rather than merely labelled.
+    let mut out = Vec::new();
+    match waivers.get(b.id.as_str()) {
+        Some(id) => out.push(format!("<code>{id}</code>")),
+        None if matches!(b.decision, Decision::IntentionalDivergence) => {
+            out.push("<strong>no waiver</strong>".to_string());
+        }
+        None => {}
+    }
+    out.extend(refs);
+    out.join(" ")
 }
 
 fn html_escape(s: &str) -> String {
@@ -441,6 +463,11 @@ A further {deacon_only} are deacon-only, with nothing to compare against.
 | 🔵 | deacon-only; the CLI has no equivalent |
 | · | **Not checked yet** — a real gap |
 | *(blank)* | Does not arise in this scenario |
+
+A row's Notes name the **waiver** backing a deliberate difference, or say **no waiver**
+where a deliberate difference has none. A waiver is verified to keep reproducing and fails
+as *stale* when the difference stops, so it is what prevents a characterization outliving
+the thing it characterized — a `⚠️` row with no waiver is one nothing will ever re-examine.
 
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it

--- a/crates/conformance/src/validate.rs
+++ b/crates/conformance/src/validate.rs
@@ -4457,6 +4457,7 @@ mod tests {
             reference,
             decision,
             notes: None,
+            scenario_applicability: Default::default(),
         }
     }
 

--- a/crates/conformance/tests/allowed_difference_scoping.rs
+++ b/crates/conformance/tests/allowed_difference_scoping.rs
@@ -31,6 +31,7 @@ fn behavior(id: &str, decision: Decision) -> BehaviorUnit {
         reference: ReferenceStatus::Aligned,
         decision,
         notes: None,
+        scenario_applicability: Default::default(),
     }
 }
 

--- a/crates/conformance/tests/behavior_duplicates.rs
+++ b/crates/conformance/tests/behavior_duplicates.rs
@@ -28,6 +28,7 @@ fn behavior(id: &str, statement: &str) -> BehaviorUnit {
         reference: ReferenceStatus::Aligned,
         decision: Decision::FollowSpec,
         notes: None,
+        scenario_applicability: Default::default(),
     }
 }
 

--- a/crates/conformance/tests/case_schema_valid.rs
+++ b/crates/conformance/tests/case_schema_valid.rs
@@ -27,6 +27,7 @@ fn behavior(id: &str) -> BehaviorUnit {
         reference: ReferenceStatus::Aligned,
         decision: Decision::FollowSpec,
         notes: None,
+        scenario_applicability: Default::default(),
     }
 }
 

--- a/crates/conformance/tests/clause_classification_join.rs
+++ b/crates/conformance/tests/clause_classification_join.rs
@@ -44,6 +44,7 @@ fn behavior(id: &str) -> BehaviorUnit {
         reference: ReferenceStatus::Aligned,
         decision: Decision::FollowSpec,
         notes: None,
+        scenario_applicability: Default::default(),
     }
 }
 

--- a/crates/core/src/outdated.rs
+++ b/crates/core/src/outdated.rs
@@ -207,7 +207,7 @@ pub fn wanted_major(version: &Option<String>) -> Option<String> {
 ///
 /// // Without lockfile, falls back to wanted version
 /// let reference = "ghcr.io/devcontainers/features/node:18";
-/// assert_eq!(derive_current_version(reference, None), Some("18".to_string()));
+/// assert_eq!(derive_current_version(reference, None, &[]), Some("18".to_string()));
 ///
 /// // With lockfile entry
 /// let mut features = HashMap::new();
@@ -221,11 +221,12 @@ pub fn wanted_major(version: &Option<String>) -> Option<String> {
 ///     }
 /// );
 /// let lockfile = Lockfile { features };
-/// assert_eq!(derive_current_version(reference, Some(&lockfile)), Some("16.0.0".to_string()));
+/// assert_eq!(derive_current_version(reference, Some(&lockfile), &[]), Some("16.0.0".to_string()));
 /// ```
 pub fn derive_current_version(
     reference: &str,
     lockfile_opt: Option<&lockfile::Lockfile>,
+    stable_tags: &[String],
 ) -> Option<String> {
     let canonical = canonical_feature_id(reference);
     if let Some(ld) = lockfile_opt {
@@ -234,8 +235,11 @@ pub fn derive_current_version(
         }
     }
 
-    // Fallback
-    compute_wanted_version(reference)
+    // No lockfile entry: what is installed is whatever the declared reference resolves
+    // to, which for a partial pin is the newest published version satisfying it — the
+    // same resolution `wanted` performs (#407). Returning the pin's literal text here
+    // reported `"current": "1"`, which is not a version.
+    resolve_wanted_version(reference, stable_tags)
 }
 
 /// Fetch the latest stable semver tag for the given declared feature reference.
@@ -243,7 +247,7 @@ pub fn derive_current_version(
 /// This performs a registry `list_tags` via the core `FeatureFetcher` and uses
 /// `semver_utils` to filter and sort tags. Returns `None` on any error or if
 /// no stable semver tags are present.
-pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
+pub async fn fetch_stable_tags_descending(reference: &str) -> Option<Vec<String>> {
     // Build a FeatureRef for listing tags. We make a best-effort parse: registry is the
     // first path segment, repository is the remainder. For nested namespaces we keep them.
     let canonical = canonical_feature_id(reference);
@@ -289,9 +293,63 @@ pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
         return None;
     }
     semver_utils::sort_tags_descending(&mut semver_tags);
+    Some(semver_tags)
+}
 
-    // First element is the highest stable semver
-    semver_tags.into_iter().next()
+/// The highest stable published version, i.e. the first of
+/// [`fetch_stable_tags_descending`].
+pub async fn fetch_latest_stable_version(reference: &str) -> Option<String> {
+    fetch_stable_tags_descending(reference)
+        .await?
+        .into_iter()
+        .next()
+}
+
+/// Resolve the version the declared reference ASKS FOR, given the published stable tags
+/// in descending order.
+///
+/// `wanted` means "the newest published version satisfying what the configuration
+/// declared" — which is what the neighbouring `latest` and `wantedMajor` fields imply,
+/// and what the reference CLI reports. deacon used to return the declared tag STRING
+/// verbatim, so a configuration pinning `git:1` reported `"wanted": "1"` — not a version
+/// at all, and unusable for deciding whether an upgrade is available (#407 divergence 2).
+///
+/// An exactly-pinned reference resolves to itself and needs no tag list; only a partial
+/// pin (`1`, `1.3`) has to consult the registry. Non-numeric tags (`latest`, a named
+/// channel) are returned as declared: they name a moving target the registry alone
+/// resolves, and guessing would be worse than echoing.
+///
+/// deacon's own `upgrade` already resolved ranges this way, so the two subcommands
+/// disagreed with each other as well as with the reference — which is what settled the
+/// direction.
+pub fn resolve_wanted_version(reference: &str, stable_tags: &[String]) -> Option<String> {
+    let declared = compute_wanted_version(reference)?;
+
+    // A full `major.minor.patch` pin is already the answer.
+    let parts: Vec<&str> = declared.split('.').collect();
+    if parts.len() >= 3 || !parts.iter().all(|p| p.chars().all(|c| c.is_ascii_digit())) {
+        return Some(declared);
+    }
+    if parts.iter().any(|p| p.is_empty()) {
+        return Some(declared);
+    }
+
+    // A partial pin selects the highest published version sharing its prefix. Tags are
+    // already sorted descending, so the first match wins.
+    let prefix: Vec<&str> = parts;
+    let matched = stable_tags.iter().find(|tag| {
+        let tag_parts: Vec<&str> = tag.trim_start_matches('v').split('.').collect();
+        tag_parts.len() >= prefix.len()
+            && prefix
+                .iter()
+                .zip(tag_parts.iter())
+                .all(|(want, have)| want == have)
+    });
+
+    // No published tag satisfies the pin (or the registry was unreachable): echo what was
+    // declared rather than reporting nothing. Degrading to today's answer is better than
+    // turning a transient lookup failure into a missing field.
+    Some(matched.cloned().unwrap_or(declared))
 }
 
 /// Return the major portion of the latest stable version string.
@@ -441,6 +499,96 @@ mod tests {
     }
 
     // wanted_major tests
+    // -- resolve_wanted_version (#407 divergence 2) ---------------------------------
+
+    fn tags(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// A partial pin resolves to the newest published version satisfying it — NOT the
+    /// pin's literal text, which is what deacon used to report.
+    #[test]
+    fn wanted_resolves_a_major_only_pin_to_the_newest_matching_version() {
+        let published = tags(&["2.1.0", "1.7.1", "1.6.0", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/node:1", &published),
+            Some("1.7.1".to_string())
+        );
+    }
+
+    #[test]
+    fn wanted_resolves_a_minor_pin_within_that_minor() {
+        let published = tags(&["1.7.1", "1.3.8", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/git:1.3", &published),
+            Some("1.3.8".to_string())
+        );
+    }
+
+    /// An exact pin is already the answer and must not drift to a newer patch.
+    #[test]
+    fn wanted_leaves_an_exact_pin_alone() {
+        let published = tags(&["1.3.8", "1.3.2"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/git:1.3.2", &published),
+            Some("1.3.2".to_string())
+        );
+    }
+
+    /// `1` must not match `10.x`: the comparison is per component, not textual prefix.
+    #[test]
+    fn wanted_does_not_match_a_longer_major() {
+        let published = tags(&["10.0.0", "1.2.0"]);
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:1", &published),
+            Some("1.2.0".to_string())
+        );
+    }
+
+    /// An unreachable registry (or a pin nothing published satisfies) degrades to the
+    /// declared text rather than reporting nothing — a transient lookup failure must not
+    /// turn into a missing field.
+    #[test]
+    fn wanted_falls_back_to_the_declared_pin_when_nothing_matches() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:9", &tags(&["1.0.0"])),
+            Some("9".to_string())
+        );
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:1", &[]),
+            Some("1".to_string())
+        );
+    }
+
+    /// A non-numeric tag names a moving target only the registry resolves; echoing it is
+    /// better than guessing which published version it points at.
+    #[test]
+    fn wanted_echoes_a_non_numeric_tag() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z:latest", &tags(&["2.0.0"])),
+            Some("latest".to_string())
+        );
+    }
+
+    /// A digest reference carries no version to want.
+    #[test]
+    fn wanted_is_none_for_a_digest_reference() {
+        assert_eq!(
+            resolve_wanted_version("ghcr.io/x/y/z@sha256:abc", &tags(&["2.0.0"])),
+            None
+        );
+    }
+
+    /// Without a lockfile, `current` resolves the same way `wanted` does — reporting the
+    /// pin's literal text said `"current": "1"`, which is not a version.
+    #[test]
+    fn current_without_a_lockfile_resolves_the_pin() {
+        assert_eq!(
+            derive_current_version("ghcr.io/x/y/node:1", None, &tags(&["1.7.1", "1.6.0"])),
+            Some("1.7.1".to_string())
+        );
+    }
+
     #[test]
     fn test_wanted_major_valid() {
         assert_eq!(
@@ -492,7 +640,7 @@ mod tests {
     fn test_derive_current_version_no_lockfile() {
         let reference = "ghcr.io/devcontainers/features/node:18";
         assert_eq!(
-            derive_current_version(reference, None),
+            derive_current_version(reference, None, &[]),
             Some("18".to_string())
         );
     }
@@ -514,7 +662,7 @@ mod tests {
 
         // Should return lockfile version, not wanted version
         assert_eq!(
-            derive_current_version(reference, Some(&lockfile)),
+            derive_current_version(reference, Some(&lockfile), &[]),
             Some("18.5.0".to_string())
         );
     }
@@ -536,7 +684,7 @@ mod tests {
 
         // No match in lockfile, should fall back to wanted
         assert_eq!(
-            derive_current_version(reference, Some(&lockfile)),
+            derive_current_version(reference, Some(&lockfile), &[]),
             Some("3.11".to_string())
         );
     }
@@ -545,7 +693,7 @@ mod tests {
     fn test_derive_current_version_digest_no_lockfile() {
         let reference = "ghcr.io/devcontainers/features/node@sha256:abcdef";
         // Digest with no lockfile should return None (can't derive version)
-        assert_eq!(derive_current_version(reference, None), None);
+        assert_eq!(derive_current_version(reference, None, &[]), None);
     }
 
     // FeatureVersionInfo serialization tests

--- a/crates/core/tests/outdated_helpers.rs
+++ b/crates/core/tests/outdated_helpers.rs
@@ -40,17 +40,18 @@ fn test_derive_current_version_from_lockfile() {
     );
 
     // When lockfile has entry, derive_current_version should return the locked version
-    let current = derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", Some(&lf));
+    let current =
+        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", Some(&lf), &[]);
     assert_eq!(current.as_deref(), Some("7.8.9"));
 
     // When lockfile is absent, it should fall back to the wanted tag
     let current_no_lock =
-        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", None);
+        derive_current_version("ghcr.io/devcontainers/features/node:10.0.0", None, &[]);
     assert_eq!(current_no_lock.as_deref(), Some("10.0.0"));
 
     // Digest-based reference with no lockfile should yield None
     let digest_ref = "ghcr.io/devcontainers/features/node@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let current_digest = derive_current_version(digest_ref, None);
+    let current_digest = derive_current_version(digest_ref, None, &[]);
     assert!(current_digest.is_none());
 }
 

--- a/crates/core/tests/outdated_helpers_additional.rs
+++ b/crates/core/tests/outdated_helpers_additional.rs
@@ -56,11 +56,15 @@ fn test_derive_current_version_lockfile_behavior() {
     );
 
     // Derive from lockfile
-    let current = derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", Some(&lf));
+    let current = derive_current_version(
+        "ghcr.io/devcontainers/features/sample:9.9.9",
+        Some(&lf),
+        &[],
+    );
     assert_eq!(current.as_deref(), Some("0.1.2"));
 
     // No lockfile -> fallback to wanted
     let current_no_lock =
-        derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", None);
+        derive_current_version("ghcr.io/devcontainers/features/sample:9.9.9", None, &[]);
     assert_eq!(current_no_lock.as_deref(), Some("9.9.9"));
 }

--- a/crates/deacon/src/commands/outdated.rs
+++ b/crates/deacon/src/commands/outdated.rs
@@ -199,7 +199,10 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
         declared_refs.push(feature_key.clone());
     }
 
-    // Bounded parallel fetching of latest versions with timeout and deterministic ordering
+    // Bounded parallel fetching of the published tag list, with timeout and deterministic
+    // ordering. The list serves BOTH `latest` (its first element) and `wanted` (the
+    // highest entry satisfying the declared pin), so resolving ranges costs no extra
+    // request — the tags were already being fetched for `latest` alone (#407).
     let concurrency_limit = std::env::var("DEACON_OUTDATED_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -239,19 +242,19 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
                 // Use core helper; enforce timeout per attempt
                 let attempt_result = tokio::time::timeout(
                     timeout_dur,
-                    core_outdated::fetch_latest_stable_version(&dr_clone),
+                    core_outdated::fetch_stable_tags_descending(&dr_clone),
                 )
                 .await;
 
                 match attempt_result {
-                    Ok(latest_opt) => {
+                    Ok(tags_opt) => {
                         // Either Some or None returned by fetcher; treat as final
-                        break latest_opt;
+                        break tags_opt;
                     }
                     Err(_) => {
                         // Timeout during fetch
                         let canonical = core_outdated::canonical_feature_id(&dr_clone);
-                        debug!(feature = %canonical, attempt, "Timeout fetching latest version (attempt {})", attempt);
+                        debug!(feature = %canonical, attempt, "Timeout fetching published tags (attempt {})", attempt);
 
                         if attempt >= max_retries {
                             // Give up after max retries
@@ -270,13 +273,13 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     }
 
     // Await handles in order to preserve deterministic output ordering
-    let mut latests: Vec<Option<String>> = Vec::with_capacity(handles.len());
+    let mut tag_lists: Vec<Option<Vec<String>>> = Vec::with_capacity(handles.len());
     for h in handles {
         match h.await {
-            Ok(latest_opt) => latests.push(latest_opt),
+            Ok(tags_opt) => tag_lists.push(tags_opt),
             Err(e) => {
-                debug!(error = ?e, "Task join error when fetching latest");
-                latests.push(None);
+                debug!(error = ?e, "Task join error when fetching published tags");
+                tag_lists.push(None);
             }
         }
     }
@@ -284,9 +287,13 @@ pub async fn run(args: OutdatedArgs) -> Result<()> {
     // Build results preserving original declaration order
     for (i, declared_ref) in declared_refs.iter().enumerate() {
         let declared_ref = declared_ref.as_str();
-        let wanted = core_outdated::compute_wanted_version(declared_ref);
-        let current = core_outdated::derive_current_version(declared_ref, lockfile_opt.as_ref());
-        let latest = latests.get(i).cloned().unwrap_or(None);
+        // `wanted` is the newest published version satisfying the declared pin, not the
+        // pin's literal text (#407 divergence 2). Both fields come from one tag list.
+        let tags: &[String] = tag_lists.get(i).and_then(|o| o.as_deref()).unwrap_or(&[]);
+        let wanted = core_outdated::resolve_wanted_version(declared_ref, tags);
+        let current =
+            core_outdated::derive_current_version(declared_ref, lockfile_opt.as_ref(), tags);
+        let latest = tags.first().cloned();
 
         let wanted_major = core_outdated::wanted_major(&wanted);
         let latest_major = core_outdated::latest_major(&latest);

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -127,7 +127,7 @@ down a column is reliable; reading along a row needs that in mind.
 <tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
 <tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
 <tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
-<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td></td></tr>
+<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>#407</td></tr>
 </tbody>
 </table>
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -22,6 +22,11 @@ A further 16 are deacon-only, with nothing to compare against.
 | · | **Not checked yet** — a real gap |
 | *(blank)* | Does not arise in this scenario |
 
+A row's Notes name the **waiver** backing a deliberate difference, or say **no waiver**
+where a deliberate difference has none. A waiver is verified to keep reproducing and fails
+as *stale* when the difference stops, so it is what prevents a characterization outliving
+the thing it characterized — a `⚠️` row with no waiver is one nothing will ever re-examine.
+
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
 declares (**–** none / **1** one / **many** several / **deps** several with dependency
@@ -89,7 +94,7 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td></td></tr>
 <tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
 <tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
-<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>#370</td></tr>
+<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td><strong>no waiver</strong> #370</td></tr>
 </tbody>
 </table>
 
@@ -107,12 +112,12 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#265</td></tr>
+<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-compose-project-file-set</code></td></tr>
+<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong> #265</td></tr>
 <tr><td>🔵</td><td>deacon stamps five identity/bookkeeping labels onto a created container that the…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong></td></tr>
 <tr><td>✅</td><td>The `devcontainer.metadata` label records the image metadata the configuration and…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373</td></tr>
-<tr><td>⚠️</td><td>The BYTE FORM of the `devcontainer.metadata` label value — JSON whitespace and object…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373 #394</td></tr>
+<tr><td>⚠️</td><td>The BYTE FORM of the `devcontainer.metadata` label value — JSON whitespace and object…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-container-metadata-label-serialization</code> #373 #394</td></tr>
 <tr><td>◐</td><td>The observable container state after up (running status, labels, mounts, environment)…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>✅</td><td>The normalized observable-state diff between deacon and the reference is empty for the…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
@@ -126,8 +131,8 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td>#389</td></tr>
-<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#406 #407</td></tr>
+<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td><code>wvr-outdated-extends-chain-features</code> #389</td></tr>
+<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-outdated-malformed-lockfile-rejected</code> #406 #407</td></tr>
 <tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
 <tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>#407</td></tr>
 </tbody>
@@ -154,32 +159,32 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 </thead>
 <tbody>
 <tr><td>🔵</td><td>When a link of an `extends` chain declares a Feature its base already declared at a…</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
-<tr><td>⚠️</td><td>A single configuration document whose `features` map contains two keys resolving to…</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
-<tr><td>⚠️</td><td>deacon's resolved-configuration output omits a property the author wrote as `null`,…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#398</td></tr>
-<tr><td>·</td><td>An explicit --config pointing at a file that does not exist is rejected (no silent…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>A single configuration document whose `features` map contains two keys resolving to…</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-features-duplicate-in-one-document</code> #411</td></tr>
+<tr><td>⚠️</td><td>deacon's resolved-configuration output omits a property the author wrote as `null`,…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-authored-empty-omitted</code> #398</td></tr>
+<tr><td>·</td><td>An explicit --config pointing at a file that does not exist is rejected (no silent…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-bad-config-path</code></td></tr>
 <tr><td>✅</td><td>Reading a well-formed devcontainer.json exits 0 and emits the resolved configuration…</td><td>✅</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>✅</td><td>Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`,…</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
-<tr><td>❌</td><td>Configuration discovery searches exactly the three locations the spec names —…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>A JSON object with a duplicate top-level key is accepted with last-wins semantics,…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>🔵</td><td>A cyclic extends chain (a -&gt; b -&gt; a) is detected and rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
-<tr><td>🔵</td><td>read-configuration --include-merged-configuration resolves the full extends chain…</td><td>🔵</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>#297</td></tr>
-<tr><td>🔵</td><td>An extends chain pointing at a nonexistent target file is rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>❌</td><td>Configuration discovery searches exactly the three locations the spec names —…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-discovery-named-subfolder</code></td></tr>
+<tr><td>✅</td><td>A JSON object with a duplicate top-level key is accepted with last-wins semantics,…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-duplicate-keys</code></td></tr>
+<tr><td>🔵</td><td>A cyclic extends chain (a -&gt; b -&gt; a) is detected and rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-extends-cycle</code> #297</td></tr>
+<tr><td>🔵</td><td>read-configuration --include-merged-configuration resolves the full extends chain…</td><td>🔵</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td><code>wvr-extends-child-merged</code> #297</td></tr>
+<tr><td>🔵</td><td>An extends chain pointing at a nonexistent target file is rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-extends-missing</code> #297</td></tr>
 <tr><td>❌</td><td>`--include-features-configuration` reports the resolved Feature set in install order,…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td></td></tr>
 <tr><td>✅</td><td>`featuresConfiguration` is reported only when Feature resolution produced at least one…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#387</td></tr>
-<tr><td>⚠️</td><td>A devcontainer.json with a hard JSONC syntax error is rejected at parse rather than…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>·</td><td>deacon's `mergedConfiguration` omits the computed-empty properties the reference…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#398</td></tr>
+<tr><td>⚠️</td><td>A devcontainer.json with a hard JSONC syntax error is rejected at parse rather than…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-malformed-json</code></td></tr>
+<tr><td>·</td><td>deacon's `mergedConfiguration` omits the computed-empty properties the reference…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-merged-computed-empties</code> #398</td></tr>
 <tr><td>❌</td><td>read-configuration --include-merged-configuration over the tier1 corpus emits a merged…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
 <tr><td>✅</td><td>`mergedConfiguration` reports all five plural lifecycle hook arrays…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>·</td><td>A workspace folder with no devcontainer configuration at all is rejected rather than…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>A workspace folder with no devcontainer configuration at all is rejected rather than…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-missing-config</code></td></tr>
 <tr><td>✅</td><td>A `portsAttributes` / `otherPortsAttributes` entry reports the keys the author wrote…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>◐</td><td>Variable substitution reaches the object-shaped fields that carry user templates —…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#312</td></tr>
 <tr><td>❌</td><td>Reading real-world devcontainer.json configurations from the tier1 corpus produces…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
-<tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unknown-field-preserved</code></td></tr>
+<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unsupported-enum-values</code></td></tr>
 <tr><td>✅</td><td>The reported `workspace.workspaceFolder` is the automatic source-code mount location…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#273 #383</td></tr>
 <tr><td>✅</td><td>The `workspace` section carries exactly `workspaceFolder` and the optional…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
-<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-features</code></td></tr>
+<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-forwardports</code></td></tr>
 </tbody>
 </table>
 
@@ -191,7 +196,7 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>❌</td><td>A lifecycle hook that exits non-zero fails the run rather than being reported as a…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>❌</td><td>A lifecycle hook that exits non-zero fails the run rather than being reported as a…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-ruc-completed-hooks-not-rerun</code></td></tr>
 <tr><td>✅</td><td>Lifecycle hooks run in spec order — onCreate, updateContent, postCreate, postStart —…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
@@ -227,7 +232,7 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>⚠️</td><td>Re-entering a workspace whose configuration has CHANGED since its container was…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>Re-entering a workspace whose configuration has CHANGED since its container was…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-up-changed-config-recreates</code></td></tr>
 <tr><td>◐</td><td>A `containerEnv` variable declared by BOTH the configuration and a Feature takes the…</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>#374</td></tr>
 <tr><td>◐</td><td>`up` applies the declared container user so the container process runs as that user…</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>✅</td><td>up creates a container from the resolved configuration such that a subsequent exec…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
@@ -251,7 +256,7 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 </thead>
 <tbody>
 <tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>·</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>#409</td></tr>
-<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td><code>wvr-upgrade-empty-feature-set</code></td></tr>
 <tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -19,7 +19,8 @@ A further 16 are deacon-only, with nothing to compare against.
 | ⚠️ | Differs on purpose |
 | ❌ | Differs, and we intend to fix it |
 | 🔵 | deacon-only; the CLI has no equivalent |
-| · | Not checked in this scenario |
+| · | **Not checked yet** — a real gap |
+| *(blank)* | Does not arise in this scenario |
 
 Columns are the scenarios a behavior was checked in: the configuration's shape
 (**img**age / **dkr** Dockerfile / **cmp** Compose) crossed with how many Features it
@@ -28,15 +29,16 @@ ordering / **lock** with a lockfile).
 
 **A column only appears where that scenario is possible.** `outdated` never resolves a
 dependency graph, so it has no **deps** column at all rather than a column of `·` implying
-an untested hole. So a `·` means genuinely not yet checked — with one caveat below.
+an untested hole. So a `·` means genuinely not yet checked.
 
 A cell says a case exercised that scenario — not that the case's assertions were strong.
 The leading glyph rolls the row up; where a row is mostly `·`, that is the honest signal.
 
-The caveat: columns are dropped per AREA, not per behavior. A behavior that is inherently
-about one configuration shape — deriving a Compose project name, say — still shows `·`
-under **img** and **dkr**, where the truth is that the question does not arise. Reading
-down a column is reliable; reading along a row needs that in mind.
+A **blank** cell means the behavior does not arise in that scenario at all — deriving a
+Compose project name has no meaning under an image configuration. Blank rather than a
+glyph, because there is no question there to answer.
+
+So every `·` is a real gap: a scenario this behavior COULD be checked in and has not been.
 
 ### build
 
@@ -70,7 +72,7 @@ down a column is reliable; reading along a row needs that in mind.
 <tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`down --remove` on a Compose configuration removes the project it created, identifying…</td><td>·</td><td>·</td><td>🔵</td><td></td></tr>
+<tr><td>🔵</td><td>`down --remove` on a Compose configuration removes the project it created, identifying…</td><td></td><td></td><td>🔵</td><td></td></tr>
 <tr><td>🔵</td><td>`down` over a workspace folder that has no devcontainer configuration reports that…</td><td>🔵</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>🔵</td><td>`down --remove` stops and removes the workspace's container, so a subsequent command…</td><td>🔵</td><td>🔵</td><td>·</td><td></td></tr>
 </tbody>
@@ -105,8 +107,8 @@ down a column is reliable; reading along a row needs that in mind.
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#265</td></tr>
+<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#265</td></tr>
 <tr><td>🔵</td><td>deacon stamps five identity/bookkeeping labels onto a created container that the…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 <tr><td>✅</td><td>The `devcontainer.metadata` label records the image metadata the configuration and…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373</td></tr>


### PR DESCRIPTION
Two changes that turn the page from a report into something you can work through.

## 1. A blank cell now means "does not arise"

`BehaviorUnit` gains `scenarioApplicability` — the `sdim-` values a behavior can be exercised
under at all. Distinct from the existing `applicability`, which conditions on **environment**
dimensions (os, arch, runtime): *where does this evidence hold*. This answers *where does the
question even arise*.

Three behaviors declare it today, all Compose-only — compose project name, compose file set,
compose project teardown. Their `img`/`dkr` cells were rendering as `·`, indistinguishable from
an untested gap when there's no question to answer.

Worth noting why this needed a new field: **zero of 73 behaviors previously declared any
applicability**, and the context dimensions are platform/runtime only, so nothing in the
registry could express it. The page carried a caveat paragraph instead — prose the reader had
to hold in their head down two hundred rows. Being asked twice what the dots meant is the
signal that it wasn't working.

**Every remaining `·` is now a real gap.**

## 2. `parity-page --open` lists them as a queue

Each line is a concrete (behavior, scenario) pair: author a case for this behavior in this
scenario, run it, learn whether deacon matches. That's a better driver than the pairwise
obligation counts, which say how many abstract value-pairs remain but never what to test.

Ordered most-neglected first, with flags:

```
[no evidence anywhere]       no case and no waiver
[waiver-backed, no case]     a waiver stands behind it, no case does
[never compared to the CLI]  only deacon-side evidence exists
```

**The queue caught a flaw in itself on first run.** It reported a waiver-backed behavior as
having no evidence, because it counted only cases. A waiver *is* evidence — verified to keep
reproducing, stale when it stops — it's just scoped to a difference rather than a scenario, so
it never fills a cell. With that fixed, **zero behaviors have no evidence at all**.

## The queue today — 736 open cells

| area | cells | | area | cells |
|---|---|---|---|---|
| read-configuration | 353 | | outdated | 31 |
| up | 158 | | run-user-commands | 25 |
| observable-state | 85 | | exec | 20 |
| build | 41 | | upgrade | 20 |
| | | | down | 3 |

**214 belong to behaviors never compared against the reference at all** — that's where the
parity risk actually concentrates, and it's the natural head of the queue.

Verified: `validate` ok, page matches a fresh render, fmt/clippy clean, 4190 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)