### PR TITLE
chore(core): move test_parse_invalid_template_schema off the shared %TEMP% namespace (#540)

### DIFF
--- a/crates/core/src/templates.rs
+++ b/crates/core/src/templates.rs
@@ -538,10 +538,15 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(invalid_template.as_bytes()).unwrap();
+        // A test-owned TempDir, not NamedTempFile::new(): `.tmpXXXXXX` names in
+        // the shared %TEMP% root can collide with a sibling test's delete-pending
+        // file on Windows, which surfaces as PermissionDenied (os error 5) that
+        // the tempfile crate does not retry (#540).
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_path = temp_dir.path().join("devcontainer-template.json");
+        std::fs::write(&temp_path, invalid_template).unwrap();
 
-        let result = parse_template_metadata(temp_file.path());
+        let result = parse_template_metadata(&temp_path);
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
The one measured instance of the #540 flake class, fixed at the site that failed: `NamedTempFile::new()` in the shared `%TEMP%` root collided with a sibling test's delete-pending file on Windows (PermissionDenied, os error 5, not retried by the tempfile crate). The test now writes into its own `TempDir`, a namespace no other test can churn.

Evidence: failed on docs-only PR #539 (https://github.com/get2knowio/deacon/actions/runs/31136323232/job/92736892249) while the identical code state passed on `main` minutes earlier. Local: fmt, clippy (`-D warnings`), and the test pass.

Refs #540 (the remaining ~38 sites — left open as the cross-cutting audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a