### PR TITLE
docs(specs): update 009 local-Feature examples to the contained layout (#506)

### DIFF
--- a/specs/009-complete-feature-support/contracts/feature-refs.md
+++ b/specs/009-complete-feature-support/contracts/feature-refs.md
@@ -14,7 +14,7 @@ Defines the contract for detecting and parsing different types of feature refere
 | Type | Pattern | Example |
 |------|---------|---------|
 | OCI Registry | No special prefix | `ghcr.io/devcontainers/features/node:18` |
-| Local Path | Starts with `./` or `../` | `./local-feature`, `../shared/feature` |
+| Local Path | Starts with `./` or `../` | `./local-feature`, `./nested/local-feature` |
 | HTTPS Tarball | Starts with `https://` | `https://example.com/feature.tgz` |
 
 ---
@@ -72,12 +72,38 @@ THEN FeatureRefType::LocalPath
 
 **Valid Examples**:
 - `./local-feature` → `LocalPath("./local-feature")`
-- `../shared/feature` → `LocalPath("../shared/feature")`
 - `./deeply/nested/feature` → `LocalPath("./deeply/nested/feature")`
+- `../sibling-feature` → `LocalPath("../sibling-feature")` (detected as local; see the
+  containment rule below — it only resolves when it still lands inside
+  `<workspace>/.devcontainer/`)
 
 **Invalid (NOT local paths)**:
-- `/absolute/path` → Error (not relative)
+- `/absolute/path` → Error: a local Feature may **not** be referenced by absolute path
 - `feature` → OCI reference (no prefix)
+
+### Rule 1a: Containment
+
+Detection classifies the reference; resolution then enforces the two path clauses of
+`devcontainer-features-distribution.md` §Locally Referenced Features, in the reference
+CLI's order:
+
+1. **No absolute paths.** "A local Feature may **not** be referenced by absolute path."
+   Checked unconditionally, before any path resolution.
+2. **Must be contained.** "A local Feature's source code **must** be contained within a
+   sub-folder of the `.devcontainer/` folder." The containment anchor is
+   `<workspace root>/.devcontainer`, independent of where the active config file sits.
+
+Local paths are **config-dir-relative**, not workspace-relative: they resolve against the
+directory holding the active `devcontainer.json`. The two spellings below name the same
+directory, and both are contained:
+
+| Config location | Reference | Resolves to |
+|---|---|---|
+| `<workspace>/.devcontainer/devcontainer.json` | `./my-feature` | `<workspace>/.devcontainer/my-feature` |
+| `<workspace>/.devcontainer.json` (root) | `./.devcontainer/my-feature` | `<workspace>/.devcontainer/my-feature` |
+
+A `../` that escapes `<workspace>/.devcontainer/` (e.g. `../shared-features/common`) is
+rejected.
 
 ### Rule 2: HTTPS URL Detection
 
@@ -217,6 +243,8 @@ async fn fetch_https_feature(
 | Check | Error |
 |-------|-------|
 | Path is relative (starts with ./ or ../) | Enforced by detection |
+| Path is not absolute | `"Absolute path to a local Feature is not allowed: {path}"` |
+| Resolved path is a child of `<workspace>/.devcontainer/` | `"Local file path parse error. Resolved path must be a child of the .devcontainer/ folder."` |
 | Resolved path exists | `"Local feature not found: {path}"` |
 | devcontainer-feature.json exists | `"Missing devcontainer-feature.json in: {path}"` |
 | JSON is valid | `"Failed to parse feature metadata: {path}: {error}"` |
@@ -267,12 +295,33 @@ Uses existing validation from `parse_registry_reference()`.
 ### Example 2: Local Path Resolution
 
 **Config Location**: `/workspace/.devcontainer/devcontainer.json`
-**Reference**: `../shared-features/my-feature`
+**Reference**: `./shared/my-feature`
 
 **Resolution**:
-1. Join: `/workspace/.devcontainer/../shared-features/my-feature`
-2. Canonicalize: `/workspace/shared-features/my-feature`
-3. Read: `/workspace/shared-features/my-feature/devcontainer-feature.json`
+1. Join against the config directory: `/workspace/.devcontainer/./shared/my-feature`
+2. Canonicalize: `/workspace/.devcontainer/shared/my-feature`
+3. Check containment against `/workspace/.devcontainer` → contained, accepted
+4. Read: `/workspace/.devcontainer/shared/my-feature/devcontainer-feature.json`
+
+### Example 2b: Local Path Resolution from a Root-Level Config
+
+**Config Location**: `/workspace/.devcontainer.json`
+**Reference**: `./.devcontainer/my-feature`
+
+**Resolution**:
+1. Join against the config directory: `/workspace/./.devcontainer/my-feature`
+2. Canonicalize: `/workspace/.devcontainer/my-feature`
+3. Check containment against `/workspace/.devcontainer` → contained, accepted
+4. Read: `/workspace/.devcontainer/my-feature/devcontainer-feature.json`
+
+### Example 2c: Rejected — Escapes Containment
+
+**Config Location**: `/workspace/.devcontainer/devcontainer.json`
+**Reference**: `../shared-features/my-feature`
+
+Resolves to `/workspace/shared-features/my-feature`, which is outside
+`/workspace/.devcontainer` → rejected with "Local file path parse error. Resolved path
+must be a child of the .devcontainer/ folder."
 
 ---
 
@@ -281,7 +330,8 @@ Uses existing validation from `parse_registry_reference()`.
 | Input | Error |
 |-------|-------|
 | `http://example.com/f.tgz` | "HTTP not supported, use HTTPS: http://..." |
-| `/absolute/path/feature` | "Invalid feature reference: /absolute/path/feature" |
+| `/absolute/path/feature` | "Absolute path to a local Feature is not allowed: /absolute/path/feature" |
+| `../outside-feature` (escaping `.devcontainer/`) | "Local file path parse error. Resolved path must be a child of the .devcontainer/ folder." |
 | `./missing-feature` | "Local feature not found: ./missing-feature" |
 | `./no-metadata-feature` | "Missing devcontainer-feature.json in: ./no-metadata-feature" |
 | `https://example.com/404.tgz` | "Feature not found: https://example.com/404.tgz" |

--- a/specs/009-complete-feature-support/data-model.md
+++ b/specs/009-complete-feature-support/data-model.md
@@ -21,7 +21,7 @@ Represents the type of feature reference used in devcontainer.json.
 pub enum FeatureRefType {
     /// OCI registry reference: ghcr.io/devcontainers/features/node:18
     Oci(OciFeatureRef),
-    /// Local path reference: ./local-feature, ../shared-feature
+    /// Local path reference: ./local-feature, ./shared/local-feature
     LocalPath(PathBuf),
     /// HTTPS tarball URL: https://example.com/feature.tgz
     HttpsTarball(Url),
@@ -39,6 +39,9 @@ pub struct OciFeatureRef {
 
 **Validation Rules**:
 - Local paths MUST start with `./` or `../`
+- Local paths MUST NOT be absolute (a local Feature may not be referenced by absolute path)
+- Local paths resolve against the **config directory** and MUST resolve inside
+  `<workspace root>/.devcontainer/`; a `../` that escapes it is rejected
 - HTTPS URLs MUST start with `https://`
 - OCI references MUST NOT start with `./`, `../`, or `https://`
 

--- a/specs/009-complete-feature-support/quickstart.md
+++ b/specs/009-complete-feature-support/quickstart.md
@@ -176,32 +176,61 @@ Reference features from your repository using relative paths.
 
 ### Path Format
 
-- `./feature-name` - Relative to devcontainer.json directory
-- `../shared/feature` - Can reference parent directories
+- `./feature-name` - Relative to the **directory containing devcontainer.json**
+- Paths are config-dir-relative, never workspace-relative
+- Absolute paths are **not allowed**
+
+### Containment Rule
+
+A local feature's source **must** live in a sub-folder of `<workspace>/.devcontainer/`
+(`devcontainer-features-distribution.md` §Locally Referenced Features). Since local paths
+resolve against the config directory, the spelling depends on where your config file sits:
+
+| Config location | Reference to `<workspace>/.devcontainer/my-feature` |
+|---|---|
+| `.devcontainer/devcontainer.json` | `./my-feature` |
+| `.devcontainer.json` (workspace root) | `./.devcontainer/my-feature` |
+
+A `../` path that escapes `<workspace>/.devcontainer/` (for example
+`../shared-features/common`) is rejected.
 
 ### Directory Structure
 
 ```
 project/
-├── .devcontainer/
-│   ├── devcontainer.json
-│   └── my-feature/
-│       ├── devcontainer-feature.json
-│       └── install.sh
-└── shared-features/
-    └── common/
-        ├── devcontainer-feature.json
-        └── install.sh
+└── .devcontainer/
+    ├── devcontainer.json
+    ├── my-feature/
+    │   ├── devcontainer-feature.json
+    │   └── install.sh
+    └── shared/
+        └── common/
+            ├── devcontainer-feature.json
+            └── install.sh
 ```
 
 ### Configuration
+
+With the config at `.devcontainer/devcontainer.json`:
 
 ```json
 {
     "image": "ubuntu",
     "features": {
         "./my-feature": {},
-        "../shared-features/common": {"version": "1.0"}
+        "./shared/common": {"version": "1.0"}
+    }
+}
+```
+
+The equivalent from a root-level `.devcontainer.json`:
+
+```json
+{
+    "image": "ubuntu",
+    "features": {
+        "./.devcontainer/my-feature": {},
+        "./.devcontainer/shared/common": {"version": "1.0"}
     }
 }
 ```
@@ -254,6 +283,24 @@ Error: Local feature not found: ./missing-feature
 ```
 
 **Fix**: Check the path is correct relative to devcontainer.json.
+
+### Outside the `.devcontainer/` Folder
+
+```
+Error: Local file path parse error. Resolved path must be a child of the .devcontainer/ folder.
+```
+
+**Fix**: Move the feature under `<workspace>/.devcontainer/` and reference it from there
+(`./my-feature` from `.devcontainer/devcontainer.json`, or `./.devcontainer/my-feature`
+from a root-level `.devcontainer.json`).
+
+### Absolute Path
+
+```
+Error: Absolute path to a local Feature is not allowed: /workspace/.devcontainer/my-feature
+```
+
+**Fix**: Use the `./`-relative spelling instead — `./my-feature`.
 
 ### Missing Metadata
 
@@ -308,7 +355,8 @@ docker inspect <container_id> | jq '.[0].HostConfig.CapAdd'
 ## Best Practices
 
 1. **Pin feature versions**: Use tags like `:1` or `:1.0.0` instead of `:latest`
-2. **Test features locally first**: Develop features in `./` before publishing
+2. **Test features locally first**: Develop features in a sub-folder of `.devcontainer/`
+   before publishing
 3. **Keep lifecycle commands idempotent**: They may run on container rebuild
 4. **Document security requirements**: If your feature needs `privileged`, explain why
 5. **Use entrypoints sparingly**: Only when environment setup is truly needed at startup

--- a/specs/009-complete-feature-support/spec.md
+++ b/specs/009-complete-feature-support/spec.md
@@ -85,8 +85,9 @@ As a developer with custom features in my repository, I need to reference them v
 **Acceptance Scenarios**:
 
 1. **Given** a feature reference `"./local-feature"` and directory `.devcontainer/local-feature/devcontainer-feature.json`, **When** `deacon up` runs, **Then** the local feature is installed correctly
-2. **Given** a feature reference `"../shared-feature"` resolving outside the .devcontainer directory, **When** `deacon up` runs, **Then** the path is resolved correctly relative to devcontainer.json
-3. **Given** a local feature reference to a non-existent path, **When** `deacon up` runs, **Then** a clear error message indicates the missing path
+2. **Given** a root-level `.devcontainer.json` and a feature reference `"./.devcontainer/local-feature"`, **When** `deacon up` runs, **Then** the path is resolved relative to the config directory and installs the same feature
+3. **Given** a feature reference `"../shared-feature"` resolving outside the `.devcontainer/` directory, **When** `deacon up` runs, **Then** it is rejected — a local Feature's source must be contained within a sub-folder of `.devcontainer/`
+4. **Given** a local feature reference to a non-existent path, **When** `deacon up` runs, **Then** a clear error message indicates the missing path
 
 ---
 
@@ -134,7 +135,7 @@ As a developer referencing features via direct HTTPS URLs to tarballs, I need th
 - **FR-012**: System MUST extract and chain feature entrypoints in feature installation order
 - **FR-013**: System MUST ensure user commands execute through the entrypoint chain
 - **FR-014**: System MUST detect feature references starting with `./` or `../` as local path references
-- **FR-015**: System MUST resolve local feature paths relative to devcontainer.json location
+- **FR-015**: System MUST resolve local feature paths relative to the directory containing the active devcontainer.json, MUST reject absolute local-Feature paths, and MUST reject any path that resolves outside `<workspace root>/.devcontainer/`
 - **FR-016**: System MUST parse `devcontainer-feature.json` from local feature directories
 - **FR-017**: System MUST report clear errors for missing local feature paths
 - **FR-018**: System MUST detect feature references starting with `https://` as direct tarball URLs


### PR DESCRIPTION
## What

`specs/009-complete-feature-support/` still documented local-Feature layouts the product now **rejects**:

- `./my-feature` shown with no `.devcontainer/` context, and
- `../shared-features/common`, which escapes the containment root.

Updated `quickstart.md`, `contracts/feature-refs.md`, `data-model.md` and `spec.md` to the contained layout.

## Why

`resolve_local_feature_dir` (`crates/core/src/features.rs`) now enforces both path clauses of `devcontainer-features-distribution.md` §Locally Referenced Features, in the reference CLI's order:

1. **#495** — "A local Feature may **not** be referenced by absolute path." Unconditional, before any path resolution.
2. **#488** — "A local Feature's source code **must** be contained within a sub-folder of the `.devcontainer/` folder." Anchored at `<workspace root>/.devcontainer`, independent of where the active config sits.

The docs predate both, so they described layouts a user following them would watch fail.

## The contained layout, spelled out

Local paths are **config-dir-relative**, never workspace-relative — so the correct spelling depends on where the config file lives. Both rows below name the same directory:

| Config location | Reference to `<workspace>/.devcontainer/my-feature` |
|---|---|
| `.devcontainer/devcontainer.json` | `./my-feature` |
| `.devcontainer.json` (workspace root) | `./.devcontainer/my-feature` |

## Notes

- **Detection is unchanged** and still classifies both `./` and `../` as local paths — only *resolution* rejects an escape. So the detection rules keep both prefixes and gained a containment clause describing what happens next, rather than pretending `../` is unclassifiable. A `../` that stays inside `.devcontainer/` is still legal.
- Added the two rejection paths to the error tables (absolute path, escapes containment) with the messages the product actually emits.
- Renumbered the User Story 5 acceptance scenarios, which had two `3.`s; the former "resolves outside `.devcontainer/`, resolves correctly" scenario is now a rejection scenario, and FR-015 gained the two constraints.
- Docs only. No product behavior change, and no `SPEC_STATUS` change — this is not a parity behavior.

## Swept, found nothing else

Grepped `specs/`, `specs-completed/`, `docs/` and `examples/` for other `../`-escape or uncontained local-Feature examples. The remaining `../` hits are all `extends` targets (which have no containment rule) or inter-README cross-links. One cosmetic leftover deliberately not touched: `specs/009-.../research.md:122` carries `// ./local-feature, ../shared` in a code comment, but that is a historical decision record of the *detection* enum, and detection genuinely still accepts both prefixes.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
