### PR TITLE
fix(parity-page): give the spec and the CLI a column each

### DIFF
--- a/crates/conformance/src/parity_page.rs
+++ b/crates/conformance/src/parity_page.rs
@@ -24,15 +24,30 @@
 //! The cross product shows two cells of fifteen. The projection flatters; the product
 //! does not, so the product is what ships.
 //!
-//! Each cell carries the status **in that scenario**, from one vocabulary — an earlier
-//! draft used ✅ to mean "same as reference" in a status column and "checked against the
-//! reference" in the cells, so a deliberately-divergent row rendered as a line of green.
+//! Each cell carries how strongly the row was **checked in that scenario**, and nothing
+//! else — an earlier draft used ✅ to mean "same as reference" in a status column and
+//! "checked against the reference" in the cells, so a deliberately-divergent row rendered
+//! as a line of green.
+//!
+//! ## One symbol, one axis
+//!
+//! The record has three axes (spec × reference × decision) and the page used to fold them
+//! into a single glyph. Every fold of that kind has so far turned out to assert more than
+//! the record supports — most sharply, "the two tools differ" rendered as ❌ *"we intend
+//! to fix it"* for six behaviors where deacon matches the spec and the REFERENCE deviates.
+//!
+//! So the axes are unfolded: a **spec** column and a **CLI** column say what deacon is
+//! measured against and whether it matches, the leading glyph says what we decided, and
+//! the grid cells say only how well it has been checked. Some combinations are then
+//! redundant by construction — a behavior sourced from observing the CLI can hardly show
+//! `CLI ?` — and that is the intended trade: a redundant true cell costs a reader nothing,
+//! a collapsed one costs them the distinction between our defect and theirs.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 
 use crate::load::Registry;
-use crate::model::{Decision, OracleType, ReferenceStatus, RevisionKind, TestCase};
+use crate::model::{Decision, OracleType, ReferenceStatus, RevisionKind, SpecStatus, TestCase};
 use crate::scenario::ScenarioModel;
 
 /// A cell's verdict: exactly one meaning per glyph.
@@ -44,7 +59,8 @@ enum Cell {
     SameUnverified,
     /// A deliberate difference, characterized.
     DiffersOnPurpose,
-    /// A difference we intend to remove.
+    /// A difference we intend to remove — deacon is the nonconformant side. Which side
+    /// is at fault is NOT inferable from "the two differ": see [`rollup`].
     DiffersFixing,
     /// deacon-only capability; the reference has no equivalent to compare against.
     DeaconOnly,
@@ -70,17 +86,57 @@ impl Cell {
     }
 }
 
-/// The per-scenario status a behavior takes wherever it IS covered, derived from its
-/// three-axis disposition. The axes are collapsed here and nowhere else.
-fn covered_verdict(b: &crate::model::BehaviorUnit, live: bool) -> Cell {
-    match (b.decision, b.reference) {
-        (Decision::DeaconExtension, _) | (_, ReferenceStatus::NotApplicable) => Cell::DeaconOnly,
-        (Decision::IntentionalDivergence, _) => Cell::DiffersOnPurpose,
-        // Divergent while intending to follow the spec or the reference means we are
-        // behind and mean to fix it — the only honest reading of R5/R6.
-        (_, ReferenceStatus::Divergent) => Cell::DiffersFixing,
+/// The row's leading glyph: what we DECIDED about this behavior, plus whether anything
+/// has checked it.
+///
+/// It deliberately does not say who deviates when the two tools differ — that is what the
+/// `spec` and `CLI` columns carry, one axis each, unfolded rather than collapsed. Folding
+/// them in is what made a divergence read as deacon's fault: R5 lets `follow-spec` stand
+/// only on `spec: conformant`, so every behavior this page has ever rendered ❌ was one
+/// where deacon matches the spec and the REFERENCE deviates from it. Only a
+/// `nonconformant` spec axis puts deacon on the wrong side, and no behavior carries one.
+fn rollup(b: &crate::model::BehaviorUnit, live: bool) -> Cell {
+    match (b.decision, b.reference, b.spec) {
+        (Decision::DeaconExtension, _, _) | (_, ReferenceStatus::NotApplicable, _) => {
+            Cell::DeaconOnly
+        }
+        (Decision::IntentionalDivergence, _, _) => Cell::DiffersOnPurpose,
+        (_, _, SpecStatus::Nonconformant) => Cell::DiffersFixing,
         _ if live => Cell::SameVerified,
         _ => Cell::SameUnverified,
+    }
+}
+
+/// A grid cell: how strong the evidence is IN THIS SCENARIO, and nothing else.
+///
+/// Cells used to repeat the row's disposition, so a deliberate difference painted ⚠️
+/// across every scenario it was covered in — including ones nothing had run. That reads
+/// as breadth of checking when it is breadth of assertion.
+fn evidence(live: bool) -> Cell {
+    if live {
+        Cell::SameVerified
+    } else {
+        Cell::SameUnverified
+    }
+}
+
+/// One axis rendered as its own column: `✔` deacon matches it, `✘` it deviates from
+/// deacon, `?` unsettled, blank where the axis does not apply.
+fn spec_mark(s: SpecStatus) -> &'static str {
+    match s {
+        SpecStatus::Conformant => "✔",
+        SpecStatus::Nonconformant => "✘",
+        SpecStatus::Unspecified => "?",
+        SpecStatus::NotApplicable => "",
+    }
+}
+
+fn reference_mark(r: ReferenceStatus) -> &'static str {
+    match r {
+        ReferenceStatus::Aligned => "✔",
+        ReferenceStatus::Divergent => "✘",
+        ReferenceStatus::Unknown => "?",
+        ReferenceStatus::NotApplicable => "",
     }
 }
 
@@ -249,20 +305,22 @@ pub fn render(registry: &Registry) -> String {
 
         if active.is_empty() {
             // No scenario evidence to grid: a flat list is honest and smaller.
-            out.push_str("| | Behavior | Notes |\n|---|---|---|\n");
+            out.push_str("| | Behavior | spec | CLI | Notes |\n|---|---|---|---|---|\n");
             for b in behaviors {
                 // No covering case at all is `·`, not a verdict. Falling through to
-                // `covered_verdict` here rendered ◐ — "believed the same" — for a
-                // behavior nothing has ever exercised, which is a claim, not a gap.
+                // `rollup` here rendered ◐ — "believed the same" — for a behavior
+                // nothing has ever exercised, which is a claim, not a gap.
                 let cell = match coverage.get(b.id.as_str()) {
                     None => Cell::Unchecked,
-                    Some(cs) => covered_verdict(b, cs.iter().any(|(_, l)| *l)),
+                    Some(cs) => rollup(b, cs.iter().any(|(_, l)| *l)),
                 };
                 let _ = writeln!(
                     out,
-                    "| {} | {} | {} |",
+                    "| {} | {} | {} | {} | {} |",
                     cell.glyph(),
                     first_sentence(&b.statement),
+                    spec_mark(b.spec),
+                    reference_mark(b.reference),
                     notes_cell(b, &waivers)
                 );
             }
@@ -301,7 +359,10 @@ fn grid(
     if active.len() > 1 {
         // Two header rows: the outer dimension spans the inner one's width.
         let inner: usize = active[1..].iter().map(|d| d.values.len()).product();
-        s.push_str("<tr><th rowspan=\"2\"></th><th rowspan=\"2\">Behavior</th>");
+        s.push_str(
+            "<tr><th rowspan=\"2\"></th><th rowspan=\"2\">Behavior</th>\
+             <th rowspan=\"2\">spec</th><th rowspan=\"2\">CLI</th>",
+        );
         for (_, label) in active[0].values.iter() {
             let _ = write!(s, "<th colspan=\"{inner}\">{label}</th>");
         }
@@ -315,7 +376,7 @@ fn grid(
     } else {
         // One dimension: a single header row. Emitting the two-row form anyway left an
         // empty second row of `<th></th>` under every column.
-        s.push_str("<tr><th></th><th>Behavior</th>");
+        s.push_str("<tr><th></th><th>Behavior</th><th>spec</th><th>CLI</th>");
         for (_, label) in active[0].values.iter() {
             let _ = write!(s, "<th>{label}</th>");
         }
@@ -350,19 +411,27 @@ fn grid(
                 .collect();
             cells.push(match hits.iter().any(|l| *l) {
                 _ if hits.is_empty() => Cell::Unchecked,
-                live => covered_verdict(b, live),
+                live => evidence(live),
             });
         }
-        let roll = cells
+        // The rollup comes from the RECORD, not from scanning the cells: cells now carry
+        // evidence strength only, so deriving it from them would report every covered row
+        // as ✅ regardless of what we decided about it.
+        let anything_covered = cells
             .iter()
-            .copied()
-            .find(|c| !matches!(c, Cell::Unchecked | Cell::NotApplicable))
-            .unwrap_or(Cell::Unchecked);
+            .any(|c| !matches!(c, Cell::Unchecked | Cell::NotApplicable));
+        let roll = if anything_covered {
+            rollup(b, cells.iter().any(|c| matches!(c, Cell::SameVerified)))
+        } else {
+            Cell::Unchecked
+        };
         let _ = write!(
             s,
-            "<tr><td>{}</td><td>{}</td>",
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td>",
             roll.glyph(),
-            first_sentence(&b.statement)
+            first_sentence(&b.statement),
+            spec_mark(b.spec),
+            reference_mark(b.reference)
         );
         for c in &cells {
             let _ = write!(s, "<td>{}</td>", c.glyph());
@@ -481,15 +550,20 @@ fn header(registry: &Registry) -> String {
     // `same` is still a residual — a behavior lands there by being in neither
     // divergence bucket — which is exactly why it must not be reported as a
     // measurement without saying how much of it was measured.
-    let mut counts = [[0usize; 2]; 3];
+    let mut counts = [[0usize; 2]; 4];
     for b in &registry.behaviors {
         if matches!(b.decision, Decision::DeaconExtension)
             || matches!(b.reference, ReferenceStatus::NotApplicable)
         {
             continue;
         }
+        // Same order of tests as `rollup`, so the headline cannot claim a fault the row
+        // does not show. "The two differ" is split by WHOSE deviation it is: only a
+        // nonconformant spec axis is deacon's.
         let bucket = if matches!(b.decision, Decision::IntentionalDivergence) {
             1
+        } else if matches!(b.spec, SpecStatus::Nonconformant) {
+            3
         } else if matches!(b.reference, ReferenceStatus::Divergent) {
             2
         } else {
@@ -500,9 +574,10 @@ fn header(registry: &Registry) -> String {
     let [
         [same_asserted, same],
         [delib_asserted, deliberate],
+        [spec_backed_asserted, spec_backed],
         [behind_asserted, behind],
     ] = counts;
-    let unverified = same_asserted + delib_asserted + behind_asserted;
+    let unverified = same_asserted + delib_asserted + spec_backed_asserted + behind_asserted;
 
     format!(
         r#"# Does deacon behave like the DevContainers CLI?
@@ -514,25 +589,53 @@ Compared against **`@devcontainers/cli` {oracle}** and the [containers.dev spec]
 (https://github.com/devcontainers/spec) at commit `{spec}`.
 
 **Of {comparable} behaviors that both tools implement, {same} are verified to match.**
-{deliberate} are verified to differ deliberately, and {behind} to differ in ways we intend
-to remove. A further {deacon_only} are deacon-only, with nothing to compare against.
+{deliberate} are verified to differ deliberately, and {spec_backed} differ because deacon
+follows the spec where the CLI does not — those are the CLI's deviation, not work we owe.
+{behind} are differences where deacon is the nonconformant side. A further {deacon_only}
+are deacon-only, with nothing to compare against.
 
 **{unverified} more have never been compared against the CLI at all** — {same_asserted} assumed
-to match, {delib_asserted} assumed to differ on purpose, {behind_asserted} assumed to be behind.
-These are claims, not measurements: nothing has run the reference for them, so each could turn
-out to be any of the three. They are listed separately rather than folded into the totals above,
-because a claim nobody has checked is not evidence of parity — and a page that counted it as such
-would improve every time someone asserted something new.
+to match, {delib_asserted} assumed to differ on purpose, {spec_backed_asserted} assumed to be the
+CLI deviating from the spec, {behind_asserted} assumed to be deacon's fault. These are claims, not
+measurements: nothing has run the reference for them, so each could turn out to be any of the
+four. They are listed separately rather than folded into the totals above, because a claim nobody
+has checked is not evidence of parity — and a page that counted it as such would improve every
+time someone asserted something new.
 
 ## How to read this
 
-| | Meaning |
+Two columns carry the two things deacon is measured against, one axis each — **spec** is
+the containers.dev specification, **CLI** is the reference implementation:
+
+| | **spec** / **CLI** column |
 |---|---|
-| ✅ | Same as the CLI, and checked against it in this scenario |
-| ◐ | Believed the same, but only deacon-side evidence here — **never compared** |
+| ✔ | deacon matches it |
+| ✘ | it and deacon differ |
+| ? | unsettled — the spec is silent, or nothing has compared us to the CLI |
+| *(blank)* | no equivalent exists to compare against |
+
+Read them together: `✔ ✘` is a difference where **the spec is on deacon's side and the
+CLI is the one deviating** — it is not work we owe. `✘ ✘` would be deacon being wrong; no
+behavior currently carries it. `? ✘` is a difference the spec does not settle either way,
+which is where a deliberate decision — and only there, a waiver — belongs.
+
+The leading glyph is what we **decided**, and the grid cells are how strongly it has been
+**checked**. They are kept apart on purpose: a decision repeated across every scenario
+column reads as breadth of testing when it is breadth of assertion.
+
+| | Leading glyph — our decision |
+|---|---|
+| ✅ | Follow the spec / match the CLI, and something has compared us |
+| ◐ | The same intent, but only deacon-side evidence — **never compared** |
 | ⚠️ | Differs on purpose |
-| ❌ | Differs, and we intend to fix it |
+| ❌ | deacon is the nonconformant side, and we intend to fix it |
 | 🔵 | deacon-only; the CLI has no equivalent |
+| · | **Not checked yet** — a real gap |
+
+| | Grid cell — evidence in that scenario |
+|---|---|
+| ✅ | Checked against the CLI here |
+| ◐ | Exercised here, but only deacon-side evidence |
 | · | **Not checked yet** — a real gap |
 | *(blank)* | Does not arise in this scenario |
 
@@ -682,6 +785,52 @@ mod tests {
             page.contains("**Of 1 behaviors that both tools implement, 1 are verified to match.**"),
             "running the reference is what must move the count:\n{page}"
         );
+    }
+
+    /// R5 permits `follow-spec` only on `spec: conformant`, so "the two tools differ"
+    /// never by itself means deacon is wrong. Collapsing both axes into one glyph
+    /// reported the CLI's deviation from the spec as deacon's defect — for every ❌ the
+    /// page had ever rendered.
+    #[test]
+    fn a_difference_where_the_spec_backs_deacon_is_not_reported_as_deacons_fault() {
+        let mut b = behavior();
+        b.reference = ReferenceStatus::Divergent; // deacon and the CLI differ …
+        b.spec = SpecStatus::Conformant; // … and the spec is on deacon's side.
+        let reg = Registry {
+            behaviors: vec![b],
+            cases: vec![case_with(serde_json::json!({"contains": "x"}))],
+            ..Registry::default()
+        };
+        let page = render(&reg);
+        assert!(
+            page.contains("0 are differences where deacon is the nonconformant side"),
+            "the spec backs deacon here; nothing is owed:\n{page}"
+        );
+        assert!(
+            page.contains("1 differ because deacon\nfollows the spec where the CLI does not"),
+            "the difference must be attributed to the CLI:\n{page}"
+        );
+        let rows = rows_of(&page);
+        assert!(!rows.contains('❌'), "no row is deacon's fault:\n{rows}");
+        assert!(
+            rows.contains("✔") && rows.contains("✘"),
+            "both axes must be shown unfolded, one column each:\n{rows}"
+        );
+
+        // Flip only the spec axis: now deacon IS the nonconformant side.
+        let mut b = behavior();
+        b.reference = ReferenceStatus::Divergent;
+        b.spec = SpecStatus::Nonconformant;
+        let reg = Registry {
+            behaviors: vec![b],
+            ..reg
+        };
+        let page = render(&reg);
+        assert!(
+            page.contains("1 are differences where deacon is the nonconformant side"),
+            "a nonconformant spec axis is the one thing that makes it ours:\n{page}"
+        );
+        assert!(rows_of(&page).contains('❌'), "{page}");
     }
 
     /// A waiver no case tolerates is enforced by nothing, and must not read as though it

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -7,25 +7,53 @@ Compared against **`@devcontainers/cli` 0.87.0** and the [containers.dev spec]\
 (https://github.com/devcontainers/spec) at commit `113500f4`.
 
 **Of 57 behaviors that both tools implement, 29 are verified to match.**
-10 are verified to differ deliberately, and 4 to differ in ways we intend
-to remove. A further 16 are deacon-only, with nothing to compare against.
+10 are verified to differ deliberately, and 4 differ because deacon
+follows the spec where the CLI does not — those are the CLI's deviation, not work we owe.
+0 are differences where deacon is the nonconformant side. A further 16
+are deacon-only, with nothing to compare against.
 
 **14 more have never been compared against the CLI at all** — 7 assumed
-to match, 5 assumed to differ on purpose, 2 assumed to be behind.
-These are claims, not measurements: nothing has run the reference for them, so each could turn
-out to be any of the three. They are listed separately rather than folded into the totals above,
-because a claim nobody has checked is not evidence of parity — and a page that counted it as such
-would improve every time someone asserted something new.
+to match, 5 assumed to differ on purpose, 2 assumed to be the
+CLI deviating from the spec, 0 assumed to be deacon's fault. These are claims, not
+measurements: nothing has run the reference for them, so each could turn out to be any of the
+four. They are listed separately rather than folded into the totals above, because a claim nobody
+has checked is not evidence of parity — and a page that counted it as such would improve every
+time someone asserted something new.
 
 ## How to read this
 
-| | Meaning |
+Two columns carry the two things deacon is measured against, one axis each — **spec** is
+the containers.dev specification, **CLI** is the reference implementation:
+
+| | **spec** / **CLI** column |
 |---|---|
-| ✅ | Same as the CLI, and checked against it in this scenario |
-| ◐ | Believed the same, but only deacon-side evidence here — **never compared** |
+| ✔ | deacon matches it |
+| ✘ | it and deacon differ |
+| ? | unsettled — the spec is silent, or nothing has compared us to the CLI |
+| *(blank)* | no equivalent exists to compare against |
+
+Read them together: `✔ ✘` is a difference where **the spec is on deacon's side and the
+CLI is the one deviating** — it is not work we owe. `✘ ✘` would be deacon being wrong; no
+behavior currently carries it. `? ✘` is a difference the spec does not settle either way,
+which is where a deliberate decision — and only there, a waiver — belongs.
+
+The leading glyph is what we **decided**, and the grid cells are how strongly it has been
+**checked**. They are kept apart on purpose: a decision repeated across every scenario
+column reads as breadth of testing when it is breadth of assertion.
+
+| | Leading glyph — our decision |
+|---|---|
+| ✅ | Follow the spec / match the CLI, and something has compared us |
+| ◐ | The same intent, but only deacon-side evidence — **never compared** |
 | ⚠️ | Differs on purpose |
-| ❌ | Differs, and we intend to fix it |
+| ❌ | deacon is the nonconformant side, and we intend to fix it |
 | 🔵 | deacon-only; the CLI has no equivalent |
+| · | **Not checked yet** — a real gap |
+
+| | Grid cell — evidence in that scenario |
+|---|---|
+| ✅ | Checked against the CLI here |
+| ◐ | Exercised here, but only deacon-side evidence |
 | · | **Not checked yet** — a real gap |
 | *(blank)* | Does not arise in this scenario |
 
@@ -62,13 +90,13 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>✅</td><td>A Dockerfile instruction that exits non-zero fails the build, and the failure is…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>`build` reports and tags the FEATURE-EXTENDED image, so a user-supplied `--image-name`…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>build produces a container image and reports the build outcome, matching the reference</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A Dockerfile instruction that exits non-zero fails the build, and the failure is…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`build` reports and tags the FEATURE-EXTENDED image, so a user-supplied `--image-name`…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>build produces a container image and reports the build outcome, matching the reference</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 
@@ -76,10 +104,10 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+<tr><th></th><th>Behavior</th><th>spec</th><th>CLI</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`doctor` reports host, platform, and runtime diagnostics in both a human rendering and…</td><td>🔵</td><td>🔵</td><td>🔵</td><td></td></tr>
+<tr><td>🔵</td><td>`doctor` reports host, platform, and runtime diagnostics in both a human rendering and…</td><td>?</td><td></td><td>◐</td><td>◐</td><td>◐</td><td></td></tr>
 </tbody>
 </table>
 
@@ -87,12 +115,12 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+<tr><th></th><th>Behavior</th><th>spec</th><th>CLI</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`down --remove` on a Compose configuration removes the project it created, identifying…</td><td></td><td></td><td>🔵</td><td></td></tr>
-<tr><td>🔵</td><td>`down` over a workspace folder that has no devcontainer configuration reports that…</td><td>🔵</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>🔵</td><td>`down --remove` stops and removes the workspace's container, so a subsequent command…</td><td>🔵</td><td>🔵</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>`down --remove` on a Compose configuration removes the project it created, identifying…</td><td>?</td><td></td><td></td><td></td><td>◐</td><td></td></tr>
+<tr><td>🔵</td><td>`down` over a workspace folder that has no devcontainer configuration reports that…</td><td>?</td><td></td><td>◐</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>`down --remove` stops and removes the workspace's container, so a subsequent command…</td><td>?</td><td></td><td>◐</td><td>◐</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 
@@ -100,39 +128,39 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="2">img</th><th colspan="2">dkr</th><th colspan="2">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="2">img</th><th colspan="2">dkr</th><th colspan="2">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>–</th><th>1</th><th>–</th><th>1</th></tr>
 </thead>
 <tbody>
-<tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td></td></tr>
-<tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
-<tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
-<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td><strong>no waiver</strong> #370</td></tr>
+<tr><td>✅</td><td>exec runs a command inside the target container and streams its stdout/stderr and…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>exec --container-id (no --workspace-folder/--config) recovers remoteUser and remoteEnv…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#322</td></tr>
+<tr><td>·</td><td>`exec` runs the command with the environment the user-env probe captured, with the…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#370</td></tr>
+<tr><td>⚠️</td><td>The relative order of a restored image `PATH` entry against one a Feature contributed…</td><td>?</td><td>✘</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td><strong>no waiver</strong> #370</td></tr>
 </tbody>
 </table>
 
 ### host ca
 
-| | Behavior | Notes |
-|---|---|---|
-| 🔵 | deacon can inject the host's CA certificates into the TLS trust store used for OCI… |  |
+| | Behavior | spec | CLI | Notes |
+|---|---|---|---|---|
+| 🔵 | deacon can inject the host's CA certificates into the TLS trust store used for OCI… | ? |  |  |
 
 ### observable state
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-compose-project-file-set</code></td></tr>
-<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong> #265</td></tr>
-<tr><td>🔵</td><td>deacon stamps five identity/bookkeeping labels onto a created container that the…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong></td></tr>
-<tr><td>✅</td><td>The `devcontainer.metadata` label records the image metadata the configuration and…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373</td></tr>
-<tr><td>⚠️</td><td>The BYTE FORM of the `devcontainer.metadata` label value — JSON whitespace and object…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-container-metadata-label-serialization</code> #373 #394</td></tr>
-<tr><td>◐</td><td>The observable container state after up (running status, labels, mounts, environment)…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>The normalized observable-state diff between deacon and the reference is empty for the…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>The set of Compose files a CLI composes with, and the Compose labels derived from that…</td><td>?</td><td>✘</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-compose-project-file-set</code></td></tr>
+<tr><td>⚠️</td><td>deacon derives a valid, deacon-namespaced compose project name…</td><td>?</td><td>✘</td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong> #265</td></tr>
+<tr><td>🔵</td><td>deacon stamps five identity/bookkeeping labels onto a created container that the…</td><td>?</td><td></td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>Both CLIs override the container command with a shell keep-alive that holds the…</td><td>?</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td><strong>no waiver</strong></td></tr>
+<tr><td>✅</td><td>The `devcontainer.metadata` label records the image metadata the configuration and…</td><td>✔</td><td>✔</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#373</td></tr>
+<tr><td>⚠️</td><td>The BYTE FORM of the `devcontainer.metadata` label value — JSON whitespace and object…</td><td>?</td><td>✘</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-container-metadata-label-serialization</code> #373 #394</td></tr>
+<tr><td>◐</td><td>The observable container state after up (running status, labels, mounts, environment)…</td><td>✔</td><td>✔</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>The normalized observable-state diff between deacon and the reference is empty for the…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 
@@ -140,64 +168,64 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="4">img</th><th colspan="4">dkr</th><th colspan="4">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="4">img</th><th colspan="4">dkr</th><th colspan="4">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>❌</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td>❌</td><td>·</td><td>·</td><td>❌</td><td><code>wvr-outdated-extends-chain-features</code> <strong>(unchecked)</strong> #389</td></tr>
-<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-outdated-malformed-lockfile-rejected</code> <strong>(unchecked)</strong> #406 #407</td></tr>
-<tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
-<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>#407</td></tr>
+<tr><td>◐</td><td>`outdated` resolves the full extends chain before reporting versions, so a Feature…</td><td>✔</td><td>✘</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>◐</td><td><code>wvr-outdated-extends-chain-features</code> <strong>(unchecked)</strong> #389</td></tr>
+<tr><td>⚠️</td><td>`outdated` fails with a non-zero exit and a diagnostic naming the file when a…</td><td>?</td><td>✘</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-outdated-malformed-lockfile-rejected</code> <strong>(unchecked)</strong> #406 #407</td></tr>
+<tr><td>◐</td><td>`outdated` keys each report entry by the Feature reference the configuration DECLARED,…</td><td>?</td><td>✔</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#407 #411</td></tr>
+<tr><td>✅</td><td>`outdated` reports each configured Feature's current, wanted, and latest version, and…</td><td>✔</td><td>✔</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>◐</td><td>✅</td><td>·</td><td>◐</td><td>✅</td><td>◐</td><td>◐</td><td>◐</td><td>#407</td></tr>
 </tbody>
 </table>
 
 ### ports
 
-| | Behavior | Notes |
-|---|---|---|
-| 🔵 | deacon can auto-forward container ports to the host via a host-side daemon backed by a… |  |
+| | Behavior | spec | CLI | Notes |
+|---|---|---|---|---|
+| 🔵 | deacon can auto-forward container ports to the host via a host-side daemon backed by a… | ? |  |  |
 
 ### profiles
 
-| | Behavior | Notes |
-|---|---|---|
-| 🔵 | deacon applies a user-defined profile from settings.json (selected via the global… |  |
+| | Behavior | spec | CLI | Notes |
+|---|---|---|---|---|
+| 🔵 | deacon applies a user-defined profile from settings.json (selected via the global… |  |  |  |
 
 ### read configuration
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>When a link of an `extends` chain declares a Feature its base already declared at a…</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
-<tr><td>⚠️</td><td>A single configuration document whose `features` map contains two keys resolving to…</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-features-duplicate-in-one-document</code> <strong>(unchecked)</strong> #411</td></tr>
-<tr><td>⚠️</td><td>deacon's resolved-configuration output omits a property the author wrote as `null`,…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-authored-empty-omitted</code> #398</td></tr>
-<tr><td>·</td><td>An explicit --config pointing at a file that does not exist is rejected (no silent…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>Reading a well-formed devcontainer.json exits 0 and emits the resolved configuration…</td><td>✅</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`,…</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
-<tr><td>❌</td><td>Configuration discovery searches exactly the three locations the spec names —…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-discovery-named-subfolder</code></td></tr>
-<tr><td>✅</td><td>A JSON object with a duplicate top-level key is accepted with last-wins semantics,…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>🔵</td><td>A cyclic extends chain (a -&gt; b -&gt; a) is detected and rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
-<tr><td>🔵</td><td>read-configuration --include-merged-configuration resolves the full extends chain…</td><td>🔵</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>#297</td></tr>
-<tr><td>🔵</td><td>An extends chain pointing at a nonexistent target file is rejected during…</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
-<tr><td>❌</td><td>`--include-features-configuration` reports the resolved Feature set in install order,…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>`featuresConfiguration` is reported only when Feature resolution produced at least one…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#387</td></tr>
-<tr><td>⚠️</td><td>A devcontainer.json with a hard JSONC syntax error is rejected at parse rather than…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-malformed-json</code></td></tr>
-<tr><td>·</td><td>deacon's `mergedConfiguration` omits the computed-empty properties the reference…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-merged-computed-empties</code> <strong>(unchecked)</strong> #398</td></tr>
-<tr><td>❌</td><td>read-configuration --include-merged-configuration over the tier1 corpus emits a merged…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
-<tr><td>✅</td><td>`mergedConfiguration` reports all five plural lifecycle hook arrays…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>·</td><td>A workspace folder with no devcontainer configuration at all is rejected rather than…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>A `portsAttributes` / `otherPortsAttributes` entry reports the keys the author wrote…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>◐</td><td>Variable substitution reaches the object-shaped fields that carry user templates —…</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#312</td></tr>
-<tr><td>❌</td><td>Reading real-world devcontainer.json configurations from the tier1 corpus produces…</td><td>❌</td><td>❌</td><td>❌</td><td>❌</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>❌</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
-<tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unsupported-enum-values</code></td></tr>
-<tr><td>✅</td><td>The reported `workspace.workspaceFolder` is the automatic source-code mount location…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#273 #383</td></tr>
-<tr><td>✅</td><td>The `workspace` section carries exactly `workspaceFolder` and the optional…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
-<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-features</code></td></tr>
-<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-forwardports</code></td></tr>
+<tr><td>🔵</td><td>When a link of an `extends` chain declares a Feature its base already declared at a…</td><td>?</td><td></td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#411</td></tr>
+<tr><td>⚠️</td><td>A single configuration document whose `features` map contains two keys resolving to…</td><td>?</td><td>✘</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-features-duplicate-in-one-document</code> <strong>(unchecked)</strong> #411</td></tr>
+<tr><td>⚠️</td><td>deacon's resolved-configuration output omits a property the author wrote as `null`,…</td><td>?</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-authored-empty-omitted</code> #398</td></tr>
+<tr><td>·</td><td>An explicit --config pointing at a file that does not exist is rejected (no silent…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Reading a well-formed devcontainer.json exits 0 and emits the resolved configuration…</td><td>✔</td><td>✔</td><td>✅</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Both the `configuration` and `mergedConfiguration` documents carry `configFilePath`,…</td><td>?</td><td>✔</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
+<tr><td>✅</td><td>Configuration discovery searches exactly the three locations the spec names —…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-discovery-named-subfolder</code></td></tr>
+<tr><td>✅</td><td>A JSON object with a duplicate top-level key is accepted with last-wins semantics,…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>A cyclic extends chain (a -&gt; b -&gt; a) is detected and rejected during…</td><td>?</td><td>✘</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>🔵</td><td>read-configuration --include-merged-configuration resolves the full extends chain…</td><td>?</td><td>✘</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>◐</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>🔵</td><td>An extends chain pointing at a nonexistent target file is rejected during…</td><td>?</td><td>✘</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#297</td></tr>
+<tr><td>◐</td><td>`--include-features-configuration` reports the resolved Feature set in install order,…</td><td>✔</td><td>✘</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`featuresConfiguration` is reported only when Feature resolution produced at least one…</td><td>?</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#387</td></tr>
+<tr><td>⚠️</td><td>A devcontainer.json with a hard JSONC syntax error is rejected at parse rather than…</td><td>?</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-malformed-json</code></td></tr>
+<tr><td>·</td><td>deacon's `mergedConfiguration` omits the computed-empty properties the reference…</td><td>?</td><td>✘</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-readconfig-merged-computed-empties</code> <strong>(unchecked)</strong> #398</td></tr>
+<tr><td>✅</td><td>read-configuration --include-merged-configuration over the tier1 corpus emits a merged…</td><td>✔</td><td>✘</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
+<tr><td>✅</td><td>`mergedConfiguration` reports all five plural lifecycle hook arrays…</td><td>?</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>·</td><td>A workspace folder with no devcontainer configuration at all is rejected rather than…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A `portsAttributes` / `otherPortsAttributes` entry reports the keys the author wrote…</td><td>?</td><td>✔</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>Variable substitution reaches the object-shaped fields that carry user templates —…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#312</td></tr>
+<tr><td>✅</td><td>Reading real-world devcontainer.json configurations from the tier1 corpus produces…</td><td>✔</td><td>✘</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
+<tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unsupported-enum-values</code></td></tr>
+<tr><td>✅</td><td>The reported `workspace.workspaceFolder` is the automatic source-code mount location…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#273 #383</td></tr>
+<tr><td>✅</td><td>The `workspace` section carries exactly `workspaceFolder` and the optional…</td><td>?</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
+<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-features</code></td></tr>
+<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-forwardports</code></td></tr>
 </tbody>
 </table>
 
@@ -205,58 +233,58 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>❌</td><td>A lifecycle hook that exits non-zero fails the run rather than being reported as a…</td><td>❌</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-ruc-completed-hooks-not-rerun</code></td></tr>
-<tr><td>✅</td><td>Lifecycle hooks run in spec order — onCreate, updateContent, postCreate, postStart —…</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A lifecycle hook that exits non-zero fails the run rather than being reported as a…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-ruc-completed-hooks-not-rerun</code></td></tr>
+<tr><td>✅</td><td>Lifecycle hooks run in spec order — onCreate, updateContent, postCreate, postStart —…</td><td>✔</td><td>✔</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 
 ### secrets
 
-| | Behavior | Notes |
-|---|---|---|
-| 🔵 | The --secrets-file flag auto-detects and accepts both a flat JSON object and a… |  |
+| | Behavior | spec | CLI | Notes |
+|---|---|---|---|---|
+| 🔵 | The --secrets-file flag auto-detects and accepts both a flat JSON object and a… | ? |  |  |
 
 ### templates apply
 
 <table>
 <thead>
-<tr><th></th><th>Behavior</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
+<tr><th></th><th>Behavior</th><th>spec</th><th>CLI</th><th>img</th><th>dkr</th><th>cmp</th><th>Notes</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`templates apply` scaffolds the template's files into the target directory with…</td><td>🔵</td><td>🔵</td><td>🔵</td><td></td></tr>
+<tr><td>🔵</td><td>`templates apply` scaffolds the template's files into the target directory with…</td><td>✔</td><td></td><td>◐</td><td>◐</td><td>◐</td><td></td></tr>
 </tbody>
 </table>
 
 ### trust
 
-| | Behavior | Notes |
-|---|---|---|
-| 🔵 | Host-side lifecycle hooks (initializeCommand and other workspace-resident host hooks)… |  |
+| | Behavior | spec | CLI | Notes |
+|---|---|---|---|---|
+| 🔵 | Host-side lifecycle hooks (initializeCommand and other workspace-resident host hooks)… | ? |  |  |
 
 ### up
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="5">img</th><th colspan="5">dkr</th><th colspan="5">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th><th>–</th><th>1</th><th>many</th><th>deps</th><th>lock</th></tr>
 </thead>
 <tbody>
-<tr><td>⚠️</td><td>Re-entering a workspace whose configuration has CHANGED since its container was…</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-up-changed-config-recreates</code> <strong>(unchecked)</strong></td></tr>
-<tr><td>◐</td><td>A `containerEnv` variable declared by BOTH the configuration and a Feature takes the…</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>#374</td></tr>
-<tr><td>◐</td><td>`up` applies the declared container user so the container process runs as that user…</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>up creates a container from the resolved configuration such that a subsequent exec…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>Entrypoints contributed by multiple Features are chained and all run, in the resolved…</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>A Feature that cannot be installed — its install script exiting non-zero, or a…</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>`up` installs the configuration's Features into the container it creates, in the…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>◐</td><td>A lifecycle hook runs with its working directory set to the container workspace…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>A lifecycle hook declared in the array (argv) form and one declared in the object…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>Each declared mount is applied with both its declared source and its declared shape —…</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>✅</td><td>A PATH segment contributed by a Feature's `containerEnv` is prepended to the image…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>◐</td><td>Re-entering a workspace whose container already exists, with the SAME configuration,…</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>⚠️</td><td>Re-entering a workspace whose configuration has CHANGED since its container was…</td><td>?</td><td>✘</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-up-changed-config-recreates</code> <strong>(unchecked)</strong></td></tr>
+<tr><td>✅</td><td>A `containerEnv` variable declared by BOTH the configuration and a Feature takes the…</td><td>✔</td><td>✔</td><td>◐</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>#374</td></tr>
+<tr><td>◐</td><td>`up` applies the declared container user so the container process runs as that user…</td><td>✔</td><td>✔</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>up creates a container from the resolved configuration such that a subsequent exec…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Entrypoints contributed by multiple Features are chained and all run, in the resolved…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A Feature that cannot be installed — its install script exiting non-zero, or a…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>`up` installs the configuration's Features into the container it creates, in the…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>A lifecycle hook runs with its working directory set to the container workspace…</td><td>✔</td><td>✔</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A lifecycle hook declared in the array (argv) form and one declared in the object…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>Each declared mount is applied with both its declared source and its declared shape —…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>✅</td><td>A PATH segment contributed by a Feature's `containerEnv` is prepended to the image…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>◐</td><td>Re-entering a workspace whose container already exists, with the SAME configuration,…</td><td>✔</td><td>✔</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 
@@ -264,13 +292,13 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 
 <table>
 <thead>
-<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th colspan="3">img</th><th colspan="3">dkr</th><th colspan="3">cmp</th><th rowspan="2">Notes</th></tr>
+<tr><th rowspan="2"></th><th rowspan="2">Behavior</th><th rowspan="2">spec</th><th rowspan="2">CLI</th><th colspan="3">img</th><th colspan="3">dkr</th><th colspan="3">cmp</th><th rowspan="2">Notes</th></tr>
 <tr><th>–</th><th>1</th><th>many</th><th>–</th><th>1</th><th>many</th><th>–</th><th>1</th><th>many</th></tr>
 </thead>
 <tbody>
-<tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>·</td><td>🔵</td><td>·</td><td>🔵</td><td>·</td><td>·</td><td>·</td><td>·</td><td>🔵</td><td>#409</td></tr>
-<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>⚠️</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>⚠️</td><td>·</td><td>·</td><td><code>wvr-upgrade-empty-feature-set</code></td></tr>
-<tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
+<tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>?</td><td></td><td>·</td><td>◐</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>#409</td></tr>
+<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td><code>wvr-upgrade-empty-feature-set</code></td></tr>
+<tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
> Stacked on #425. **Retarget to `main` before merging #425 with `--delete-branch`** — GitHub closes rather than retargets the child.

You asked whether the reference should be a column. Yes — and building it surfaced why the page needed it.

## The defect

`❌` is legended *"differs, and we intend to fix it."* Six behaviors render it. **Every one is `spec: conformant` + `follow-spec`** — deacon matches the specification and the **reference** is the side deviating from it.

Not a near-miss: R5 permits `follow-spec` only on `spec: conformant`, and R6 permits `align-with-reference` only on `reference: aligned`. For any divergent behavior the rules make `❌`'s stated meaning **structurally unreachable**. The one axis value that would put deacon in the wrong — `spec: nonconformant` — is carried by no behavior at all.

The page has been reporting the reference's deviations as deacon's defects for its whole existence, four of them in the headline.

## The fix: unfold the axes rather than pick a better fold

| | **spec** / **CLI** column |
|---|---|
| ✔ | deacon matches it |
| ✘ | it and deacon differ |
| ? | unsettled |
| *(blank)* | no equivalent exists |

`✔ ✘` now reads directly as *"the spec is on deacon's side and the CLI is deviating."* `✘ ✘` would be deacon being wrong. `? ✘` is where the spec is silent — the only place a deliberate decision, and only there a waiver, belongs.

- the **leading glyph** carries the decision + whether anything checked it;
- **grid cells** carry evidence strength only. They used to repeat the row's disposition, so a deliberate difference painted ⚠️ across every scenario it was covered in — breadth of *assertion* reading as breadth of *testing*.

On your point about redundancy: yes, some combinations are now true by construction (a behavior sourced from observing the CLI can hardly show `CLI ?`). That is the right trade — a redundant true cell costs a reader nothing; a collapsed one costs them the distinction between our defect and theirs.

## Headline

Before: *"10 differ deliberately, and 4 differ in ways we intend to remove."*
After: *"10 differ deliberately, and **4 differ because deacon follows the spec where the CLI does not** — those are the CLI's deviation, not work we owe. **0** are differences where deacon is the nonconformant side."*

## Verification

`a_difference_where_the_spec_backs_deacon_is_not_reported_as_deacons_fault` pins both directions and was verified to fail against the old collapse. `make test-nextest-fast` 4194/4194; fmt + `clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018w19xeFFqaocSDxQ1y2tQD