### PR TITLE
fix(doctor): probe the runtime selected by --runtime, not hardcoded docker (#516)

### DIFF
--- a/crates/core/src/doctor.rs
+++ b/crates/core/src/doctor.rs
@@ -3,8 +3,8 @@
 //! This module provides functionality to collect system information, Docker details,
 //! configuration discovery results, and create support bundles for troubleshooting.
 
-use crate::docker::CliDocker;
 use crate::errors::{DeaconError, Result};
+use crate::runtime::{RuntimeFactory, RuntimeKind};
 use bytesize::ByteSize;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -36,6 +36,13 @@ pub struct DoctorContext {
     pub workspace_folder: Option<PathBuf>,
     /// Configuration file path
     pub config: Option<PathBuf>,
+    /// Container runtime selected by the global `--runtime` flag (already
+    /// resolved against `DEACON_CONTAINER_RUNTIME` by clap's `env=` at the CLI
+    /// tier), or `None` for the default.
+    ///
+    /// `doctor` probes THIS runtime. Reporting one runtime while probing
+    /// another is the defect this field exists to prevent (#516).
+    pub runtime: Option<RuntimeKind>,
 }
 
 /// Doctor information collected from the system
@@ -88,6 +95,15 @@ pub struct PlatformInfo {
 /// Docker diagnostics information
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DockerDiagnostics {
+    /// The runtime CLI these facts were probed from, e.g. `docker` or `podman`.
+    ///
+    /// The JSON key of the block itself stays `docker_info` (renaming it would
+    /// break every consumer of `doctor --json`), so this field is what makes
+    /// the block self-describing when `--runtime podman` selected something
+    /// else. It always agrees with `runtime_config.container_runtime` — both
+    /// come from the one runtime the CLI resolved.
+    #[serde(default)]
+    pub runtime: String,
     pub installed: bool,
     pub version: Option<String>,
     pub daemon_running: bool,
@@ -452,17 +468,25 @@ pub async fn run_doctor(
 async fn collect_diagnostics(context: &DoctorContext) -> Result<DoctorInfo> {
     debug!("Collecting diagnostic information");
 
+    // One runtime decision, used for BOTH the probes and the reported name.
+    // `create_runtime(...).cli_docker()` reuses the single kind → binary
+    // mapping that `runtime.rs` already owns, rather than restringing
+    // "docker"/"podman" here.
+    let runtime_kind = RuntimeFactory::detect_runtime(context.runtime);
+    let runtime_cli = RuntimeFactory::create_runtime(runtime_kind)?.cli_docker();
+    let runtime_path = runtime_cli.runtime_path();
+
     let cli_version = crate::version().to_string();
     let host_os = collect_host_os_info();
     let platform = collect_platform_info();
-    let docker_info = collect_docker_info(PROBE_TIMEOUT).await;
+    let docker_info = collect_docker_info(runtime_path, PROBE_TIMEOUT).await;
     let disk_space = collect_disk_space_info();
     let config_discovery = collect_config_discovery_info(context);
     let features = collect_features_info();
     let last_build_hash = collect_last_build_hash();
     let cache_stats = collect_cache_stats().await;
     let environment = collect_environment_info();
-    let runtime_config = collect_runtime_config();
+    let runtime_config = collect_runtime_config(runtime_kind);
     let resources = collect_resource_info();
 
     Ok(DoctorInfo {
@@ -534,23 +558,25 @@ fn collect_platform_info() -> PlatformInfo {
     }
 }
 
-/// Collect Docker diagnostics information.
+/// Collect container runtime diagnostics information.
+///
+/// `runtime` is the CLI binary the caller selected (`docker`, `podman`, …) —
+/// every probe below targets THAT binary, so the facts reported here can never
+/// come from a runtime other than the one `doctor` says it inspected (#516).
 ///
 /// Every call into the container runtime here is bounded by `timeout` (see
 /// [`PROBE_TIMEOUT`]), and every bounded-out or failed probe is reported in
 /// `skipped_probes` rather than dropped.
-async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
-    debug!("Collecting Docker information");
+async fn collect_docker_info(runtime: &str, timeout: Duration) -> DockerDiagnostics {
+    debug!(runtime = %runtime, "Collecting container runtime information");
 
-    let docker_client = CliDocker::new();
-    let runtime = docker_client.runtime_path().to_string();
     let mut skipped_probes = Vec::new();
 
     // Probe 1 — the CLI binary itself. A launch failure here IS the "not
     // installed" signal, so this one bounded async call replaces the previous
     // pairing of a *blocking* `check_docker_installed()` (a `std::process`
     // call inside an async fn) with a second, duplicate `--version` exec.
-    let version = match probe_stdout("runtime_version", &runtime, &["--version"], timeout).await {
+    let version = match probe_stdout("runtime_version", runtime, &["--version"], timeout).await {
         Probed::Value(out) => Some(String::from_utf8_lossy(&out).trim().to_string()),
         Probed::Skipped(skip) => {
             skipped_probes.push(skip);
@@ -559,6 +585,7 @@ async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
         Probed::NotLaunched(reason) => {
             debug!("Container runtime not installed: {}", reason);
             return DockerDiagnostics {
+                runtime: runtime.to_string(),
                 installed: false,
                 version: None,
                 daemon_running: false,
@@ -572,7 +599,7 @@ async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
     // round-trips to the daemon, so it is the ping.
     let daemon_running = match probe_stdout(
         "daemon_ping",
-        &runtime,
+        runtime,
         &["version", "--format", "json"],
         timeout,
     )
@@ -601,7 +628,7 @@ async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
     let info_summary = if daemon_running {
         match probe_stdout(
             "docker_info",
-            &runtime,
+            runtime,
             &["info", "--format", "json"],
             timeout,
         )
@@ -635,6 +662,7 @@ async fn collect_docker_info(timeout: Duration) -> DockerDiagnostics {
     };
 
     DockerDiagnostics {
+        runtime: runtime.to_string(),
         installed: true,
         version,
         daemon_running,
@@ -877,8 +905,14 @@ fn collect_environment_info() -> EnvironmentInfo {
     }
 }
 
-/// Collect runtime configuration details
-fn collect_runtime_config() -> RuntimeConfig {
+/// Collect runtime configuration details.
+///
+/// `runtime` is the runtime the CLI resolved — the same one
+/// [`collect_docker_info`] probed. It is NOT re-read from
+/// `DEACON_CONTAINER_RUNTIME` here: that variable backs the `--runtime` flag
+/// and clap owns its precedence (flag > env > default), so reading it again
+/// below the CLI layer would ignore an explicit `--runtime docker` (#516).
+fn collect_runtime_config(runtime: RuntimeKind) -> RuntimeConfig {
     debug!("Collecting runtime configuration");
 
     let log_level = std::env::var("DEACON_LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
@@ -889,9 +923,7 @@ fn collect_runtime_config() -> RuntimeConfig {
         .map(|v| v != "1" && v.to_lowercase() != "true")
         .unwrap_or(true);
 
-    // Container runtime - default to docker
-    let container_runtime =
-        std::env::var("DEACON_CONTAINER_RUNTIME").unwrap_or_else(|_| "docker".to_string());
+    let container_runtime = runtime.as_str().to_string();
 
     RuntimeConfig {
         log_level,
@@ -973,7 +1005,14 @@ fn print_text_output_with_redaction(
     );
     println!();
 
-    println_redacted!(redaction_config, "Docker:");
+    // The heading names the runtime that was actually probed. A fixed "Docker:"
+    // here read as a docker report even when `--runtime podman` was in force
+    // (#516) — the one thing this section must never do.
+    println_redacted!(
+        redaction_config,
+        "Container Runtime ({}):",
+        info.docker_info.runtime
+    );
     println_redacted!(
         redaction_config,
         "  Installed: {}",
@@ -1570,6 +1609,7 @@ mod tests {
     #[test]
     fn test_json_mode_carries_skipped_probe_shape() {
         let diagnostics = DockerDiagnostics {
+            runtime: "docker".to_string(),
             installed: true,
             version: Some("Docker version 29.6.2".to_string()),
             daemon_running: true,
@@ -1596,6 +1636,7 @@ mod tests {
     #[test]
     fn test_json_mode_omits_empty_skipped_probes() {
         let diagnostics = DockerDiagnostics {
+            runtime: "docker".to_string(),
             installed: true,
             version: None,
             daemon_running: true,
@@ -1627,6 +1668,35 @@ mod tests {
     #[test]
     fn test_text_mode_says_nothing_when_nothing_skipped() {
         assert!(skipped_probe_lines(&[]).is_empty());
+    }
+
+    /// The reported runtime name comes from the resolved CLI selection, not
+    /// from a second, hand-rolled read of `DEACON_CONTAINER_RUNTIME` — which is
+    /// what let `--runtime podman` be reported while docker was probed (#516).
+    #[test]
+    fn test_runtime_config_reports_the_selected_runtime() {
+        assert_eq!(
+            collect_runtime_config(RuntimeKind::Docker).container_runtime,
+            "docker"
+        );
+        assert_eq!(
+            collect_runtime_config(RuntimeKind::Podman).container_runtime,
+            "podman"
+        );
+    }
+
+    /// An absent runtime binary is reported as absent *for the runtime that was
+    /// asked for* — never backfilled from whatever else is installed.
+    #[tokio::test]
+    async fn test_collect_docker_info_names_the_probed_runtime() {
+        let diagnostics =
+            collect_docker_info("deacon-no-such-runtime-binary", Duration::from_secs(5)).await;
+
+        assert_eq!(diagnostics.runtime, "deacon-no-such-runtime-binary");
+        assert!(!diagnostics.installed);
+        assert!(diagnostics.version.is_none());
+        assert!(!diagnostics.daemon_running);
+        assert!(diagnostics.info_summary.is_none());
     }
 
     #[test]

--- a/crates/core/tests/integration_redaction.rs
+++ b/crates/core/tests/integration_redaction.rs
@@ -686,6 +686,7 @@ fn test_doctor_output_redaction() {
     let _context = DoctorContext {
         workspace_folder: Some(workspace_path),
         config: None,
+        runtime: None,
     };
 
     // Add some secrets to test redaction

--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -2013,6 +2013,10 @@ impl Cli {
                 let context = deacon_core::doctor::DoctorContext {
                     workspace_folder: self.workspace_folder.clone(),
                     config: self.config.clone(),
+                    // The global `--runtime` (already resolved against
+                    // DEACON_CONTAINER_RUNTIME by clap) selects which runtime
+                    // doctor probes — same threading as up/exec/down (#516).
+                    runtime: self.runtime.map(|r| r.into()),
                 };
 
                 // Execute doctor command with redaction config

--- a/crates/deacon/tests/integration_doctor.rs
+++ b/crates/deacon/tests/integration_doctor.rs
@@ -5,9 +5,21 @@ use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
 
+/// A `deacon` invocation with the runtime selection under the test's control.
+///
+/// `DEACON_CONTAINER_RUNTIME` backs the global `--runtime` flag, and the Podman
+/// CI lane exports it job-wide — so a doctor test that says nothing about the
+/// runtime is asserting against whichever runtime that lane happens to select.
+/// Every test here states its runtime, by flag or by removing the variable.
+fn deacon() -> Command {
+    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    cmd.env_remove("DEACON_CONTAINER_RUNTIME");
+    cmd
+}
+
 #[test]
 fn test_doctor_command_basic() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.arg("doctor");
 
     cmd.assert()
@@ -15,12 +27,13 @@ fn test_doctor_command_basic() {
         .stdout(predicate::str::contains("Deacon Doctor Diagnostics"))
         .stdout(predicate::str::contains("CLI Version:"))
         .stdout(predicate::str::contains("Host OS:"))
-        .stdout(predicate::str::contains("Docker:"));
+        // The section names the runtime it was probed from (#516).
+        .stdout(predicate::str::contains("Container Runtime (docker):"));
 }
 
 #[test]
 fn test_doctor_command_json() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.arg("doctor").arg("--json");
 
     cmd.assert()
@@ -35,7 +48,7 @@ fn test_doctor_command_bundle_creation() {
     let temp_dir = TempDir::new().unwrap();
     let bundle_path = temp_dir.path().join("test-bundle.zip");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     // Explicitly enable info logging so the support bundle log message is emitted
     cmd.arg("--log-level")
         .arg("info")
@@ -66,7 +79,7 @@ fn test_doctor_command_bundle_creation() {
 
 #[test]
 fn test_doctor_command_exits_successfully() {
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.arg("doctor");
 
     cmd.assert().success().code(0);
@@ -77,7 +90,7 @@ fn test_doctor_bundle_contains_enhanced_details() {
     let temp_dir = TempDir::new().unwrap();
     let bundle_path = temp_dir.path().join("enhanced-bundle.zip");
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.arg("--log-level")
         .arg("info")
         .arg("doctor")
@@ -132,30 +145,40 @@ fn test_doctor_bundle_contains_enhanced_details() {
     assert!(env_json.get("home").is_some());
 }
 
-/// Stand up a directory holding a fake `docker` whose `info` fails, so the
-/// daemon-counters probe is exercised end to end without a real daemon.
+/// Write a fake runtime CLI named `name` into `bin_dir`, reporting `version`
+/// and failing `info`, so the probes are exercised end to end without a real
+/// daemon. The version string is the marker that says WHICH binary was probed.
 ///
 /// Unix-only: it relies on a shebang script and the executable bit.
 #[cfg(unix)]
-fn fake_docker_dir(temp_dir: &TempDir) -> std::path::PathBuf {
+fn write_fake_runtime(bin_dir: &std::path::Path, name: &str, version: &str) {
     use std::os::unix::fs::PermissionsExt;
 
-    let bin_dir = temp_dir.path().join("bin");
-    fs::create_dir_all(&bin_dir).unwrap();
-    let script = bin_dir.join("docker");
+    fs::create_dir_all(bin_dir).unwrap();
+    let script = bin_dir.join(name);
     fs::write(
         &script,
-        r#"#!/bin/sh
+        format!(
+            r#"#!/bin/sh
 case "$1" in
-  --version) echo "Docker version 99.9.9, build deadbeef"; exit 0 ;;
-  version)   echo '{"Client":{"Version":"99.9.9"}}'; exit 0 ;;
+  --version) echo "{name} version {version}, build deadbeef"; exit 0 ;;
+  version)   echo '{{"Client":{{"Version":"{version}"}}}}'; exit 0 ;;
   info)      echo "the daemon is wedged" >&2; exit 1 ;;
   *)         exit 1 ;;
 esac
-"#,
+"#
+        ),
     )
     .unwrap();
     fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// Stand up a directory holding a fake `docker` whose `info` fails, so the
+/// daemon-counters probe is exercised end to end without a real daemon.
+#[cfg(unix)]
+fn fake_docker_dir(temp_dir: &TempDir) -> std::path::PathBuf {
+    let bin_dir = temp_dir.path().join("bin");
+    write_fake_runtime(&bin_dir, "docker", "99.9.9");
     bin_dir
 }
 
@@ -178,7 +201,7 @@ fn test_doctor_text_reports_skipped_probe() {
     let temp_dir = TempDir::new().unwrap();
     let bin_dir = fake_docker_dir(&temp_dir);
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.env("PATH", path_with(&bin_dir)).arg("doctor");
 
     cmd.assert()
@@ -197,7 +220,7 @@ fn test_doctor_json_reports_skipped_probe() {
     let temp_dir = TempDir::new().unwrap();
     let bin_dir = fake_docker_dir(&temp_dir);
 
-    let mut cmd = Command::cargo_bin("deacon").unwrap();
+    let mut cmd = deacon();
     cmd.env("PATH", path_with(&bin_dir))
         .arg("doctor")
         .arg("--json");
@@ -221,4 +244,166 @@ fn test_doctor_json_reports_skipped_probe() {
     );
     // Never a fabricated stand-in for the value that could not be read.
     assert!(json["docker_info"]["info_summary"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// #516 — `doctor` probes the runtime `--runtime` selected.
+//
+// Two fake runtimes with different version markers sit on PATH, so the reported
+// version says unambiguously WHICH binary answered. Hermetic: no daemon, no
+// Docker, no Podman needed.
+// ---------------------------------------------------------------------------
+
+/// A bin dir holding both fakes, each with its own version marker.
+#[cfg(unix)]
+fn fake_both_runtimes_dir(temp_dir: &TempDir) -> std::path::PathBuf {
+    let bin_dir = temp_dir.path().join("bin");
+    write_fake_runtime(&bin_dir, "docker", "11.1.1");
+    write_fake_runtime(&bin_dir, "podman", "22.2.2");
+    bin_dir
+}
+
+/// Run `doctor --json` with the fakes on PATH and return the parsed report.
+#[cfg(unix)]
+fn doctor_json_with(
+    bin_dir: &std::path::Path,
+    configure: impl FnOnce(&mut Command),
+) -> serde_json::Value {
+    let mut cmd = deacon();
+    cmd.env("PATH", path_with(bin_dir));
+    configure(&mut cmd);
+    cmd.arg("doctor").arg("--json");
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    serde_json::from_slice(&output).expect("doctor --json must emit one JSON document")
+}
+
+/// Assert the report was probed from `expected` — the probed binary and the
+/// reported runtime name have to be the same runtime, which is the whole of
+/// #516.
+#[cfg(unix)]
+fn assert_probed(json: &serde_json::Value, expected: &str, version_marker: &str) {
+    assert_eq!(
+        json["docker_info"]["runtime"], expected,
+        "the diagnostics block must name the runtime it was probed from"
+    );
+    assert_eq!(
+        json["runtime_config"]["container_runtime"], expected,
+        "the reported runtime must be the one that was probed"
+    );
+    let version = json["docker_info"]["version"]
+        .as_str()
+        .expect("the fake runtime reports a version");
+    assert!(
+        version.contains(version_marker),
+        "expected {expected}'s version marker {version_marker}, got: {version}"
+    );
+}
+
+/// No selection: docker, as before.
+#[cfg(unix)]
+#[test]
+fn test_doctor_defaults_to_docker() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_both_runtimes_dir(&temp_dir);
+
+    let json = doctor_json_with(&bin_dir, |_| {});
+    assert_probed(&json, "docker", "11.1.1");
+}
+
+/// `--runtime podman` probes podman. Before #516 this reported
+/// `container_runtime: "podman"` beside docker-probed facts.
+#[cfg(unix)]
+#[test]
+fn test_doctor_probes_runtime_selected_by_flag() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_both_runtimes_dir(&temp_dir);
+
+    let json = doctor_json_with(&bin_dir, |cmd| {
+        cmd.arg("--runtime").arg("podman");
+    });
+    assert_probed(&json, "podman", "22.2.2");
+}
+
+/// The env var backing the flag selects it too — clap resolves it, so doctor
+/// needs no read of its own.
+#[cfg(unix)]
+#[test]
+fn test_doctor_probes_runtime_selected_by_env() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_both_runtimes_dir(&temp_dir);
+
+    let json = doctor_json_with(&bin_dir, |cmd| {
+        cmd.env("DEACON_CONTAINER_RUNTIME", "podman");
+    });
+    assert_probed(&json, "podman", "22.2.2");
+}
+
+/// Flag beats env, exactly as clap's precedence says — a hand-rolled env read
+/// below the CLI layer would report podman here.
+#[cfg(unix)]
+#[test]
+fn test_doctor_runtime_flag_beats_env() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_both_runtimes_dir(&temp_dir);
+
+    let json = doctor_json_with(&bin_dir, |cmd| {
+        cmd.env("DEACON_CONTAINER_RUNTIME", "podman")
+            .arg("--runtime")
+            .arg("docker");
+    });
+    assert_probed(&json, "docker", "11.1.1");
+}
+
+/// The text report names the probed runtime in its heading, so a human reading
+/// it cannot mistake podman diagnostics for docker ones.
+#[cfg(unix)]
+#[test]
+fn test_doctor_text_names_the_probed_runtime() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = fake_both_runtimes_dir(&temp_dir);
+
+    let mut cmd = deacon();
+    cmd.env("PATH", path_with(&bin_dir))
+        .arg("--runtime")
+        .arg("podman")
+        .arg("doctor");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Container Runtime (podman):"))
+        .stdout(predicate::str::contains("22.2.2"))
+        .stdout(predicate::str::contains("11.1.1").not());
+}
+
+/// A selected runtime that is not installed is reported absent — never
+/// backfilled from the other runtime that happens to be on PATH. PATH holds
+/// ONLY the docker fake, so a regression would show docker's version here.
+#[cfg(unix)]
+#[test]
+fn test_doctor_reports_selected_runtime_absent() {
+    let temp_dir = TempDir::new().unwrap();
+    let bin_dir = temp_dir.path().join("bin");
+    write_fake_runtime(&bin_dir, "docker", "11.1.1");
+
+    let mut cmd = deacon();
+    // Not `path_with`: the real PATH may carry a real podman.
+    cmd.env("PATH", bin_dir.display().to_string())
+        .arg("--runtime")
+        .arg("podman")
+        .arg("doctor")
+        .arg("--json");
+
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+
+    assert_eq!(json["docker_info"]["runtime"], "podman");
+    assert_eq!(json["runtime_config"]["container_runtime"], "podman");
+    assert_eq!(json["docker_info"]["installed"], false);
+    assert_eq!(json["docker_info"]["daemon_running"], false);
+    assert!(
+        json["docker_info"]["version"].is_null(),
+        "an absent podman must not be reported with another runtime's version: {}",
+        json["docker_info"]["version"]
+    );
 }


### PR DESCRIPTION
`doctor` built its runtime probes against `CliDocker::new()` — a hardcoded `docker`
binary — regardless of the global `--runtime` flag, and separately re-read
`DEACON_CONTAINER_RUNTIME` by hand to print a runtime *name*. The two could not agree.

## Before / after

Measured on this host (docker installed, **podman not installed**).

**Before** — `DEACON_CONTAINER_RUNTIME=podman deacon doctor --json` (the symptom in #516):

```json
"docker_info": {
  "installed": true,
  "version": "Docker version 29.6.2-1, build dfc4efb1e2ab8c06d70d2a1366ad448d2f917e90",
  "daemon_running": true,
  "info_summary": { "containers_running": 48, "images": 4355, "server_version": "29.6.2-1", "storage_driver": "overlayfs" }
},
"runtime_config": { "container_runtime": "podman" }
```

Podman is not even installed on this host, yet the report claims a running podman with
4355 images — those are docker's counters. And via the **flag** it was wrong the other
way: `deacon --runtime podman doctor` reported `"container_runtime": "docker"`, because
the flag never reached the reader at all (only the env var did).

**After** — both `deacon --runtime podman doctor --json` and
`DEACON_CONTAINER_RUNTIME=podman deacon doctor --json`:

```json
"docker_info": {
  "runtime": "podman",
  "installed": false,
  "version": null,
  "daemon_running": false,
  "info_summary": null
},
"runtime_config": { "container_runtime": "podman" }
```

Text mode, before → after:

```
Docker:                              Container Runtime (podman):
  Installed: true                      Installed: false
  Version: Docker version 29.6.2-1     Daemon Running: false
  Daemon Running: true
  Images: 4355
```

Default (no flag, no env) is unchanged apart from the heading:
`Container Runtime (docker):` with docker's real facts.

## Threading path

```
Cli::runtime  (clap `env = "DEACON_CONTAINER_RUNTIME"`, flag > env > default)
  └─ cli.rs Commands::Doctor → DoctorContext { runtime: self.runtime.map(|r| r.into()) }
       └─ core::doctor::collect_diagnostics
            ├─ RuntimeFactory::detect_runtime(context.runtime) → RuntimeKind
            ├─ RuntimeFactory::create_runtime(kind).cli_docker().runtime_path()
            │     → collect_docker_info(runtime_path, PROBE_TIMEOUT)   // all 3 probes
            └─ collect_runtime_config(kind)                            // reported name
```

Same shape `up`/`exec`/`down`/`run-user-commands` already use (`runtime: Option<RuntimeKind>`
threaded from the `Cli` struct). One decision feeds **both** the probes and the reported
name, so they cannot disagree again. The kind → binary mapping is the existing one in
`runtime.rs`/`docker.rs`; no new `"docker"`/`"podman"` strings.

The hand-rolled `std::env::var("DEACON_CONTAINER_RUNTIME")` in `collect_runtime_config` is
**deleted** — per CLAUDE.md, a flag-backed env var is clap's to resolve, and reading it
again below the CLI layer is exactly why `--runtime docker` could not override
`DEACON_CONTAINER_RUNTIME=podman` in this output. `doctor`'s env *snapshot*
(`collect_environment_info`) is untouched: that is the sanctioned diagnostic read.

## Output surface

- `docker_info` stays the JSON key — renaming it would break every consumer of
  `doctor --json` for no gain.
- The block gains `runtime` (`#[serde(default)]`, so older bundles still deserialize),
  naming the binary the facts came from. It always equals
  `runtime_config.container_runtime`.
- The text heading names the probed runtime instead of a fixed `Docker:`. Keeping a
  literal "Docker:" above podman diagnostics is the one thing this section must not do.
- An absent selected runtime is reported absent. #507's `SkippedProbe`/`NotLaunched`
  machinery already did this honestly — it was simply pointed at the wrong binary.

## Test coverage

Six new integration tests in `crates/deacon/tests/integration_doctor.rs`, hermetic — two
fake runtime CLIs (`docker` @ 11.1.1, `podman` @ 22.2.2) on `PATH`, so the reported version
says unambiguously which binary answered. No Docker, no Podman, no daemon:

- `test_doctor_defaults_to_docker` — no selection → docker.
- `test_doctor_probes_runtime_selected_by_flag` — `--runtime podman` → podman.
- `test_doctor_probes_runtime_selected_by_env` — `DEACON_CONTAINER_RUNTIME=podman` → podman.
- `test_doctor_runtime_flag_beats_env` — flag wins, i.e. clap's precedence is honored.
- `test_doctor_text_names_the_probed_runtime` — heading + version marker, and asserts
  docker's marker is *absent*.
- `test_doctor_reports_selected_runtime_absent` — `PATH` holds only the docker fake;
  `--runtime podman` reports `installed: false` / `version: null`, never docker's version.

Two unit tests in `crates/core/src/doctor.rs`
(`test_runtime_config_reports_the_selected_runtime`,
`test_collect_docker_info_names_the_probed_runtime`).

**Podman CI lane:** `test-podman` exports `DEACON_CONTAINER_RUNTIME=podman` job-wide and
runs the full integration suite, so every doctor test now states its runtime explicitly —
a new `deacon()` helper does `env_remove("DEACON_CONTAINER_RUNTIME")` and the podman cases
set it themselves. Without that, the pre-existing fake-`docker` tests
(`test_doctor_*_reports_skipped_probe`) would have started probing the lane's real podman
and failed. That is the change most likely to bite in that lane, and it is handled.

## Verification

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features
-- -D warnings` clean; `cargo build --workspace --all-targets` clean;
`cargo nextest run --profile dev-fast --no-fail-fast` → **3303 passed, 0 failed, 31
skipped**; `binary(=integration_doctor)` → 13/13 (7 pre-existing + 6 new).

## Parity ledger

**No `parity/SPEC_STATUS.md` change.** `doctor` is a deacon extension — the reference CLI
has no such subcommand, so there is no reference behavior to diverge from and no row to
move. Nothing in `parity/` is touched.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
