### PR TITLE
chore(tests): move NamedTempFile tests onto test-owned TempDirs (#540)

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -3601,8 +3601,19 @@ impl ConfigLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-    use tempfile::{NamedTempFile, TempDir};
+    use tempfile::TempDir;
+
+    /// A test-owned TempDir, not `NamedTempFile::new()`: `.tmpXXXXXX` names in
+    /// the shared %TEMP% root can collide with a sibling test's delete-pending
+    /// file on Windows, which surfaces as PermissionDenied (os error 5) that the
+    /// tempfile crate does not retry (#540). The returned `TempDir` must be bound
+    /// for as long as the path is used — dropping it deletes the directory.
+    fn write_devcontainer_json(contents: &str) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("devcontainer.json");
+        std::fs::write(&path, contents).unwrap();
+        (dir, path)
+    }
 
     #[test]
     fn test_config_default() {
@@ -3811,10 +3822,9 @@ mod tests {
             "runArgs": ["--init"], // trailing comma
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
 
         assert_eq!(config.name, Some("Test Container".to_string()));
         assert_eq!(config.image, Some("ubuntu:20.04".to_string()));
@@ -3848,10 +3858,9 @@ mod tests {
             "invalid": json syntax
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Parsing { message }) => {
@@ -3875,10 +3884,9 @@ mod tests {
             "dockerFile": "Dockerfile"
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -3898,10 +3906,9 @@ mod tests {
             "shutdownAction": "invalid"
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -3921,10 +3928,9 @@ mod tests {
             "extends": "../base/devcontainer.json"
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_ok());
         let config = result.unwrap();
         assert_eq!(
@@ -3938,10 +3944,9 @@ mod tests {
             "extends": ["../base1/devcontainer.json", "../base2/devcontainer.json"]
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_ok());
         let config = result.unwrap();
         assert_eq!(
@@ -4114,11 +4119,10 @@ mod tests {
             "anotherUnknown": 42
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
         // This should succeed despite unknown keys
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         assert_eq!(config.name, Some("Test".to_string()));
         assert_eq!(config.image, Some("ubuntu:20.04".to_string()));
 
@@ -4139,10 +4143,9 @@ mod tests {
             "extensions": [ "dbaeumer.vscode-eslint" ],
             "devPort": 1234
         }"#;
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         let customizations = config.customizations.expect("migrated customizations");
         assert_eq!(
             customizations.pointer("/vscode"),
@@ -4183,10 +4186,9 @@ mod tests {
                 "codespaces": { "kept": true }
             }
         }"#;
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         let customizations = config.customizations.clone().expect("customizations");
         assert_eq!(
             customizations.pointer("/vscode/extensions"),
@@ -4218,9 +4220,8 @@ mod tests {
     #[tokio::test]
     async fn test_load_without_legacy_properties_leaves_customizations_absent() -> anyhow::Result<()>
     {
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(br#"{ "image": "ubuntu:20.04" }"#)?;
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let (_temp_dir, config_path) = write_devcontainer_json(r#"{ "image": "ubuntu:20.04" }"#);
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         assert!(config.customizations.is_none());
         Ok(())
     }
@@ -4232,10 +4233,9 @@ mod tests {
             "image": "ubuntu:20.04"
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
 
         // Arrays should default to empty
         assert_eq!(config.mounts().len(), 0);
@@ -4620,11 +4620,10 @@ mod tests {
             "postCreateCommand": "echo 'Workspace: ${localWorkspaceFolder}'"
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
         let (config, report) =
-            ConfigLoader::load_with_substitution(temp_file.path(), workspace).await?;
+            ConfigLoader::load_with_substitution(&config_path, workspace).await?;
 
         // Check that substitution was applied
         assert!(report.has_substitutions());
@@ -5186,10 +5185,9 @@ mod tests {
             "appPort": [3000, "8080:80"]
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
 
         assert_eq!(
             config.app_port,
@@ -5226,10 +5224,9 @@ mod tests {
             }
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
 
         assert_eq!(config.name, Some("Test Container".to_string()));
         assert_eq!(config.forward_ports().len(), 2);
@@ -5301,11 +5298,10 @@ mod tests {
             }
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
         // This should not fail validation
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         assert_eq!(config.ports_attributes().len(), 3);
 
         Ok(())
@@ -5323,10 +5319,9 @@ mod tests {
             }
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         assert_eq!(config.ports_attributes().len(), 2);
 
         Ok(())
@@ -5344,11 +5339,10 @@ mod tests {
             }
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
         // This should load but log warnings about missing port 8080
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
         assert_eq!(config.ports_attributes().len(), 2);
 
         Ok(())
@@ -5376,10 +5370,9 @@ mod tests {
             "updateRemoteUserUID": true
         }"#;
 
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(config_content.as_bytes())?;
+        let (_temp_dir, config_path) = write_devcontainer_json(config_content);
 
-        let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+        let config = ConfigLoader::load_from_path(&config_path).await?;
 
         assert_eq!(
             config.name,
@@ -5422,10 +5415,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_root_is_array() -> anyhow::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(b"[]")?;
+        let (_temp_dir, config_path) = write_devcontainer_json("[]");
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -5433,7 +5425,7 @@ mod tests {
                     message,
                     format!(
                         "Dev container config ({}) must contain a JSON object literal.",
-                        temp_file.path().display()
+                        config_path.display()
                     )
                 );
             }
@@ -5444,10 +5436,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_root_is_null() -> anyhow::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(b"null")?;
+        let (_temp_dir, config_path) = write_devcontainer_json("null");
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -5455,7 +5446,7 @@ mod tests {
                     message,
                     format!(
                         "Dev container config ({}) must contain a JSON object literal.",
-                        temp_file.path().display()
+                        config_path.display()
                     )
                 );
             }
@@ -5466,10 +5457,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_root_is_number() -> anyhow::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(b"123")?;
+        let (_temp_dir, config_path) = write_devcontainer_json("123");
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -5477,7 +5467,7 @@ mod tests {
                     message,
                     format!(
                         "Dev container config ({}) must contain a JSON object literal.",
-                        temp_file.path().display()
+                        config_path.display()
                     )
                 );
             }
@@ -5488,10 +5478,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_root_is_string() -> anyhow::Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        temp_file.write_all(br#""hello""#)?;
+        let (_temp_dir, config_path) = write_devcontainer_json(r#""hello""#);
 
-        let result = ConfigLoader::load_from_path(temp_file.path()).await;
+        let result = ConfigLoader::load_from_path(&config_path).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             DeaconError::Config(ConfigError::Validation { message }) => {
@@ -5499,7 +5488,7 @@ mod tests {
                     message,
                     format!(
                         "Dev container config ({}) must contain a JSON object literal.",
-                        temp_file.path().display()
+                        config_path.display()
                     )
                 );
             }

--- a/crates/core/src/features.rs
+++ b/crates/core/src/features.rs
@@ -2508,8 +2508,18 @@ mod merge_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
+
+    /// A test-owned TempDir, not NamedTempFile::new(): `.tmpXXXXXX` names in the
+    /// shared %TEMP% root can collide with a sibling test's delete-pending file
+    /// on Windows, which surfaces as PermissionDenied (os error 5) that the
+    /// tempfile crate does not retry (#540).
+    fn write_feature_metadata(contents: &str) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("devcontainer-feature.json");
+        std::fs::write(&path, contents).unwrap();
+        (dir, path)
+    }
 
     #[test]
     fn test_option_value_conversions() {
@@ -2524,23 +2534,20 @@ mod tests {
 
     #[test]
     fn test_parse_feature_metadata_preserves_customizations() {
-        let mut file = NamedTempFile::new().unwrap();
-        write!(
-            file,
-            r#"{{
+        let (_dir, path) = write_feature_metadata(
+            r#"{
                 "id": "feature-with-customizations",
                 "version": "1.0.0",
                 "name": "Feature With Customizations",
-                "customizations": {{
-                    "vscode": {{
+                "customizations": {
+                    "vscode": {
                         "extensions": ["ms-vscode.cpptools"]
-                    }}
-                }}
-            }}"#
-        )
-        .unwrap();
+                    }
+                }
+            }"#,
+        );
 
-        let metadata = parse_feature_metadata(file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
 
         assert_eq!(
             metadata
@@ -2556,19 +2563,16 @@ mod tests {
     /// models neither key, so before this they were dropped outright.
     #[test]
     fn test_parse_feature_metadata_migrates_legacy_vscode_properties() {
-        let mut file = NamedTempFile::new().unwrap();
-        write!(
-            file,
-            r#"{{
+        let (_dir, path) = write_feature_metadata(
+            r#"{
                 "id": "localFeatureB",
                 "version": "1.0.0",
                 "extensions": ["ms-dotnettools.csharp"],
-                "settings": {{ "files.watcherExclude": {{ "**/test/**": true }} }}
-            }}"#
-        )
-        .unwrap();
+                "settings": { "files.watcherExclude": { "**/test/**": true } }
+            }"#,
+        );
 
-        let metadata = parse_feature_metadata(file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
         let customizations = metadata.customizations.expect("migrated customizations");
         assert_eq!(
             customizations.pointer("/vscode/extensions"),
@@ -2585,25 +2589,22 @@ mod tests {
     /// UNDER them (the authored `customizations.vscode.settings` key wins).
     #[test]
     fn test_legacy_vscode_properties_merge_with_authored_customizations() {
-        let mut file = NamedTempFile::new().unwrap();
-        write!(
-            file,
-            r#"{{
+        let (_dir, path) = write_feature_metadata(
+            r#"{
                 "id": "both",
                 "extensions": ["legacy.ext"],
-                "settings": {{ "shared": "legacy", "only.legacy": 1 }},
-                "customizations": {{
-                    "vscode": {{
+                "settings": { "shared": "legacy", "only.legacy": 1 },
+                "customizations": {
+                    "vscode": {
                         "extensions": ["authored.ext"],
-                        "settings": {{ "shared": "authored" }}
-                    }},
-                    "codespaces": {{ "kept": true }}
-                }}
-            }}"#
-        )
-        .unwrap();
+                        "settings": { "shared": "authored" }
+                    },
+                    "codespaces": { "kept": true }
+                }
+            }"#,
+        );
 
-        let metadata = parse_feature_metadata(file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
         let customizations = metadata.customizations.expect("customizations");
         assert_eq!(
             customizations.pointer("/vscode/extensions"),
@@ -2626,9 +2627,8 @@ mod tests {
     /// `customizations` block — the migration is a rewrite, not an injection.
     #[test]
     fn test_no_legacy_properties_leaves_customizations_absent() {
-        let mut file = NamedTempFile::new().unwrap();
-        write!(file, r#"{{ "id": "plain", "version": "1.0.0" }}"#).unwrap();
-        let metadata = parse_feature_metadata(file.path()).unwrap();
+        let (_dir, path) = write_feature_metadata(r#"{ "id": "plain", "version": "1.0.0" }"#);
+        let metadata = parse_feature_metadata(&path).unwrap();
         assert!(metadata.customizations.is_none());
     }
 
@@ -3033,10 +3033,9 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(minimal_feature.as_bytes()).unwrap();
+        let (_dir, path) = write_feature_metadata(minimal_feature);
 
-        let metadata = parse_feature_metadata(temp_file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
         assert_eq!(metadata.id, "test-feature");
         assert_eq!(metadata.name, None);
         assert_eq!(metadata.options.len(), 0);
@@ -3067,12 +3066,9 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file
-            .write_all(feature_with_options.as_bytes())
-            .unwrap();
+        let (_dir, path) = write_feature_metadata(feature_with_options);
 
-        let metadata = parse_feature_metadata(temp_file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
         assert_eq!(metadata.id, "test-feature");
         assert_eq!(metadata.name, Some("Test Feature".to_string()));
         assert_eq!(metadata.options.len(), 2);
@@ -3117,10 +3113,9 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(feature_with_mounts.as_bytes()).unwrap();
+        let (_dir, path) = write_feature_metadata(feature_with_mounts);
 
-        let metadata = parse_feature_metadata(temp_file.path()).unwrap();
+        let metadata = parse_feature_metadata(&path).unwrap();
         assert_eq!(metadata.id, "mounty");
         assert_eq!(metadata.mounts.len(), 2);
         assert_eq!(
@@ -3148,10 +3143,9 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(invalid_feature.as_bytes()).unwrap();
+        let (_dir, path) = write_feature_metadata(invalid_feature);
 
-        let result = parse_feature_metadata(temp_file.path());
+        let result = parse_feature_metadata(&path);
         assert!(result.is_ok()); // Parsing should succeed
 
         let metadata = result.unwrap();
@@ -3186,10 +3180,9 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(invalid_json.as_bytes()).unwrap();
+        let (_dir, path) = write_feature_metadata(invalid_json);
 
-        let result = parse_feature_metadata(temp_file.path());
+        let result = parse_feature_metadata(&path);
         assert!(result.is_err());
 
         if let Err(crate::errors::DeaconError::Feature(FeatureError::Parsing { .. })) = result {

--- a/crates/core/src/templates.rs
+++ b/crates/core/src/templates.rs
@@ -440,8 +440,7 @@ fn should_apply_substitution(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
-    use tempfile::{NamedTempFile, TempDir};
+    use tempfile::TempDir;
 
     #[test]
     fn test_parse_minimal_template_metadata() {
@@ -451,10 +450,11 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file.write_all(minimal_template.as_bytes()).unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path().join("devcontainer-template.json");
+        std::fs::write(&temp_path, minimal_template).unwrap();
 
-        let metadata = parse_template_metadata(temp_file.path()).unwrap();
+        let metadata = parse_template_metadata(&temp_path).unwrap();
         assert_eq!(metadata.id, "test-template");
         assert_eq!(metadata.name, None);
         assert_eq!(metadata.options.len(), 0);
@@ -489,12 +489,11 @@ mod tests {
         }
         "#;
 
-        let mut temp_file = NamedTempFile::new().unwrap();
-        temp_file
-            .write_all(template_with_options.as_bytes())
-            .unwrap();
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path().join("devcontainer-template.json");
+        std::fs::write(&temp_path, template_with_options).unwrap();
 
-        let metadata = parse_template_metadata(temp_file.path()).unwrap();
+        let metadata = parse_template_metadata(&temp_path).unwrap();
         assert_eq!(metadata.id, "test-template");
         assert_eq!(metadata.name, Some("Test Template".to_string()));
         assert_eq!(metadata.options.len(), 2);

--- a/crates/core/tests/integration_logging.rs
+++ b/crates/core/tests/integration_logging.rs
@@ -6,8 +6,7 @@
 
 use assert_cmd::Command;
 use deacon_core::{config::ConfigLoader, logging};
-use std::io::Write;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
 #[tokio::test]
 async fn test_debug_logging_from_config_loader() {
@@ -23,13 +22,16 @@ async fn test_debug_logging_from_config_loader() {
         "features": {}
     }"#;
 
-    let mut temp_file = NamedTempFile::new().expect("Should create temp file");
-    temp_file
-        .write_all(config_content.as_bytes())
-        .expect("Should write config content");
+    // A test-owned TempDir, not NamedTempFile::new(): `.tmpXXXXXX` names in the
+    // shared %TEMP% root can collide with a sibling test's delete-pending file on
+    // Windows, which surfaces as PermissionDenied (os error 5) that the tempfile
+    // crate does not retry (#540).
+    let temp_dir = TempDir::new().expect("Should create temp dir");
+    let config_path = temp_dir.path().join("devcontainer.json");
+    std::fs::write(&config_path, config_content).expect("Should write config content");
 
     // Load the configuration - this should trigger debug logs about unknown keys
-    let result = ConfigLoader::load_from_path(temp_file.path()).await;
+    let result = ConfigLoader::load_from_path(&config_path).await;
     assert!(result.is_ok());
 
     // We can't easily capture the debug output in unit tests, but we can

--- a/crates/core/tests/integration_security.rs
+++ b/crates/core/tests/integration_security.rs
@@ -6,8 +6,7 @@ use deacon_core::config::{ConfigLoader, DevContainerConfig};
 use deacon_core::security::SecurityOptions;
 use serde_json::json;
 use std::collections::HashMap;
-use std::io::Write;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
 #[tokio::test]
 async fn test_security_options_in_config_parsing() -> anyhow::Result<()> {
@@ -19,11 +18,16 @@ async fn test_security_options_in_config_parsing() -> anyhow::Result<()> {
         "securityOpt": ["seccomp=unconfined", "apparmor=unconfined"]
     });
 
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(config_content.to_string().as_bytes())?;
+    // A test-owned TempDir, not NamedTempFile::new(): `.tmpXXXXXX` names in the
+    // shared %TEMP% root can collide with a sibling test's delete-pending file on
+    // Windows, which surfaces as PermissionDenied (os error 5) that the tempfile
+    // crate does not retry (#540).
+    let temp_dir = TempDir::new()?;
+    let config_path = temp_dir.path().join("devcontainer.json");
+    std::fs::write(&config_path, config_content.to_string())?;
 
     // Load and parse the configuration
-    let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+    let config = ConfigLoader::load_from_path(&config_path).await?;
 
     // Verify security options are parsed correctly
     assert_eq!(config.privileged, Some(true));

--- a/crates/core/tests/integration_user_mapping.rs
+++ b/crates/core/tests/integration_user_mapping.rs
@@ -6,8 +6,7 @@
 
 use deacon_core::config::{ConfigLoader, DevContainerConfig};
 use deacon_core::user_mapping::{UserInfo, UserMappingConfig};
-use std::io::Write;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
 #[tokio::test]
 async fn test_user_mapping_config_parsing() -> anyhow::Result<()> {
@@ -20,10 +19,15 @@ async fn test_user_mapping_config_parsing() -> anyhow::Result<()> {
         "workspaceFolder": "/workspace"
     }"#;
 
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(config_content.as_bytes())?;
+    // A test-owned TempDir, not NamedTempFile::new(): `.tmpXXXXXX` names in the
+    // shared %TEMP% root can collide with a sibling test's delete-pending file on
+    // Windows, which surfaces as PermissionDenied (os error 5) that the tempfile
+    // crate does not retry (#540).
+    let temp_dir = TempDir::new()?;
+    let config_path = temp_dir.path().join("devcontainer.json");
+    std::fs::write(&config_path, config_content)?;
 
-    let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+    let config = ConfigLoader::load_from_path(&config_path).await?;
 
     assert_eq!(config.name, Some("User Mapping Test".to_string()));
     assert_eq!(config.image, Some("alpine:3.19".to_string()));
@@ -91,10 +95,11 @@ async fn test_config_with_minimal_user_mapping() -> anyhow::Result<()> {
         "remoteUser": "vscode"
     }"#;
 
-    let mut temp_file = NamedTempFile::new()?;
-    temp_file.write_all(config_content.as_bytes())?;
+    let temp_dir = TempDir::new()?;
+    let config_path = temp_dir.path().join("devcontainer.json");
+    std::fs::write(&config_path, config_content)?;
 
-    let config = ConfigLoader::load_from_path(temp_file.path()).await?;
+    let config = ConfigLoader::load_from_path(&config_path).await?;
 
     assert_eq!(config.name, Some("Minimal User Test".to_string()));
     assert_eq!(config.remote_user, Some("vscode".to_string()));


### PR DESCRIPTION
## Problem

Every `NamedTempFile::new()` caller shares one namespace: the `%TEMP%` root. On Windows deletion is asynchronous — a deleted temp file sits in *delete-pending* until its last handle closes, and creating a same-named file in that window fails with **PermissionDenied (os error 5)**, not `AlreadyExists`. The tempfile crate retries `AlreadyExists` when generating random names but propagates `PermissionDenied`, so under nextest parallelism (~3,300 tests) the collision surfaces as a hard failure *inside `NamedTempFile::new()` itself*.

Caught live on #539 (docs-only, so the diff was exonerated). #541 converted the one measured instance; this converts the remaining 37.

## Fix

Each test creates a `TempDir` it owns and writes its fixture inside it — a fresh directory namespace that no sibling test churns.

| File | Sites converted |
|---|---|
| `crates/core/src/config.rs` | 22 |
| `crates/core/src/features.rs` | 9 |
| `crates/core/src/templates.rs` | 2 (remainder after #541) |
| `crates/core/tests/integration_user_mapping.rs` | 2 |
| `crates/core/tests/integration_logging.rs` | 1 |
| `crates/core/tests/integration_security.rs` | 1 |
| **Total** | **37** |

`crates/core/src/docker.rs` has no test-mod site — its only `NamedTempFile` is the production `iidfile` at :2715.

`config.rs` and `features.rs` get a small local helper returning `(TempDir, PathBuf)`; the `TempDir` is bound at every call site (`let (_temp_dir, config_path) = …`), never dropped mid-test, since dropping it deletes the directory out from under the path.

## Out of scope

The four production sites — `crates/core/src/docker.rs:2715`, `crates/deacon/src/commands/up/image_build.rs:143`, `crates/deacon/src/commands/build/mod.rs` (~2413, ~2563) — are unchanged. They are fallible `map_err`/`.context` paths, low-churn, and an error there is a real diagnostic rather than a flake.

## Semantics preserved

Verified rather than assumed:

- **No converted site's code under test sniffs the file name or extension.** `ConfigLoader::load_from_path`, `parse_feature_metadata` and `parse_template_metadata` all read by path and parse content. (`templates.rs::should_apply_substitution` *does* switch on extension, but nothing on these paths calls it.)
- **`load_with_substitution` anchors on its `workspace` argument**, not on the config file's parent, so moving the config out of `%TEMP%` into a fresh dir changes nothing for `test_load_with_substitution`.
- **Lifetimes**: the four `test_load_root_is_*` tests use the path *twice* — once to load, then again in the expected error message — so the `TempDir` must outlive the assertion. Binding it covers this, and the faithfulness check below confirms it empirically (a dropped dir would have produced `NotFound`, not the `Validation` error with the real path in it).
- `test_extends_field_parsing` shadows the binding for its second fixture; the first `TempDir` still drops at end of scope, not at the shadow.

## Faithfulness evidence

A mechanical namespace change has no per-site watched-to-fail, so instead each shape of conversion was proven to still fail for its *original* reason by temporarily breaking the code under test / fixture:

1. **`config.rs` helper + path-reuse shape** — appended `XX` to the production "must contain a JSON object literal." message. `test_load_root_is_{array,null,number,string}` failed on the message `assert_eq!`, with the real temp path present on both sides:
   ```
   left:  "Dev container config (/tmp/.tmp1wGekn/devcontainer.json) must contain a JSON object literal.XX"
   right: "Dev container config (/tmp/.tmp1wGekn/devcontainer.json) must contain a JSON object literal."
   ```
   This also proves the `TempDir` was alive through the assertion.
2. **`features.rs` helper shape** — no-op'd `migrate_legacy_vscode_properties` in `parse_feature_metadata`. `test_parse_feature_metadata_migrates_legacy_vscode_properties` panicked on its original `expect("migrated customizations")`, and `test_legacy_vscode_properties_merge_with_authored_customizations` on its original pointer assertion.
3. **Integration-test inline shape** — changed `SYS_PTRACE` → `SYS_ADMIN` in the `integration_security.rs` fixture. `test_security_options_in_config_parsing` failed on its original `cap_add()` `assert_eq!`, proving the fixture content reaches the loader from the new directory.

All three breaks were reverted.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --all-targets` ✅
- `cargo nextest run -E 'package(deacon-core)'` — 1719 passed ✅
- `make test-nextest-fast` — 3337 passed, 31 skipped ✅
- Touched binaries + core lib re-run 5× at `--test-threads 32` — 1453 passed each time, no lifetime flakes ✅

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a