### PR TITLE
fix(set-up): collect lifecycle hooks from every container-label entry (#477)

### DIFF
--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -36,11 +36,11 @@ use crate::commands::shared::resolve_runtime;
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
-    AggregatedLifecycleCommand, ContainerLifecycleCommands, ContainerLifecycleConfig,
-    DotfilesConfig, LifecycleCommandList, LifecycleCommandSource, LifecycleCommandValue,
-    execute_container_lifecycle_with_progress_callback_and_docker,
+    ContainerLifecycleCommands, ContainerLifecycleConfig, DotfilesConfig, LifecycleCommandList,
+    aggregate_lifecycle_commands, execute_container_lifecycle_with_progress_callback_and_docker,
 };
 use deacon_core::docker::{CliRuntime, ContainerInfo, Docker, ExecConfig};
+use deacon_core::lifecycle::LifecyclePhase;
 use deacon_core::runtime::RuntimeKind;
 use deacon_core::variable::SubstitutionContext;
 use std::collections::HashMap;
@@ -366,46 +366,39 @@ async fn execute_lifecycle_hooks(
 
     let mut commands = ContainerLifecycleCommands::new();
 
-    let parse_phase_command =
-        |json_val: &serde_json::Value, phase: &str| -> Result<Option<LifecycleCommandList>> {
-            let parsed = LifecycleCommandValue::from_json_value(json_val)
-                .with_context(|| format!("Failed to parse {} command", phase))?;
-            Ok(match parsed {
-                Some(cmd) if !cmd.is_empty() => Some(LifecycleCommandList {
-                    commands: vec![AggregatedLifecycleCommand {
-                        command: cmd,
-                        source: LifecycleCommandSource::Config,
-                    }],
-                }),
-                _ => None,
-            })
-        };
+    // Every hook the container's `devcontainer.metadata` label declares for a
+    // phase runs, in label order, ahead of the one `--config` declares — the
+    // spec's "Collected list of all `<phase>Command`s … the devcontainer.json is
+    // considered last" (#477). Reading the five SINGULAR fields ran only the
+    // last survivor of the fold; `aggregate_lifecycle_commands` is the
+    // collection `up` and `run-user-commands` already use, so set-up joins it
+    // rather than growing a second one.
+    //
+    // No separately-resolved features: a stamped label already carries each
+    // Feature's contribution as its own entry, so those arrive as layers too —
+    // which is how set-up gains Feature-hook execution it never had.
+    const NO_FEATURES: &[deacon_core::features::ResolvedFeature] = &[];
+    let collect = |phase: LifecyclePhase| -> Result<Option<LifecycleCommandList>> {
+        let list = aggregate_lifecycle_commands(phase, NO_FEATURES, merged_config)
+            .with_context(|| format!("Failed to parse {:?} commands", phase))?;
+        Ok((!list.commands.is_empty()).then_some(list))
+    };
 
-    if let Some(ref on_create) = merged_config.on_create_command {
-        if let Some(cmd) = parse_phase_command(on_create, "onCreateCommand")? {
-            commands = commands.with_on_create(cmd);
-        }
+    if let Some(list) = collect(LifecyclePhase::OnCreate)? {
+        commands = commands.with_on_create(list);
     }
-    if let Some(ref update_content) = merged_config.update_content_command {
-        if let Some(cmd) = parse_phase_command(update_content, "updateContentCommand")? {
-            commands = commands.with_update_content(cmd);
-        }
+    if let Some(list) = collect(LifecyclePhase::UpdateContent)? {
+        commands = commands.with_update_content(list);
     }
-    if let Some(ref post_create) = merged_config.post_create_command {
-        if let Some(cmd) = parse_phase_command(post_create, "postCreateCommand")? {
-            commands = commands.with_post_create(cmd);
-        }
+    if let Some(list) = collect(LifecyclePhase::PostCreate)? {
+        commands = commands.with_post_create(list);
     }
     if !args.skip_non_blocking_commands {
-        if let Some(ref post_start) = merged_config.post_start_command {
-            if let Some(cmd) = parse_phase_command(post_start, "postStartCommand")? {
-                commands = commands.with_post_start(cmd);
-            }
+        if let Some(list) = collect(LifecyclePhase::PostStart)? {
+            commands = commands.with_post_start(list);
         }
-        if let Some(ref post_attach) = merged_config.post_attach_command {
-            if let Some(cmd) = parse_phase_command(post_attach, "postAttachCommand")? {
-                commands = commands.with_post_attach(cmd);
-            }
+        if let Some(list) = collect(LifecyclePhase::PostAttach)? {
+            commands = commands.with_post_attach(list);
         }
     }
 
@@ -856,6 +849,85 @@ mod tests {
         };
         let merged = merge_configs(&file_cfg, None);
         assert_eq!(merged.name.as_deref(), Some("only-file"));
+    }
+
+    /// #477, hermetically: the whole set-up path from the container's stamped
+    /// label through `merge_configs` to the aggregation that feeds
+    /// `ContainerLifecycleCommands`.
+    ///
+    /// Both collapse points are covered at once, because they compose. The
+    /// label's own fragments used to fold last-wins (so `e0-onCreate` and
+    /// `feat-onCreate` vanished), and then reading the five SINGULAR fields off
+    /// the `--config` merge dropped whatever had survived (so only `ws-onCreate`
+    /// ran). The reference runs all four, devcontainer.json last — measured at
+    /// oracle 0.87.0, whose log on this exact shape reads the lines asserted
+    /// below.
+    ///
+    /// `postStart` is the control the fix must not break twice over: only the
+    /// FEATURE entry declares it, so it must appear exactly ONCE. A hook
+    /// recorded as a layer while the merge also left it in the singular field
+    /// would run twice, and an equality assertion over the whole list is the
+    /// only kind that can see that.
+    #[test]
+    fn set_up_collects_every_label_entry_hook_ahead_of_the_config_hook() {
+        let mut labels = HashMap::new();
+        labels.insert(
+            "devcontainer.metadata".to_string(),
+            r#"[
+                {"onCreateCommand": "e0-onCreate", "postCreateCommand": "e0-postCreate"},
+                {"id": "ghcr.io/example/feat:1", "onCreateCommand": "feat-onCreate",
+                 "postStartCommand": "feat-postStart"},
+                {"onCreateCommand": "e2-onCreate", "postCreateCommand": "e2-postCreate"}
+            ]"#
+            .to_string(),
+        );
+        let container = make_container("abc", "alpine:3.18", labels);
+        let metadata = extract_image_metadata_config(&container).unwrap();
+
+        let file_cfg = DevContainerConfig {
+            on_create_command: Some(serde_json::json!("ws-onCreate")),
+            post_create_command: Some(serde_json::json!("ws-postCreate")),
+            ..DevContainerConfig::default()
+        };
+        let merged = merge_configs(&file_cfg, metadata.as_ref());
+
+        let phase_commands = |phase: LifecyclePhase| {
+            aggregate_lifecycle_commands(phase, &[], &merged)
+                .unwrap()
+                .commands
+                .into_iter()
+                .map(|c| c.command)
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(
+            phase_commands(LifecyclePhase::OnCreate),
+            vec![
+                serde_json::json!("e0-onCreate"),
+                serde_json::json!("feat-onCreate"),
+                serde_json::json!("e2-onCreate"),
+                serde_json::json!("ws-onCreate"),
+            ],
+            "every label entry's onCreateCommand runs in label order, the \
+             devcontainer.json's last"
+        );
+        assert_eq!(
+            phase_commands(LifecyclePhase::PostCreate),
+            vec![
+                serde_json::json!("e0-postCreate"),
+                serde_json::json!("e2-postCreate"),
+                serde_json::json!("ws-postCreate"),
+            ],
+            "the hookless-for-this-phase feature entry contributes nothing"
+        );
+        assert_eq!(
+            phase_commands(LifecyclePhase::PostStart),
+            vec![serde_json::json!("feat-postStart")],
+            "a phase only ONE entry declares must run exactly once — a layer that \
+             also stayed in the singular field would run twice"
+        );
+        assert!(phase_commands(LifecyclePhase::UpdateContent).is_empty());
+        assert!(phase_commands(LifecyclePhase::PostAttach).is_empty());
     }
 
     #[test]

--- a/crates/deacon/src/commands/shared/container_metadata.rs
+++ b/crates/deacon/src/commands/shared/container_metadata.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use deacon_core::config::{ConfigMerger, DevContainerConfig};
+use deacon_core::config::{ConfigMerger, DevContainerConfig, LifecycleHookLayer};
 use deacon_core::docker::{ContainerInfo, Docker};
 
 /// Extract a merged [`DevContainerConfig`] from a container's
@@ -24,6 +24,28 @@ use deacon_core::docker::{ContainerInfo, Docker};
 /// single-object form) that [`ConfigMerger`] folds together. A missing label is
 /// NOT an error — many containers aren't built by `deacon up` — so this returns
 /// `Ok(None)` and the caller falls back to whatever config it already has.
+///
+/// # Lifecycle hooks do not fold (#477)
+///
+/// The fold is last-wins, which is right for every row of the spec's
+/// image-metadata Merge Logic table EXCEPT the five lifecycle hooks — each of
+/// those is a "Collected list of all `<phase>Command`s", so every fragment that
+/// declares a phase contributes a hook that RUNS, in fragment order. deacon's
+/// own `up` stamps `[...image entries, ...feature entries, config entry]`
+/// (`build_container_metadata_label`), so a phase two of those sources declare
+/// arrives here as two fragments — and left this function as one.
+///
+/// The hooks are therefore lifted OFF the merged configuration and onto
+/// [`DevContainerConfig::metadata_lifecycle_layers`], where
+/// `container_lifecycle::aggregate_lifecycle_commands` replays them in order —
+/// the same carrier and the same aggregation #467 introduced for the IMAGE's
+/// label, given one more source rather than a second mechanism.
+///
+/// Every fragment of this label sits BELOW anything the caller layers on top
+/// (`set-up`'s `--config`), so ALL of them become layers and the five singular
+/// fields are left empty. That is the invariant callers depend on: each hook has
+/// exactly one home, so a caller that both merges this config and aggregates its
+/// layers cannot run the same hook twice.
 pub fn config_from_metadata_label(container: &ContainerInfo) -> Result<Option<DevContainerConfig>> {
     let Some(label) = container.labels.get("devcontainer.metadata") else {
         return Ok(None);
@@ -55,7 +77,26 @@ pub fn config_from_metadata_label(container: &ContainerInfo) -> Result<Option<De
         configs.push(cfg);
     }
 
-    Ok(Some(ConfigMerger::merge_configs(&configs)))
+    // Collected BEFORE the fold, because after it only the last fragment's hook
+    // per phase survives. A fragment declaring no hook at all (the common
+    // `{"remoteUser": …}` base-image shape) contributes no layer.
+    let hook_layers: Vec<LifecycleHookLayer> = configs
+        .iter()
+        .filter_map(LifecycleHookLayer::from_config)
+        .collect();
+
+    let mut merged = ConfigMerger::merge_configs(&configs);
+
+    // One home per hook: clear the five singular fields the fold just last-won,
+    // since every one of their values is now carried as a layer. Leaving a copy
+    // behind would make `aggregate_lifecycle_commands` queue it twice.
+    LifecycleHookLayer::default().apply_to(&mut merged);
+    // Assignment, not append: the fragments were freshly deserialized from the
+    // label and `metadata_lifecycle_layers` is `#[serde(skip)]`, so the fold
+    // concatenated nothing and `merged`'s vec is empty by construction.
+    merged.metadata_lifecycle_layers = hook_layers;
+
+    Ok(Some(merged))
 }
 
 /// Resolve a workspace-loaded config against a RUNNING container: fold the
@@ -94,5 +135,137 @@ pub async fn resolve_config_against_container<D: Docker>(
             tracing::warn!("Failed to resolve effective config with labels: {}", e);
             base
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use deacon_core::docker::ContainerInfo;
+    use std::collections::HashMap;
+
+    fn container_with_metadata(label: &str) -> ContainerInfo {
+        let mut labels = HashMap::new();
+        labels.insert("devcontainer.metadata".to_string(), label.to_string());
+        ContainerInfo {
+            id: "c0ffee".to_string(),
+            names: vec![],
+            image: "alpine:3.18".to_string(),
+            status: "running".to_string(),
+            state: "running".to_string(),
+            exposed_ports: vec![],
+            port_mappings: vec![],
+            env: HashMap::new(),
+            labels,
+            mounts: vec![],
+        }
+    }
+
+    /// #477: the label's own fragments are a COLLECTION for the five lifecycle
+    /// hooks, not a last-wins fold. `deacon up` stamps
+    /// `[...image entries, ...feature entries, config entry]`, so a phase two of
+    /// those sources declare arrives as two fragments — and used to leave as one.
+    #[test]
+    fn label_fragments_contribute_one_hook_layer_each_in_order() {
+        let container = container_with_metadata(
+            r#"[
+                {"onCreateCommand": "e0-onCreate", "postCreateCommand": "e0-postCreate"},
+                {"id": "ghcr.io/example/feat:1", "onCreateCommand": "feat-onCreate"},
+                {"onCreateCommand": "e2-onCreate", "postCreateCommand": "e2-postCreate"}
+            ]"#,
+        );
+
+        let cfg = config_from_metadata_label(&container).unwrap().unwrap();
+
+        let layers = &cfg.metadata_lifecycle_layers;
+        assert_eq!(
+            layers.len(),
+            3,
+            "every fragment declaring a hook must contribute a layer, in label order"
+        );
+        assert_eq!(
+            layers[0].on_create_command,
+            Some(serde_json::json!("e0-onCreate"))
+        );
+        assert_eq!(
+            layers[1].on_create_command,
+            Some(serde_json::json!("feat-onCreate")),
+            "a FEATURE entry's hook is a layer like any other — this is the \
+             contribution set-up never aggregated at all"
+        );
+        assert_eq!(
+            layers[2].on_create_command,
+            Some(serde_json::json!("e2-onCreate"))
+        );
+        // The hookless phase of the feature entry stays empty rather than
+        // inheriting a neighbour's.
+        assert_eq!(layers[1].post_create_command, None);
+    }
+
+    /// The other half, and the trap #467's fix documented: a hook lifted onto a
+    /// layer must NOT also remain in the singular field, or a caller that both
+    /// merges this config and aggregates its layers runs it twice.
+    #[test]
+    fn lifted_hooks_leave_the_singular_fields_empty() {
+        let container = container_with_metadata(
+            r#"[
+                {"onCreateCommand": "e0-onCreate"},
+                {"postStartCommand": "e1-postStart"}
+            ]"#,
+        );
+
+        let cfg = config_from_metadata_label(&container).unwrap().unwrap();
+
+        assert_eq!(cfg.metadata_lifecycle_layers.len(), 2);
+        for (field, value) in [
+            ("onCreateCommand", &cfg.on_create_command),
+            ("updateContentCommand", &cfg.update_content_command),
+            ("postCreateCommand", &cfg.post_create_command),
+            ("postStartCommand", &cfg.post_start_command),
+            ("postAttachCommand", &cfg.post_attach_command),
+        ] {
+            assert_eq!(
+                *value, None,
+                "{field} must have exactly one home — the layer — or aggregation queues it twice"
+            );
+        }
+    }
+
+    /// Collecting the hooks must not turn the last-wins rows of the Merge Logic
+    /// table into collections. `exec --container-id` reads exactly these two
+    /// scalars off this function (#322) and nothing else, which is why the
+    /// change is invisible there.
+    #[test]
+    fn scalar_properties_still_last_win_across_fragments() {
+        let container = container_with_metadata(
+            r#"[
+                {"remoteUser": "first", "onCreateCommand": "e0-onCreate"},
+                {"remoteUser": "second", "remoteEnv": {"FROM_LABEL": "yes"}}
+            ]"#,
+        );
+
+        let cfg = config_from_metadata_label(&container).unwrap().unwrap();
+
+        assert_eq!(
+            cfg.remote_user.as_deref(),
+            Some("second"),
+            "remoteUser is 'Last value wins' — the later fragment must win outright"
+        );
+        assert_eq!(
+            cfg.remote_env().get("FROM_LABEL"),
+            Some(&Some("yes".to_string()))
+        );
+        assert_eq!(cfg.metadata_lifecycle_layers.len(), 1);
+    }
+
+    /// A fragment carrying no hook at all (the common
+    /// `mcr.microsoft.com/devcontainers/*` `{"remoteUser": …}` shape)
+    /// contributes no layer rather than an empty one.
+    #[test]
+    fn hookless_label_contributes_no_layers() {
+        let container = container_with_metadata(r#"[{"remoteUser": "vscode"}]"#);
+        let cfg = config_from_metadata_label(&container).unwrap().unwrap();
+        assert!(cfg.metadata_lifecycle_layers.is_empty());
+        assert_eq!(cfg.remote_user.as_deref(), Some("vscode"));
     }
 }

--- a/crates/deacon/tests/integration_feature_lifecycle.rs
+++ b/crates/deacon/tests/integration_feature_lifecycle.rs
@@ -1470,3 +1470,184 @@ fn test_image_metadata_layers_features_and_config_run_in_spec_order() {
         lines
     );
 }
+
+/// #477 (`set-up` surface): every lifecycle hook the CONTAINER's stamped
+/// `devcontainer.metadata` label declares for a phase runs, in label order,
+/// ahead of the one `--config` declares — instead of only the last survivor of
+/// a last-wins fold.
+///
+/// Same defect CLASS as #467, different SOURCE. #467 was the IMAGE's label
+/// collapsed by `ConfigMerger` on the `up` path; this is the CONTAINER's
+/// stamped label collapsed the same way on a path #467's fix did not reach.
+/// There were two collapse points and they compose, so both shapes are
+/// measured here:
+///   - **no `--config`** isolates `config_from_metadata_label`, which folded the
+///     label's own fragments last-wins. `deacon up` stamps
+///     `[...image entries, ...feature entries, config entry]`, so a phase two of
+///     those sources declare arrives as two fragments and used to leave as one.
+///   - **with `--config`** adds the second point, where `set_up.rs` folded that
+///     result again and read the five SINGULAR fields off it.
+///
+/// The label below is that stamped shape: an image entry, a FEATURE entry, and a
+/// config entry. The feature entry is deliberate — `set-up` never called
+/// `aggregate_lifecycle_commands` at all, so Feature-contributed hooks were not
+/// merely mis-ordered, they never ran unless no other entry declared the phase.
+///
+/// `postStart` is declared by the feature entry ALONE and must appear exactly
+/// ONCE. That is the trap #467's fix documented: a hook lifted onto a layer that
+/// also stays in the singular field runs twice. It is why every assertion here
+/// spans the WHOLE log — a `contains` assertion cannot see an appended
+/// duplicate.
+///
+/// Both CLIs exit 0 on every one of these shapes, so the marker file is the
+/// entire observation. Measured against the pinned reference CLI 0.87.0: its
+/// logs are exactly the two vectors asserted below.
+#[test]
+fn test_set_up_collects_container_label_hooks_alongside_the_config_hook() {
+    if !is_docker_available() {
+        eprintln!(
+            "Skipping test_set_up_collects_container_label_hooks_alongside_the_config_hook: Docker not available"
+        );
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let guard = ContainerGuard::new();
+
+    // Unique tag/names so parallel runs in the docker-shared group never collide.
+    let unique = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default()
+    );
+    let image_tag = format!("deacon-test-setup-label-hooks-{}:local", unique);
+    let _image = ImageGuard(image_tag.clone());
+
+    // A PLAIN container is the point: one a prior `up` has already set up
+    // carries in-container phase markers that suppress every hook and make the
+    // surface unmeasurable. This container merely inherits the image's label.
+    let image_dir = temp_dir.path().join("image");
+    fs::create_dir_all(&image_dir).unwrap();
+    fs::write(
+        image_dir.join("Dockerfile"),
+        concat!(
+            "FROM alpine:3.19\n",
+            "LABEL devcontainer.metadata='[",
+            "{\"onCreateCommand\":\"echo e0-onCreate >> /tmp/setup.log\",",
+            "\"postCreateCommand\":\"echo e0-postCreate >> /tmp/setup.log\"},",
+            "{\"id\":\"ghcr.io/example/feat:1\",",
+            "\"onCreateCommand\":\"echo feat-onCreate >> /tmp/setup.log\",",
+            "\"postStartCommand\":\"echo feat-postStart >> /tmp/setup.log\"},",
+            "{\"onCreateCommand\":\"echo e2-onCreate >> /tmp/setup.log\",",
+            "\"postCreateCommand\":\"echo e2-postCreate >> /tmp/setup.log\"}",
+            "]'\n",
+            "CMD [\"sleep\", \"infinity\"]\n",
+        ),
+    )
+    .unwrap();
+
+    let build = StdCommand::new("docker")
+        .args(["build", "-q", "-t", &image_tag])
+        .arg(&image_dir)
+        .output()
+        .expect("docker build should run");
+    assert!(
+        build.status.success(),
+        "docker build failed: {}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+
+    // `set-up`'s `--config` shape. The config declares the same two phases the
+    // image entry does, which is the collision the reference collects.
+    let config_path = temp_dir.path().join("set-up-config.json");
+    fs::write(
+        &config_path,
+        serde_json::to_string_pretty(&json!({
+            "image": image_tag,
+            "onCreateCommand": "echo ws-onCreate >> /tmp/setup.log",
+            "postCreateCommand": "echo ws-postCreate >> /tmp/setup.log",
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let start_container = |name: &str| -> String {
+        let out = StdCommand::new("docker")
+            .args(["run", "-d", "--name", name, &image_tag])
+            .output()
+            .expect("docker run should execute");
+        assert!(
+            out.status.success(),
+            "docker run failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        guard.register(id.clone());
+        id
+    };
+
+    let run_set_up = |container_id: &str, extra: &[&str]| {
+        let mut cmd = Command::cargo_bin("deacon").expect("deacon binary");
+        let mut args = vec!["set-up", "--container-id", container_id];
+        args.extend_from_slice(extra);
+        let assert = cmd.env("DEACON_LOG", "warn").args(&args).assert();
+        let output = assert.get_output();
+        assert!(
+            output.status.success(),
+            "deacon set-up failed:\nSTDOUT:\n{}\nSTDERR:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+
+    let log_lines = |container_id: &str| -> Vec<String> {
+        read_container_file(container_id, "/tmp/setup.log")
+            .expect("the lifecycle hooks should have written /tmp/setup.log")
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect()
+    };
+
+    // --- Collapse point 1, isolated: no `--config` at all. ---
+    let bare = start_container(&format!("deacon-test-setup-477-bare-{}", unique));
+    run_set_up(&bare, &[]);
+    assert_eq!(
+        log_lines(&bare),
+        vec![
+            "e0-onCreate",
+            "feat-onCreate",
+            "e2-onCreate",
+            "e0-postCreate",
+            "e2-postCreate",
+            "feat-postStart",
+        ],
+        "with no --config, every entry of the container's devcontainer.metadata \
+         label must contribute its hook in label order — including the FEATURE \
+         entry's, which set-up never aggregated — and the feature-only postStart \
+         exactly once (#477)"
+    );
+
+    // --- Both collapse points: the same label plus a `--config`. ---
+    let with_config = start_container(&format!("deacon-test-setup-477-cfg-{}", unique));
+    run_set_up(&with_config, &["--config", config_path.to_str().unwrap()]);
+    assert_eq!(
+        log_lines(&with_config),
+        vec![
+            "e0-onCreate",
+            "feat-onCreate",
+            "e2-onCreate",
+            "ws-onCreate",
+            "e0-postCreate",
+            "e2-postCreate",
+            "ws-postCreate",
+            "feat-postStart",
+        ],
+        "the devcontainer.json's hook is collected LAST for each phase, never \
+         instead of the label's (#477)"
+    );
+}

--- a/parity/SPEC_STATUS.md
+++ b/parity/SPEC_STATUS.md
@@ -24,11 +24,11 @@ alone. Where a row has no scenario yet, it says so.
 
 Of **90 recorded behaviors**:
 
-- **1** — open nonconformance — [#477](https://github.com/get2knowio/deacon/issues/477)
+- **0** — open nonconformance
 - **9** — deacon follows the spec where the CLI does not
 - **11** — documented choice
 - **19** — deacon extension
-- **50** — conformant and matching
+- **51** — conformant and matching
 
 The open-nonconformance column emptied on 2026-08-03 when duplicate Features
 ([#430](https://github.com/get2knowio/deacon/issues/430)) left it, refilled the same day
@@ -54,10 +54,19 @@ link.
 It had a shelf life of hours. Closing #467 prompted an audit for other callers of the merge
 it fixed, and [#477](https://github.com/get2knowio/deacon/issues/477) is what that audit
 measured: the same collapse on the CONTAINER's stamped label, which `set-up` reads and #467's
-fix did not reach. It refilled the column the day #467 emptied it. That is the fourth link in
-the same chain and it was found the same way as the other three — by measuring a surface
-against the pinned oracle rather than by reasoning about the code — so the column reads one,
-and reading zero here would have meant nobody looked.
+fix did not reach. It refilled the column the day #467 emptied it, and left again the same
+day when the fix was measured against the oracle on all three of its shapes. That is the
+fourth link in the same chain and it was found the same way as the other three — by
+measuring a surface against the pinned oracle rather than by reasoning about the code.
+
+So the column reads zero again, with the same caveat it carried the last time it did: an
+empty column is a statement about what has been MEASURED, and its shelf life is however
+long it takes someone to look somewhere new. #477 is the standing evidence for that — it
+existed the whole time #467 was open and became visible only when someone audited the other
+callers of the merge #467 fixed. The audit that closed it went one step further and found
+`exec`, the only other caller, clean for a reason rather than by luck: it reads the
+last-wins scalars off that helper and runs no lifecycle phase at all. The next link, if
+there is one, will come from measuring a surface nobody has measured yet.
 
 Two rows moved from "deacon follows the spec where the CLI does not" to "conformant and
 matching" at [#439](https://github.com/get2knowio/deacon/issues/439) — not because deacon
@@ -234,7 +243,7 @@ oversight nobody noticed.
 
 | Behavior | Status | Evidence | Notes |
 |---|---|---|---|
-| A lifecycle hook contributed by the CONTAINER's `devcontainer.metadata` label runs ALONGSIDE the ones other entries of that label — and a `--config` — declare for the same phase, rather than only the last one running. | **open nonconformance** | no scenario yet — measured repro on the issue | OPEN — filed as [#477](https://github.com/get2knowio/deacon/issues/477), found by auditing for more instances of [#467](https://github.com/get2knowio/deacon/issues/467)'s pattern after fixing it. Same defect CLASS, different SOURCE: #467 was the IMAGE's label collapsed by `ConfigMerger`; this is the CONTAINER's stamped label collapsed the same way, on the `set-up` surface, which #467's fix did not reach. Two collapse points, both measured separately: `container_metadata::config_from_metadata_label` folds the label's own fragments last-wins (and deacon's `up` stamps `[...image entries, ...feature entries, config entry]`, so a collision arrives as two entries and leaves as one), then `set_up.rs` folds that under `--config` and reads the five SINGULAR fields off the result. Measured at oracle 0.87.0 on an already-running plain container inheriting an image label with `onCreateCommand` + `postCreateCommand`, plus a `--config` declaring both: the reference's log reads `img-onCreate` / `ws-onCreate` / `img-postCreate` / `ws-postCreate` and deacon's reads only the two `ws-` lines, both exit 0 — so the marker file is the whole observation, and the reference's own output confirms it collects (it prints "Running the onCreateCommand from devcontainer.json..." twice per phase). The second collapse point is visible with NO `--config` at all: against a container `deacon up` created, whose stamped label carries an image entry and a config entry for the same phase, `deacon set-up --container-id` writes only the `ws-` lines, which isolates `config_from_metadata_label`. The container is a PLAIN one deliberately — a container a prior `up` has already set up carries the reference's in-container phase markers, which suppress every hook and make the surface unmeasurable. Measured and found CLEAN in the same session, so nobody re-checks it: `read-configuration --container-id --include-merged-configuration` against the same stamped container matches the reference byte for byte, emitting the collected `onCreateCommands` / `postCreateCommands` — that surface collects the label's entries through `apply_upstream_merge_shape` rather than through `ConfigMerger`, so it never had the defect. That is #467's asymmetry again, and the reason this is worth its own row: deacon REPORTS the collected list correctly here and EXECUTES only the last one. #467's machinery is the fix to reuse — `aggregate_lifecycle_commands_with_image_metadata` and `LifecycleCommandSource::ImageMetadata { index }` already exist — with the same trap it documented: lift the hooks OFF the merged config, or an entry that is both merged and collected runs twice. `set-up` also does not aggregate FEATURE-contributed hooks at all, which the same change closes. |
+| A lifecycle hook contributed by the CONTAINER's `devcontainer.metadata` label runs ALONGSIDE the ones other entries of that label — and a `--config` — declare for the same phase, rather than only the last one running. | matches the reference | 1 Docker-gated test — no parity case, see notes | Was an open nonconformance ([#477](https://github.com/get2knowio/deacon/issues/477)), closed 2026-08-04. Both collapse points are gone and all three shapes are byte-identical to oracle 0.87.0, re-measured live on the issue's own repro: with `--config` over a single-entry label, `img-onCreate` / `ws-onCreate` / `img-postCreate` / `ws-postCreate` (deacon previously wrote only the two `ws-` lines); against a three-entry `[image, feature, config]` label with NO `--config`, `e0-onCreate` / `feat-onCreate` / `e2-onCreate` / `e0-postCreate` / `e2-postCreate` / `feat-postStart` (deacon previously wrote only `e2-onCreate` / `e2-postCreate` / `feat-postStart`); and the same label plus a `--config`, which interleaves `ws-onCreate` / `ws-postCreate` last in their phases. The FEATURE entry's hook running at all is new: `set-up` never called `aggregate_lifecycle_commands`, so a Feature-contributed hook ran only when no other entry declared that phase. The fix reuses #467's machinery rather than adding a parallel one — `config_from_metadata_label` lifts each fragment's hooks onto `DevContainerConfig::metadata_lifecycle_layers` and leaves the five singular fields EMPTY, so `aggregate_lifecycle_commands` replays them in label order ahead of the `--config`'s. Leaving a hook in both homes is the double-run trap #467 documented, and it is observed rather than argued: with the clearing removed the Docker-gated test reports `e2-onCreate` / `e2-postCreate` / `feat-postStart` each appearing twice. **No parity case:** `set-up` is not in the harness's `CONSUMER_SUBCOMMANDS` vocabulary, and this fix is not a reason to grow the case model — the evidence is `test_set_up_collects_container_label_hooks_alongside_the_config_hook` (docker-shared, gates every PR), which asserts the WHOLE marker log on both shapes because a `contains` assertion cannot see an appended duplicate. Two neighbours were re-measured and are clean, so nobody re-checks them: `read-configuration --container-id --include-merged-configuration` is byte-identical before and after the change (it collects through `apply_upstream_merge_shape`, never through this helper), and `exec --container-id` — the other caller of `config_from_metadata_label` — reads only the LAST-WINS `remoteUser` / `remoteEnv` off it and runs no lifecycle phase at all, so it was never exposed and still recovers both across a multi-entry label. One divergence remains on this surface and is NOT #477: `set-up --include-merged-configuration` emits deacon's flat config under a `merged_configuration` key, where the reference emits `mergedConfiguration` carrying the collected `onCreateCommands` / `postCreateCommands` plural arrays. That block was already the wrong shape before this change and is untouched by it. |
 
 ### `templates-apply`
 


### PR DESCRIPTION
`set-up` ran only the LAST lifecycle hook per phase when the container's
`devcontainer.metadata` label declared that phase more than once. The spec's
image-metadata Merge Logic table gives each of the five hooks a "Collected list of all
`<phase>Command`s", with *"the devcontainer.json is considered last"* — every entry's
hook RUNS, in array order. Every **other** row of that table is last-wins, which is
exactly how the label was folded in: precedence was right, accumulation was missing.

Same defect **class** as #467, different **source**. #467 was the IMAGE's label collapsed
by `ConfigMerger` on the `up` path; this is the CONTAINER's stamped label collapsed the
same way on a path #467's fix did not reach.

## Measured, at oracle 0.87.0, on all three shapes

Both sides exit 0 on every shape, so the marker log is the entire observation.

| Shape | reference 0.87.0 | deacon before | deacon after |
|---|---|---|---|
| single-entry label + `--config` | `img-onCreate` / `ws-onCreate` / `img-postCreate` / `ws-postCreate` | `ws-onCreate` / `ws-postCreate` | **identical to reference** |
| three-entry `[image, feature, config]` label, **no** `--config` | `e0-onCreate` / `feat-onCreate` / `e2-onCreate` / `e0-postCreate` / `e2-postCreate` / `feat-postStart` | `e2-onCreate` / `e2-postCreate` / `feat-postStart` | **identical to reference** |
| same three-entry label + `--config` | `e0-onCreate` / `feat-onCreate` / `e2-onCreate` / `ws-onCreate` / `e0-postCreate` / `e2-postCreate` / `ws-postCreate` / `feat-postStart` | `ws-onCreate` / `ws-postCreate` / `feat-postStart` | **identical to reference** |

The two collapse points compose, which is why all three shapes are here: fixing either
one alone leaves the other. The no-`--config` row isolates
`config_from_metadata_label`, which folded the label's own fragments last-wins; the
`--config` rows add `set_up.rs`, which folded that result again and read the five
SINGULAR fields off it.

The FEATURE entry's hook running at all is new. `set-up` never called
`aggregate_lifecycle_commands`, so a Feature-contributed hook ran only when no other
entry happened to declare that phase.

## The fix extends #467's machinery rather than paralleling it

`config_from_metadata_label` lifts each fragment's hooks onto
`DevContainerConfig::metadata_lifecycle_layers` — the `#[serde(skip)]` carrier #467
introduced — and `set_up.rs` calls the `aggregate_lifecycle_commands` that `up` and
`run-user-commands` already use instead of reading the singular fields. One collection
mechanism, given one more source.

Every fragment of this label sits BELOW anything the caller layers on top, so ALL of them
become layers and the merged config's five singular fields are left EMPTY. That is the
invariant the callers depend on — each hook has exactly one home — and it is the trap
#467's first draft hit: a hook recorded as a layer while the merge also left it in a
singular field runs twice.

## Verification

Each new assertion was broken once and watched to fail:

- **clearing removed** (hook in both homes) → the Docker-gated test reports `e2-onCreate`,
  `e2-postCreate` and `feat-postStart` each appearing **twice**; the two unit tests fail on
  the singular field and the doubled command list.
- **whole fix stashed** (true pre-fix source) → the same test reports exactly
  `["e2-onCreate", "e2-postCreate", "feat-postStart"]`, the three lines deacon wrote in the
  wild.

Every assertion spans the WHOLE marker log for that reason — a `contains` assertion cannot
see an appended duplicate.

**Neighbouring surfaces re-measured, not assumed:**

- `read-configuration --container-id --include-merged-configuration` — **byte-identical**
  before and after (sha256 `9af915a4…`). It collects through `apply_upstream_merge_shape`
  and never calls this helper. Its only delta vs the reference is still the characterized
  `bhv-readconfig-merged-computed-empties-omitted` (three empty maps).
- `exec --container-id` — the only other caller of `config_from_metadata_label`. It reads
  only the LAST-WINS `remoteUser`/`remoteEnv` off it and runs no lifecycle phase at all, so
  it was never exposed. Verified live against a multi-entry label where those two come from
  different entries: deacon and the reference both report `metauser` / `FROM_LABEL=yes`,
  and no hook fires.
- `run-user-commands` — reaches the IMAGE's label through a different helper (#405/#472),
  not this one. Re-measured: still collects `img-onCreate` / `ws-onCreate` /
  `img-postCreate` / `ws-postCreate`.

## Coverage

One Docker-gated test in `integration_feature_lifecycle` (docker-shared; already wired
into every nextest profile, so no `.config/nextest.toml` change) covering both shapes.

**No parity case, deliberately:** `set-up` is not in the harness's `CONSUMER_SUBCOMMANDS`
vocabulary, and a fix is not a reason to grow the case model. `parity/SPEC_STATUS.md`
carries the measurement instead, and the #477 row moves out of open nonconformance —
the column goes to **0** by row census (90 rows: 51 matching / 19 extension / 11
documented choice / 9 follows-spec).

One divergence remains on this surface and is **not** #477:
`set-up --include-merged-configuration` emits deacon's flat config under a
`merged_configuration` key where the reference emits `mergedConfiguration` carrying the
collected plural arrays. That block was already the wrong shape before this change and is
untouched by it; it is recorded in the row.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
