### PR TITLE
fix(oci): align feature-fetch timeout with FR-023 (30s), not 2s (#525)

### DIFF
--- a/crates/core/src/oci/fetcher.rs
+++ b/crates/core/src/oci/fetcher.rs
@@ -941,6 +941,35 @@ impl<C: HttpClient> FeatureFetcher<C> {
     }
 }
 
+/// Per-request timeout for feature manifest/blob fetches during configuration
+/// resolution, per spec FR-023 ("30-second timeout for HTTPS feature downloads
+/// with a single retry on transient network errors").
+///
+/// This bounds the *total* request; the connect phase is separately bounded by
+/// [`ReqwestClient`]'s connect timeout, so an unreachable registry still fails
+/// fast instead of burning the full budget. Only a registry that accepts the
+/// connection and then responds slowly consumes it.
+///
+/// Do not tighten this to "make config resolution feel fast". A budget shorter
+/// than a real registry round-trip turns ordinary registry latency into a hard
+/// failure — a 2s cap here made `read-configuration` fail against `ghcr.io`
+/// where the reference CLI (which sets no timeout at all) succeeded (#525).
+pub const FEATURE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Retry policy for feature fetches during configuration resolution, per spec
+/// FR-023: exactly one retry on a transient network error, with a small
+/// jittered backoff. The reference CLI performs no transient retry at all, so a
+/// single retry is strictly more forgiving while keeping the worst case bounded
+/// at two attempts.
+pub fn feature_fetch_retry_config() -> RetryConfig {
+    RetryConfig::new(
+        1,                                        // one retry after the initial attempt
+        std::time::Duration::from_millis(100),    // base backoff
+        std::time::Duration::from_secs(1),        // backoff cap
+        crate::retry::JitterStrategy::FullJitter, // spread concurrent retries
+    )
+}
+
 /// Convenience function to create a default feature fetcher
 pub fn default_fetcher() -> Result<FeatureFetcher<ReqwestClient>> {
     let client = ReqwestClient::new().map_err(|e| FeatureError::Authentication {
@@ -951,29 +980,24 @@ pub fn default_fetcher() -> Result<FeatureFetcher<ReqwestClient>> {
 
 /// Create a feature fetcher with custom timeout and retry configuration
 ///
-/// This function is useful for operations that need predictable performance guarantees,
-/// such as the read-configuration command which should minimize latency.
+/// Prefer [`FEATURE_FETCH_TIMEOUT`] + [`feature_fetch_retry_config`] for
+/// configuration-resolution paths; they encode the FR-023 policy. Pass a custom
+/// bound only when a caller genuinely needs a different one.
 ///
 /// # Arguments
-/// * `timeout` - Timeout for each HTTP request (e.g., 2 seconds)
+/// * `timeout` - Total timeout for each HTTP request
 /// * `retry_config` - Retry configuration (max attempts, backoff delays)
 ///
 /// # Examples
 /// ```
-/// use deacon_core::oci::default_fetcher_with_config;
-/// use deacon_core::retry::RetryConfig;
-/// use std::time::Duration;
+/// use deacon_core::oci::{
+///     FEATURE_FETCH_TIMEOUT, default_fetcher_with_config, feature_fetch_retry_config,
+/// };
 ///
-/// // Create fetcher with 2s timeout and 1 retry
-/// let retry_config = RetryConfig::new(
-///     1, // max_attempts (1 retry after initial attempt)
-///     Duration::from_millis(100), // base_delay
-///     Duration::from_secs(1), // max_delay
-///     deacon_core::retry::JitterStrategy::FullJitter,
-/// );
+/// // The FR-023 policy: 30s per request, a single retry on transient errors.
 /// let fetcher = default_fetcher_with_config(
-///     Some(Duration::from_secs(2)),
-///     retry_config,
+///     Some(FEATURE_FETCH_TIMEOUT),
+///     feature_fetch_retry_config(),
 /// );
 /// ```
 pub fn default_fetcher_with_config(

--- a/crates/core/src/oci/mod.rs
+++ b/crates/core/src/oci/mod.rs
@@ -43,7 +43,10 @@ mod utils;
 // Re-export public types
 pub use auth::{RegistryAuth, RegistryCredentials};
 pub use client::{HttpClient, MockHttpClient, ReqwestClient};
-pub use fetcher::{FeatureFetcher, default_fetcher, default_fetcher_with_config};
+pub use fetcher::{
+    FEATURE_FETCH_TIMEOUT, FeatureFetcher, default_fetcher, default_fetcher_with_config,
+    feature_fetch_retry_config,
+};
 pub use types::{
     CollectionFeature, CollectionMetadata, CollectionSourceInfo, CollectionTemplate,
     DownloadedFeature, DownloadedTemplate, FeatureRef, HttpResponse, Layer, Manifest, TagList,

--- a/crates/core/tests/oci_timeout.rs
+++ b/crates/core/tests/oci_timeout.rs
@@ -350,3 +350,233 @@ async fn test_pagination_timeout_accumulation() {
     // May succeed with partial results or fail, but shouldn't hang
     let _ = result;
 }
+
+// --- #525: transient-failure recovery on the config-resolution fetch path ---
+
+/// Mock that fails the first `failures` calls with a transient, timeout-shaped
+/// error and then serves `body`. Records how many calls it received so a test
+/// can assert the retry budget is both used and bounded.
+#[derive(Debug, Clone)]
+struct FlakyMockHttpClient {
+    failures_remaining: Arc<Mutex<usize>>,
+    calls: Arc<Mutex<usize>>,
+    body: Bytes,
+}
+
+impl FlakyMockHttpClient {
+    fn new(failures: usize, body: Bytes) -> Self {
+        Self {
+            failures_remaining: Arc::new(Mutex::new(failures)),
+            calls: Arc::new(Mutex::new(0)),
+            body,
+        }
+    }
+
+    async fn call_count(&self) -> usize {
+        *self.calls.lock().await
+    }
+
+    async fn next(
+        &self,
+        url: &str,
+    ) -> std::result::Result<Bytes, Box<dyn std::error::Error + Send + Sync>> {
+        *self.calls.lock().await += 1;
+        let mut remaining = self.failures_remaining.lock().await;
+        if *remaining > 0 {
+            *remaining -= 1;
+            // Mirrors ReqwestClient's phrasing for a timed-out request, which is
+            // what the #525 nightly actually hit against ghcr.io.
+            return Err(format!(
+                "Request timeout for URL: {}. Check network connectivity.",
+                url
+            )
+            .into());
+        }
+        Ok(self.body.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpClient for FlakyMockHttpClient {
+    async fn get(
+        &self,
+        url: &str,
+    ) -> std::result::Result<Bytes, Box<dyn std::error::Error + Send + Sync>> {
+        self.next(url).await
+    }
+
+    async fn get_with_headers(
+        &self,
+        url: &str,
+        _headers: HashMap<String, String>,
+    ) -> std::result::Result<Bytes, Box<dyn std::error::Error + Send + Sync>> {
+        self.next(url).await
+    }
+
+    async fn get_with_headers_and_response(
+        &self,
+        url: &str,
+        _headers: HashMap<String, String>,
+    ) -> std::result::Result<HttpResponse, Box<dyn std::error::Error + Send + Sync>> {
+        let body = self.next(url).await?;
+        Ok(HttpResponse {
+            status: 200,
+            headers: HashMap::new(),
+            body,
+        })
+    }
+
+    async fn head(
+        &self,
+        url: &str,
+        _headers: HashMap<String, String>,
+    ) -> std::result::Result<u16, Box<dyn std::error::Error + Send + Sync>> {
+        self.next(url).await.map(|_| 200)
+    }
+}
+
+fn valid_manifest_bytes() -> Bytes {
+    Bytes::from(
+        serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "layers": [{
+                "mediaType": "application/vnd.devcontainers.layer.v1+tar",
+                "size": 1024,
+                "digest": "sha256:abc123"
+            }]
+        })
+        .to_string(),
+    )
+}
+
+fn flaky_feature_ref() -> FeatureRef {
+    FeatureRef::new(
+        "test.registry".to_string(),
+        "test".to_string(),
+        "feature".to_string(),
+        Some("latest".to_string()),
+    )
+}
+
+/// A single transient failure must NOT surface to the caller: the FR-023 policy
+/// grants one retry, and the second attempt succeeds. This is the exact shape of
+/// the #525 false divergence, where deacon reported a hard failure on a manifest
+/// fetch that the reference CLI completed.
+#[tokio::test]
+async fn test_transient_manifest_failure_recovers_on_retry() {
+    let client = FlakyMockHttpClient::new(1, valid_manifest_bytes());
+    let cache = tempfile::TempDir::new().unwrap();
+    let fetcher = FeatureFetcher::with_retry_config(
+        client.clone(),
+        cache.path().to_path_buf(),
+        deacon_core::oci::feature_fetch_retry_config(),
+    );
+
+    let manifest = fetcher
+        .get_manifest(&flaky_feature_ref())
+        .await
+        .expect("one transient failure must be absorbed by the single retry");
+
+    assert_eq!(
+        manifest.layers.len(),
+        1,
+        "manifest should parse after retry"
+    );
+    assert_eq!(
+        client.call_count().await,
+        2,
+        "should have taken exactly the initial attempt plus one retry"
+    );
+}
+
+/// Retries stay bounded and the underlying cause is propagated verbatim rather
+/// than being flattened into a generic message — a persistent outage must still
+/// fail, and fail legibly.
+#[tokio::test]
+async fn test_persistent_failure_exhausts_retries_and_propagates_cause() {
+    // More failures than the budget can absorb.
+    let client = FlakyMockHttpClient::new(5, valid_manifest_bytes());
+    let cache = tempfile::TempDir::new().unwrap();
+    let fetcher = FeatureFetcher::with_retry_config(
+        client.clone(),
+        cache.path().to_path_buf(),
+        deacon_core::oci::feature_fetch_retry_config(),
+    );
+
+    let err = fetcher
+        .get_manifest(&flaky_feature_ref())
+        .await
+        .expect_err("a persistent failure must still fail");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Request timeout for URL"),
+        "the real transport error must survive to the caller, got: {msg}"
+    );
+    assert_eq!(
+        client.call_count().await,
+        2,
+        "retries must stay bounded at the initial attempt plus one retry"
+    );
+}
+
+/// The behavioral regression test for #525: one healthy-but-slow registry
+/// response, served twice from the same server. The FR-023 budget in force today
+/// absorbs it; the 2s cap it replaced does not. This is the difference that made
+/// the nightly red while the reference CLI — which sets no timeout at all —
+/// succeeded against the same endpoint.
+#[tokio::test]
+async fn test_fr023_budget_tolerates_slow_registry_that_two_second_cap_killed() {
+    use deacon_core::oci::ReqwestClient;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v2/test/feature/manifests/latest"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(valid_manifest_bytes().to_vec())
+                .set_delay(Duration::from_secs(3)),
+        )
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/v2/test/feature/manifests/latest", server.uri());
+
+    let current = ReqwestClient::with_timeout(Some(deacon_core::oci::FEATURE_FETCH_TIMEOUT))
+        .expect("client construction");
+    current
+        .get(&url)
+        .await
+        .expect("FR-023's 30s budget must tolerate a 3s registry response");
+
+    let old_cap =
+        ReqwestClient::with_timeout(Some(Duration::from_secs(2))).expect("client construction");
+    let err = old_cap
+        .get(&url)
+        .await
+        .expect_err("the replaced 2s cap must fail on this very same response");
+    assert!(
+        err.to_string().contains("Request timeout"),
+        "the 2s cap should fail as a timeout, got: {err}"
+    );
+}
+
+/// Guards the FR-023 policy values themselves. The 2s timeout this replaced was
+/// shorter than a real ghcr.io round-trip and produced #525's false divergence;
+/// re-tightening it should be a deliberate act, not a silent edit.
+#[test]
+fn test_feature_fetch_policy_matches_fr_023() {
+    assert_eq!(
+        deacon_core::oci::FEATURE_FETCH_TIMEOUT,
+        Duration::from_secs(30),
+        "FR-023 mandates a 30-second timeout for HTTPS feature downloads"
+    );
+    assert_eq!(
+        deacon_core::oci::feature_fetch_retry_config().max_attempts,
+        1,
+        "FR-023 mandates a single retry on transient network errors"
+    );
+}

--- a/crates/deacon/src/commands/read_configuration.rs
+++ b/crates/deacon/src/commands/read_configuration.rs
@@ -1924,20 +1924,19 @@ pub async fn execute_read_configuration(args: ReadConfigurationArgs) -> Result<(
         None
     };
 
-    // Create fetcher with tight timeouts for features resolution
-    // Per FR-009: Use 2s timeout and exactly 1 retry for predictable performance
-    use deacon_core::retry::{JitterStrategy, RetryConfig};
-    use std::time::Duration;
-
-    let retry_config = RetryConfig::new(
-        1,                          // max_attempts: exactly 1 retry
-        Duration::from_millis(100), // base_delay: small backoff
-        Duration::from_secs(1),     // max_delay
-        JitterStrategy::FullJitter,
-    );
-
-    let fetcher = default_fetcher_with_config(Some(Duration::from_secs(2)), retry_config)
-        .map_err(|e| anyhow::anyhow!("Failed to create OCI fetcher: {}", e))?;
+    // Create the fetcher for features resolution using the shared FR-023 policy
+    // (30s per request, a single retry on transient network errors).
+    //
+    // This deliberately does NOT use a tighter bound. Config resolution fetches
+    // feature manifests from a live registry, and a budget shorter than a real
+    // registry round-trip converts ordinary latency into a hard failure: a
+    // previous 2s cap made this path fail against `ghcr.io` while the reference
+    // CLI — which sets no timeout at all — succeeded (#525).
+    let fetcher = default_fetcher_with_config(
+        Some(deacon_core::oci::FEATURE_FETCH_TIMEOUT),
+        deacon_core::oci::feature_fetch_retry_config(),
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to create OCI fetcher: {}", e))?;
 
     // Resolve features if requested or needed for merged config
     // Per spec: Features are needed for:


### PR DESCRIPTION
## Measured, not assumed

The issue proposed three options and hypothesised a transient ghcr **403**. Pulling the actual log from run `31066922806` shows a different, simpler defect — and one that is already a written requirement violation:

```
WARN deacon_core::retry: Retrying after transient error (attempt 1/1):
  Download { "Failed to download manifest: Request timeout for ..." }
WARN deacon_core::retry: All 2 retry attempts exhausted, final error: ...
  Request timeout for URL: https://ghcr.io/v2/devcontainers/features/node/manifests/1
```

It was a **timeout**, not a 403 — and the entire budget was spent in **2.03 seconds** (`03:03:31.047` → `03:03:33.083`).

### The reference's measured policy

From the pinned oracle bundle (`@devcontainers/cli@0.87.0`, `dist/spec-node/devContainersSpecCLI.js`):

- Its raw request helper builds `https.request` options with **no `timeout` key at all** — it waits as long as the socket lives.
- Its OCI wrapper retries **only to re-authenticate**: on 401 *or* 403 it reads `WWW-Authenticate`, gets a token, and re-issues **once**. There is **no transient/backoff retry** anywhere.
- No cross-run on-disk feature cache; tarballs go to a per-invocation tmp dir. A prior successful fetch does **not** make later runs immune.

So the reference is *infinitely patient and never retries transients*.

### Deacon's gap

`read-configuration` built its feature-resolution fetcher with a **2-second** total HTTP timeout and one retry, citing **"FR-009"** — a requirement that does not exist for this path. The repo's actual requirement is **FR-023** (`specs/009-complete-feature-support/spec.md:146`):

> System MUST use a **30-second timeout** for HTTPS feature downloads with a **single retry** on transient network errors.

The code was **15× tighter than its own spec**. Any ghcr manifest response slower than 2s → deacon hard-fails, reference succeeds → one-sided false divergence.

This was the **only** production caller of `default_fetcher_with_config`; every other path (`up`, `upgrade`, `templates`, `run-user-commands`) uses `default_fetcher()` at 300s and was never exposed.

### Exposure

**60 parity cases across 38 fixtures** fetch OCI Features from `ghcr.io` at runtime (37 `read-configuration`, 15 `outdated`, 6 `upgrade`, 2 `doctor`), all anonymous and all cold — the nightly's prepull script warms container **images** only, never Features. The failing fixture reaches the registry *transitively*: local feature `./needs-node` declares `dependsOn: ghcr.io/devcontainers/features/node:1`, so it is invisible to a grep of the devcontainer.json. Notably the blob cache would not have saved it either — the manifest is refetched on every run before the cache key can be computed.

## The change

Replaces the magic 2s with a shared, spec-cited policy in `deacon_core::oci`:

- `FEATURE_FETCH_TIMEOUT` = 30s
- `feature_fetch_retry_config()` = one retry, jittered backoff

**The retry count is unchanged.** FR-023 mandates exactly one and the reference performs none, so one retry is already strictly more forgiving. Only the patience changes.

An unreachable registry still fails fast: `with_timeout` bounds the connect phase at 10s *independently*, so the 30s budget is consumed only by a registry that accepts the connection and then responds slowly — precisely the case that must not be a hard failure.

This is a **product** fix, not just nightly hygiene: any user resolving features over a slow or distant link hit the same wall.

## Why not the other options

- **(b) harness re-run of network-marked cases** — masks the defect instead of fixing it, and would have hidden a real 15× spec violation. Also needs a `network` marker that doesn't exist (`ResourceGroup` is a closed, test-guarded 4-variant enum).
- **(c) workflow prewarm** — cannot help. The manifest is refetched every run *before* the cache key is derived from `manifest.layers[0].digest`, so a warm blob cache does not protect the path that actually failed.

## Test evidence

`crates/core/tests/oci_timeout.rs`, all passing:

| Test | Proves |
|---|---|
| `test_fr023_budget_tolerates_slow_registry_that_two_second_cap_killed` | **The behavioral regression.** One 3s wiremock response served twice: the FR-023 budget absorbs it; the replaced 2s cap times out on the *very same* response. |
| `test_transient_manifest_failure_recovers_on_retry` | A mock failing once then succeeding is absorbed in exactly 2 calls. |
| `test_persistent_failure_exhausts_retries_and_propagates_cause` | Retries stay bounded at 2 calls; the real transport error propagates verbatim. |
| `test_feature_fetch_policy_matches_fr_023` | Pins the policy values so re-tightening is deliberate, not a silent edit. |

## Gate

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo build --workspace --all-targets` clean
- `make test-nextest-fast` — **3310 passed**, 0 failed
- **`cargo nextest run --profile parity --no-fail-fast` — 8/8 passed, diverging set EMPTY**, including `differential_group_none` (74s) where `case-merged-decl-dependson-autoinstall` lives. Oracle `0.87.0` (matches pin); Docker resources reclaimed before and after.

**No ledger change warranted.** This removes a *false* divergence rather than characterizing a real one — no behavior observable on any of the eleven channels changes, and fetch timing is not an observable channel. No `SPEC_STATUS.md` row, so no Summary-header/census interaction (#518).

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
