### PR TITLE
docs(parity): correct the SPEC_STATUS summary to the row census

### DIFF
--- a/parity/SPEC_STATUS.md
+++ b/parity/SPEC_STATUS.md
@@ -22,13 +22,13 @@ alone. Where a row has no scenario yet, it says so.
 
 ## Summary
 
-Of **114 recorded behaviors**:
+Of **115 recorded behaviors**:
 
 - **0** — open nonconformance
 - **9** — deacon follows the spec where the CLI does not
 - **11** — documented choice
 - **19** — deacon extension
-- **75** — conformant and matching
+- **76** — conformant and matching
 
 **The batch-1 mining pass is fully dispositioned, and the differential lane's diverging set
 is empty.** The pass ([#480](https://github.com/get2knowio/deacon/issues/480)) ran 22 scenarios harvested from the reference CLI's own e2e


### PR DESCRIPTION
PRs #504 and #509 each added a "matches the reference" row while censusing against a base that lacked the other's; the silent same-file auto-merge left the summary header one short. Row census of the table on current `main`: **115 behaviors — 76 matching, 19 extension, 11 documented choice, 9 follows-spec, 0 open**. Two-line header fix, no row changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb