### PR TITLE
fix(conformance): stop filing the CLI's schema deviation as deacon's deliberate choice

### DIFF
--- a/conformance/registry/behaviors/read-configuration.json
+++ b/conformance/registry/behaviors/read-configuration.json
@@ -227,8 +227,8 @@
       "applicability": [],
       "spec": "conformant",
       "reference": "divergent",
-      "decision": "intentional-divergence",
-      "notes": "Same family as the wrong-type rejections: the reference's read-configuration is a lenient parse-and-echo that accepts and prints the value back, while deacon validates modelled fields eagerly (constitution IV). Characterized, not repaired — backed by wvr-unsupported-enum-values and a direction-pinning spec-expectation twin."
+      "decision": "follow-spec",
+      "notes": "The pinned schema declares the enum closed, so a value outside it is not a valid configuration and deacon rejects it (constitution IV). The reference's read-configuration is a lenient parse-and-echo that accepts the value and prints it back — the divergence is the reference departing from the schema, not deacon choosing to differ from the reference. wvr-unsupported-enum-values remains, because it is what keeps the live-differential case from failing on a difference we expect to keep seeing; it records the reference's leniency, not a deacon deviation. A direction-pinning spec-expectation twin fixes which side is which."
     },
     {
       "id": "bhv-readconfig-workspace-folder-subpath",
@@ -257,8 +257,8 @@
       "applicability": [],
       "spec": "conformant",
       "reference": "divergent",
-      "decision": "intentional-divergence",
-      "notes": "Deliberate consistency fix: modeled object-shaped fields enforce their spec shape and fail fast on a clear mistake, matching the typed strictness forwardPorts already had. Backed by case-errors-wrong-type-features and wvr-wrong-type-features."
+      "decision": "follow-spec",
+      "notes": "The schema declares `features` an object; a bare string is not a valid configuration, and deacon enforces the declared shape (constitution IV) as it already did for the typed `forwardPorts`. The reference keeps the raw JSON and accepts, so the divergence is the reference not enforcing its own schema — not deacon choosing to differ. Backed by case-errors-wrong-type-features; wvr-wrong-type-features remains as the tolerance that keeps the live-differential case from failing on the reference's leniency."
     },
     {
       "id": "bhv-readconfig-wrong-type-forwardports-rejected",
@@ -267,8 +267,8 @@
       "applicability": [],
       "spec": "conformant",
       "reference": "divergent",
-      "decision": "intentional-divergence",
-      "notes": "Typed (deacon) vs untyped (reference) read-configuration. Backed by case-errors-wrong-type-forwardports and wvr-wrong-type-forwardports."
+      "decision": "follow-spec",
+      "notes": "The schema declares `forwardPorts` an array; a bare string is not a valid configuration, and deacon's typed deserialization rejects it. The reference keeps the raw JSON and accepts, so the divergence is the reference not enforcing its own schema — not deacon choosing to differ. Backed by case-errors-wrong-type-forwardports; wvr-wrong-type-forwardports remains as the tolerance that keeps the live-differential case from failing on the reference's leniency."
     }
   ]
 }

--- a/conformance/registry/behaviors/upgrade.json
+++ b/conformance/registry/behaviors/upgrade.json
@@ -18,8 +18,8 @@
       "applicability": [],
       "spec": "conformant",
       "reference": "divergent",
-      "decision": "intentional-divergence",
-      "notes": "The pinned reference treats the empty Feature set as an error (`Failed to update lockfile`, exit 1); deacon emits `{\"features\":{}}` and succeeds (observed 2026-07-26, src-obs-upgrade-empty-feature-set). Characterized rather than followed: an operation that cannot express 'nothing to pin' is unusable as an idempotent step in a script that does not know in advance whether the configuration has Features. Backed by wvr-upgrade-empty-feature-set."
+      "decision": "follow-spec",
+      "notes": "devcontainer-lockfile.md defines the lockfile as \"a JSON object with a `features` property\" and nowhere makes an empty Feature set an error, so `{\"features\":{}}` is the document the spec describes for a configuration that declares none. deacon emits it and exits 0; the pinned reference fails with `Failed to update lockfile`, exit 1 (observed 2026-07-26, src-obs-upgrade-empty-feature-set). The direction is inverted from the read-configuration family — here the reference is the STRICTER side — but the shape is the same: deacon does what the spec describes and the reference departs from it. It is also the behavior that composes, since an operation that cannot express 'nothing to pin' is unusable as an idempotent step in a script that does not know in advance whether the configuration has Features; that is corroboration, not the ground. Backed by src-spec-lockfile and wvr-upgrade-empty-feature-set."
     },
     {
       "id": "bhv-upgrade-regenerates-lockfile",

--- a/conformance/registry/waivers/wvr-unsupported-enum-values.json
+++ b/conformance/registry/waivers/wvr-unsupported-enum-values.json
@@ -11,7 +11,7 @@
   "expect": {
     "kind": "deacon-stricter"
   },
-  "rationale": "deacon validates modelled fields against the pinned schema's closed enums during configuration resolution; the reference's read-configuration is a lenient parse-and-echo that accepts and prints the value back. Same family, and the same deliberate choice, as the wrong-type rejections: constitution IV requires failing fast on a developer's mistake in a modelled field.",
+  "rationale": "deacon validates modelled fields against the pinned schema's closed enums during configuration resolution; the reference's read-configuration is a lenient parse-and-echo that accepts and prints the value back. This tolerance absorbs the REFERENCE's departure from the schema — bhv-readconfig-unsupported-enum-rejected is `follow-spec`, so nothing here waives a deacon deviation. It exists because the live-differential case would otherwise fail on a difference we expect to keep seeing, and it self-invalidates the day the reference starts validating.",
   "added": "2026-07-26",
   "expires": "2027-07-26"
 }

--- a/conformance/registry/waivers/wvr-upgrade-empty-feature-set.json
+++ b/conformance/registry/waivers/wvr-upgrade-empty-feature-set.json
@@ -11,7 +11,7 @@
   "expect": {
     "kind": "reference-stricter"
   },
-  "rationale": "Asked to regenerate a lockfile for a configuration that declares no Features, the reference fails with `Failed to update lockfile` while deacon emits an empty lockfile and exits 0. deacon's behavior is the one that composes: a lockfile step in a script that does not know in advance whether the configuration has Features must not fail on the empty case. Characterized rather than followed.",
+  "rationale": "Asked to regenerate a lockfile for a configuration that declares no Features, the reference fails with `Failed to update lockfile` while deacon emits an empty lockfile and exits 0. devcontainer-lockfile.md describes the lockfile document and nowhere makes an empty Feature set an error, so this tolerance absorbs the REFERENCE's departure from it — bhv-upgrade-empty-feature-set is `follow-spec`, so nothing here waives a deacon deviation. Unlike its read-configuration siblings the reference is the stricter side, but the direction of the deviation is the same. It exists because the live-differential case would otherwise fail on a difference we expect to keep seeing.",
   "added": "2026-07-26",
   "expires": "2027-07-26"
 }

--- a/conformance/registry/waivers/wvr-wrong-type-features.json
+++ b/conformance/registry/waivers/wvr-wrong-type-features.json
@@ -3,7 +3,7 @@
   "behaviors": ["bhv-readconfig-wrong-type-features-rejected"],
   "scope": { "kind": "corpus_case", "corpus": "errors", "case": "wrong-type-features" },
   "expect": { "kind": "deacon-stricter" },
-  "rationale": "features is a bare string instead of a map. deacon now rejects this (type-strict, matching forwardPorts) instead of passing it through untyped. This is the deliberate consistency fix: modeled fields enforce their spec shape and fail fast on a clear mistake. The reference keeps the raw JSON and accepts.",
+  "rationale": "features is a bare string instead of the object the schema declares. deacon rejects it (type-strict, matching forwardPorts); the reference keeps the raw JSON and accepts. This tolerance absorbs the REFERENCE's departure from the schema — bhv-readconfig-wrong-type-features-rejected is `follow-spec`, so nothing here waives a deacon deviation. It exists because the live-differential case would otherwise fail on a difference we expect to keep seeing, and it self-invalidates the day the reference starts enforcing the shape.",
   "added": "2026-07-19",
   "expires": "2027-01-19"
 }

--- a/conformance/registry/waivers/wvr-wrong-type-forwardports.json
+++ b/conformance/registry/waivers/wvr-wrong-type-forwardports.json
@@ -3,7 +3,7 @@
   "behaviors": ["bhv-readconfig-wrong-type-forwardports-rejected"],
   "scope": { "kind": "corpus_case", "corpus": "errors", "case": "wrong-type-forwardports" },
   "expect": { "kind": "deacon-stricter" },
-  "rationale": "forwardPorts is a bare string instead of an array. deacon deserializes into a typed struct and rejects the type mismatch; the reference keeps the raw JSON and accepts. Characterized divergence: typed (deacon) vs untyped (reference) read-configuration. Note deacon is NOT uniformly strict here — see wrong-type-features.",
+  "rationale": "forwardPorts is a bare string instead of the array the schema declares. deacon deserializes into a typed struct and rejects the type mismatch; the reference keeps the raw JSON and accepts. This tolerance absorbs the REFERENCE's departure from the schema — bhv-readconfig-wrong-type-forwardports-rejected is `follow-spec`, so nothing here waives a deacon deviation. It exists because the live-differential case would otherwise fail on a difference we expect to keep seeing, and it self-invalidates the day the reference starts enforcing the shape. See wrong-type-features for the sibling that closed the strictness inconsistency this note once flagged.",
   "added": "2026-07-19",
   "expires": "2027-01-19"
 }

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -7,7 +7,7 @@ Compared against **`@devcontainers/cli` 0.87.0** and the [containers.dev spec]\
 (https://github.com/devcontainers/spec) at commit `113500f4`.
 
 **Of 57 behaviors that both tools implement, 29 are verified to match.**
-10 are verified to differ deliberately, and 4 differ because deacon
+6 are verified to differ deliberately, and 8 differ because deacon
 follows the spec where the CLI does not — those are the CLI's deviation, not work we owe.
 0 are differences where deacon is the nonconformant side. A further 16
 are deacon-only, with nothing to compare against.
@@ -221,11 +221,11 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 <tr><td>◐</td><td>Variable substitution reaches the object-shaped fields that carry user templates —…</td><td>✔</td><td>✔</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#312</td></tr>
 <tr><td>✅</td><td>Reading real-world devcontainer.json configurations from the tier1 corpus produces…</td><td>✔</td><td>✘</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>#383 #387</td></tr>
 <tr><td>✅</td><td>Unknown / forward-compatible top-level fields are accepted and preserved verbatim in…</td><td>✔</td><td>✔</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
-<tr><td>⚠️</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unsupported-enum-values</code></td></tr>
+<tr><td>✅</td><td>A modelled field whose value is outside the schema's closed enum (for example…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-unsupported-enum-values</code></td></tr>
 <tr><td>✅</td><td>The reported `workspace.workspaceFolder` is the automatic source-code mount location…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#273 #383</td></tr>
 <tr><td>✅</td><td>The `workspace` section carries exactly `workspaceFolder` and the optional…</td><td>?</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>#376</td></tr>
-<tr><td>⚠️</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-features</code></td></tr>
-<tr><td>⚠️</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-forwardports</code></td></tr>
+<tr><td>✅</td><td>A `features` value that is a bare string instead of an object is rejected…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-features</code></td></tr>
+<tr><td>✅</td><td>A `forwardPorts` value that is a bare string instead of an array is rejected (typed…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td><code>wvr-wrong-type-forwardports</code></td></tr>
 </tbody>
 </table>
 
@@ -297,7 +297,7 @@ So every `·` is a real gap: a scenario this behavior COULD be checked in and ha
 </thead>
 <tbody>
 <tr><td>🔵</td><td>`upgrade` regenerates the lockfile from the configuration AFTER the command-line…</td><td>?</td><td></td><td>·</td><td>◐</td><td>·</td><td>◐</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>#409</td></tr>
-<tr><td>⚠️</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td><code>wvr-upgrade-empty-feature-set</code></td></tr>
+<tr><td>✅</td><td>`upgrade` on a configuration that declares no Features regenerates an EMPTY lockfile…</td><td>✔</td><td>✘</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td>·</td><td>◐</td><td>·</td><td>·</td><td><code>wvr-upgrade-empty-feature-set</code></td></tr>
 <tr><td>✅</td><td>`upgrade` regenerates the devcontainer lockfile from the effective configuration's…</td><td>✔</td><td>✔</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>✅</td><td>·</td><td>·</td><td>·</td><td>·</td><td></td></tr>
 </tbody>
 </table>


### PR DESCRIPTION
Group A of the waiver adjudication queue in `docs/HANDOFF.md`. No ruling needed — this changes what four records *mean*, not what deacon does.

## The problem

Four behaviors carried `spec: conformant` + `decision: intentional-divergence`. That pairing reads "deacon deliberately differs from the reference." In every one of these cases deacon does exactly what the pinned schema or spec prose says, and the reference is the side that departs from it:

| Behavior | The schema/spec says | deacon | reference |
|---|---|---|---|
| `bhv-readconfig-wrong-type-features-rejected` | `features` is an object | rejects a bare string | accepts |
| `bhv-readconfig-wrong-type-forwardports-rejected` | `forwardPorts` is an array | rejects a bare string | accepts |
| `bhv-readconfig-unsupported-enum-rejected` | `userEnvProbe` is a closed enum | rejects a value outside it | accepts and echoes |
| `bhv-upgrade-empty-feature-set` | `devcontainer-lockfile.md` nowhere makes an empty Feature set an error | emits `{"features":{}}`, exit 0 | `Failed to update lockfile`, exit 1 |

Filing those as *our* deviation understates deacon and misdirects a reader looking for work we owe.

## The change

Each behavior's `decision` becomes `follow-spec`. R5 is already satisfied — the spec axis reads `conformant` on all four, and the lockfile one is backed by `src-spec-lockfile`. The notes are rewritten to argue from the spec rather than from preference.

The `upgrade` one is the odd member and its note now says so: the reference is the **stricter** side there, the inverse of its read-configuration siblings. The direction of the deviation is the same, but the previous note grounded it in composability ("an operation that cannot express 'nothing to pin' is unusable as an idempotent step") rather than in the spec. That argument is kept as corroboration and demoted from the ground.

The four `wvr-` records **stay**. Each is what keeps its live-differential case from failing on a difference we expect to keep seeing. Only their meaning changes, so their rationales now state which side they absorb and that they waive no deacon deviation.

## Why this was blocked on #426

With a single verdict column, `follow-spec` + `reference: divergent` rendered as ❌ *"deacon is the nonconformant side, and we intend to fix it"* — worse than the `⚠️` it replaced. With the spec/CLI columns it reads `✅ ✔ ✘`, which is correct.

`docs/PARITY.md` headline moves accordingly:

```
-10 are verified to differ deliberately, and 4 differ because deacon
+6 are verified to differ deliberately, and 8 differ because deacon
 follows the spec where the CLI does not — those are the CLI's deviation, not work we owe.
```

## Verification

- `conformance validate` — ok
- `conformance certify` — **48 blocking, 15 waived**, both unchanged; no coverage moved
- `cargo test -p deacon-conformance` — 469 + all integration binaries green, including `a_reference_lenient_case_is_paired_with_a_direction_pinning_twin`
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `parity-page --check` was stale; regenerated with `--write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N63dYwzi1tmKSsvXH54dYE