### PR TITLE
chore(parity): make a failing gating lane diagnosable — evidence artifacts and stderr in exit-code verdicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,19 @@ jobs:
       # cross-platform failure set, not just the earliest).
       run: cargo nextest run --profile dev-fast --no-fail-fast
 
+    # `parity_hermetic` is selected by `dev-fast` too, so this lane also owes its evidence
+    # on failure (#474). The name carries the matrix leg because one run's artifacts share a
+    # namespace; `if-no-files-found: ignore` is doing real work here rather than guarding a
+    # hypothetical — the macOS and Windows legs run no parity binary at all (#441), so they
+    # have no `target/parity/` to upload even when they fail.
+    - name: Upload parity evidence
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: parity-evidence-fast-${{ matrix.os }}
+        path: target/parity/
+        if-no-files-found: ignore
+
   test-integration:
     name: Test (MVP integration)
     if: github.event_name != 'schedule'
@@ -254,6 +267,25 @@ jobs:
     - name: Run MVP integration tests
       run: make test-nextest-mvp-integration
 
+    # The evidence for the parity binaries this job runs (#474). `parity.yml` has always
+    # uploaded `target/parity/`, but that lane GATES NOTHING — the two lanes that gate a pull
+    # request run here, and until now they retained nothing but a 267-byte timing file. Both
+    # CI occurrences of the #470 export-tar flake were therefore undiagnosable after the fact,
+    # and #470's own "download the evidence before rerunning" instruction was unfollowable.
+    #
+    # `if: failure()` rather than `always()`: this lane runs on every pull request, and a
+    # green run's raw capture is not worth the storage. `if-no-files-found: ignore`, because a
+    # failure BEFORE the harness runs (a cache miss, a compile error, the engine precondition
+    # above) leaves no tree, and a missing artifact must not become a second failure obscuring
+    # the first.
+    - name: Upload parity evidence
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: parity-evidence-mvp-integration
+        path: target/parity/
+        if-no-files-found: ignore
+
     - name: Upload timing artifacts
       if: always()
       uses: actions/upload-artifact@v7
@@ -342,3 +374,14 @@ jobs:
     # pass here. `parity_hermetic` is unaffected: it is runtime-agnostic.
     - name: Run integration suite against Podman (full failure set)
       run: cargo nextest run --profile mvp-integration --no-fail-fast -E 'not binary(=parity_docker)'
+
+    # `parity_hermetic` runs in this job (it is runtime-agnostic and NOT excluded above), so
+    # this job owes the same evidence as the Docker one (#474). Same conditions, same reasons;
+    # a distinct artifact name because two jobs of one run cannot share one.
+    - name: Upload parity evidence
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: parity-evidence-podman
+        path: target/parity/
+        if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,19 @@ jobs:
       - name: Pinned parity scenarios (hermetic + Docker, no oracle)
         run: cargo nextest run -E 'binary(=parity_hermetic) | binary(=parity_docker)'
 
+      # The evidence for the step above (#474). This is the RELEASE gate: a parity failure
+      # here blocks a tag, and the raw capture behind it must outlive the runner rather than
+      # force a re-run to be understood. `if: failure()` keeps green releases unencumbered;
+      # `if-no-files-found: ignore` because a failure before the harness runs (the engine
+      # precondition, the pre-pull) leaves no tree to upload.
+      - name: Upload parity evidence
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: parity-evidence-release-verify
+          path: target/parity/
+          if-no-files-found: ignore
+
   create-release:
     name: Create Release
     needs: verify

--- a/crates/deacon/tests/parity_harness_faults.rs
+++ b/crates/deacon/tests/parity_harness_faults.rs
@@ -733,6 +733,7 @@ fn p_no_reference_for_platform_is_its_own_outcome() {
         channel: "chan-exit-code".to_string(),
         outcome: DeclOutcome::NoReferenceForPlatform,
         detail: Some(serde_json::json!({ "platform": "linux-aarch64" })),
+        stderr_excerpt: None,
     };
     assert_ne!(
         verdict.outcome,

--- a/crates/parity-harness/src/compare.rs
+++ b/crates/parity-harness/src/compare.rs
@@ -93,6 +93,7 @@ pub fn verdict_differential(
             channel: channel.to_string(),
             outcome: Outcome::AllowedDifference,
             detail: Some(json!({ "allowed": covered })),
+            stderr_excerpt: None,
         }
     } else {
         diverge(
@@ -246,6 +247,7 @@ fn agree(channel: &str) -> ChannelVerdict {
         channel: channel.to_string(),
         outcome: Outcome::Agree,
         detail: None,
+        stderr_excerpt: None,
     }
 }
 
@@ -255,6 +257,9 @@ fn diverge(channel: &str, detail: Value) -> ChannelVerdict {
         channel: channel.to_string(),
         outcome: Outcome::Diverge,
         detail: Some(detail),
+        // Attached later, by the runner, and only for the exit-code channel (#474): the
+        // comparison sees normalized evidence, never the process that produced it.
+        stderr_excerpt: None,
     }
 }
 

--- a/crates/parity-harness/src/driver.rs
+++ b/crates/parity-harness/src/driver.rs
@@ -414,7 +414,12 @@ async fn drive_group_with_concurrency(
                         "{}: no committed snapshot for this platform (no-reference-for-platform)",
                         verdict.case_id
                     )),
-                    _ => failures.push(format!("{}: {}", verdict.case_id, summarize(&verdict))),
+                    _ => failures.push(format!(
+                        "{}: {}{}",
+                        verdict.case_id,
+                        summarize(&verdict),
+                        stderr_excerpts(&verdict)
+                    )),
                 }
                 // A tolerance whose difference no longer reproduces FAILS, on the same
                 // footing as an un-allowlisted divergence.
@@ -749,6 +754,27 @@ fn summarize(verdict: &CaseVerdict) -> String {
         })
         .collect::<Vec<_>>()
         .join("; ")
+}
+
+/// The failing side(s)' stderr, appended to a case's FAILURE line (#474).
+///
+/// Empty for every case except one whose `chan-exit-code` diverged — that is where
+/// [`crate::runner::attach_stderr_excerpt`] attaches an excerpt, and nowhere else. So this
+/// needs no channel filter of its own: the presence of the excerpt IS the filter.
+///
+/// Deliberately absent from [`summarize`], which also feeds the persisted report fragment.
+/// The fragment already carries `RawPaths` pointing at the complete streams on disk; what it
+/// must not carry is unbounded, path-bearing process output in a `detail` string. The panic
+/// text is the surface that cannot be gone back to, which is why the excerpt lands here.
+fn stderr_excerpts(verdict: &CaseVerdict) -> String {
+    let mut out = String::new();
+    for channel in &verdict.channels {
+        if let Some(excerpt) = &channel.stderr_excerpt {
+            out.push('\n');
+            out.push_str(excerpt);
+        }
+    }
+    out
 }
 
 /// How many diverging paths a channel's summary names before it says `+N more`.

--- a/crates/parity-harness/src/evidence.rs
+++ b/crates/parity-harness/src/evidence.rs
@@ -120,6 +120,22 @@ pub struct ChannelVerdict {
     /// serialized (even when `null`) so the report body is byte-deterministic
     /// (contract runner-cli.md).
     pub detail: Option<Value>,
+    /// The failing side(s)' captured stderr, tail-bounded and pre-labeled — attached ONLY
+    /// when `chan-exit-code` itself diverges (#474), by
+    /// [`crate::runner::attach_stderr_excerpt`].
+    ///
+    /// An exit-code `Diverge` names a channel and nothing else, so the failure that reaches
+    /// the nextest panic says only *that* the codes disagreed; the stderr of the side that
+    /// exited non-zero is what names the fix. Both prior occurrences of the #470 flake were
+    /// undiagnosable from CI for exactly this reason.
+    ///
+    /// **Never serialized.** The verdict report is contractually path-free and byte-stable
+    /// (contract runner-cli.md), and raw stderr is neither — the full streams are already
+    /// persisted verbatim under `raw/<binary>/<case>__<op>/{deacon,oracle}.stderr`, which is
+    /// where a reader goes for more than the tail. This field exists solely to carry the tail
+    /// into the panic text, in memory.
+    #[serde(skip)]
+    pub stderr_excerpt: Option<String>,
 }
 
 /// The whole-case verdict (data-model §9, report shape contract runner-cli.md).
@@ -273,6 +289,7 @@ mod tests {
             channel: "chan-exit-code".to_string(),
             outcome,
             detail: None,
+            stderr_excerpt: None,
         };
         assert_eq!(
             CaseVerdict::compute_overall(&[mk(Outcome::Agree), mk(Outcome::Diverge)]),
@@ -404,6 +421,7 @@ mod tests {
             channel: "chan-exit-code".to_string(),
             outcome: Outcome::Agree,
             detail: None,
+            stderr_excerpt: None,
         };
         let json = serde_json::to_string(&v).unwrap();
         assert!(

--- a/crates/parity-harness/src/oracle_type.rs
+++ b/crates/parity-harness/src/oracle_type.rs
@@ -77,6 +77,7 @@ async fn spec_expectation(
                 })?;
         let mut verdict = verdict_spec_expectation(&exp.channel, normalized, assertion)?;
         runner::attach_failure_phase(&mut verdict, case, exp, &ctx, None);
+        runner::attach_stderr_excerpt(&mut verdict, case, exp, &ctx, None);
         channels.push(verdict);
     }
     // Allowed differences do not apply to spec-expectation (no reference to diverge from);
@@ -181,6 +182,7 @@ async fn live_differential(
             }
         }
         runner::attach_failure_phase(&mut verdict, case, exp, &deacon_ctx, Some(&oracle_ctx));
+        runner::attach_stderr_excerpt(&mut verdict, case, exp, &deacon_ctx, Some(&oracle_ctx));
         channels.push(verdict);
     }
     Ok((channels, tolerances.stale(&consumed)))
@@ -330,6 +332,7 @@ fn evaluate_relationship(
                     "reason": "missing container snapshot for the operation or its sibling \
                                (a metamorphic case must be Docker-backed)",
                 })),
+                stderr_excerpt: None,
             };
         }
     };
@@ -380,6 +383,7 @@ fn evaluate_relationship(
             "containerCount": this_count,
             "running": running,
         })),
+        stderr_excerpt: None,
     }
 }
 

--- a/crates/parity-harness/src/runner.rs
+++ b/crates/parity-harness/src/runner.rs
@@ -19,7 +19,9 @@ use crate::model::{
 };
 
 use crate::HarnessError;
-use crate::evidence::{CaseVerdict, ChannelVerdict, NormalizedChannelEvidence, RawChannelEvidence};
+use crate::evidence::{
+    CaseVerdict, ChannelVerdict, NormalizedChannelEvidence, Outcome, RawChannelEvidence,
+};
 use crate::exec::{ExecKind, Side, run_and_capture};
 use crate::observe::{ProcessOutcome, RunContext, cli_process, observer_for};
 use crate::oracle::VerifiedOracle;
@@ -850,6 +852,112 @@ pub(crate) fn attach_failure_phase(
     }
 }
 
+/// How many trailing stderr lines one side's excerpt carries (#474).
+const STDERR_EXCERPT_LINES: usize = 20;
+
+/// The byte ceiling on one side's excerpt. Whichever bound bites first wins, so a run that
+/// logs one enormous line cannot flood the panic text any more than one that logs a thousand.
+const STDERR_EXCERPT_BYTES: usize = 2048;
+
+/// Attach the failing side(s)' captured stderr — tail-bounded — to a DIVERGING
+/// `chan-exit-code` verdict (#474).
+///
+/// An exit-code divergence is the one channel whose verdict names nothing actionable on its
+/// own: "the codes disagreed" is the entire message, and the reason the process exited that
+/// way is on its stderr. This is formatting over evidence the harness ALREADY captured
+/// ([`ProcessOutcome::stderr`], also persisted verbatim under `raw/…`), not new capture.
+///
+/// Deliberately scoped three ways, because an excerpt everywhere is noise:
+///
+/// - **`chan-exit-code` only.** A structured-output or container-state divergence already
+///   names the diverging path; stderr adds nothing there.
+/// - **Diverging verdicts only.** An agreeing exit code — including an agreeing *failure*,
+///   which the error-path cases assert — has nothing to explain.
+/// - **Non-zero sides only.** A side that succeeded emits progress logs, not a cause.
+pub(crate) fn attach_stderr_excerpt(
+    verdict: &mut ChannelVerdict,
+    case: &TestCase,
+    exp: &ExpectedObservable,
+    ctx: &RunContext,
+    reference: Option<&RunContext>,
+) {
+    if verdict.channel != CHAN_EXIT_CODE || !matches!(verdict.outcome, Outcome::Diverge) {
+        return;
+    }
+    let Ok(op) = resolve_expected_op(case, exp) else {
+        return;
+    };
+    let mut blocks: Vec<String> = Vec::new();
+    if let Some(block) = side_stderr("deacon", ctx.outcome(&op.id)) {
+        blocks.push(block);
+    }
+    if let Some(block) = reference.and_then(|r| side_stderr("reference", r.outcome(&op.id))) {
+        blocks.push(block);
+    }
+    if !blocks.is_empty() {
+        verdict.stderr_excerpt = Some(blocks.join("\n"));
+    }
+}
+
+/// One side's labeled stderr excerpt, or `None` when the side did not run, succeeded, or
+/// wrote nothing.
+fn side_stderr(label: &str, outcome: Option<&ProcessOutcome>) -> Option<String> {
+    let outcome = outcome?;
+    if outcome.success {
+        return None;
+    }
+    let excerpt = tail_excerpt(&outcome.stderr)?;
+    let code = outcome
+        .exit_code
+        .map_or_else(|| "signal".to_string(), |c| c.to_string());
+    Some(format!("  {label} stderr (exit {code}):\n{excerpt}"))
+}
+
+/// The last [`STDERR_EXCERPT_LINES`] lines of `stderr`, further clipped to
+/// [`STDERR_EXCERPT_BYTES`], each line prefixed so the excerpt is visibly quoted inside the
+/// failure text. `None` when there is nothing to show.
+///
+/// Bounded from the TAIL because that is where a CLI puts the error it died on. Truncation is
+/// announced rather than silent, and the announcement carries only counts derived from the
+/// input, so the excerpt's SHAPE is a deterministic function of the stderr it quotes.
+fn tail_excerpt(stderr: &[u8]) -> Option<String> {
+    // Lossy: a CLI that emitted invalid UTF-8 still has a diagnosable tail, and the raw
+    // bytes are preserved on disk regardless.
+    let stderr = String::from_utf8_lossy(stderr);
+    let trimmed = stderr.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let lines: Vec<&str> = trimmed.lines().collect();
+    let dropped = lines.len().saturating_sub(STDERR_EXCERPT_LINES);
+    let mut tail = lines[dropped..].join("\n");
+    let clipped = tail.len() > STDERR_EXCERPT_BYTES;
+    if clipped {
+        // Walk forward to a char boundary so a multi-byte character is never split.
+        let mut start = tail.len() - STDERR_EXCERPT_BYTES;
+        while start < tail.len() && !tail.is_char_boundary(start) {
+            start += 1;
+        }
+        tail = tail[start..].to_string();
+    }
+    let mut out = String::new();
+    if dropped > 0 || clipped {
+        out.push_str(&format!(
+            "    […truncated: showing the last {} line(s), {} byte(s)]\n",
+            tail.lines().count(),
+            tail.len()
+        ));
+    }
+    for line in tail.lines() {
+        out.push_str("    | ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    // Trailing newline removed: the caller joins blocks and the driver appends this to a
+    // failure line, both of which own their own separators.
+    Some(out.trim_end_matches('\n').to_string())
+}
+
 /// One side's observable outcome for the exit-code channel: the exit code (`null` for a
 /// signal-terminated process, which stays distinct from `0`) and whether it failed.
 /// `null` throughout when the operation did not run on that side at all — which is a
@@ -1115,6 +1223,39 @@ mod tests {
         std::fs::create_dir_all(&dc2).unwrap();
         std::fs::write(dc2.join("devcontainer.json"), r#"{ "name": "x" }"#).unwrap();
         assert_eq!(fixture_image(&dir.path().join("fx2")), None);
+    }
+
+    /// #474: the excerpt is bounded by BOTH rules, and empty stderr produces nothing at all.
+    /// The byte ceiling is what keeps one enormous line from flooding the panic text that the
+    /// line ceiling alone would wave through.
+    #[test]
+    fn tail_excerpt_is_bounded_by_lines_and_by_bytes() {
+        assert_eq!(tail_excerpt(b""), None, "no stderr, nothing to quote");
+        assert_eq!(tail_excerpt(b"   \n\n"), None, "whitespace-only is nothing");
+
+        let short = tail_excerpt(b"boom").expect("non-empty stderr yields an excerpt");
+        assert_eq!(
+            short, "    | boom",
+            "an unbounded excerpt is quoted verbatim"
+        );
+
+        // 30 lines → the last 20 survive, and the truncation says so.
+        let many: String = (1..=30).map(|i| format!("line-{i:02}\n")).collect();
+        let excerpt = tail_excerpt(many.as_bytes()).expect("excerpt");
+        assert_eq!(excerpt.lines().count(), 21, "20 quoted lines + the marker");
+        assert!(excerpt.contains("line-30") && excerpt.contains("line-11"));
+        assert!(!excerpt.contains("line-10"));
+
+        // One line, far over the byte ceiling → clipped to the tail, marker present.
+        let huge = "x".repeat(STDERR_EXCERPT_BYTES * 3) + "TAIL";
+        let excerpt = tail_excerpt(huge.as_bytes()).expect("excerpt");
+        assert!(
+            excerpt.len() < STDERR_EXCERPT_BYTES + 200,
+            "the byte ceiling must bite even when the line ceiling does not: {} bytes",
+            excerpt.len()
+        );
+        assert!(excerpt.ends_with("TAIL"), "the TAIL is what is kept");
+        assert!(excerpt.contains("truncated"));
     }
 
     #[test]

--- a/crates/parity-harness/tests/runner_record_replay.rs
+++ b/crates/parity-harness/tests/runner_record_replay.rs
@@ -60,11 +60,13 @@ fn verdict_report_is_byte_stable_and_path_free() {
                 channel: CHAN_EXIT_CODE.to_string(),
                 outcome: Outcome::Agree,
                 detail: None,
+                stderr_excerpt: None,
             },
             ChannelVerdict {
                 channel: CHAN_STRUCTURED_OUTPUT.to_string(),
                 outcome: Outcome::Agree,
                 detail: None,
+                stderr_excerpt: None,
             },
         ],
         overall: Outcome::Agree,
@@ -111,6 +113,34 @@ mod spec_expectation {
         let p = dir.join(name);
         // `printf '%s'` avoids a trailing newline mattering; the runner trims for JSON.
         let body = format!("#!/bin/sh\nprintf '%s' '{stdout}'\nexit {code}\n");
+        std::fs::write(&p, body).expect("write stub");
+        let mut perms = std::fs::metadata(&p).expect("stat").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&p, perms).expect("chmod");
+        p
+    }
+
+    /// Write a stub that prints `stdout`, then writes `stderr_lines` numbered lines to
+    /// STDERR, and exits with `code`.
+    ///
+    /// The stderr is the point: an exit-code divergence's verdict names the channel and
+    /// nothing else, and #474 makes the failing side's stderr tail travel with it. A stub
+    /// that writes nothing to stderr cannot tell an attached excerpt from an absent one.
+    fn write_noisy_stub(
+        dir: &Path,
+        name: &str,
+        stdout: &str,
+        stderr_lines: usize,
+        code: i32,
+    ) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let p = dir.join(name);
+        // Zero-padded so `line-10` is not a substring of `line-100` (and so an assertion
+        // about which lines survived the tail bound cannot pass by accident).
+        let body = format!(
+            "#!/bin/sh\nprintf '%s' '{stdout}'\ni=1\nwhile [ $i -le {stderr_lines} ]; do \
+             printf 'line-%02d\\n' \"$i\" >&2; i=$((i+1)); done\nexit {code}\n"
+        );
         std::fs::write(&p, body).expect("write stub");
         let mut perms = std::fs::metadata(&p).expect("stat").permissions();
         perms.set_mode(0o755);
@@ -226,6 +256,102 @@ mod spec_expectation {
             .find(|c| c.channel == CHAN_EXIT_CODE)
             .expect("exit-code channel");
         assert_eq!(exit.outcome, Outcome::Diverge);
+    }
+
+    /// #474: a DIVERGING exit code carries the failing side's stderr tail, labeled and
+    /// bounded. Without it the verdict reads `chan-exit-code: Diverge` and names nothing to
+    /// fix — which is precisely how both CI occurrences of the #470 flake became
+    /// expeditions.
+    #[tokio::test]
+    async fn diverging_exit_code_carries_the_failing_side_stderr_tail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Right JSON, 30 lines of stderr, exit 1 → the `{equals:0}` assertion diverges.
+        let stub = write_noisy_stub(dir.path(), "deacon-noisy", GOOD_STDOUT, 30, 1);
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+        };
+        let verdict = run_case(&spec_case(), &cfg).await.expect("run");
+        let exit = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_EXIT_CODE)
+            .expect("exit-code channel");
+        assert_eq!(exit.outcome, Outcome::Diverge);
+
+        let excerpt = exit
+            .stderr_excerpt
+            .as_deref()
+            .expect("a diverging exit code must carry the failing side's stderr (#474)");
+        assert!(
+            excerpt.contains("deacon stderr (exit 1)"),
+            "the excerpt must name its side and that side's exit code: {excerpt}"
+        );
+        // Tail-bounded to the last 20 of 30 lines: 11..=30 survive, 01..=10 do not, and the
+        // truncation is announced rather than silent.
+        assert!(
+            excerpt.contains("line-30"),
+            "the tail must survive: {excerpt}"
+        );
+        assert!(excerpt.contains("line-11"), "20 lines are kept: {excerpt}");
+        assert!(
+            !excerpt.contains("line-10"),
+            "only the last 20 lines are kept: {excerpt}"
+        );
+        assert!(
+            excerpt.contains("truncated"),
+            "truncation must be announced, never silent: {excerpt}"
+        );
+        // No reference ran (spec-expectation), so no reference block may be fabricated.
+        assert!(
+            !excerpt.contains("reference stderr"),
+            "a spec-expectation case has no reference side: {excerpt}"
+        );
+    }
+
+    /// #474, the other half: the excerpt is scoped to a DIVERGING EXIT CODE and appears
+    /// nowhere else. Same noisy stub, but here the exit code AGREES (`nonZero` matched the
+    /// failure) while structured-output diverges — so stderr is present and plentiful, and
+    /// neither channel may carry it. An excerpt on every divergence would bury the one place
+    /// stderr names the fix.
+    #[tokio::test]
+    async fn a_non_exit_code_divergence_carries_no_stderr_excerpt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stub = write_noisy_stub(dir.path(), "deacon-noisy-fail", "error: bad config", 30, 1);
+        let fixtures = make_fixtures(dir.path());
+        let cfg = RunConfig {
+            deacon_path: &stub,
+            oracle: None,
+            fixtures_root: &fixtures,
+            report_root: &dir.path().join("report"),
+        };
+        let verdict = run_case(&failure_case(), &cfg).await.expect("run");
+
+        let exit = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_EXIT_CODE)
+            .expect("exit-code channel");
+        assert_eq!(exit.outcome, Outcome::Agree, "nonZero matched the failure");
+        assert!(
+            exit.stderr_excerpt.is_none(),
+            "an AGREEING exit code has nothing to explain: {exit:?}"
+        );
+
+        let structured = verdict
+            .channels
+            .iter()
+            .find(|c| c.channel == CHAN_STRUCTURED_OUTPUT)
+            .expect("structured channel");
+        assert_eq!(structured.outcome, Outcome::Diverge);
+        assert!(
+            structured.stderr_excerpt.is_none(),
+            "a non-exit-code divergence already names its diverging path; stderr there is \
+             noise: {structured:?}"
+        );
     }
 
     /// A negative case: read-configuration fails (exit 1, non-JSON stdout). The runner

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -182,6 +182,15 @@ failure.
 current verdict, the latest nightly run (`gh run list --workflow=parity.yml --branch=main`).
 Neither belongs in this file — status snapshots in prose go stale within the day.
 
+**What a failing run leaves behind.** Every lane writes its raw capture and report fragments
+under `target/parity/`, and every job that runs a parity binary uploads that tree as a
+`parity-evidence-*` artifact — the nightly on any outcome, the gating lanes (`ci.yml`'s fast,
+MVP-integration and Podman jobs; `release.yml`'s verify job) on failure only. Download it
+before re-running: a re-run that goes green destroys the only copy of what happened (#474).
+The failure text itself carries the diverging observable paths, and — for a `chan-exit-code`
+divergence specifically — a tail-bounded excerpt of the stderr of whichever side exited
+non-zero, because that channel's verdict otherwise names nothing to fix.
+
 ## What to do when you find a difference
 
 1. **Measure it.** Run both CLIs over the same fixture and record both values verbatim. A


### PR DESCRIPTION
Closes #474.

Two independent, both small. Surfaced while root-causing #470, where both prior CI occurrences of the export-tar flake were undiagnosable from what CI retained.

## 1. Evidence artifacts on failure in every gating job

`parity.yml` has always uploaded `target/parity/`, but **that lane gates nothing**. The lanes that gate a pull request retained nothing but a 267-byte timing file — so #470's own "download the evidence before rerunning" instruction was unfollowable as the workflows stood.

Added the equivalent step to every job that runs a parity binary:

| Workflow / job | Parity binaries it runs | Artifact name |
|---|---|---|
| `ci.yml` → Test (MVP fast) | `parity_hermetic` (selected by `dev-fast`) | `parity-evidence-fast-${{ matrix.os }}` |
| `ci.yml` → Test (MVP integration) | `parity_hermetic` + `parity_docker` | `parity-evidence-mvp-integration` |
| `ci.yml` → Test (Podman) | `parity_hermetic` (`parity_docker` excluded) | `parity-evidence-podman` |
| `release.yml` → verify | `parity_hermetic` + `parity_docker` | `parity-evidence-release-verify` |

`coverage.yml` runs parity binaries under `--ignore-run-fail` — it neither gates on nor produces a parity verdict, so it is deliberately left alone.

Two deliberate differences from `parity.yml`'s step:

- **`if: failure()`, not `always()`** — these run on every pull request; a green run's raw capture is not worth the storage.
- **`if-no-files-found: ignore`, not `warn`** — a failure *before* the harness runs (a compile error, the Docker engine precondition) leaves no tree, and a missing artifact must not become a second failure obscuring the first. This is load-bearing on the fast lane's macOS and Windows legs, which run no parity binary at all (#441).

Everything else (`actions/upload-artifact@v7`, `path: target/parity/`) is field-identical.

## 2. The failing side's stderr in exit-code divergence verdicts

Every other channel's verdict names the observable paths that differed. `chan-exit-code` has one observable, so `chan-exit-code: Diverge` is the *entire* message — and #470's root cause was one line of deacon's stderr away from a one-line diagnosis.

`runner::attach_stderr_excerpt` attaches a tail-bounded excerpt (last 20 lines, further clipped to 2 KiB, whichever bites first) of the stderr of each side that exited non-zero; `driver::stderr_excerpts` appends it to the failure that reaches the nextest panic. **Formatting over evidence already captured** (`ProcessOutcome::stderr`, also persisted verbatim under `raw/…`) — no new capture machinery.

Scoped three ways, because an excerpt everywhere is noise: the `chan-exit-code` channel only, diverging verdicts only, non-zero sides only. It rides on a `#[serde(skip)]` field so the verdict report stays contractually path-free and byte-stable — the tail exists to reach the panic; the full streams stay on disk for anything more.

### Watch it fail

Forced an exit-code divergence in a real hermetic case (a bogus flag on `case-doctor-boundary-no-configuration`, restored after):

```
hermetic parity failure(s) in resource group `none`:
case-doctor-boundary-no-configuration: chan-exit-code: Diverge; chan-stdout: Diverge
  deacon stderr (exit 2):
    | error: unexpected argument '--this-flag-does-not-exist' found
    |
    | Usage: deacon doctor --workspace-folder <PATH>
    |
    | For more information, try '--help'.
```

Note `chan-stdout: Diverge` in that same verdict picked up **no** excerpt. Forcing a `chan-stdout`-only divergence confirms the negative directly:

```
hermetic parity failure(s) in resource group `none`:
case-doctor-boundary-no-configuration: chan-stdout: Diverge
```

— byte-identical to the pre-change format, which is the point.

## Verification

- `cargo nextest run -p parity-harness` — 239/239 pass, including three new tests: the excerpt is attached, labeled and line/byte-bounded; an agreeing exit code and a non-exit-code divergence carry none (with a noisy stub, so the negative is not vacuous); `tail_excerpt` bounds by lines *and* bytes.
- `cargo nextest run --profile dev-fast --no-fail-fast` — 3202/3202 pass.
- `parity_hermetic` (64 cases) and `parity_docker` green individually.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Workflows: `actionlint` clean on all three edited/compared files, plus a field-by-field diff against `parity.yml`'s working step (above). A CI failure cannot be cheaply forced to exercise the upload itself, so that review rigor stands in for it.

Existing harness tests assert on verdict *keys*, never on exact verdict strings, so none needed updating for the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb