### PR TITLE
fix(run-user-commands): honor the image's devcontainer.metadata, and accept --output-format on outdated

### DIFF
--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -774,8 +774,18 @@ pub enum Commands {
         /// Workspace folder to inspect (default: current directory)
         #[arg(long, value_name = "PATH")]
         workspace_folder: Option<PathBuf>,
-        /// Output format (text or json)
-        #[arg(long, value_enum, default_value = "text")]
+        /// Output format (text or json).
+        ///
+        /// `--output-format` is accepted as an alias: that is how the reference
+        /// CLI spells this flag, and accepting both lets one argv drive both
+        /// CLIs in the differential parity suite (#389). `--output` stays the
+        /// documented deacon spelling.
+        #[arg(
+            long,
+            visible_alias = "output-format",
+            value_enum,
+            default_value = "text"
+        )]
         output: OutputFormat,
         /// Fail CI with exit code 2 when any outdated feature is detected
         #[arg(long)]

--- a/crates/deacon/src/commands/exec.rs
+++ b/crates/deacon/src/commands/exec.rs
@@ -638,24 +638,14 @@ where
                     // fall back to `root`. Re-apply that same image-metadata merge
                     // against the running container's image before resolving the
                     // effective config, so exec runs as the same user `up` reported.
-                    let base =
-                        crate::commands::up::merged_config::merge_image_metadata_after_image_ready(
-                            docker_client,
-                            &container_info.image,
-                            config_ctx.config.clone(),
-                        )
-                        .await;
-                    match deacon_core::config::ConfigMerger::resolve_effective_config(
-                        &base,
-                        Some(&container_info.labels),
+                    // Shared with `run-user-commands` (#405).
+                    crate::commands::shared::container_metadata::resolve_config_against_container(
+                        docker_client,
+                        &container_info,
+                        config_ctx.config.clone(),
                         config_ctx.workspace_folder.as_path(),
-                    ) {
-                        Ok((resolved_config, _report)) => resolved_config,
-                        Err(e) => {
-                            tracing::warn!("Failed to resolve effective config with labels: {}", e);
-                            base
-                        }
-                    }
+                    )
+                    .await
                 }
                 Ok(None) => config_ctx.config.clone(),
                 Err(e) => {

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -205,15 +205,48 @@ async fn execute_lifecycle_commands(
     // Compose config without an explicit workspaceFolder resolves to `/` (the
     // reference default), not the single-container `/workspaces/<basename>` the
     // service never mounts (#294/#295).
-    let mounts = {
+    let container_info = {
         use deacon_core::docker::Docker;
         match cli.inspect_container(container_id).await {
-            Ok(Some(info)) => info.mounts,
-            _ => Vec::new(),
+            Ok(Some(info)) => Some(info),
+            _ => None,
         }
     };
+    let mounts = container_info
+        .as_ref()
+        .map(|info| info.mounts.clone())
+        .unwrap_or_default();
+
+    // #405: fold the running container's image `devcontainer.metadata` into the
+    // workspace config, exactly as `exec` does — otherwise a `remoteUser`,
+    // `remoteEnv` or lifecycle hook contributed only by image metadata is
+    // silently ignored here while `up` and `exec` honor it. The reference CLI
+    // 0.87.0 runs its user commands with all three applied (measured).
+    let merged_config = match container_info.as_ref() {
+        Some(info) => {
+            crate::commands::shared::container_metadata::resolve_config_against_container(
+                cli,
+                info,
+                config.clone(),
+                workspace_folder,
+            )
+            .await
+        }
+        None => config.clone(),
+    };
+    let config = &merged_config;
+
     let container_workspace_folder =
         crate::commands::shared::resolve_container_cwd(config, workspace_folder, &mounts, true);
+
+    // `remoteEnv` is layered over `containerEnv` for user commands, matching the
+    // `up` flow (`resolve_env_and_user` → `build_effective_env`) and the
+    // reference CLI. A `None` value means "set to the empty string" per the
+    // spec's null handling.
+    let mut lifecycle_env = config.container_env().clone();
+    for (name, value) in config.remote_env() {
+        lifecycle_env.insert(name.clone(), value.clone().unwrap_or_default());
+    }
 
     // Create container lifecycle configuration
     let lifecycle_config = ContainerLifecycleConfig {
@@ -224,7 +257,7 @@ async fn execute_lifecycle_commands(
             .clone()
             .or_else(|| config.container_user.clone()),
         container_workspace_folder,
-        container_env: config.container_env().clone(),
+        container_env: lifecycle_env,
         skip_post_create: args.skip_post_create,
         skip_non_blocking_commands: args.skip_non_blocking_commands,
         non_blocking_timeout: Duration::from_secs(300), // 5 minutes default timeout

--- a/crates/deacon/src/commands/shared/container_metadata.rs
+++ b/crates/deacon/src/commands/shared/container_metadata.rs
@@ -5,11 +5,17 @@
 //! `set-up`, `read-configuration --container-id`, and `exec --container-id`.
 //! This is the single parser those callers share (CLAUDE.md principle 6),
 //! rather than each re-implementing the fold.
+//!
+//! The module also owns the other direction — resolving a config the caller
+//! already loaded from the workspace AGAINST a running container, which folds in
+//! the container's IMAGE metadata. `exec` and `run-user-commands` share it (#405).
+
+use std::path::Path;
 
 use anyhow::{Context, Result};
 
 use deacon_core::config::{ConfigMerger, DevContainerConfig};
-use deacon_core::docker::ContainerInfo;
+use deacon_core::docker::{ContainerInfo, Docker};
 
 /// Extract a merged [`DevContainerConfig`] from a container's
 /// `devcontainer.metadata` label.
@@ -50,4 +56,43 @@ pub fn config_from_metadata_label(container: &ContainerInfo) -> Result<Option<De
     }
 
     Ok(Some(ConfigMerger::merge_configs(&configs)))
+}
+
+/// Resolve a workspace-loaded config against a RUNNING container: fold the
+/// container's image `devcontainer.metadata` label in at lower precedence, then
+/// resolve the effective configuration against the container's own labels.
+///
+/// Why this is shared (#405): `up` merges image metadata while creating the
+/// container, so any subcommand that later attaches to that container has to
+/// re-apply the same merge or it will disagree with `up` about `remoteUser`,
+/// `remoteEnv` and the lifecycle hooks the image contributes. `exec` did this
+/// inline (#223); `run-user-commands` did not, and silently ran hooks as `root`
+/// with none of the image's environment. Measured against the pinned reference
+/// CLI 0.87.0, whose `run-user-commands` honors all three. This is the single
+/// implementation both share (CLAUDE.md principle 6).
+///
+/// Best-effort by construction: an image that cannot be inspected, an absent
+/// label, or a label that fails to parse all leave the caller's config
+/// unchanged (see `merge_image_metadata_after_image_ready`), and a failed
+/// effective-config resolution warns and returns the merged base.
+pub async fn resolve_config_against_container<D: Docker>(
+    docker: &D,
+    container: &ContainerInfo,
+    config: DevContainerConfig,
+    workspace_folder: &Path,
+) -> DevContainerConfig {
+    let base = crate::commands::up::merged_config::merge_image_metadata_after_image_ready(
+        docker,
+        &container.image,
+        config,
+    )
+    .await;
+
+    match ConfigMerger::resolve_effective_config(&base, Some(&container.labels), workspace_folder) {
+        Ok((resolved, _report)) => resolved,
+        Err(e) => {
+            tracing::warn!("Failed to resolve effective config with labels: {}", e);
+            base
+        }
+    }
 }

--- a/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
+++ b/crates/deacon/tests/run_user_commands_feature_lifecycle.rs
@@ -158,3 +158,132 @@ fn test_run_user_commands_runs_feature_lifecycle_commands() {
         "run-user-commands must still execute the config's postCreateCommand"
     );
 }
+
+/// Read a file out of the container, or `None` when it does not exist.
+fn read_marker(container_id: &str, path: &str) -> Option<String> {
+    let output = std::process::Command::new("docker")
+        .args(["exec", container_id, "cat", path])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Removes the fixture image the metadata test builds.
+struct ImageGuard(String);
+impl Drop for ImageGuard {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["rmi", "-f", &self.0])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+/// #405: `run-user-commands` must honor the image's `devcontainer.metadata`, the
+/// way `up` and `exec` already do.
+///
+/// Everything lifecycle-relevant lives ONLY in the base image's label — the
+/// devcontainer.json declares no `remoteUser`, no `remoteEnv` and no hook — so
+/// the single marker line pins all three at once: the hook ran at all, it ran as
+/// `metauser`, and it saw `META_ENV`. Before the fix nothing was written and the
+/// exit code was still 0, which is why the assertion is on the FILE.
+///
+/// This is the PR-lane twin of the nightly
+/// `case-run-user-commands-image-metadata-differential`, whose fixture base is a
+/// `:local` image only the parity/release lanes build.
+#[test]
+fn run_user_commands_honors_image_metadata_user_env_and_hook() {
+    if !is_docker_available() {
+        eprintln!(
+            "Skipping run_user_commands_honors_image_metadata_user_env_and_hook: Docker not available"
+        );
+        return;
+    }
+
+    let name = "Deacon RUC Image Metadata Test";
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+
+    // A base image whose `devcontainer.metadata` label carries the remote user,
+    // the remote environment and the lifecycle hook.
+    let image_dir = root.join("image");
+    fs::create_dir_all(&image_dir).unwrap();
+    fs::write(
+        image_dir.join("Dockerfile"),
+        "FROM debian:bookworm-slim\n\
+         RUN useradd -m -s /bin/bash metauser\n\
+         LABEL devcontainer.metadata='[{\"remoteUser\":\"metauser\",\
+         \"remoteEnv\":{\"META_ENV\":\"from-image-metadata\"},\
+         \"postCreateCommand\":\"echo $(whoami) ${META_ENV:-UNSET} > /tmp/ruc-image-metadata.flag\"}]'\n",
+    )
+    .unwrap();
+
+    let tag = format!(
+        "deacon-ruc-image-metadata-test-{}:latest",
+        std::process::id()
+    );
+    let built = std::process::Command::new("docker")
+        .args(["build", "-q", "-t", &tag])
+        .arg(&image_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(built, "the metadata-carrying fixture image must build");
+    let _image_guard = ImageGuard(tag.clone());
+
+    fs::create_dir_all(root.join(".devcontainer")).unwrap();
+    fs::write(
+        root.join(".devcontainer/devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "{name}",
+  "image": "{tag}",
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${{localWorkspaceFolder}},target=/workspace,type=bind"
+}}"#
+        ),
+    )
+    .unwrap();
+
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("up")
+        .arg("--workspace-folder")
+        .arg(root)
+        .arg("--remove-existing-container")
+        .arg("--skip-post-create")
+        .assert()
+        .success();
+
+    let container_id = find_container(name).expect("container should exist after up");
+    let _guard = ContainerGuard(container_id.clone());
+
+    assert!(
+        !marker_present(&container_id, "/tmp/ruc-image-metadata.flag"),
+        "the image-metadata postCreate must not have run yet (up --skip-post-create)"
+    );
+
+    Command::cargo_bin("deacon")
+        .unwrap()
+        .current_dir(root)
+        .arg("run-user-commands")
+        .arg("--workspace-folder")
+        .arg(root)
+        .assert()
+        .success();
+
+    let marker = read_marker(&container_id, "/tmp/ruc-image-metadata.flag").expect(
+        "run-user-commands must execute the lifecycle hook contributed by image metadata (#405)",
+    );
+    assert_eq!(
+        marker.trim_end(),
+        "metauser from-image-metadata",
+        "the hook must run as the image-metadata remoteUser with the image-metadata remoteEnv \
+         applied (#405)"
+    );
+}

--- a/parity/SPEC_STATUS.md
+++ b/parity/SPEC_STATUS.md
@@ -22,13 +22,13 @@ alone. Where a row has no scenario yet, it says so.
 
 ## Summary
 
-Of **83 recorded behaviors**:
+Of **84 recorded behaviors**:
 
 - **1** — open nonconformance — [#430](https://github.com/get2knowio/deacon/issues/430)
 - **8** — deacon follows the spec where the CLI does not
 - **11** — documented choice
 - **19** — deacon extension
-- **44** — conformant and matching
+- **45** — conformant and matching
 
 Two rows moved from "deacon follows the spec where the CLI does not" to "conformant and
 matching" at [#439](https://github.com/get2knowio/deacon/issues/439) — not because deacon
@@ -192,6 +192,7 @@ oversight nobody noticed.
 |---|---|---|---|
 | A lifecycle hook that exits non-zero fails the run rather than being reported as a successful setup. | deacon follows the spec, the CLI deviates | 7 scenarios | The failing hook arrives as a command-line override so the preceding `up` can succeed: a hook failure during creation is a different case, and conflating the two would… |
 | Lifecycle hooks run in spec order — onCreate, updateContent, postCreate, postStart — and a Feature-contributed hook runs exactly once alongside the configuration's own. | matches the reference | 6 scenarios | Observed by having each hook append its own name to a file inside the container, so the file IS the order. `grep -c` rather than a presence check pins the Feature hook's… |
+| The running container's image `devcontainer.metadata` contributes `remoteUser`, `remoteEnv` and lifecycle hooks to `run-user-commands`, as it already does to `up` and `exec`. | matches the reference | 1 scenario | Fixes #405. Measured against the pin on a base image whose label carried all three and a devcontainer.json that declared none: the reference ran the image's `postCreateCommand`, as `metauser`, with `META_ENV` set; deacon ran nothing, as `root`, with neither — the exit code was 0 on both sides, so only the marker file showed it. `exec` had done this merge inline since #223 and `run-user-commands` loaded the workspace config alone, which is the whole asymmetry. The merge is now the one shared `container_metadata::resolve_config_against_container`, and `remoteEnv` is layered over `containerEnv` for the hook environment the way `up` layers it. Backed by `case-run-user-commands-image-metadata-differential` (nightly; its `assertion` also pins deacon's side) and by the Docker-gated `run_user_commands_feature_lifecycle::run_user_commands_honors_image_metadata_user_env_and_hook` on the PR lane. `up`'s COMPOSE path never calls the merge either — still open, tracked on #405. |
 
 ### `secrets`
 

--- a/parity/cases/run-user-commands.json
+++ b/parity/cases/run-user-commands.json
@@ -665,6 +665,63 @@
       "notes": "Covers the high-risk triple `hrt-run-user-commands-image-single-feature-running`, alignment half: the container already exists and the configuration declares four hooks while an installed Feature contributes a fifth. Both CLIs must run them without failing."
     },
     {
+      "id": "case-run-user-commands-image-metadata-differential",
+      "behaviors": [
+        "bhv-run-user-commands-image-metadata"
+      ],
+      "context": [],
+      "oracleType": "live-differential",
+      "resourceGroup": "docker-shared",
+      "operations": [
+        {
+          "id": "op-up",
+          "subcommand": "up",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}",
+            "--skip-post-create"
+          ],
+          "fixtures": [
+            "fx-ruc-image-metadata"
+          ]
+        },
+        {
+          "id": "op-ruc",
+          "subcommand": "run-user-commands",
+          "argv": [
+            "--workspace-folder",
+            "${WORKSPACE}"
+          ]
+        }
+      ],
+      "expected": [
+        {
+          "channel": "chan-exit-code",
+          "operation": "op-ruc"
+        },
+        {
+          "channel": "chan-file-content",
+          "operation": "op-ruc",
+          "assertion": {
+            "jsonSubset": {
+              "ruc-image-metadata.txt": "metauser from-image-metadata\n"
+            }
+          }
+        }
+      ],
+      "fsAllowlist": [
+        "ruc-image-metadata.txt"
+      ],
+      "cleanup": {
+        "containers": true,
+        "images": false,
+        "networks": true,
+        "volumes": true,
+        "tempdir": true
+      },
+      "notes": "#405, measured against the pinned 0.87.0 before the fix was written: the reference's `run-user-commands` ran the image-metadata `postCreateCommand`, as `metauser`, with `META_ENV` set; deacon ran nothing, as `root`, with neither. `remoteUser`, `remoteEnv` and the hook live ONLY in the image's `devcontainer.metadata` label — the fixture's devcontainer.json declares none of the three — and `up` runs with `--skip-post-create`, so the marker file can only be written by `run-user-commands` and its single line pins all three at once. The observation is the FILE, not the exit code: before the fix nothing was written and the status still said 0.\n\nNo spec-expectation twin: the fixture's base is a `:local` image built from its sibling Dockerfile by `scripts/parity/prepull-fixture-images.sh`, which only the nightly and release lanes run — so a Docker-lane twin would fail on the PR lane for a missing image rather than for a divergence (the same reason `case-tier1-decl-object-form-metadata` is differential-only). The direction is pinned instead by the `assertion` carried HERE, which is evaluated against deacon's side on top of the comparison, and by the Docker-gated `run_user_commands_feature_lifecycle::run_user_commands_honors_image_metadata_user_env_and_hook`."
+    },
+    {
       "id": "case-run-user-commands-reference-lenient-wrong-type",
       "behaviors": [
         "bhv-readconfig-wrong-type-forwardports-rejected"

--- a/parity/fixtures/fx-ruc-image-metadata/.devcontainer/devcontainer.json
+++ b/parity/fixtures/fx-ruc-image-metadata/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+	"name": "ConformanceRucImageMetadata",
+	"image": "deacon-parity-ruc-image-metadata:local",
+	"workspaceFolder": "/workspace",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind"
+}

--- a/parity/fixtures/fx-ruc-image-metadata/image/Dockerfile
+++ b/parity/fixtures/fx-ruc-image-metadata/image/Dockerfile
@@ -1,0 +1,15 @@
+# Fixture image for the `run-user-commands` image-metadata cases (#405).
+#
+# Every lifecycle-relevant property here lives ONLY in the image's
+# `devcontainer.metadata` label — the sibling devcontainer.json declares no
+# `remoteUser`, no `remoteEnv` and no hook at all. So the marker file can only
+# appear, and can only carry `metauser from-image-metadata`, if the CLI folded
+# the image metadata into the configuration it ran the user commands with.
+#
+# Built locally (never published) by `scripts/parity/prepull-fixture-images.sh`
+# and the parity workflow's fixture-image step, to the tag the fixture's
+# devcontainer.json names. Both CLIs resolve the label by local `docker
+# inspect`, so no registry is involved.
+FROM alpine:3.19
+RUN adduser -D -s /bin/sh metauser
+LABEL devcontainer.metadata='[{"remoteUser":"metauser","remoteEnv":{"META_ENV":"from-image-metadata"},"postCreateCommand":["sh","-c","echo $(whoami) ${META_ENV:-UNSET} > /workspace/ruc-image-metadata.txt"]}]'


### PR DESCRIPTION
Closes #405
Closes #389

**#405** — `run-user-commands` ignored the running container's image `devcontainer.metadata` while `up` and `exec` honored it. exec's inline mechanism (#223) is extracted to the shared `container_metadata::resolve_config_against_container`; both subcommands now call the one implementation, and `run-user-commands` folds it into the container inspect it already performed (no extra round trip). Measured against oracle 0.87.0 on a base image contributing a hook, a `remoteUser`, and `remoteEnv`: before — hook never ran, hooks ran as `root`, no metadata env; after — byte-identical log to the reference. A **third miss surfaced and fixed**: `run-user-commands` applied no `remoteEnv` at all (not even the workspace config's); it now layers `remoteEnv` over `containerEnv` exactly as `up` does.

Coverage: new `case-run-user-commands-image-metadata-differential` (differential lane; broken once and watched fail on exactly its own id) + `run_user_commands_honors_image_metadata_user_env_and_hook` in an existing Docker binary for the PR lane (`nextest.toml` untouched). `parity/SPEC_STATUS.md` row added (83→84 behaviors, 45 matching).

Confirmed-not-fixed sibling gap filed as #448: `up`'s compose path also never merges image metadata.

**#389** — the issue held: the reference spells the flag `--output-format`; deacon rejected it. `visible_alias = "output-format"` on `outdated` — additive, `--output` unchanged, both spellings verified emitting identical JSON.

Verification: fmt / clippy `--all-features -D warnings` / `build --all-targets` clean; `dev-fast` 3193/3193; `differential_group_docker_shared` 50/50 including the new case, against the live oracle; injected-failure control failed on exactly the new case; exec Docker suite 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N63dYwzi1tmKSsvXH54dYE