### PR TITLE
fix(doctor): bound runtime probes with a timeout and report skips honestly (#507)

### DIFF
--- a/crates/core/src/doctor.rs
+++ b/crates/core/src/doctor.rs
@@ -226,6 +226,18 @@ pub struct ResourceInfo {
 /// parity suite's 120s per-invocation limit.
 pub const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How long to wait for a killed probe to be reaped before handing it to
+/// tokio's orphan reaper. SIGKILL is prompt unless the child is stuck in
+/// uninterruptible sleep, which is exactly the case this bound exists for.
+const REAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap on how much of a probe's output is read.
+///
+/// The probes read small JSON documents; anything beyond this is a runtime
+/// misbehaving, and reading it unbounded would put megabytes into a diagnostic
+/// report (and, via `reason`, into a support bundle).
+const MAX_PROBE_OUTPUT: u64 = 1 << 20;
+
 /// Outcome of a bounded probe process.
 enum ProbeOutcome {
     /// The process exited within the bound.
@@ -273,14 +285,18 @@ async fn run_bounded_probe(
 
     // `spawn` with piped stdio always populates these; a missing pipe is an I/O
     // condition to report, not something to unwrap.
+    // Capped so a runtime that floods a pipe cannot put megabytes into a
+    // diagnostic report (and, via `reason`, into a support bundle).
     let mut stdout_pipe = child
         .stdout
         .take()
-        .ok_or_else(|| std::io::Error::other("probe stdout pipe missing"))?;
+        .ok_or_else(|| std::io::Error::other("probe stdout pipe missing"))?
+        .take(MAX_PROBE_OUTPUT);
     let mut stderr_pipe = child
         .stderr
         .take()
-        .ok_or_else(|| std::io::Error::other("probe stderr pipe missing"))?;
+        .ok_or_else(|| std::io::Error::other("probe stderr pipe missing"))?
+        .take(MAX_PROBE_OUTPUT);
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -305,9 +321,19 @@ async fn run_bounded_probe(
         }),
         Ok(Err(e)) => Err(e),
         Err(_elapsed) => {
-            // Kill AND reap in one call: `kill` sends SIGKILL then waits.
-            if let Err(e) = child.kill().await {
-                debug!("Failed to reap timed-out probe `{}`: {}", program, e);
+            // Kill AND reap in one call: `kill` sends SIGKILL then waits. The
+            // wait is itself bounded, because it is the last thing in this
+            // module that could block forever — a child wedged in uninterruptible
+            // sleep (a dead `DOCKER_HOST` over a stuck mount) never reaps. If
+            // that bound trips, `kill_on_drop` hands the corpse to tokio's
+            // orphan reaper instead, so it is still collected, just not here.
+            match tokio::time::timeout(REAP_TIMEOUT, child.kill()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => debug!("Failed to reap timed-out probe `{}`: {}", program, e),
+                Err(_) => debug!(
+                    "Timed-out probe `{}` did not reap within {:?}; leaving it to kill_on_drop",
+                    program, REAP_TIMEOUT
+                ),
             }
             Ok(ProbeOutcome::TimedOut)
         }
@@ -341,7 +367,7 @@ async fn probe_stdout(
                 "{} exited with {}: {}",
                 display,
                 status,
-                String::from_utf8_lossy(&stderr).trim()
+                summarize_stderr(&stderr)
             ),
         )),
         // `{:?}` on a `Duration` renders "10s" / "250ms" — the bound is stated
@@ -350,7 +376,39 @@ async fn probe_stdout(
             probe,
             format!("{} exceeded the {:?} probe timeout", display, timeout),
         )),
-        Err(e) => Probed::NotLaunched(format!("{} could not be launched: {}", display, e)),
+        // Only an ABSENT (or unexecutable) binary means "the runtime is not
+        // installed" — that verdict makes `doctor` report `installed: false`,
+        // so it must not absorb every other I/O condition. A fork failure under
+        // load or a broken pipe mid-read is a probe that FAILED, and gets
+        // reported as such rather than silently reclassified.
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            Probed::NotLaunched(format!("{} could not be launched: {}", display, e))
+        }
+        Err(e) => Probed::Skipped(SkippedProbe::new(
+            probe,
+            format!("{} failed: {}", display, e),
+        )),
+    }
+}
+
+/// Reduce a probe's stderr to a bounded, single-line fragment for its reason.
+///
+/// The reason string travels into `--json`, the text report and the support
+/// bundle, so an unbounded copy of a noisy runtime's stderr would land in all
+/// three. Keep the tail short enough to read.
+fn summarize_stderr(stderr: &[u8]) -> String {
+    const MAX_REASON_STDERR: usize = 512;
+
+    let text = String::from_utf8_lossy(stderr);
+    let trimmed = text.trim();
+    match trimmed.char_indices().nth(MAX_REASON_STDERR) {
+        Some((cut, _)) => format!("{}…", &trimmed[..cut]),
+        None => trimmed.to_string(),
     }
 }
 
@@ -604,9 +662,32 @@ struct DockerInfoRaw {
     storage_driver: Option<String>,
 }
 
+/// Why `<runtime> info --format json` could not be turned into a summary.
+#[derive(Debug, thiserror::Error)]
+enum InfoParseError {
+    #[error("{0}")]
+    Json(#[from] serde_json::Error),
+    /// The document parsed but carried none of the fields the summary reports —
+    /// e.g. podman's `info`, which nests its counters under `store`/`host`
+    /// rather than using Docker's `types.Info` keys. Every field being
+    /// `Option`, this would otherwise deserialize "successfully" into a summary
+    /// of nothings, which the text report would then render as zeros.
+    #[error("no recognized fields (not a Docker `info` document)")]
+    NoRecognizedFields,
+}
+
 /// Parse `<runtime> info --format json` into the reported summary.
-fn parse_info_summary(stdout: &[u8]) -> std::result::Result<DockerInfoSummary, serde_json::Error> {
+fn parse_info_summary(stdout: &[u8]) -> std::result::Result<DockerInfoSummary, InfoParseError> {
     let raw: DockerInfoRaw = serde_json::from_slice(stdout)?;
+    if raw.containers_running.is_none()
+        && raw.containers_paused.is_none()
+        && raw.containers_stopped.is_none()
+        && raw.images.is_none()
+        && raw.server_version.is_none()
+        && raw.storage_driver.is_none()
+    {
+        return Err(InfoParseError::NoRecognizedFields);
+    }
     Ok(DockerInfoSummary {
         containers_running: raw.containers_running,
         containers_paused: raw.containers_paused,
@@ -907,16 +988,18 @@ fn print_text_output_with_redaction(
         info.docker_info.daemon_running
     );
     if let Some(summary) = &info.docker_info.info_summary {
-        println_redacted!(
-            redaction_config,
-            "  Containers Running: {}",
-            summary.containers_running.unwrap_or(0)
-        );
-        println_redacted!(
-            redaction_config,
-            "  Images: {}",
-            summary.images.unwrap_or(0)
-        );
+        // Each line only where the daemon actually reported the field. An
+        // `unwrap_or(0)` here would print "Images: 0" on a host with thousands
+        // — the same fabrication this probe was fixed to stop producing.
+        if let Some(running) = summary.containers_running {
+            println_redacted!(redaction_config, "  Containers Running: {}", running);
+        }
+        if let Some(images) = summary.images {
+            println_redacted!(redaction_config, "  Images: {}", images);
+        }
+        if let Some(server_version) = &summary.server_version {
+            println_redacted!(redaction_config, "  Server Version: {}", server_version);
+        }
         if let Some(storage) = &summary.storage_driver {
             println_redacted!(redaction_config, "  Storage Driver: {}", storage);
         }
@@ -1077,6 +1160,14 @@ async fn create_support_bundle(
                 message: format!("Failed to serialize doctor info: {}", e),
             })
         })?;
+        // Redact, as `environment.json` below already does. A bundle exists to
+        // be sent to someone else, and this document now carries a runtime's
+        // verbatim stderr in `skipped_probes[].reason` — which routinely names
+        // `DOCKER_HOST`, proxy URLs and registry-auth detail.
+        let doctor_json = crate::redaction::redact_if_enabled(
+            &doctor_json,
+            &crate::redaction::RedactionConfig::default(),
+        );
         zip.write_all(doctor_json.as_bytes()).map_err(|e| {
             DeaconError::Internal(crate::errors::InternalError::Generic {
                 message: format!("Failed to write doctor.json: {}", e),
@@ -1240,57 +1331,6 @@ pub fn sanitize_secrets(content: &str) -> Result<String> {
     Ok(sanitized)
 }
 
-impl crate::docker::CliDocker {
-    /// Get the container runtime CLI version, bounded by [`PROBE_TIMEOUT`].
-    ///
-    /// Uses the configured runtime binary rather than a hardcoded `docker`, so
-    /// the reported version is the one deacon would actually drive.
-    pub async fn get_version(&self) -> Result<String> {
-        match probe_stdout(
-            "runtime_version",
-            self.runtime_path(),
-            &["--version"],
-            PROBE_TIMEOUT,
-        )
-        .await
-        {
-            Probed::Value(out) => Ok(String::from_utf8_lossy(&out).trim().to_string()),
-            Probed::Skipped(skip) => Err(probe_error(skip.reason)),
-            Probed::NotLaunched(reason) => Err(probe_error(reason)),
-        }
-    }
-
-    /// Get summarized runtime info, bounded by [`PROBE_TIMEOUT`].
-    ///
-    /// Reads `<runtime> info --format json` and reports what it says — see
-    /// [`collect_docker_info`] for why this is not `system df`.
-    pub async fn get_info_summary(&self) -> Result<DockerInfoSummary> {
-        match probe_stdout(
-            "docker_info",
-            self.runtime_path(),
-            &["info", "--format", "json"],
-            PROBE_TIMEOUT,
-        )
-        .await
-        {
-            Probed::Value(out) => parse_info_summary(&out).map_err(|e| {
-                probe_error(format!(
-                    "could not parse `{} info --format json`: {}",
-                    self.runtime_path(),
-                    e
-                ))
-            }),
-            Probed::Skipped(skip) => Err(probe_error(skip.reason)),
-            Probed::NotLaunched(reason) => Err(probe_error(reason)),
-        }
-    }
-}
-
-/// Wrap a probe failure reason as a runtime CLI error.
-fn probe_error(reason: impl Into<String>) -> DeaconError {
-    DeaconError::Docker(crate::errors::DockerError::CLIError(reason.into()))
-}
-
 /// Render skipped probes for the human-readable report.
 ///
 /// The text mode's counterpart to the `skipped_probes` array in `--json`: the
@@ -1338,6 +1378,86 @@ mod tests {
     #[test]
     fn test_parse_info_summary_rejects_non_json() {
         assert!(parse_info_summary(b"Cannot connect to the Docker daemon").is_err());
+    }
+
+    /// A well-formed JSON document carrying none of the fields — podman's
+    /// `info`, which nests its counters under `store`/`host` — must be a
+    /// recorded failure, not a summary of nothings that renders as zeros.
+    #[test]
+    fn test_parse_info_summary_rejects_unrecognized_shape() {
+        let podman_shaped = br#"{
+            "host": {"arch": "amd64"},
+            "store": {"graphDriverName": "overlay",
+                      "imageStore": {"number": 12},
+                      "containerStore": {"number": 3, "running": 2}},
+            "version": {"Version": "5.0.0"}
+        }"#;
+
+        let err = parse_info_summary(podman_shaped)
+            .expect_err("a document with no recognized fields must not parse to all-None");
+        assert!(
+            err.to_string().contains("no recognized fields"),
+            "got: {err}"
+        );
+    }
+
+    /// A partially-populated document is still usable — the fields are
+    /// genuinely optional, and `None` is reported as absent rather than zero.
+    #[test]
+    fn test_parse_info_summary_accepts_partial() {
+        let summary = parse_info_summary(br#"{"Images": 7}"#).expect("a known field should parse");
+        assert_eq!(summary.images, Some(7));
+        assert_eq!(summary.containers_running, None);
+    }
+
+    /// Only an absent binary means "not installed". Every other I/O condition
+    /// is a probe that FAILED, and must be reported rather than reclassified
+    /// into `installed: false` with no reason attached.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_unexecutable_binary_is_not_launched() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("wedged-runtime");
+        fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write");
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).expect("chmod");
+
+        let probed = probe_stdout(
+            "runtime_version",
+            &script.to_string_lossy(),
+            &["--version"],
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(
+            matches!(probed, Probed::NotLaunched(_)),
+            "a non-executable runtime binary is 'not installed', not a failed probe"
+        );
+    }
+
+    /// Stderr in a reason is bounded — it travels into `--json`, the text
+    /// report and the support bundle.
+    #[test]
+    fn test_stderr_summary_is_bounded() {
+        let noisy = "x".repeat(10_000);
+        let summarized = summarize_stderr(noisy.as_bytes());
+
+        assert!(
+            summarized.chars().count() <= 513,
+            "reason stderr must be capped, got {} chars",
+            summarized.chars().count()
+        );
+        assert!(summarized.ends_with('…'));
+    }
+
+    #[test]
+    fn test_stderr_summary_passes_short_output_through() {
+        assert_eq!(
+            summarize_stderr(b"  Cannot connect to the Docker daemon\n"),
+            "Cannot connect to the Docker daemon"
+        );
     }
 
     /// The bound must actually bound: a probe that outlives it returns promptly

--- a/crates/core/src/doctor.rs
+++ b/crates/core/src/doctor.rs
@@ -3,13 +3,16 @@
 //! This module provides functionality to collect system information, Docker details,
 //! configuration discovery results, and create support bundles for troubleshooting.
 
-use crate::docker::{CliDocker, Docker};
+use crate::docker::CliDocker;
 use crate::errors::{DeaconError, Result};
 use bytesize::ByteSize;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
 use tracing::{debug, info, warn};
 
 /// Macro for printing redacted output
@@ -89,6 +92,46 @@ pub struct DockerDiagnostics {
     pub version: Option<String>,
     pub daemon_running: bool,
     pub info_summary: Option<DockerInfoSummary>,
+    /// Probes that produced no value, each with the reason why.
+    ///
+    /// Omitted when every probe reported — an always-present empty list would
+    /// say nothing. See [`SkippedProbe`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skipped_probes: Vec<SkippedProbe>,
+}
+
+/// A diagnostic probe that produced no value, and why.
+///
+/// `doctor` shells out to the container runtime for several facts, and any of
+/// those calls can take unbounded time on a loaded daemon. Every one of them is
+/// therefore bounded by [`PROBE_TIMEOUT`]. A probe that is bounded out, fails,
+/// or cannot be launched is **reported here** — never silently omitted, and
+/// never replaced with a fabricated value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkippedProbe {
+    /// Stable probe identifier, e.g. `docker_info`.
+    pub probe: String,
+    /// Always `"skipped"`, so an entry read on its own is self-describing.
+    pub status: String,
+    /// Why the probe produced nothing, e.g.
+    /// ``"`docker info --format json` exceeded the 10s probe timeout"``.
+    pub reason: String,
+}
+
+impl SkippedProbe {
+    /// Record a skipped probe. Construction is also the point where the skip is
+    /// logged, so a skip can never be reported in the output without also being
+    /// audible in the logs.
+    fn new(probe: impl Into<String>, reason: impl Into<String>) -> Self {
+        let probe = probe.into();
+        let reason = reason.into();
+        warn!(probe = %probe, reason = %reason, "doctor probe skipped");
+        Self {
+            probe,
+            status: "skipped".to_string(),
+            reason,
+        }
+    }
 }
 
 /// Summarized Docker info (not full docker info to avoid sensitive data)
@@ -167,6 +210,150 @@ pub struct ResourceInfo {
     pub load_average: Option<(f64, f64, f64)>,
 }
 
+/// Wall-clock bound for a single `doctor` probe that shells out to the
+/// container runtime.
+///
+/// Matches the container environment probe's existing bound
+/// ([`crate::container_env_probe`]'s `probe_timeout`), so deacon has one answer
+/// to "how long may a diagnostic probe take".
+///
+/// Sized against measurement rather than taste (#507). On the daemon that
+/// motivated the bound — ~4.1k images, ~300 volumes, 81 containers —
+/// `docker info` and `docker version` each cost ~0.3s, so 10s leaves better
+/// than an order of magnitude of headroom: a far more loaded daemon still
+/// reports rather than being skipped. It also keeps `doctor`'s worst case at
+/// three bounded probes (~30s) instead of unbounded, comfortably inside the
+/// parity suite's 120s per-invocation limit.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Outcome of a bounded probe process.
+enum ProbeOutcome {
+    /// The process exited within the bound.
+    Completed {
+        status: std::process::ExitStatus,
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+    },
+    /// The process exceeded the bound and was killed and reaped.
+    TimedOut,
+}
+
+/// What a bounded probe produced: a value, or the reason there is none.
+enum Probed<T> {
+    /// The probe reported.
+    Value(T),
+    /// The probe ran (or was launched) but produced nothing usable.
+    Skipped(SkippedProbe),
+    /// The program could not be launched at all — the runtime CLI is absent.
+    NotLaunched(String),
+}
+
+/// Run `program args…` with a hard wall-clock bound.
+///
+/// The single place `doctor` shells out to a subprocess. Two properties matter
+/// and neither is free:
+///
+/// * **On timeout the child is killed _and reaped_.** [`tokio::process::Child::kill`]
+///   signals and then waits, so a hung daemon call leaves no zombie behind.
+/// * **stdout and stderr are drained concurrently with the wait.** Waiting on
+///   exit without reading the pipes deadlocks any process that outfills a pipe
+///   buffer.
+async fn run_bounded_probe(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> std::io::Result<ProbeOutcome> {
+    let mut child = tokio::process::Command::new(program)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    // `spawn` with piped stdio always populates these; a missing pipe is an I/O
+    // condition to report, not something to unwrap.
+    let mut stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("probe stdout pipe missing"))?;
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("probe stderr pipe missing"))?;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let waited = tokio::time::timeout(timeout, async {
+        let (out, err, status) = tokio::join!(
+            stdout_pipe.read_to_end(&mut stdout),
+            stderr_pipe.read_to_end(&mut stderr),
+            child.wait(),
+        );
+        out?;
+        err?;
+        status
+    })
+    .await;
+
+    match waited {
+        Ok(Ok(status)) => Ok(ProbeOutcome::Completed {
+            status,
+            stdout,
+            stderr,
+        }),
+        Ok(Err(e)) => Err(e),
+        Err(_elapsed) => {
+            // Kill AND reap in one call: `kill` sends SIGKILL then waits.
+            if let Err(e) = child.kill().await {
+                debug!("Failed to reap timed-out probe `{}`: {}", program, e);
+            }
+            Ok(ProbeOutcome::TimedOut)
+        }
+    }
+}
+
+/// Run a bounded probe and reduce it to its stdout bytes or a recorded skip.
+///
+/// Every `doctor` runtime probe goes through here, so the skip vocabulary
+/// (timeout, non-zero exit, absent binary) is written once.
+async fn probe_stdout(
+    probe: &str,
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Probed<Vec<u8>> {
+    let display = format!(
+        "`{}`",
+        std::iter::once(program)
+            .chain(args.iter().copied())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    match run_bounded_probe(program, args, timeout).await {
+        Ok(ProbeOutcome::Completed { status, stdout, .. }) if status.success() => {
+            Probed::Value(stdout)
+        }
+        Ok(ProbeOutcome::Completed { status, stderr, .. }) => Probed::Skipped(SkippedProbe::new(
+            probe,
+            format!(
+                "{} exited with {}: {}",
+                display,
+                status,
+                String::from_utf8_lossy(&stderr).trim()
+            ),
+        )),
+        // `{:?}` on a `Duration` renders "10s" / "250ms" — the bound is stated
+        // in the reason so the reader can tell a slow daemon from a broken one.
+        Ok(ProbeOutcome::TimedOut) => Probed::Skipped(SkippedProbe::new(
+            probe,
+            format!("{} exceeded the {:?} probe timeout", display, timeout),
+        )),
+        Err(e) => Probed::NotLaunched(format!("{} could not be launched: {}", display, e)),
+    }
+}
+
 /// Run the doctor command to collect diagnostics and optionally create a bundle
 pub async fn run_doctor(
     json_output: bool,
@@ -210,7 +397,7 @@ async fn collect_diagnostics(context: &DoctorContext) -> Result<DoctorInfo> {
     let cli_version = crate::version().to_string();
     let host_os = collect_host_os_info();
     let platform = collect_platform_info();
-    let docker_info = collect_docker_info().await;
+    let docker_info = collect_docker_info(PROBE_TIMEOUT).await;
     let disk_space = collect_disk_space_info();
     let config_discovery = collect_config_discovery_info(context);
     let features = collect_features_info();
@@ -289,43 +476,145 @@ fn collect_platform_info() -> PlatformInfo {
     }
 }
 
-/// Collect Docker diagnostics information
-async fn collect_docker_info() -> DockerDiagnostics {
+/// Collect Docker diagnostics information.
+///
+/// Every call into the container runtime here is bounded by `timeout` (see
+/// [`PROBE_TIMEOUT`]), and every bounded-out or failed probe is reported in
+/// `skipped_probes` rather than dropped.
+async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
     debug!("Collecting Docker information");
 
     let docker_client = CliDocker::new();
+    let runtime = docker_client.runtime_path().to_string();
+    let mut skipped_probes = Vec::new();
 
-    // Check if Docker is installed
-    let installed = docker_client.check_docker_installed().is_ok();
+    // Probe 1 — the CLI binary itself. A launch failure here IS the "not
+    // installed" signal, so this one bounded async call replaces the previous
+    // pairing of a *blocking* `check_docker_installed()` (a `std::process`
+    // call inside an async fn) with a second, duplicate `--version` exec.
+    let version = match probe_stdout("runtime_version", &runtime, &["--version"], timeout).await {
+        Probed::Value(out) => Some(String::from_utf8_lossy(&out).trim().to_string()),
+        Probed::Skipped(skip) => {
+            skipped_probes.push(skip);
+            None
+        }
+        Probed::NotLaunched(reason) => {
+            debug!("Container runtime not installed: {}", reason);
+            return DockerDiagnostics {
+                installed: false,
+                version: None,
+                daemon_running: false,
+                info_summary: None,
+                skipped_probes,
+            };
+        }
+    };
 
-    if !installed {
-        return DockerDiagnostics {
-            installed: false,
-            version: None,
-            daemon_running: false,
-            info_summary: None,
-        };
-    }
+    // Probe 2 — daemon reachability. `<runtime> version` (unlike `--version`)
+    // round-trips to the daemon, so it is the ping.
+    let daemon_running = match probe_stdout(
+        "daemon_ping",
+        &runtime,
+        &["version", "--format", "json"],
+        timeout,
+    )
+    .await
+    {
+        Probed::Value(_) => true,
+        Probed::Skipped(skip) => {
+            skipped_probes.push(skip);
+            false
+        }
+        Probed::NotLaunched(reason) => {
+            skipped_probes.push(SkippedProbe::new("daemon_ping", reason));
+            false
+        }
+    };
 
-    // Get Docker version
-    let version = docker_client.get_version().await.ok();
-
-    // Check if daemon is running
-    let daemon_running = docker_client.ping().await.is_ok();
-
-    // Get Docker info summary if daemon is running
+    // Probe 3 — daemon counters, via `<runtime> info`.
+    //
+    // NOT `<runtime> system df`, which this probe used to run: `system df`
+    // walks the disk usage of every image, container, volume and build-cache
+    // record and was measured in *minutes* on a loaded daemon (#507), while
+    // `info` returns these very fields in ~0.3s on the same host. The old code
+    // also discarded `system df`'s output entirely and returned hardcoded
+    // zeros and a hardcoded storage driver, so bounding it alone would have
+    // produced a fast fabrication rather than an answer.
     let info_summary = if daemon_running {
-        docker_client.get_info_summary().await.ok()
+        match probe_stdout(
+            "docker_info",
+            &runtime,
+            &["info", "--format", "json"],
+            timeout,
+        )
+        .await
+        {
+            Probed::Value(out) => match parse_info_summary(&out) {
+                Ok(summary) => Some(summary),
+                Err(e) => {
+                    skipped_probes.push(SkippedProbe::new(
+                        "docker_info",
+                        format!("could not parse `{} info --format json`: {}", runtime, e),
+                    ));
+                    None
+                }
+            },
+            Probed::Skipped(skip) => {
+                skipped_probes.push(skip);
+                None
+            }
+            Probed::NotLaunched(reason) => {
+                skipped_probes.push(SkippedProbe::new("docker_info", reason));
+                None
+            }
+        }
     } else {
+        skipped_probes.push(SkippedProbe::new(
+            "docker_info",
+            "the container runtime daemon is not reachable",
+        ));
         None
     };
 
     DockerDiagnostics {
-        installed,
+        installed: true,
         version,
         daemon_running,
         info_summary,
+        skipped_probes,
     }
+}
+
+/// The subset of `<runtime> info --format json` that [`DockerInfoSummary`]
+/// reports. Everything else the daemon returns (registry credentials, proxy
+/// settings, plugin paths) is deliberately not read.
+#[derive(Deserialize)]
+struct DockerInfoRaw {
+    #[serde(rename = "ContainersRunning")]
+    containers_running: Option<u32>,
+    #[serde(rename = "ContainersPaused")]
+    containers_paused: Option<u32>,
+    #[serde(rename = "ContainersStopped")]
+    containers_stopped: Option<u32>,
+    #[serde(rename = "Images")]
+    images: Option<u32>,
+    #[serde(rename = "ServerVersion")]
+    server_version: Option<String>,
+    #[serde(rename = "Driver")]
+    storage_driver: Option<String>,
+}
+
+/// Parse `<runtime> info --format json` into the reported summary.
+fn parse_info_summary(stdout: &[u8]) -> std::result::Result<DockerInfoSummary, serde_json::Error> {
+    let raw: DockerInfoRaw = serde_json::from_slice(stdout)?;
+    Ok(DockerInfoSummary {
+        containers_running: raw.containers_running,
+        containers_paused: raw.containers_paused,
+        containers_stopped: raw.containers_stopped,
+        images: raw.images,
+        server_version: raw.server_version,
+        storage_driver: raw.storage_driver,
+    })
 }
 
 /// Collect disk space information for current directory
@@ -631,6 +920,11 @@ fn print_text_output_with_redaction(
         if let Some(storage) = &summary.storage_driver {
             println_redacted!(redaction_config, "  Storage Driver: {}", storage);
         }
+    }
+    // A skipped probe is stated, not silently dropped: without these lines the
+    // text report is indistinguishable from a runtime that had nothing to say.
+    for line in skipped_probe_lines(&info.docker_info.skipped_probes) {
+        println_redacted!(redaction_config, "{}", line);
     }
     println!();
 
@@ -947,75 +1241,273 @@ pub fn sanitize_secrets(content: &str) -> Result<String> {
 }
 
 impl crate::docker::CliDocker {
-    /// Get Docker version information
+    /// Get the container runtime CLI version, bounded by [`PROBE_TIMEOUT`].
+    ///
+    /// Uses the configured runtime binary rather than a hardcoded `docker`, so
+    /// the reported version is the one deacon would actually drive.
     pub async fn get_version(&self) -> Result<String> {
-        let output = tokio::process::Command::new("docker")
-            .arg("--version")
-            .output()
-            .await
-            .map_err(|e| {
-                DeaconError::Docker(crate::errors::DockerError::CLIError(format!(
-                    "Failed to execute docker --version: {}",
-                    e
-                )))
-            })?;
-
-        if output.status.success() {
-            let version = String::from_utf8(output.stdout)
-                .map_err(|e| {
-                    DeaconError::Docker(crate::errors::DockerError::CLIError(format!(
-                        "Invalid UTF-8 in docker version output: {}",
-                        e
-                    )))
-                })?
-                .trim()
-                .to_string();
-            Ok(version)
-        } else {
-            Err(DeaconError::Docker(crate::errors::DockerError::CLIError(
-                "Failed to get Docker version".to_string(),
-            )))
+        match probe_stdout(
+            "runtime_version",
+            self.runtime_path(),
+            &["--version"],
+            PROBE_TIMEOUT,
+        )
+        .await
+        {
+            Probed::Value(out) => Ok(String::from_utf8_lossy(&out).trim().to_string()),
+            Probed::Skipped(skip) => Err(probe_error(skip.reason)),
+            Probed::NotLaunched(reason) => Err(probe_error(reason)),
         }
     }
 
-    /// Get summarized Docker info (not full docker info to avoid sensitive data)
+    /// Get summarized runtime info, bounded by [`PROBE_TIMEOUT`].
+    ///
+    /// Reads `<runtime> info --format json` and reports what it says — see
+    /// [`collect_docker_info`] for why this is not `system df`.
     pub async fn get_info_summary(&self) -> Result<DockerInfoSummary> {
-        let output = tokio::process::Command::new("docker")
-            .arg("system")
-            .arg("df")
-            .arg("--format")
-            .arg("json")
-            .output()
-            .await
-            .map_err(|e| {
-                DeaconError::Docker(crate::errors::DockerError::CLIError(format!(
-                    "Failed to execute docker system df: {}",
+        match probe_stdout(
+            "docker_info",
+            self.runtime_path(),
+            &["info", "--format", "json"],
+            PROBE_TIMEOUT,
+        )
+        .await
+        {
+            Probed::Value(out) => parse_info_summary(&out).map_err(|e| {
+                probe_error(format!(
+                    "could not parse `{} info --format json`: {}",
+                    self.runtime_path(),
                     e
-                )))
-            })?;
-
-        if output.status.success() {
-            // For now, return a basic summary. In a real implementation,
-            // this would parse docker info and extract safe, non-sensitive information
-            Ok(DockerInfoSummary {
-                containers_running: Some(0),
-                containers_paused: Some(0),
-                containers_stopped: Some(0),
-                images: Some(0),
-                server_version: None,
-                storage_driver: Some("overlay2".to_string()),
-            })
-        } else {
-            Err(DeaconError::Docker(crate::errors::DockerError::CLIError(
-                "Failed to get Docker info".to_string(),
-            )))
+                ))
+            }),
+            Probed::Skipped(skip) => Err(probe_error(skip.reason)),
+            Probed::NotLaunched(reason) => Err(probe_error(reason)),
         }
     }
+}
+
+/// Wrap a probe failure reason as a runtime CLI error.
+fn probe_error(reason: impl Into<String>) -> DeaconError {
+    DeaconError::Docker(crate::errors::DockerError::CLIError(reason.into()))
+}
+
+/// Render skipped probes for the human-readable report.
+///
+/// The text mode's counterpart to the `skipped_probes` array in `--json`: the
+/// two modes must agree that a probe was skipped and why, so this is the single
+/// definition of the text shape and the printer emits exactly what it returns.
+fn skipped_probe_lines(skipped: &[SkippedProbe]) -> Vec<String> {
+    skipped
+        .iter()
+        .map(|skip| format!("  Probe {}: {} ({})", skip.probe, skip.status, skip.reason))
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A realistic `docker info --format json` payload, trimmed to the keys the
+    /// summary reads plus a few it must ignore.
+    const INFO_JSON: &str = r#"{
+        "Containers": 81,
+        "ContainersRunning": 79,
+        "ContainersPaused": 1,
+        "ContainersStopped": 1,
+        "Images": 4068,
+        "ServerVersion": "29.6.2-1",
+        "Driver": "overlayfs",
+        "RegistryConfig": {"IndexConfigs": {}},
+        "HttpProxy": "http://proxy.example:3128"
+    }"#;
+
+    #[test]
+    fn test_parse_info_summary_reports_what_the_daemon_said() {
+        let summary = parse_info_summary(INFO_JSON.as_bytes()).expect("info json should parse");
+
+        // The point of the change behind #507: these are the daemon's numbers,
+        // not the hardcoded zeros the `system df` probe used to fabricate.
+        assert_eq!(summary.containers_running, Some(79));
+        assert_eq!(summary.containers_paused, Some(1));
+        assert_eq!(summary.containers_stopped, Some(1));
+        assert_eq!(summary.images, Some(4068));
+        assert_eq!(summary.server_version.as_deref(), Some("29.6.2-1"));
+        assert_eq!(summary.storage_driver.as_deref(), Some("overlayfs"));
+    }
+
+    #[test]
+    fn test_parse_info_summary_rejects_non_json() {
+        assert!(parse_info_summary(b"Cannot connect to the Docker daemon").is_err());
+    }
+
+    /// The bound must actually bound: a probe that outlives it returns promptly
+    /// rather than waiting for the child.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_bounded_probe_times_out_instead_of_hanging() {
+        let started = std::time::Instant::now();
+        let outcome = run_bounded_probe("sleep", &["30"], Duration::from_millis(200))
+            .await
+            .expect("spawning `sleep` should succeed");
+
+        assert!(matches!(outcome, ProbeOutcome::TimedOut));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "the bound did not take effect: probe took {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// A timed-out probe is killed AND reaped. Without the reap, every slow
+    /// `doctor` run would leave a zombie behind.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn test_timed_out_probe_leaves_no_zombie() {
+        let outcome = run_bounded_probe("sleep", &["30"], Duration::from_millis(200))
+            .await
+            .expect("spawning `sleep` should succeed");
+        assert!(matches!(outcome, ProbeOutcome::TimedOut));
+
+        let own_pid = std::process::id();
+        let mut zombies = Vec::new();
+        for entry in fs::read_dir("/proc")
+            .expect("/proc should be readable")
+            .flatten()
+        {
+            let Ok(stat) = fs::read_to_string(entry.path().join("stat")) else {
+                continue;
+            };
+            // `stat` is "pid (comm) state ppid …"; comm can contain spaces and
+            // parens, so split after the final ')'.
+            let Some(rest) = stat.rsplit_once(')').map(|(_, rest)| rest) else {
+                continue;
+            };
+            let fields: Vec<&str> = rest.split_whitespace().collect();
+            let (Some(state), Some(ppid)) = (fields.first(), fields.get(1)) else {
+                continue;
+            };
+            if *state == "Z" && ppid.parse::<u32>() == Ok(own_pid) {
+                zombies.push(entry.file_name().to_string_lossy().to_string());
+            }
+        }
+
+        assert!(
+            zombies.is_empty(),
+            "timed-out probe was not reaped; zombie children: {:?}",
+            zombies
+        );
+    }
+
+    /// A timed-out probe becomes a reported skip naming the probe and the bound.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_timed_out_probe_is_reported_as_skipped() {
+        let probed =
+            probe_stdout("docker_info", "sleep", &["30"], Duration::from_millis(200)).await;
+
+        let Probed::Skipped(skip) = probed else {
+            panic!("a probe that outran its bound must be reported as skipped");
+        };
+        assert_eq!(skip.probe, "docker_info");
+        assert_eq!(skip.status, "skipped");
+        assert!(
+            skip.reason.contains("exceeded the 200ms probe timeout"),
+            "the reason must state the bound, got: {}",
+            skip.reason
+        );
+    }
+
+    /// A non-zero exit is a skip too — reported, not silently swallowed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_failing_probe_is_reported_as_skipped() {
+        let probed = probe_stdout("docker_info", "false", &[], Duration::from_secs(5)).await;
+
+        let Probed::Skipped(skip) = probed else {
+            panic!("a probe exiting non-zero must be reported as skipped");
+        };
+        assert_eq!(skip.probe, "docker_info");
+        assert!(skip.reason.contains("exited with"), "got: {}", skip.reason);
+    }
+
+    /// An absent binary is distinguishable from a slow one — that distinction is
+    /// what lets `collect_docker_info` report `installed: false`.
+    #[tokio::test]
+    async fn test_absent_binary_is_not_launched() {
+        let probed = probe_stdout(
+            "runtime_version",
+            "deacon-no-such-runtime-binary",
+            &["--version"],
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(probed, Probed::NotLaunched(_)));
+    }
+
+    /// Both output modes must carry the skip. JSON mode: the array is present
+    /// with the self-describing entry shape.
+    #[test]
+    fn test_json_mode_carries_skipped_probe_shape() {
+        let diagnostics = DockerDiagnostics {
+            installed: true,
+            version: Some("Docker version 29.6.2".to_string()),
+            daemon_running: true,
+            info_summary: None,
+            skipped_probes: vec![SkippedProbe::new(
+                "docker_info",
+                "`docker info --format json` exceeded the 10s probe timeout",
+            )],
+        };
+
+        let json = serde_json::to_value(&diagnostics).expect("diagnostics should serialize");
+        let entry = &json["skipped_probes"][0];
+        assert_eq!(entry["probe"], "docker_info");
+        assert_eq!(entry["status"], "skipped");
+        assert_eq!(
+            entry["reason"],
+            "`docker info --format json` exceeded the 10s probe timeout"
+        );
+        // A skip is never a fabricated value.
+        assert!(json["info_summary"].is_null());
+    }
+
+    /// …and nothing is claimed when nothing was skipped.
+    #[test]
+    fn test_json_mode_omits_empty_skipped_probes() {
+        let diagnostics = DockerDiagnostics {
+            installed: true,
+            version: None,
+            daemon_running: true,
+            info_summary: None,
+            skipped_probes: Vec::new(),
+        };
+
+        let json = serde_json::to_value(&diagnostics).expect("diagnostics should serialize");
+        assert!(json.get("skipped_probes").is_none());
+    }
+
+    /// Text mode: the same fact, in the human report.
+    #[test]
+    fn test_text_mode_carries_skipped_probe_shape() {
+        let lines = skipped_probe_lines(&[SkippedProbe::new(
+            "docker_info",
+            "`docker info --format json` exceeded the 10s probe timeout",
+        )]);
+
+        assert_eq!(
+            lines,
+            vec![
+                "  Probe docker_info: skipped (`docker info --format json` exceeded the 10s probe timeout)"
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_text_mode_says_nothing_when_nothing_skipped() {
+        assert!(skipped_probe_lines(&[]).is_empty());
+    }
 
     #[test]
     fn test_sanitize_secrets_quoted_keys() {

--- a/crates/deacon/tests/integration_doctor.rs
+++ b/crates/deacon/tests/integration_doctor.rs
@@ -131,3 +131,94 @@ fn test_doctor_bundle_contains_enhanced_details() {
     assert!(env_json.get("shell").is_some());
     assert!(env_json.get("home").is_some());
 }
+
+/// Stand up a directory holding a fake `docker` whose `info` fails, so the
+/// daemon-counters probe is exercised end to end without a real daemon.
+///
+/// Unix-only: it relies on a shebang script and the executable bit.
+#[cfg(unix)]
+fn fake_docker_dir(temp_dir: &TempDir) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin_dir = temp_dir.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let script = bin_dir.join("docker");
+    fs::write(
+        &script,
+        r#"#!/bin/sh
+case "$1" in
+  --version) echo "Docker version 99.9.9, build deadbeef"; exit 0 ;;
+  version)   echo '{"Client":{"Version":"99.9.9"}}'; exit 0 ;;
+  info)      echo "the daemon is wedged" >&2; exit 1 ;;
+  *)         exit 1 ;;
+esac
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+    bin_dir
+}
+
+/// PATH with the fake runtime ahead of the real one.
+#[cfg(unix)]
+fn path_with(bin_dir: &std::path::Path) -> String {
+    format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+/// A probe that produces nothing is *stated* in the human report — regression
+/// cover for #507, where an unbounded `docker system df` could only ever hang
+/// or vanish silently.
+#[cfg(unix)]
+#[test]
+fn test_doctor_text_reports_skipped_probe() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_docker_dir(&temp_dir);
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    cmd.env("PATH", path_with(&bin_dir)).arg("doctor");
+
+    cmd.assert()
+        .success()
+        // The fake runtime was the one probed…
+        .stdout(predicate::str::contains("99.9.9"))
+        // …and its failure is reported, with the cause.
+        .stdout(predicate::str::contains("Probe docker_info: skipped"))
+        .stdout(predicate::str::contains("the daemon is wedged"));
+}
+
+/// The same fact in `--json`: a skip is data, not a silent omission.
+#[cfg(unix)]
+#[test]
+fn test_doctor_json_reports_skipped_probe() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_docker_dir(&temp_dir);
+
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    cmd.env("PATH", path_with(&bin_dir))
+        .arg("doctor")
+        .arg("--json");
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+
+    let skipped = json["docker_info"]["skipped_probes"]
+        .as_array()
+        .expect("a failing probe must appear in skipped_probes");
+    let entry = skipped
+        .iter()
+        .find(|e| e["probe"] == "docker_info")
+        .expect("the info probe must be named");
+
+    assert_eq!(entry["status"], "skipped");
+    assert!(
+        entry["reason"].as_str().unwrap().contains("exited with"),
+        "the reason must say why: {}",
+        entry["reason"]
+    );
+    // Never a fabricated stand-in for the value that could not be read.
+    assert!(json["docker_info"]["info_summary"].is_null());
+}


### PR DESCRIPTION
`deacon doctor` had no upper bound on how long it could take, because one of its probes
shelled out to `docker system df` — a command whose cost scales with everything the daemon
has ever stored. On a loaded daemon that is minutes; on a clean CI runner it is
milliseconds, which is why this only ever bit locally, and only ever in the parity suite's
doctor cases.

## Measured, on this dev container's daemon

Daemon state: **4169 images, 82 containers, 306 volumes**.

**End to end, the same command, two builds, minutes apart:**

| `deacon doctor --json` | Wall clock |
|---|---|
| before (at `main`) | **399.89 s** |
| after (this PR) | **0.59 s** / **1.09 s** (two runs, minutes apart) |

A **370–680×** reduction — and, more to the point, 399.89 s is **3.3× the parity harness's
120 s per-invocation bound**, which is exactly why the hermetic lane's doctor cases failed
locally and passed on CI's clean runners.

**Per probe:**

| Probe | Latency |
|---|---|
| `docker system df --format json` | **337.01 s** (a second, warm run was still going past 12 min when I stopped it — this is not a cold-cache artifact) |
| `docker info --format json` | **0.31 s** |
| `docker version --format json` | ~0.3 s |
| `docker --version` | ~0.02 s |

Independently corroborated by #507 (3m24s for `system df` against 0.35 s for `docker
info`) and by three agents this week measuring it in the 54 s – 5 min range.

## Two defects, not one

Bounding the call was the assignment. Reading the probe turned up that the same function
was also **fabricating its answer**: it ran `docker system df`, discarded the output
entirely, and returned hardcoded zeros plus a hardcoded `"overlay2"` storage driver.
Bounding that alone would have produced a fast fabrication rather than an answer.

`DockerInfoSummary`'s fields — containers running/paused/stopped, images, server version,
storage driver — are exactly what `docker info` returns, in 0.31 s. So the probe now runs
`<runtime> info --format json` and **reports what the daemon said**. On this host that
turns `images: 0` / `overlay2` into `images: 4068` / `overlayfs`.

## The bound

`PROBE_TIMEOUT = 10s`, matching the bound `container_env_probe` already uses, so deacon has
one answer to "how long may a diagnostic probe take". Sized from the measurements above:
the heaviest remaining probe costs ~0.3 s, so 10 s leaves better than an order of magnitude
of headroom — a far more loaded daemon still *reports* rather than being skipped — while
capping `doctor`'s worst case at three bounded probes (~30 s) instead of unbounded,
comfortably inside the 120 s per-invocation limit. No new flag: the bounded behavior is the
only behavior.

## No silent fallbacks

A bounded-out, failed, or unlaunchable probe is **reported** — never omitted, never
replaced with a stand-in value. Both output modes carry it, and `SkippedProbe::new` emits
the `tracing::warn` as part of construction, so a skip cannot reach the output without also
being audible in the logs.

```
  Probe docker_info: skipped (`docker info --format json` exceeded the 10s probe timeout)
```

```json
"docker_info": {
  "installed": true, "daemon_running": true, "info_summary": null,
  "skipped_probes": [
    { "probe": "docker_info", "status": "skipped",
      "reason": "`docker info --format json` exceeded the 10s probe timeout" }
  ]
}
```

The array is omitted entirely when nothing was skipped — an always-present empty list would
say nothing.

## Probe audit

Every subprocess `doctor` spawns, not just the reported one. `run_bounded_probe` is now the
**only** `Command::new` in `doctor.rs` — one helper, not N copies.

| Probe | Before | After |
|---|---|---|
| runtime installed | `std::process::Command` — a **blocking** call inside an `async fn` — unbounded | folded into the version probe: a spawn failure *is* the "not installed" signal, so one bounded async call replaces two execs |
| CLI version | `tokio` `docker --version`, unbounded | bounded 10 s (still the default `docker` client — see the pre-existing `--runtime` gap noted below) |
| daemon ping | `tokio` `docker version --format json`, unbounded | bounded 10 s |
| daemon counters | `tokio` `docker system df --format json`, **unbounded (337 s measured)**, output discarded → fabricated zeros | `<runtime> info --format json`, bounded 10 s, **parsed** |
| disk space | `statvfs`, in-process | unchanged |
| resources | `sysinfo`, in-process | unchanged |
| cache stats / config discovery / env / runtime config | in-process fs + env reads | unchanged |

On timeout the child is killed **and reaped** (`Child::kill` signals then waits), and
stdout/stderr are drained concurrently with the wait so a chatty process cannot deadlock on
a full pipe. Both properties are under test.

## Hermetic lane, on this same loaded daemon

The acceptance test for #507, with all 9 doctor cases in:

```
PASS [   0.414s] (1/2) deacon::parity_hermetic hermetic_group_fs_heavy
PASS [   6.600s] (2/2) deacon::parity_hermetic hermetic_group_none
Summary [   6.601s] 2 tests run: 2 passed, 0 skipped
```

Before, each of those 9 doctor invocations cost ~400 s against a 120 s bound.

## Review follow-ups (second commit)

A review pass found more of the same class — places the new code could still hand
back a stand-in rather than an answer — all fixed here:

- **`probe_stdout` mapped *every* `io::Error` to "not launched"**, and that verdict makes
  `collect_docker_info` return `installed: false` and **return early**, so the reason
  reached neither output mode. A fork failure under load (`EMFILE`) or a mid-read broken
  pipe therefore reported "the container runtime is not installed" with no stated cause.
  Only `NotFound`/`PermissionDenied` now means that; every other I/O condition is a
  recorded skip.
- **`parse_info_summary` accepted any JSON object.** Every field being `Option`, podman's
  `info` (counters nested under `store`/`host`, not Docker's `types.Info` keys)
  deserialized "successfully" into a summary of nothings. A document carrying none of the
  six reported fields is now an error, hence a recorded skip.
- **The text report's `unwrap_or(0)`** then rendered those `None`s as `Images: 0` — the
  exact fabrication this PR exists to remove. Harmless while the old code hardcoded
  `Some(0)`; live once the fields became reachably absent. Each line now prints only when
  the daemon reported the field. Server version joins them: it was collected but never
  shown.
- **The support bundle wrote `doctor.json` unredacted** while `environment.json` beside it
  was redacted — and `reason` now embeds a runtime's verbatim stderr, which routinely
  names `DOCKER_HOST`, proxy URLs and registry-auth detail.
- **Output is read capped** (1 MiB) and the stderr fragment in `reason` truncated to 512
  chars, so a noisy runtime cannot put megabytes into a diagnostic report.
- **`child.kill().await` was the last unbounded await in the module** — SIGKILL is prompt
  unless the child sits in uninterruptible sleep (a dead `DOCKER_HOST` over a stuck
  mount). Bounded now, falling back to `kill_on_drop` and tokio's orphan reaper, so the
  corpse is collected either way.
- Dropped `CliDocker::{get_version, get_info_summary}`: with the probes inlined they had
  no callers left, and two uncalled, untested entry points in `doctor.rs` would only
  drift. `check_docker_installed` is untouched — `build` still uses it.

Observed but **not** changed here, as it predates this PR and is a different bug:
`doctor` builds `CliDocker::new()` (hardcoded `docker`) regardless of `--runtime`, so
`deacon --runtime podman doctor` reports `container_runtime: "podman"` beside a
`docker_info` block probed from `docker`. Worth its own issue.

Verified after the fixes, same host:

```
Docker:
  Installed: true
  Version: Docker version 29.6.2-1, build dfc4efb…
  Daemon Running: true
  Containers Running: 44
  Images: 4117
  Server Version: 29.6.2-1
  Storage Driver: overlayfs
```

## Tests

New, all hermetic (no Docker — the timeout path uses `sleep`, the skip shape uses a fake
`docker` on `PATH`):

- `run_bounded_probe` returns promptly instead of hanging when the child outlives the bound
- a timed-out probe **leaves no zombie** (scans `/proc` for `Z`-state children of the test
  process)
- a timed-out probe becomes a skip whose reason names the probe and the bound
- a non-zero-exit probe becomes a skip too, with the child's stderr as the reason
- an absent binary is distinguishable from a slow one (that is what makes
  `installed: false` reportable)
- `docker info` JSON parses to the daemon's real numbers; non-JSON is rejected
- JSON mode carries the `{probe, status, reason}` entry and omits the array when empty
- text mode renders the same fact
- end to end in both modes against a fake runtime whose `info` fails
- an unexecutable binary is "not installed"; other I/O conditions are not
- a podman-shaped `info` document is rejected rather than parsed to all-`None`
- a partially-populated document still parses (the fields are genuinely optional)
- the stderr fragment in `reason` is capped, and short output passes through intact

Full `dev-fast` suite on this host: **3285/3286 passed**, 31 skipped. The one failure is
`integration_redaction::test_redaction_performance_short_lines`, a wall-clock throughput
assertion (5000 redactions under 500 ms) on a box currently at **load average 19.8 across
8 cores**. `redaction.rs` is byte-identical to `main` in this branch, and three
back-to-back runs of that test on identical code gave FAIL 605 ms / PASS 331 ms / PASS
398 ms. It measures the machine, not the change; CI's `Test (MVP fast) (ubuntu)` is
green.

## SPEC_STATUS

**No ledger change.** `doctor` is a deacon extension (`ext-doctor-diagnostics`; the pinned
reference exposes no `doctor` command), and the row's claim — that `doctor` reports host,
platform and runtime diagnostics in both renderings regardless of the workspace's
configuration — is exactly as true after this change, across the same 9 scenarios. Those
cases assert exit code, the `Deacon Doctor Diagnostics` / `Host OS` headings, and a
`jsonSubset` over `host_os` / `config_discovery`; none touches `docker_info`, so the new
`skipped_probes` key is additive and invisible to them.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
