### PR TITLE
chore(core): remove dead BuildConfig fields (#508)

### DIFF
--- a/crates/core/src/build/mod.rs
+++ b/crates/core/src/build/mod.rs
@@ -174,12 +174,6 @@ pub struct BuildRequest {
 
     /// Cache destination for BuildKit
     pub cache_to: Option<String>,
-
-    /// Skip automatic feature-to-service mapping
-    pub skip_feature_auto_mapping: bool,
-
-    /// Skip persisting customizations in metadata
-    pub skip_persist_customizations: bool,
 }
 
 impl BuildRequest {
@@ -416,8 +410,6 @@ mod tests {
             platform: None,
             cache_from: vec![],
             cache_to: None,
-            skip_feature_auto_mapping: false,
-            skip_persist_customizations: false,
         };
 
         assert!(request.validate().is_ok());
@@ -446,8 +438,6 @@ mod tests {
             platform: None,
             cache_from: vec![],
             cache_to: None,
-            skip_feature_auto_mapping: false,
-            skip_persist_customizations: false,
         };
 
         // Both push and output set - should fail


### PR DESCRIPTION
## What

Deletes two dead boolean fields from `BuildRequest` in `crates/core/src/build/mod.rs`:

- `skip_feature_auto_mapping`
- `skip_persist_customizations`

10 lines removed, one file, no behavior change.

## Why

`skip_feature_auto_mapping` was named after a CLI flag it was **never wired to**. The flag lives on the `Cli` enum (three subcommands declare it) and is handled entirely at the CLI tier by `warn_if_skip_feature_auto_mapping`, which is inert per #498 — the value never reached this struct. `skip_persist_customizations` is its equally dead sibling: no flag, no reader, and no writer outside test literals.

## Dead-field verification

Both fields were confirmed dead *before* deleting, on the standing rule that a field written but never read is dead, while a field read anywhere is not:

1. **No read sites.** `sg --pattern '$X.skip_feature_auto_mapping' --lang rust crates/` and the `skip_persist_customizations` equivalent each match **zero** nodes across the workspace.
2. **No construction sites.** `BuildRequest` is never constructed anywhere outside this module's own `#[cfg(test)]` block — so the fields were not merely unread, they were never even set outside two test literals.
3. **Compiler agreement.** Removing the declarations produced exhaustive-literal errors at exactly those two test literals and nowhere else, which independently confirms the search found every site.
4. The `skip_feature_auto_mapping` identifiers remaining in `crates/deacon/src/cli.rs` are the clap args and their inert warn helper — a separate, still-live surface that this PR does not touch.

## Notes

- No `SPEC_STATUS` change — this is not a parity behavior.
- Local gate green: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo build --workspace --all-targets`, and `cargo nextest run --profile dev-fast` (3294/3295; the single failure is `test_redaction_performance_short_lines`, a wall-clock benchmark assertion that flakes only under CPU contention in this dev container — it passes in isolation, reproduces identically on unrelated branches, and the CI ubuntu fast lane is green).

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
