### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deacon"
-version = "0.2.0-rc.15"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "deacon-core"
-version = "0.2.0-rc.15"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 # Pin a version alongside the path so cargo-deny does not flag it as a wildcard dep.
-deacon-core = { path = "crates/core", version = "0.2.0-rc.15" }
+deacon-core = { path = "crates/core", version = "0.2.0" }
 clap = { version = "4.5", features = ["derive", "color", "env"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The install script supports a `--prerelease` flag and these environment variable
 
 ```bash
 # Install a specific version
-curl -fsSL https://get2knowio.github.io/deacon/install.sh | DEACON_VERSION=0.2.0-rc.15 bash
+curl -fsSL https://get2knowio.github.io/deacon/install.sh | DEACON_VERSION=0.2.0 bash
 
 # Install the latest pre-release
 curl -fsSL https://get2knowio.github.io/deacon/install.sh | bash -s -- --prerelease

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon-core"
-version = "0.2.0-rc.15"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/deacon/Cargo.toml
+++ b/crates/deacon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deacon"
-version = "0.2.0-rc.15"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Graduates the 0.2.0 release-candidate chain (0.2.0-rc.15 → 0.2.0).

Bumps the version in the four spots that must stay in lockstep:

- root `Cargo.toml` — the `deacon-core` dependency pin
- `crates/deacon/Cargo.toml`
- `crates/core/Cargo.toml`
- `Cargo.lock` (refreshed via `cargo update -p deacon -p deacon-core`)

Plus the README's pinned-install example, which is a version reference rather
than a changelog entry and would otherwise advertise a stale prerelease once
the tag lands. A repo-wide grep for `0.2.0-rc.15` now returns nothing.

No product code changes.

Once merged, an annotated `v0.2.0` tag on the merge commit triggers
`.github/workflows/release.yml`, which validates that the tag matches
`crates/deacon/Cargo.toml` before building. A non-rc tag publishes a full
(non-prerelease) release.

## Local gate

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build --workspace --all-targets` — clean
- `cargo nextest run --profile dev-fast --no-fail-fast` — 3199 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N63dYwzi1tmKSsvXH54dYE