### PR TITLE
fix(parity-page): count evidence in the headline, not claims

### DIFF
--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -125,26 +125,49 @@ fn area_title(area: &str) -> String {
     area.replace('-', " ")
 }
 
+/// Does this case check anything at all?
+///
+/// A case whose every declared assertion is vacuous checks nothing, so it must not
+/// colour a cell or count as evidence. `·` already means "not checked in this
+/// scenario", and a check that cannot fail IS not checking it. V37 makes such a case
+/// unauthorable; this keeps the page's claim true by construction rather than by that
+/// gate holding.
+fn checks_anything(case: &TestCase) -> bool {
+    case.expected.is_empty()
+        || !case.expected.iter().all(|e| {
+            e.assertion
+                .as_ref()
+                .is_some_and(crate::model::is_vacuous_assertion)
+        })
+}
+
+/// Did this case OBSERVE the reference implementation?
+///
+/// The single definition of "verified against the CLI", used by both the grid and the
+/// headline. They must not drift apart: the headline previously counted the recorded
+/// three-axis disposition — a claim — while the grid counted evidence, so a behavior
+/// asserting `reference: aligned` that nothing had ever run scored as parity. One
+/// predicate, one standard, or the page speaks in two voices.
+///
+/// A snapshot counts: `conformance-snapshot refresh` runs the reference and commits
+/// what it observed. A `spec-expectation` case does not — it compares deacon to a
+/// written assertion and never invokes the CLI.
+fn observed_the_reference(case: &TestCase) -> bool {
+    matches!(
+        case.oracle_type,
+        Some(OracleType::LiveDifferential) | Some(OracleType::Snapshot)
+    )
+}
+
 /// Render the page. Deterministic: same registry in, same bytes out.
 pub fn render(registry: &Registry) -> String {
     // behavior -> set of (scenario key tuple, live?) drawn from its covering cases.
     let mut coverage: BTreeMap<&str, Vec<(&TestCase, bool)>> = BTreeMap::new();
     for case in &registry.cases {
-        // A case whose every declared assertion is vacuous checks nothing, so it must
-        // not colour a cell. `·` already means "not checked in this scenario", and a
-        // check that cannot fail IS not checking it — this is a correction to an
-        // existing cell, not a new tier. V37 makes such a case unauthorable; this keeps
-        // the page's claim true by construction rather than by that gate holding.
-        if !case.expected.is_empty()
-            && case.expected.iter().all(|e| {
-                e.assertion
-                    .as_ref()
-                    .is_some_and(crate::model::is_vacuous_assertion)
-            })
-        {
+        if !checks_anything(case) {
             continue;
         }
-        let live = matches!(case.oracle_type, Some(OracleType::LiveDifferential));
+        let live = observed_the_reference(case);
         for b in &case.behaviors {
             coverage.entry(b.as_str()).or_default().push((case, live));
         }
@@ -414,6 +437,15 @@ fn pin_of(registry: &Registry, kind: RevisionKind) -> String {
 }
 
 fn header(registry: &Registry) -> String {
+    // Which behaviors has anything actually compared against the reference? Same
+    // predicate the grid uses, so the headline and the cells below it cannot disagree.
+    let observed: BTreeSet<&str> = registry
+        .cases
+        .iter()
+        .filter(|c| checks_anything(c) && observed_the_reference(c))
+        .flat_map(|c| c.behaviors.iter().map(String::as_str))
+        .collect();
+
     let total = registry.behaviors.len();
     let deacon_only = registry
         .behaviors
@@ -424,20 +456,33 @@ fn header(registry: &Registry) -> String {
         })
         .count();
     let comparable = total - deacon_only;
-    let deliberate = registry
-        .behaviors
-        .iter()
-        .filter(|b| matches!(b.decision, Decision::IntentionalDivergence))
-        .count();
-    let behind = registry
-        .behaviors
-        .iter()
-        .filter(|b| {
-            matches!(b.reference, ReferenceStatus::Divergent)
-                && !matches!(b.decision, Decision::IntentionalDivergence)
-        })
-        .count();
-    let same = comparable.saturating_sub(deliberate + behind);
+
+    // Split each bucket by whether its claim about the reference rests on evidence.
+    // `same` is still a residual — a behavior lands there by being in neither
+    // divergence bucket — which is exactly why it must not be reported as a
+    // measurement without saying how much of it was measured.
+    let mut counts = [[0usize; 2]; 3];
+    for b in &registry.behaviors {
+        if matches!(b.decision, Decision::DeaconExtension)
+            || matches!(b.reference, ReferenceStatus::NotApplicable)
+        {
+            continue;
+        }
+        let bucket = if matches!(b.decision, Decision::IntentionalDivergence) {
+            1
+        } else if matches!(b.reference, ReferenceStatus::Divergent) {
+            2
+        } else {
+            0
+        };
+        counts[bucket][usize::from(observed.contains(b.id.as_str()))] += 1;
+    }
+    let [
+        [same_asserted, same],
+        [delib_asserted, deliberate],
+        [behind_asserted, behind],
+    ] = counts;
+    let unverified = same_asserted + delib_asserted + behind_asserted;
 
     format!(
         r#"# Does deacon behave like the DevContainers CLI?
@@ -448,9 +493,16 @@ fn header(registry: &Registry) -> String {
 Compared against **`@devcontainers/cli` {oracle}** and the [containers.dev spec]\
 (https://github.com/devcontainers/spec) at commit `{spec}`.
 
-**Of {comparable} behaviors that both tools implement, {same} match.**
-{deliberate} differ deliberately, {behind} are differences we intend to remove.
-A further {deacon_only} are deacon-only, with nothing to compare against.
+**Of {comparable} behaviors that both tools implement, {same} are verified to match.**
+{deliberate} are verified to differ deliberately, and {behind} to differ in ways we intend
+to remove. A further {deacon_only} are deacon-only, with nothing to compare against.
+
+**{unverified} more have never been compared against the CLI at all** — {same_asserted} assumed
+to match, {delib_asserted} assumed to differ on purpose, {behind_asserted} assumed to be behind.
+These are claims, not measurements: nothing has run the reference for them, so each could turn
+out to be any of the three. They are listed separately rather than folded into the totals above,
+because a claim nobody has checked is not evidence of parity — and a page that counted it as such
+would improve every time someone asserted something new.
 
 ## How to read this
 
@@ -568,6 +620,41 @@ mod tests {
         assert!(
             !page.contains("✅") && !page.contains("◐"),
             "a vacuous assertion must leave the row unchecked:\n{page}"
+        );
+    }
+
+    /// The headline must count what was OBSERVED, not what the registry CLAIMS.
+    ///
+    /// It previously derived every total from the three-axis disposition, so a behavior
+    /// recorded `reference: aligned` scored as parity even though nothing had ever run
+    /// the reference for it. That let the page improve whenever someone asserted
+    /// something new, and split it against its own grid, which counts evidence. The two
+    /// now share `observed_the_reference`; this pins the header side of that.
+    #[test]
+    fn an_unobserved_claim_is_not_counted_as_verified_parity() {
+        let mut reg = Registry {
+            behaviors: vec![behavior()],
+            cases: vec![case_with(serde_json::json!({"contains": "x"}))],
+            ..Registry::default()
+        };
+        // The behavior claims alignment, but its only evidence never runs the reference.
+        reg.cases[0].oracle_type = Some(OracleType::SpecExpectation);
+        let page = render(&reg);
+        assert!(
+            page.contains("**Of 1 behaviors that both tools implement, 0 are verified to match.**"),
+            "a spec-expectation case must not verify a parity claim:\n{page}"
+        );
+        assert!(
+            page.contains("**1 more have never been compared against the CLI at all**"),
+            "the unobserved claim must be reported as uncompared:\n{page}"
+        );
+
+        // Same registry, same disposition — only the evidence changes.
+        reg.cases[0].oracle_type = Some(OracleType::LiveDifferential);
+        let page = render(&reg);
+        assert!(
+            page.contains("**Of 1 behaviors that both tools implement, 1 are verified to match.**"),
+            "running the reference is what must move the count:\n{page}"
         );
     }
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -6,9 +6,16 @@
 Compared against **`@devcontainers/cli` 0.87.0** and the [containers.dev spec]\
 (https://github.com/devcontainers/spec) at commit `113500f4`.
 
-**Of 57 behaviors that both tools implement, 33 match.**
-15 differ deliberately, 9 are differences we intend to remove.
-A further 16 are deacon-only, with nothing to compare against.
+**Of 57 behaviors that both tools implement, 29 are verified to match.**
+10 are verified to differ deliberately, and 4 to differ in ways we intend
+to remove. A further 16 are deacon-only, with nothing to compare against.
+
+**14 more have never been compared against the CLI at all** — 7 assumed
+to match, 5 assumed to differ on purpose, 2 assumed to be behind.
+These are claims, not measurements: nothing has run the reference for them, so each could turn
+out to be any of the three. They are listed separately rather than folded into the totals above,
+because a claim nobody has checked is not evidence of parity — and a page that counted it as such
+would improve every time someone asserted something new.
 
 ## How to read this
 


### PR DESCRIPTION
## Why

The page stated a **claim** in its headline and **evidence** in its grid, in the same voice.

`header()` derived every total from the recorded three-axis disposition and never asked whether anything had run. So a behavior recorded `reference: aligned` counted as parity even when its only case was `spec-expectation` — which compares deacon to a written assertion and never invokes the CLI. **12 of 57 comparable behaviors were in that state, 5 of them in the match column.**

The consequence: the score rose whenever someone asserted something new, and did not move at all when someone actually compared the two tools. That is the entire reason "make the page look better" and "make the page true" were different jobs.

## What changed

The grid and the headline now share one predicate, `observed_the_reference`. Nothing counts as verified unless something ran the reference for it.

This also corrects the grid in the other direction: a committed **snapshot** is a reference observation (`conformance-snapshot refresh` runs the CLI and commits what it saw), so it no longer renders as deacon-side-only evidence.

## A second defect the rewrite exposed

`deliberate` and `behind` were counted over **all** behaviors while `comparable` excluded deacon-only ones — and `same` was then derived by subtracting one population from the other.

The three `bhv-readconfig-extends-*` records are `deacon-extension` and correctly `reference: divergent` (the distinction is documented at length in CLAUDE.md). They were reported as "differences we intend to remove" *and* simultaneously subtracted from the match count. All three buckets are now counted over the comparable population alone.

## Headline

| | before | after |
|---|---|---|
| comparable | 57 | 57 |
| match | 33 | **29 verified** |
| differ deliberately | 15 | **10 verified** |
| intend to remove | 9 | **4 verified** |
| never compared at all | — | **14** (7 assumed match, 5 assumed deliberate, 2 assumed behind) |

The numbers get worse because they were overstated.

## Verification

- New guard `an_unobserved_claim_is_not_counted_as_verified_parity` renders the same registry twice, changing only `oracleType`, and requires the count to move only on the live one. Confirmed it **fails** when `observed_the_reference` is stubbed to `true` — its failure message reproduces the old bug verbatim.
- `cargo fmt --all -- --check`, `clippy --all-targets --all-features -D warnings`, 787 conformance tests pass.
- `parity-page --check` guard confirms the committed page matches a fresh render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)