### PR TITLE
docs(parity): record #460 and #462 as open nonconformances

### DIFF
--- a/parity/SPEC_STATUS.md
+++ b/parity/SPEC_STATUS.md
@@ -22,19 +22,23 @@ alone. Where a row has no scenario yet, it says so.
 
 ## Summary
 
-Of **85 recorded behaviors**:
+Of **88 recorded behaviors**:
 
-- **0** — open nonconformance
+- **2** — open nonconformance — [#460](https://github.com/get2knowio/deacon/issues/460), [#462](https://github.com/get2knowio/deacon/issues/462)
 - **9** — deacon follows the spec where the CLI does not
 - **11** — documented choice
 - **19** — deacon extension
-- **46** — conformant and matching
+- **47** — conformant and matching
 
-**No row is an open nonconformance** as of 2026-08-03. That is a claim with a short
-shelf life and no special weight: it means every difference we have MEASURED is either
-one deacon is on the right side of or one written down in `parity/ALLOWLIST.json`, not
-that none is left to find. The last row to leave the column was duplicate Features
-([#430](https://github.com/get2knowio/deacon/issues/430)).
+The open-nonconformance column emptied on 2026-08-03 when duplicate Features
+([#430](https://github.com/get2knowio/deacon/issues/430)) left it — and refilled the same
+day, which is the system working: closing #448 on the compose path surfaced two adjacent
+compose-path gaps ([#462](https://github.com/get2knowio/deacon/issues/462) uid remapping,
+[#460](https://github.com/get2knowio/deacon/issues/460) lifecycle phase coverage), both
+measured and filed by the suite's own cases before any user hit them. A zero here has a
+short shelf life and no special weight; the honest claim is that every difference we have
+MEASURED is either fixed, deacon-conformant, allowlisted with a ruling, or in this column
+with an issue link.
 
 Two rows moved from "deacon follows the spec where the CLI does not" to "conformant and
 matching" at [#439](https://github.com/get2knowio/deacon/issues/439) — not because deacon
@@ -236,6 +240,8 @@ oversight nobody noticed.
 | A PATH segment contributed by a Feature's `containerEnv` is prepended to the image PATH, and the resulting PATH is observable segment-by-segment in the created container. | matches the reference | 2 scenarios | PATH was captured but NOT compared until 024 US5: `drop_noise_env` removed it at capture, so the declarative container-state channel never saw it. It is compared… |
 | Re-entering a workspace whose container already exists, with the SAME configuration, reattaches to it rather than creating a second one. | matches the reference | 2 scenarios | Asserted as a metamorphic relationship (`first-create-vs-restart`) rather than against a fixed output, because what is being pinned is the relation between the two runs… |
 | The Compose service image's `devcontainer.metadata` contributes `remoteUser`, `remoteEnv` and lifecycle hooks to a compose `up`'s own lifecycle run, as it already does on the single-container path. | matches the reference | 1 scenario | Fixes #448, the second instance of the #405 shape and the last known call site. `merge_image_metadata_after_image_ready` had exactly two callers — `up`'s single-container path and the shared `container_metadata::resolve_config_against_container` that `exec` and `run-user-commands` use — and `up`'s COMPOSE path called neither. Measured against oracle 0.87.0 on a compose service whose image label carried all three and whose devcontainer.json declared only its own `remoteEnv`: the reference wrote `metauser from-image-metadata from-workspace-config`; deacon wrote no file at all, exit 0 on both sides, so only the marker showed it. The merge now runs on the compose path at the same point in the flow — image ready, before lifecycle — against the image the container actually runs (the Feature-extended tag when Features were built, else the service's own `image:`), reusing the one implementation. Making it observable also required the compose post-create exec to stop passing `user: None` and an EMPTY env: it now resolves both through the shared `resolve_env_and_user`, which is why the workspace's own `remoteEnv` had been missing too — the identical third miss #405 found. Backed by `case-up-compose-image-metadata-differential` (nightly; its `assertion` also pins deacon's side) and by the Docker-gated `integration_compose_config_mounts::test_compose_up_merges_service_image_metadata`, which runs under the `default`/`full` profiles (`make test-nextest`) — that binary is selected by neither PR lane, `dev-fast` excluding it and `mvp-integration` not listing it. The parity case measures three of the four cells and deliberately declares no `remoteUser`: an image-metadata `remoteUser` DOES reach the hook after this fix, but a non-root hook can only write into the bind-mounted workspace when its uid matches the host directory's owner, and deacon applies `updateRemoteUserUID` on the single-container path only (#462). The case's first revision declared `remoteUser` and passed locally solely because the dev container's uid and the image user's were both 1000; it failed on GitHub's runners with `Permission denied`. The user cell therefore lives in the Docker-gated test, which owns its workspace directory, makes it world-writable and pins the image user to uid 1234 so the mismatch is the norm rather than an accident. STILL OPEN on this path and NOT part of #448: the compose post-create runs `postCreateCommand` only in its STRING form and runs no other phase, so an array/object hook or an onCreate/postStart hook — from the image or the workspace — is still dropped there. |
+| A compose `up` remaps the container user's uid to the host's (`updateRemoteUserUID`), so a non-root `remoteUser` can write the bind-mounted workspace. | **open nonconformance** | no scenario yet — measured repro on the issue; the uid cell of #448's matrix lives in the Docker-gated `test_compose_up_merges_service_image_metadata` (uid pinned to 1234) | OPEN — filed as [#462](https://github.com/get2knowio/deacon/issues/462), found by `case-up-compose-image-metadata-differential`'s first revision failing on CI. Measured at oracle 0.87.0 with the image user pinned to uid 1234: the reference reports `uid=1000` (remapped to the host uid) and the hook writes; deacon keeps the image uid and the hook dies with `Permission denied` on the bind mount. deacon applies `apply_user_mapping` on the single-container path only. It passed locally solely because the dev container's uid and `adduser`'s first free uid are both 1000. When fixed, the parity fixture takes `remoteUser` back and the differential case covers the fourth cell directly. |
+| A compose `up` runs the full lifecycle phase set in every command form, as the single-container path does. | **open nonconformance** | no scenario yet — characterized while closing #448 | OPEN — filed as [#460](https://github.com/get2knowio/deacon/issues/460). The compose post-create exec runs `postCreateCommand` only in its STRING form and runs no other phase, so an array/object hook or an onCreate/postStart hook — contributed by the image label or the workspace config — is silently dropped on the compose path while the single-container path runs it. |
 
 ### `upgrade`
 


### PR DESCRIPTION
Closing #448 surfaced two adjacent compose-path gaps, both measured and filed by the suite's own cases before any user hit them: **#462** (compose `up` never applies `updateRemoteUserUID` — the reference remaps the container user to the host uid; deacon keeps the image's, so a non-root `remoteUser` cannot write the bind-mounted workspace) and **#460** (the compose post-create exec runs only string-form `postCreateCommand` and no other lifecycle phase). This records them in `SPEC_STATUS.md` the day they were found — a zero with known-but-unwritten gaps behind it would be the exact failure the ledger exists to prevent.

Also corrects the summary against a row census: **88 behaviors** (the #448 row landed without a header bump), 47 matching, **2 open nonconformances**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N63dYwzi1tmKSsvXH54dYE