### PR TITLE
fix(devcontainer): point CLAUDE_CONFIG_DIR at the mounted ~/.claude

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,16 @@
   "remoteEnv": {
     "GH_PAGER": ""
   },
+  "containerEnv": {
+      // Put Claude Code's config INSIDE the mounted ~/.claude directory.
+      // By default the config lives at ~/.claude.json, OUTSIDE that mount, so
+      // every container starts unauthenticated even though .credentials.json is
+      // shared. Bind-mounting the file directly does not work: a file bind pins
+      // to the inode, so the first atomic rewrite orphans the container's view
+      // and silently discards writes. Relocating into the directory mount avoids
+      // that entirely and shares auth across every devcontainer on the host.
+      "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+  },
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
Mounting ~/.claude alone was not enough to share authentication. Claude Code
keeps its account/session state in ~/.claude.json, which sits OUTSIDE that
directory, so a container with the mount still had .credentials.json but a fresh
.claude.json -- and treated itself as a first run, re-prompting for login.

Bind-mounting the file directly does not work: a file bind mount pins to the
inode, so the first atomic rewrite (write-temp-then-rename) leaves the container
holding an orphaned inode and silently discards writes back to the host.

CLAUDE_CONFIG_DIR relocates the whole config, .claude.json included, into the
given directory. Pointing it at the already-mounted ~/.claude puts everything
inside a DIRECTORY mount, which has no such problem, and shares auth across
every devcontainer on the host.

Verified: a container with no prior login authenticated from the shared config
with no prompt.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>