### PR TITLE
fix(run-user-commands): preserve config_hash in lifecycle markers (#372)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -176,6 +176,14 @@ filter = 'binary(=integration_up_force_tty_if_json)'
 test-group = 'docker-shared'
 slow-timeout = { period = "10m", terminate-after = 1 }
 
+# #372 marker config-hash regression: runs `up` twice plus `run-user-commands`
+# against its own temp workspace and its own `--user-data-folder`, so it shares
+# nothing with sibling cases but the daemon → docker-shared, not exclusive.
+[[profile.default.overrides]]
+filter = 'binary(=run_user_commands_marker_config_hash)'
+test-group = 'docker-shared'
+slow-timeout = { period = "10m", terminate-after = 1 }
+
 # Compose features (bead 14a/14b): pull an OCI feature, run BuildKit, and
 # bring up a compose project. Slow due to feature download + image build.
 [[profile.default.overrides]]
@@ -211,7 +219,7 @@ slow-timeout = "30s"
 # `parity_*` test binaries, not the crate's own unit tests, so the lib joins
 # `parity_harness_faults` / `parity_registry_check` as an explicit exception. Its
 # shell-dependent tests are already `#[cfg(unix)]`-gated, so the Windows lane is unaffected.
-default-filter = 'not (binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_harness) | binary(=parity_hermetic))) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=build_push_metadata) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build) | binary(=docker_channels))'
+default-filter = 'not (binary(#smoke_*) | (binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_harness) | binary(=parity_hermetic))) | binary(=build_consistency) | binary(=integration_build) | binary(=integration_build_output) | binary(=build_push_metadata) | binary(=integration_build_args) | binary(=integration_vulnerability_scan) | binary(#integration_up_*) | binary(=integration_progress) | binary(#integration_env_probe_*) | test(/^env_probe::tests::/) | binary(=integration_exec_id_label) | binary(=integration_exec_selection) | binary(=testcontainers_helpers) | binary(=workspace_mounts) | binary(=up_prebuild) | binary(=run_user_commands_prebuild) | binary(=run_user_commands_marker_config_hash) | binary(=run_user_commands_feature_lifecycle) | binary(=lifecycle_parallel_output) | binary(=up_reconnect_full_id) | binary(=up_keepalive_path) | binary(=up_dotfiles) | binary(=integration_feature_lifecycle) | binary(=integration_feature_security) | binary(=integration_feature_mounts) | binary(=integration_compose_features_build) | binary(=integration_compose_config_mounts) | binary(=integration_auto_forward) | binary(=integration_host_ca_runtime) | binary(=integration_host_ca_build) | binary(=docker_channels))'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=smoke_exec) | binary(=smoke_exec_stdin) | binary(=smoke_up_idempotent) | binary(=smoke_down) | binary(=smoke_spinner) | binary(=smoke_lifecycle)'
@@ -299,6 +307,12 @@ test-group = 'docker-shared'
 
 [[profile.dev-fast.overrides]]
 filter = 'binary(=integration_up_force_tty_if_json)'
+test-group = 'docker-shared'
+slow-timeout = { period = "10m", terminate-after = 1 }
+
+# #372 marker config-hash regression (see the default profile's note).
+[[profile.dev-fast.overrides]]
+filter = 'binary(=run_user_commands_marker_config_hash)'
 test-group = 'docker-shared'
 slow-timeout = { period = "10m", terminate-after = 1 }
 

--- a/crates/deacon/src/commands/run_user_commands.rs
+++ b/crates/deacon/src/commands/run_user_commands.rs
@@ -3,7 +3,9 @@
 //! This module provides execution of lifecycle commands in an existing container
 //! without going through the full `up` workflow.
 
-use crate::commands::shared::{ConfigLoadArgs, ConfigLoadResult, load_config, resolve_runtime};
+use crate::commands::shared::{
+    ConfigLoadArgs, ConfigLoadResult, canonical_reconnect_identity, load_config, resolve_runtime,
+};
 use anyhow::{Context, Result};
 use deacon_core::config::DevContainerConfig;
 use deacon_core::container_lifecycle::{
@@ -79,6 +81,28 @@ pub async fn execute_run_user_commands(
     .await?;
 
     debug!("Loaded configuration with overrides and secrets support");
+
+    // Lifecycle phase markers are keyed on the WORKSPACE hash alone, so `up` and
+    // `run-user-commands` write into the same directory. Writing `None` here
+    // stamped the markers as "legacy, no recorded hash" — which
+    // `read_all_markers_for_config` treats as compatible with any config — and
+    // silently erased `up`'s config-drift detection: a later
+    // `up --override-config <changed>` created a fresh container and then SKIPPED
+    // `postCreate` because the clobbered marker still claimed it had run (#372).
+    //
+    // The hash must be computed from the configuration **as loaded**, via the same
+    // `canonical_reconnect_identity` contract that makes this command's container
+    // lookup agree with `up`'s labels (#187) — i.e. BEFORE the host-CA
+    // `containerEnv` injection below and BEFORE the image-metadata fold inside
+    // `execute_lifecycle_commands`. Hashing a mutated config would produce a value
+    // `up` can never reproduce, turning the erased-drift bug into a permanent
+    // false-positive drift instead.
+    let config_hash =
+        canonical_reconnect_identity(workspace_folder.as_path(), &config, None, None).config_hash;
+    debug!(
+        config_hash = %config_hash,
+        "Resolved config hash for lifecycle markers"
+    );
 
     let container_id = {
         let docker_client = cli.clone();
@@ -177,6 +201,7 @@ pub async fn execute_run_user_commands(
         workspace_folder.as_path(),
         &args,
         &cli,
+        &config_hash,
     )
     .await?;
 
@@ -185,6 +210,10 @@ pub async fn execute_run_user_commands(
 }
 
 /// Execute lifecycle commands in the container
+///
+/// `config_hash` is the hash of the configuration **as loaded** (see the call
+/// site): it is stamped on every lifecycle marker this run writes so `up`'s
+/// config-drift detection survives a `run-user-commands` invocation (#372).
 #[instrument(skip(config, workspace_folder, args))]
 async fn execute_lifecycle_commands(
     container_id: &str,
@@ -192,6 +221,7 @@ async fn execute_lifecycle_commands(
     workspace_folder: &Path,
     args: &RunUserCommandsArgs,
     cli: &CliRuntime,
+    config_hash: &str,
 ) -> Result<()> {
     info!("Executing lifecycle commands in container");
 
@@ -281,7 +311,9 @@ async fn execute_lifecycle_commands(
         // run-user-commands does not install dotfiles - that is handled by `up` command
         dotfiles: None,
         is_prebuild: args.prebuild,
-        config_hash: None,
+        // #372: stamp the SAME hash `up` records. Markers are shared (keyed on the
+        // workspace hash only), so a `None` here would erase `up`'s drift detection.
+        config_hash: Some(config_hash.to_string()),
     };
 
     // Resolve declared features (fail-fast) so feature-contributed lifecycle

--- a/crates/deacon/src/commands/set_up.rs
+++ b/crates/deacon/src/commands/set_up.rs
@@ -466,6 +466,23 @@ async fn execute_lifecycle_hooks(
         .unwrap_or_else(|| "/".to_string());
     let substitution_workspace_folder = substitution_context.container_workspace_folder.clone();
 
+    // #372: every lifecycle-marker writer stamps the hash of the config it actually
+    // ran, so `up`'s config-drift detection stays meaningful. Markers key on the
+    // workspace hash of the marker anchor, and `set-up`'s anchor is the process cwd
+    // — which walks to the same git root as an `up --workspace-folder <same repo>`,
+    // so these markers DO land in `up`'s directory and a `None` here would stamp
+    // them "legacy, compatible with any config" and make a later `up` skip hooks it
+    // must re-run.
+    //
+    // This hash deliberately will NOT equal `up`'s: `set-up` adopts a container it
+    // did not create, folds in the container's image metadata, and substitutes
+    // without a workspace (`${localWorkspaceFolder}` stays literal). The honest
+    // consequence is that a following `up` sees drift and RE-RUNS — the fail-safe
+    // direction, and strictly better than silently skipping.
+    let marker_anchor = std::path::Path::new(&substitution_context.local_workspace_folder);
+    let config_hash =
+        deacon_core::container::ContainerIdentity::new(marker_anchor, merged_config).config_hash;
+
     let lifecycle_config = ContainerLifecycleConfig {
         capture_output: false,
         container_id: container.id.clone(),
@@ -488,7 +505,7 @@ async fn execute_lifecycle_hooks(
         force_pty: false,
         dotfiles: build_dotfiles_config(args),
         is_prebuild: false,
-        config_hash: None,
+        config_hash: Some(config_hash),
     };
 
     let mut commands = ContainerLifecycleCommands::new();

--- a/crates/deacon/src/commands/shared/identity.rs
+++ b/crates/deacon/src/commands/shared/identity.rs
@@ -91,4 +91,36 @@ mod tests {
         assert_eq!(bare.label_selector(), decorated.label_selector());
         assert_eq!(decorated.custom_name.as_deref(), Some("my-name"));
     }
+
+    #[test]
+    fn config_hash_is_shared_between_up_and_the_marker_writers() {
+        // Lifecycle phase markers key on the workspace hash alone, so `up` and
+        // `run-user-commands` write the SAME files and must stamp the SAME
+        // `config_hash` or one erases the other's config-drift detection (#372).
+        //
+        // `up` builds its identity WITH a container name and a config-file path;
+        // `run-user-commands` builds its own with neither. This pins the property
+        // that makes the two hashes equal by construction, so the fix cannot be
+        // undone by a future call site that starts passing (or stops passing)
+        // those decorations.
+        let ws = Path::new("/tmp/demo-ws");
+        let config = sample_config();
+
+        let up_side = canonical_reconnect_identity(
+            ws,
+            &config,
+            Some("deacon-demo".to_string()),
+            Some(Path::new("/tmp/demo-ws/.devcontainer/devcontainer.json")),
+        );
+        let run_user_commands_side = canonical_reconnect_identity(ws, &config, None, None);
+
+        assert_eq!(up_side.config_hash, run_user_commands_side.config_hash);
+
+        // ...and a genuinely different config must produce a different hash, or
+        // the drift detection the markers feed would be vacuous.
+        let drifted: DevContainerConfig =
+            serde_json::from_str(r#"{ "name": "demo", "image": "alpine:3.19" }"#).unwrap();
+        let drifted_side = canonical_reconnect_identity(ws, &drifted, None, None);
+        assert_ne!(up_side.config_hash, drifted_side.config_hash);
+    }
 }

--- a/crates/deacon/tests/run_user_commands_marker_config_hash.rs
+++ b/crates/deacon/tests/run_user_commands_marker_config_hash.rs
@@ -1,0 +1,198 @@
+//! Integration test for #372: `run-user-commands` must not erase `up`'s
+//! config-drift detection.
+//!
+//! Lifecycle phase markers are a deacon extension (the reference CLI has none)
+//! and they key on the WORKSPACE hash alone, so `up` and `run-user-commands`
+//! write the same `<user-data>/state/<workspace-hash>/<phase>.json` files. `up`
+//! stamps the resolved `config_hash` on each marker and drops markers whose hash
+//! differs from the current config, which is what makes a later
+//! `up --override-config <changed>` re-run `postCreate` on the fresh container it
+//! creates.
+//!
+//! `run-user-commands` used to write those markers with `config_hash: null`, and
+//! `read_all_markers_for_config` treats an absent hash as "legacy, compatible
+//! with any config" — so a single `run-user-commands` invocation permanently
+//! disarmed the drift check and `postCreate` was silently skipped.
+//!
+//! Requires Docker; self-skips when unavailable.
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+const IMAGE: &str = "alpine:3.18";
+
+fn is_docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("info")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Removes every container this test's workspace produced, even if an assertion
+/// panics mid-test. Scoped to the temp workspace's own `devcontainer.local_folder`
+/// label so it can never reap a sibling test's container.
+struct WorkspaceContainers(String);
+
+impl WorkspaceContainers {
+    fn new(workspace: &Path) -> Self {
+        let canonical = workspace
+            .canonicalize()
+            .unwrap_or_else(|_| workspace.to_path_buf());
+        Self(format!(
+            "label=devcontainer.local_folder={}",
+            canonical.display()
+        ))
+    }
+}
+
+impl Drop for WorkspaceContainers {
+    fn drop(&mut self) {
+        let listed = std::process::Command::new("docker")
+            .args(["ps", "-aq", "--filter", &self.0])
+            .output();
+        if let Ok(out) = listed {
+            for id in String::from_utf8_lossy(&out.stdout).lines() {
+                let id = id.trim();
+                if id.is_empty() {
+                    continue;
+                }
+                let _ = std::process::Command::new("docker")
+                    .args(["rm", "-f", id])
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+        }
+    }
+}
+
+/// The single `postCreate.json` marker under `--user-data-folder`. Markers live at
+/// `<user-data>/state/<workspace-hash>/postCreate.json`; the hash is computed by
+/// deacon, so the test discovers the file rather than recomputing it.
+fn post_create_marker(user_data: &Path) -> Option<PathBuf> {
+    let state = user_data.join("state");
+    for entry in fs::read_dir(state).ok()?.flatten() {
+        let candidate = entry.path().join("postCreate.json");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn marker_config_hash(user_data: &Path) -> Option<String> {
+    let path = post_create_marker(user_data)?;
+    let raw = fs::read_to_string(path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    value
+        .get("config_hash")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+#[test]
+fn run_user_commands_preserves_the_config_hash_up_recorded() {
+    if !is_docker_available() {
+        eprintln!("Skipping: Docker is not available");
+        return;
+    }
+
+    let temp = TempDir::new().expect("temp dir");
+    let workspace = temp.path().join("ws");
+    let user_data = temp.path().join("udf");
+    fs::create_dir_all(workspace.join(".devcontainer")).expect("workspace dirs");
+    fs::create_dir_all(&user_data).expect("user data dir");
+
+    fs::write(
+        workspace.join(".devcontainer").join("devcontainer.json"),
+        format!(
+            r#"{{
+  "name": "issue372-base",
+  "image": "{IMAGE}",
+  "postCreateCommand": "echo base-post-create"
+}}"#
+        ),
+    )
+    .expect("write devcontainer.json");
+
+    let changed = temp.path().join("changed.json");
+    fs::write(
+        &changed,
+        format!(
+            r#"{{
+  "name": "issue372-changed",
+  "image": "{IMAGE}",
+  "postCreateCommand": "echo changed-post-create"
+}}"#
+        ),
+    )
+    .expect("write override config");
+
+    // The label carries the WORKSPACE folder, not the temp root — filtering on the
+    // parent matches nothing and leaks both containers.
+    let _cleanup = WorkspaceContainers::new(&workspace);
+
+    // Step 1: `up` records a hash-stamped postCreate marker.
+    Command::cargo_bin("deacon")
+        .expect("deacon binary")
+        .args(["up", "--workspace-folder"])
+        .arg(&workspace)
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .args(["--mount-workspace-git-root", "false"])
+        .timeout(std::time::Duration::from_secs(300))
+        .assert()
+        .success();
+
+    let after_up = marker_config_hash(&user_data)
+        .expect("up must write a postCreate marker carrying a config_hash");
+
+    // Step 2: `run-user-commands` rewrites the SAME marker. Before #372 it wrote
+    // `config_hash: null`, which reads as "compatible with every config".
+    Command::cargo_bin("deacon")
+        .expect("deacon binary")
+        .args(["run-user-commands", "--workspace-folder"])
+        .arg(&workspace)
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .timeout(std::time::Duration::from_secs(300))
+        .assert()
+        .success();
+
+    let after_run_user_commands = marker_config_hash(&user_data)
+        .expect("run-user-commands must not erase the marker's config_hash (#372)");
+    assert_eq!(
+        after_up, after_run_user_commands,
+        "run-user-commands must stamp the same config hash `up` does (#372)"
+    );
+
+    // Step 3: the acceptance criterion — a changed config after a
+    // `run-user-commands` still re-runs postCreate. `up` builds a fresh container
+    // (different config hash → different identity) and the marker is rewritten
+    // with the NEW hash; a skipped postCreate leaves the old hash in place.
+    Command::cargo_bin("deacon")
+        .expect("deacon binary")
+        .args(["up", "--workspace-folder"])
+        .arg(&workspace)
+        .arg("--user-data-folder")
+        .arg(&user_data)
+        .args(["--mount-workspace-git-root", "false"])
+        .arg("--override-config")
+        .arg(&changed)
+        .timeout(std::time::Duration::from_secs(300))
+        .assert()
+        .success();
+
+    let after_drift =
+        marker_config_hash(&user_data).expect("the drifted up must rewrite the postCreate marker");
+    assert_ne!(
+        after_run_user_commands, after_drift,
+        "postCreate was skipped on a changed config: run-user-commands erased up's drift detection (#372)"
+    );
+}


### PR DESCRIPTION
Fixes #372

## The defect

Lifecycle phase markers are a deacon extension (the reference CLI has none) and they key on the **workspace** hash alone, so `up` and `run-user-commands` write the same `<user-data>/state/<workspace-hash>/<phase>.json` files. `up` stamps the resolved `config_hash` on each marker, and `state.rs::read_all_markers_for_config` drops a marker whose hash differs from the current config — that is what makes a later `up --override-config <changed>` re-run `postCreate` on the fresh container it creates.

`run-user-commands` wrote those markers with `config_hash: None`. An absent hash reads as "legacy, compatible with any config", so a single `run-user-commands` invocation permanently disarmed the drift check.

## Reproduction (measured, Docker, `alpine:3.18` + `postCreateCommand`)

**Arm A — control, no `run-user-commands`.** Drift is detected, the changed hook runs, the hash advances:

```
### step 1: up
POSTCREATE-RAN
{ "phase": "postCreate", …, "config_hash": "f27ddd7b" }

### step 2: up --override-config changed
POSTCREATE-RAN-CHANGED
{ "phase": "postCreate", …, "config_hash": "ad4f14a8" }
```

**Arm B — with `run-user-commands` in between (the bug).** The hash is erased and the drifted `up` silently skips `postCreate` on a brand-new container:

```
### step 1: up
{ "phase": "postCreate", …, "config_hash": "f27ddd7b" }

### step 2: run-user-commands
{ "phase": "postCreate", … }          <-- config_hash GONE

### step 3: up --override-config changed
  "containerId": "fe1e06de3d95…"      <-- a NEW container
  (no POSTCREATE-RAN-CHANGED output)
{ "phase": "postCreate", … }          <-- marker untouched; hook never ran
```

**After the fix**, the same three steps:

```
### step 1: up
{ "phase": "postCreate", …, "config_hash": "f27ddd7b" }

### step 2: run-user-commands
{ "phase": "postCreate", …, "config_hash": "f27ddd7b" }   <-- same hash up wrote

### step 3: up --override-config changed
POSTCREATE-RAN-CHANGED
{ "phase": "postCreate", …, "config_hash": "ad4f14a8" }
```

## The change

**`run-user-commands`** now stamps the hash of the configuration **as loaded**, via the same `canonical_reconnect_identity` contract that already makes its container lookup agree with `up`'s labels (#187). It is computed immediately after `load_config` — before the host-CA `containerEnv` injection and before the image-metadata fold inside `execute_lifecycle_commands` — so it is a value `up` reproduces exactly. Hashing a mutated config would have swapped the erased-drift bug for a permanent false-positive drift.

**`set-up`** was the third marker writer with `config_hash: None`. Its marker anchor is the process cwd, and `hash_workspace_path` walks to the git root, so a `set-up` run from anywhere inside a repo lands in the same marker directory as `up --workspace-folder <that repo>`. It now stamps the hash of the merged config it actually ran. That hash deliberately will **not** equal `up`'s — `set-up` adopts a container it did not create, folds in the container's image metadata, and substitutes without a workspace — so a following `up` sees drift and **re-runs**. That is the fail-safe direction and strictly better than silently skipping.

## Tests (each broken once and observed failing)

- `crates/deacon/tests/run_user_commands_marker_config_hash.rs` (new, Docker-gated) pins the issue's acceptance criterion: `up` → `run-user-commands` → `up --override-config <changed>` must still re-run `postCreate`. With `config_hash: None` restored it fails at step 2 (`run-user-commands must not erase the marker's config_hash`); with step 2's assertions relaxed it then fails at step 3 (`the drifted up must rewrite the postCreate marker`) — i.e. the hook really was skipped.
- `commands::shared::identity::tests::config_hash_is_shared_between_up_and_the_marker_writers` (new unit test) pins the property that makes the two hashes equal by construction: `up` builds its identity *with* a container name and config-file path, `run-user-commands` with neither, and the `config_hash` must match. Watched to fail by making `canonical_reconnect_identity` fold the custom name into the hashed config (`left: "a24291b3"`, `right: "9410428b"`).

Wired into `.config/nextest.toml` as `docker-shared` in the `default` and `dev-fast` override blocks plus the `dev-fast` `default-filter` exclusion; verified every profile still carries a `default-filter`. The test scopes its own cleanup to its workspace's `devcontainer.local_folder` label, so it can never reap a sibling case's container.

## Gate

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build --workspace --all-targets` — clean
- `cargo nextest run --profile dev-fast --no-fail-fast` — 3312 passed, 0 failed
- Docker lifecycle binaries (`run_user_commands_*`, `up_lifecycle_recovery`, `smoke_lifecycle`, `smoke_run_user_commands`, `integration_feature_lifecycle` — the last covers `set-up`'s hook collection) — 57 passed, 0 failed

No parity impact: lifecycle markers are a deacon extension with no `SPEC_STATUS.md` row or `ALLOWLIST.json` record, and no observable channel the parity suite compares changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126ezbe2zoixRc8iszzaRXb
