### PR TITLE
chore(tests): make the redaction perf assertion load-immune (#517)

### DIFF
--- a/crates/core/src/redaction.rs
+++ b/crates/core/src/redaction.rs
@@ -1123,15 +1123,34 @@ mod tests {
         assert!(redacted.contains("data"));
     }
 
+    /// Hash redaction must not cost an order of magnitude more than the scan it
+    /// performs. Asserted against a calibration loop rather than a fixed
+    /// wall-clock bound (#517): the previous "100 operations under 50ms" failed
+    /// roughly one run in six on an only lightly loaded box, because it measured
+    /// the machine rather than the code. The same calibrated-budget shape is used
+    /// by the throughput assertions in `tests/integration_redaction.rs`, where the
+    /// rationale is written out in full.
     #[test]
     fn test_hash_redaction_performance() {
-        use std::time::Instant;
+        use std::time::{Duration, Instant};
+
+        // 100 iterations — the original count — samples only a few milliseconds,
+        // which one scheduler preemption is enough to dominate. Iterate enough
+        // that a sample is real work and the ratio between the two loops means
+        // something.
+        const ITERATIONS: usize = 1000;
+        const MAX_RATIO: u32 = 10;
+        // Small on purpose: max(ratio * reference, floor), so a large floor would
+        // swallow the ratio. Load raises ratio * reference, never the floor.
+        const FLOOR: Duration = Duration::from_millis(100);
+        const ATTEMPTS: usize = 3;
 
         let registry = SecretRegistry::new();
 
         // Add 50 secrets
-        for i in 0..50 {
-            registry.add_secret(&format!("test-secret-{:03}", i));
+        let secrets: Vec<String> = (0..50).map(|i| format!("test-secret-{:03}", i)).collect();
+        for secret in &secrets {
+            registry.add_secret(secret);
         }
 
         let config = RedactionConfig::with_custom_registry(registry.clone());
@@ -1141,18 +1160,56 @@ mod tests {
         let hash2 = sha256_hash("test-secret-020");
         let test_text = format!("Hashes: {} and {} in logs", hash1, hash2);
 
-        // Measure performance
-        let start = Instant::now();
-        for _ in 0..100 {
-            let _result = redact_if_enabled(&test_text, &config);
-        }
-        let duration = start.elapsed();
+        // The registry scans both the exact secrets and their hashes, so the
+        // calibration loop does the same by hand: that is the irreducible work.
+        let needles: Vec<String> = secrets
+            .iter()
+            .cloned()
+            .chain(secrets.iter().map(|s| sha256_hash(s)))
+            .collect();
 
-        // Should be fast - less than 50ms for 100 operations with 50 secrets
-        assert!(
-            duration.as_millis() < 50,
-            "Hash redaction took too long: {:?}",
-            duration
+        let reference = || {
+            let start = Instant::now();
+            for _ in 0..ITERATIONS {
+                let mut owned = test_text.clone();
+                for needle in &needles {
+                    if owned.contains(needle.as_str()) {
+                        owned = owned.replace(needle.as_str(), REDACTION_PLACEHOLDER);
+                    }
+                }
+                std::hint::black_box(&owned);
+            }
+            start.elapsed()
+        };
+        let measured = || {
+            let start = Instant::now();
+            for _ in 0..ITERATIONS {
+                std::hint::black_box(redact_if_enabled(&test_text, &config));
+            }
+            start.elapsed()
+        };
+
+        // Warm up both paths so allocator growth is not billed to whichever runs first.
+        reference();
+        measured();
+
+        let mut attempts = Vec::with_capacity(ATTEMPTS);
+        for _ in 0..ATTEMPTS {
+            let baseline = reference();
+            let cost = measured();
+            let budget = std::cmp::max(baseline * MAX_RATIO, FLOOR);
+            if cost <= budget {
+                return;
+            }
+            attempts.push(format!(
+                "reference={baseline:?} measured={cost:?} budget={budget:?}"
+            ));
+        }
+
+        panic!(
+            "hash redaction exceeded {MAX_RATIO}x the calibration loop (floor {FLOOR:?}) \
+             on all {ATTEMPTS} attempts: {}",
+            attempts.join("; ")
         );
     }
 }

--- a/crates/core/tests/integration_redaction.rs
+++ b/crates/core/tests/integration_redaction.rs
@@ -13,7 +13,7 @@ use deacon_core::{
 };
 use serde_json::json;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 #[test]
 fn test_redaction_in_lifecycle_execution() {
@@ -163,14 +163,117 @@ fn test_no_redact_cli_flag() {
     cmd.assert().success();
 }
 
+/// How many times the measured cost may exceed the calibration loop.
+///
+/// The honest ratio measured 0.5x-1.6x across back-to-back samples, so 10x leaves
+/// ~6x of headroom for sampling noise while still catching the order-of-magnitude
+/// blowups these tests exist to guard against.
+const REDACTION_MAX_RATIO: u32 = 10;
+
+/// Never assert a budget tighter than this, however fast the calibration loop
+/// happens to sample.
+///
+/// Kept deliberately small: `max(ratio * reference, floor)` means a large floor
+/// would swallow the ratio and blunt the assertion on the smaller registries. The
+/// floor exists only so an anomalously quick reference sample cannot collapse the
+/// budget to nothing, and it can never cause a load-induced failure — load raises
+/// `ratio * reference`, at which point the floor stops binding entirely.
+const REDACTION_BUDGET_FLOOR: Duration = Duration::from_millis(100);
+
+/// Assert a CPU-bound cost stays within a *calibrated* budget instead of a fixed
+/// wall-clock bound (#517).
+///
+/// A fixed bound like "5000 redactions in under 500ms" measures the machine, not
+/// the code: on a box at load ~20, byte-identical code failed at 605ms and passed
+/// at 331ms and 398ms in three back-to-back runs.
+///
+/// `reference` performs the irreducible work the operation cannot avoid — for
+/// redaction, scanning every line for every registered secret — and `measured`
+/// performs the real thing over the same inputs. Both are pure-CPU loops in the
+/// same process timed back to back, so whatever slows the box (CPU contention,
+/// frequency scaling, cgroup throttling) slows both by the same factor and the
+/// ratio between them holds. Only a regression in redaction itself — recompiling
+/// a pattern per call, quadratic allocation, rebuilding the registry per line —
+/// inflates the numerator alone.
+///
+/// Sampling noise is absorbed by retrying: a spurious slow sample has to recur on
+/// every attempt to fail the test, while a real regression fails all of them.
+fn assert_cost_within_calibrated_budget(
+    label: &str,
+    max_ratio: u32,
+    floor: Duration,
+    reference: impl Fn() -> Duration,
+    measured: impl Fn() -> Duration,
+) {
+    const ATTEMPTS: usize = 3;
+
+    // Warm up both paths so allocator growth and first-touch page faults are not
+    // billed to whichever loop happens to run first.
+    reference();
+    measured();
+
+    let mut attempts = Vec::with_capacity(ATTEMPTS);
+    for _ in 0..ATTEMPTS {
+        let baseline = reference();
+        let cost = measured();
+        let budget = std::cmp::max(baseline * max_ratio, floor);
+        if cost <= budget {
+            return;
+        }
+        attempts.push(format!(
+            "reference={baseline:?} measured={cost:?} budget={budget:?}"
+        ));
+    }
+
+    panic!(
+        "{label}: cost exceeded {max_ratio}x the calibration loop (floor {floor:?}) \
+         on all {ATTEMPTS} attempts: {}",
+        attempts.join("; ")
+    );
+}
+
+/// Time the irreducible scan-every-line-for-every-secret work that redaction
+/// cannot do without. Used as the calibration baseline, never asserted on.
+///
+/// `iterations` is sized per test so a single sample is hundreds of milliseconds
+/// of real work: a sample small enough to be dominated by one scheduler
+/// preemption makes the ratio noisy no matter how the budget is drawn.
+fn time_reference_scan(iterations: usize, lines: &[&str], secrets: &[String]) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iterations {
+        for line in lines {
+            let mut owned = line.to_string();
+            for secret in secrets {
+                if owned.contains(secret.as_str()) {
+                    owned = owned.replace(secret.as_str(), "****");
+                }
+            }
+            std::hint::black_box(&owned);
+        }
+    }
+    start.elapsed()
+}
+
+/// Time the real redaction path over the same inputs as [`time_reference_scan`].
+fn time_redaction(iterations: usize, lines: &[&str], config: &RedactionConfig) -> Duration {
+    let start = Instant::now();
+    for _ in 0..iterations {
+        for line in lines {
+            std::hint::black_box(redact_if_enabled(line, config));
+        }
+    }
+    start.elapsed()
+}
+
 #[test]
 fn test_redaction_performance_short_lines() {
     // Clear any existing secrets
     global_registry().clear();
 
     // Add some secrets to the global registry
-    for i in 0..100 {
-        add_global_secret(&format!("secret-{:03}", i));
+    let secrets: Vec<String> = (0..100).map(|i| format!("secret-{:03}", i)).collect();
+    for secret in &secrets {
+        add_global_secret(secret);
     }
 
     let config = RedactionConfig::default();
@@ -182,21 +285,15 @@ fn test_redaction_performance_short_lines() {
         "INFO: operation completed successfully",
     ];
 
-    // Measure performance for short lines
-    let start = Instant::now();
-    for _ in 0..1000 {
-        for line in &test_lines {
-            let _result = redact_if_enabled(line, &config);
-        }
-    }
-    let duration = start.elapsed();
-
-    // Performance should be reasonable - less than 500ms for 5000 operations with 100 secrets
-    // This is a rough benchmark to ensure redaction doesn't add excessive overhead
-    assert!(
-        duration.as_millis() < 500,
-        "Redaction took too long: {:?}",
-        duration
+    // 5000 redactions against 100 secrets must stay within a generous multiple of
+    // the same scan done by hand — see assert_cost_within_calibrated_budget.
+    const ITERATIONS: usize = 1000;
+    assert_cost_within_calibrated_budget(
+        "redaction of 5000 short lines against 100 secrets",
+        REDACTION_MAX_RATIO,
+        REDACTION_BUDGET_FLOOR,
+        || time_reference_scan(ITERATIONS, &test_lines, &secrets),
+        || time_redaction(ITERATIONS, &test_lines, &config),
     );
 
     // Clean up
@@ -209,9 +306,12 @@ fn test_redaction_performance_with_secrets() {
     global_registry().clear();
 
     // Add some secrets
-    add_global_secret("performance-secret-1");
-    add_global_secret("performance-secret-2");
-    add_global_secret("performance-secret-3");
+    let secrets: Vec<String> = (1..=3)
+        .map(|i| format!("performance-secret-{}", i))
+        .collect();
+    for secret in &secrets {
+        add_global_secret(secret);
+    }
 
     let config = RedactionConfig::default();
     let test_lines = vec![
@@ -222,20 +322,17 @@ fn test_redaction_performance_with_secrets() {
         "Another normal line",
     ];
 
-    // Measure performance when secrets are present
-    let start = Instant::now();
-    for _ in 0..1000 {
-        for line in &test_lines {
-            let _result = redact_if_enabled(line, &config);
-        }
-    }
-    let duration = start.elapsed();
-
-    // Performance should still be reasonable even with secret redaction
-    assert!(
-        duration.as_millis() < 200,
-        "Redaction with secrets took too long: {:?}",
-        duration
+    // Same calibrated budget, now with lines that actually match — the replace
+    // path must not cost an order of magnitude more than the scan it replaces.
+    // Only three secrets are registered, so each pass is far cheaper than the
+    // 100-secret case above; iterate more to keep a sample big enough to measure.
+    const ITERATIONS: usize = 5000;
+    assert_cost_within_calibrated_budget(
+        "redaction of 25000 lines that match registered secrets",
+        REDACTION_MAX_RATIO,
+        REDACTION_BUDGET_FLOOR,
+        || time_reference_scan(ITERATIONS, &test_lines, &secrets),
+        || time_redaction(ITERATIONS, &test_lines, &config),
     );
 
     // Clean up

--- a/crates/core/tests/test_lifecycle_formats.rs
+++ b/crates/core/tests/test_lifecycle_formats.rs
@@ -341,38 +341,63 @@ fn test_format_detection_null_returns_none() {
 // futures::future::join_all for container-side) achieves actual
 // concurrency rather than sequential execution.
 
-/// Verifies that parallel execution via JoinSet (the host-side pattern)
-/// completes two 500ms tasks in roughly 500ms wall-clock time, not 1000ms.
-/// This proves the JoinSet::spawn_blocking pattern achieves true concurrency.
+/// Both concurrency tests below rendezvous instead of racing a stopwatch.
+///
+/// They used to sleep 500ms per task and assert the pair finished under 900ms,
+/// inferring concurrency from the gap between ~500ms (concurrent) and ~1000ms
+/// (sequential). That bound is intrinsically under 2x, so a loaded box can breach
+/// it without any regression — the same disease as the redaction perf assertions
+/// in #517, and unfixable by widening, since widening past 1000ms would stop
+/// distinguishing concurrent from sequential at all.
+///
+/// A rendezvous tests the property directly: each task announces its arrival and
+/// then waits for the other's. Under genuine concurrency both arrive and both
+/// proceed, however slow the machine is. Under sequential execution the first
+/// task waits for a partner that has not been started yet and never will be, so
+/// it gives up after the guard below and the test fails. The guard is orders of
+/// magnitude above any scheduling delay: reachable by the regression, never by
+/// load.
+///
+/// Every wait is *bounded* rather than infinite. An unbounded rendezvous turns
+/// the regression into a hung test instead of a failing one — a blocking task
+/// parked forever also blocks tokio's runtime shutdown, so the test never even
+/// reaches its assertion.
+const RENDEZVOUS_GUARD: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Verifies that parallel execution via JoinSet (the host-side pattern) really
+/// runs both tasks at once. This proves the JoinSet::spawn_blocking pattern
+/// achieves true concurrency rather than serializing the entries.
 #[tokio::test]
 async fn test_parallel_execution_is_concurrent() {
-    use std::time::{Duration, Instant};
+    use std::sync::mpsc;
     use tokio::task::JoinSet;
 
-    let start = Instant::now();
     let mut set = JoinSet::new();
 
-    // Spawn two blocking tasks that each sleep for 500ms,
-    // mirroring the host-side parallel execution pattern in
-    // execute_host_lifecycle_phase (JoinSet::spawn_blocking).
-    for _ in 0..2 {
-        set.spawn_blocking(|| {
-            std::thread::sleep(Duration::from_millis(500));
+    // Spawn two blocking tasks that each announce their arrival and then wait
+    // for the other's, mirroring the host-side parallel execution pattern in
+    // execute_host_lifecycle_phase (JoinSet::spawn_blocking). Only tasks that
+    // are genuinely in flight together can both observe a peer.
+    let (tx_a, rx_a) = mpsc::channel::<()>();
+    let (tx_b, rx_b) = mpsc::channel::<()>();
+    for (tx, rx) in [(tx_a, rx_b), (tx_b, rx_a)] {
+        set.spawn_blocking(move || {
+            tx.send(()).expect("peer task should still be alive");
+            rx.recv_timeout(RENDEZVOUS_GUARD).is_ok()
         });
     }
 
     // Collect all results (mirrors "wait for ALL" pattern)
+    let mut observed_peer = Vec::new();
     while let Some(result) = set.join_next().await {
-        result.expect("spawned task should not panic");
+        observed_peer.push(result.expect("spawned task should not panic"));
     }
 
-    let elapsed = start.elapsed();
-    // If concurrent: ~500ms. If sequential: ~1000ms.
-    // Use 900ms as threshold to allow generous margin for CI.
-    assert!(
-        elapsed < Duration::from_millis(900),
-        "Parallel execution took {:?}, expected < 900ms (should be ~500ms if concurrent)",
-        elapsed
+    assert_eq!(
+        observed_peer,
+        vec![true, true],
+        "spawn_blocking entries did not run concurrently: a task waited out the \
+         full {RENDEZVOUS_GUARD:?} without its peer ever starting"
     );
 }
 
@@ -380,26 +405,37 @@ async fn test_parallel_execution_is_concurrent() {
 /// also achieves true concurrency with async tasks.
 #[tokio::test]
 async fn test_parallel_execution_is_concurrent_async() {
-    use std::time::{Duration, Instant};
+    use futures::channel::oneshot;
 
-    let start = Instant::now();
+    // Each future signals its own arrival, then awaits the other's. join_all
+    // polls both before either completes, so both resolve; awaiting them one at
+    // a time would leave the first waiting forever. tokio::sync is not enabled
+    // for this workspace, so the rendezvous uses futures' oneshot channels.
+    let (tx_a, rx_a) = oneshot::channel::<()>();
+    let (tx_b, rx_b) = oneshot::channel::<()>();
 
-    // Build futures for two async tasks that each sleep 500ms,
-    // mirroring the container-side parallel execution pattern
-    // in execute_container_lifecycle_phase (join_all).
-    let futures: Vec<_> = (0..2)
-        .map(|_| async {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-        })
-        .collect();
+    let first = async move {
+        tx_a.send(()).expect("peer future should still be alive");
+        rx_b.await.expect("peer future should signal arrival");
+    };
+    let second = async move {
+        tx_b.send(()).expect("peer future should still be alive");
+        rx_a.await.expect("peer future should signal arrival");
+    };
 
-    futures::future::join_all(futures).await;
+    let joined = tokio::time::timeout(
+        RENDEZVOUS_GUARD,
+        futures::future::join_all(vec![
+            Box::pin(first) as std::pin::Pin<Box<dyn std::future::Future<Output = ()>>>,
+            Box::pin(second),
+        ]),
+    )
+    .await;
 
-    let elapsed = start.elapsed();
     assert!(
-        elapsed < Duration::from_millis(900),
-        "Async parallel execution took {:?}, expected < 900ms (should be ~500ms if concurrent)",
-        elapsed
+        joined.is_ok(),
+        "join_all did not drive the futures concurrently: neither future observed \
+         the other's arrival within {RENDEZVOUS_GUARD:?}"
     );
 }
 


### PR DESCRIPTION
## The problem

`test_redaction_performance_short_lines` asserted 5000 redactions complete under a fixed 500ms. That measures the machine, not the code.

## Sibling survey

Swept every upper-bound wall-clock assertion in `crates/*` (`elapsed`, `Instant::now`, `Duration::from_*` comparisons). Nine sites, three classes.

**Treated — bounds a loaded box can breach without any regression:**

| Assertion | Old bound | Honest cost | Headroom |
|---|---|---|---|
| `integration_redaction::test_redaction_performance_short_lines` | 500ms | 200–370ms | ~1.4x |
| `integration_redaction::test_redaction_performance_with_secrets` | 200ms | ~30–60ms | ~3x |
| `redaction::tests::test_hash_redaction_performance` | 50ms | 26–75ms | **<1x** |
| `test_lifecycle_formats::test_parallel_execution_is_concurrent` | 900ms | ~505ms | ~1.8x |
| `test_lifecycle_formats::test_parallel_execution_is_concurrent_async` | 900ms | ~505ms | ~1.8x |

The hash one was **worse than the reported bug** and nobody had filed it: it failed 1 run in 6 standalone on a box at load ~3, because 100 iterations sample only tens of milliseconds — less than a single scheduler preemption. (A sibling agent independently hit it this week, corroborating.)

**Left alone — sized and documented, not ignored:**

- `perf_outdated.rs` (5 assertions, ≤10s / ≤5s). Measured the real subprocess cost: 2.2s for the 20-feature case, 0.8s for the 5-feature baseline — 4.5–6x headroom. They also guard a *subprocess* end-to-end time whose regression mode (waiting out network timeouts; the un-mocked run takes 21.9s) a calibration loop cannot model.
- `oci_timeout.rs` (4 assertions, <2s / <13s / <26s) and `doctor.rs`'s bounded probe (<5s). These guard that a *timeout fires at all* — the alternative is an unbounded hang — with 3–25x margin over the timer they bound.

Line drawn explicitly: everything under ~2x headroom is fixed; everything above 4x is documented with its measurement.

## Approach and why

**Throughput assertions → calibrated budget.** A `reference` loop does the irreducible work redaction cannot avoid (scan every line for every registered secret); `measured` does the real thing over the same inputs. Both are pure-CPU loops in the same process, timed back to back, so CPU contention / frequency scaling / cgroup throttling slow both by the same factor and the *ratio* holds where the absolute does not. Only a regression in redaction itself inflates the numerator. Budget is `max(10 * reference, 100ms)`, best of three attempts.

Two sizing details that turned out to matter, both found by measurement rather than reasoning:

- **The floor must be small.** My first cut used a 500ms floor (the original bound). Because the budget is a `max`, that floor *swallowed the ratio* on the two smaller registries and a 20x sabotage sailed straight past them. A small floor cannot cause a load-induced failure — load raises `10 * reference` past it — so its only job is to stop an anomalously quick reference sample collapsing the budget.
- **Samples must be big enough to measure.** The hash test's original 100 iterations sample a few milliseconds, which one preemption dominates; its honest ratio swung 0.53–4.85 on an idle box. Raised to 1000 iterations (and the 3-secret case to 5000) so a sample is hundreds of milliseconds and the ratio is stable.

**Concurrency assertions → rendezvous.** These inferred concurrency from a 900ms bound over two 500ms sleeps. That discrimination is intrinsically under 2x (concurrent ~500ms vs sequential ~1000ms), so it *cannot* be widened without ceasing to distinguish the two — timing cannot fix this one. They now test the property directly: each task announces its arrival and waits for its peer's, which only genuinely concurrent tasks can both observe. Load is irrelevant. Bonus: 1s of sleeps drops out of `dev-fast`.

Every wait is **bounded** (10s), and that is load-bearing: an unbounded rendezvous turns the regression into a *hung* test rather than a failing one. I hit this — a `std::sync::Barrier` version deadlocked, because a `spawn_blocking` task parked forever also blocks tokio's runtime shutdown, so the test never reaches its assertion. The committed version uses `recv_timeout`, so the sequential regression fails cleanly in 10s.

## Proof, both directions

**Cannot fail from load.** Loaded this 8-core box to load average ~38–45 with 24 busy loops, then ran the same five tests on `main` and on this branch under identical load:

| | `main` (fixed bounds) | this branch |
|---|---|---|
| `test_redaction_performance_short_lines` | **FAIL 5/5** | PASS 10/10 |
| `test_hash_redaction_performance` | **FAIL 3/5** | PASS 10/10 |
| `test_redaction_performance_with_secrets` | **FAIL 1/5** | PASS 10/10 |
| both concurrency tests | PASS 5/5 | PASS 10/10 |

**Still fails on the regression it guards.** Injected a 20x per-call blowup into `SecretRegistry::redact_text` (the whole redaction pass repeated — a pathological constant-factor regression). All three throughput assertions failed, on all three attempts each, with a diagnostic naming both sides:

```
redaction of 5000 short lines against 100 secrets: cost exceeded 10x the calibration loop
(floor 100ms) on all 3 attempts: reference=83.298014ms measured=2.188219204s budget=832.98014ms; ...

redaction of 25000 lines that match registered secrets: cost exceeded 10x the calibration loop
(floor 100ms) on all 3 attempts: reference=30.303527ms measured=766.939088ms budget=303.03527ms; ...

hash redaction exceeded 10x the calibration loop (floor 100ms) on all 3 attempts:
reference=43.78465ms measured=1.212235709s budget=437.8465ms; ...
```

For the concurrency pair, made execution sequential (spawn-and-join one at a time; sequential `await`s instead of `join_all`). Both failed cleanly at 10.009s and 10.013s — no hang. All sabotage reverted; `grep -c SABOTAGE` is 0 on the committed tree.

## Gate

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `cargo build --workspace --all-targets` clean; `cargo nextest run --profile dev-fast` run **twice**, 3303/3303 passed both times. No `parity/` files touched — not a parity matter.

Rebased on `6e6f5b2` (current `main`, including #518–#521).

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
