### PR TITLE
chore(parity): keep the hermetic lane network-free for merged-config cases (#454)

### DIFF
--- a/parity/cases/read-configuration.json
+++ b/parity/cases/read-configuration.json
@@ -726,10 +726,12 @@
           "argv": [
             "--workspace-folder",
             "${WORKSPACE}",
-            "--include-merged-configuration"
+            "--include-merged-configuration",
+            "--docker-path",
+            "/nonexistent/deacon-parity-no-container-runtime"
           ],
           "fixtures": [
-            "fx-tier1-extends-child"
+            "fx-merged-extends-child"
           ]
         }
       ],
@@ -756,7 +758,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Merged-mode VARIANT of the tier-1 corpus case `extends-child`, and the one unit whose recorded expectation is a REFERENCE rejection: deacon resolves the full `extends` chain eagerly under --include-merged-configuration where the reference errors — the ahead-of-spec capability recorded as ext-extends-resolution and characterized by that record alone (the duplicate waiver wvr-extends-child-merged was retired 2026-08-01). Expressed as a spec-expectation, NOT a live-differential: a differential asserts the two sides are EQUAL, which both inverts this expectation into a guaranteed failure and pins nothing about deacon's own side. It pins deacon succeeding and resolving the base image from the extends chain — the recorded `image` signal — so the ahead-of-spec resolution cannot silently regress (023 T072). The reference-side rejection stays characterized by ext-extends-resolution."
+      "notes": "Merged-mode VARIANT of the tier-1 corpus case `extends-child`, and the one unit whose recorded expectation is a REFERENCE rejection: deacon resolves the full `extends` chain eagerly under --include-merged-configuration where the reference errors — the ahead-of-spec capability recorded as ext-extends-resolution and characterized by that record alone (the duplicate waiver wvr-extends-child-merged was retired 2026-08-01). Expressed as a spec-expectation, NOT a live-differential: a differential asserts the two sides are EQUAL, which both inverts this expectation into a guaranteed failure and pins nothing about deacon's own side. It pins deacon succeeding and resolving the base image from the extends chain — the recorded `image` signal — so the ahead-of-spec resolution cannot silently regress (023 T072). The reference-side rejection stays characterized by ext-extends-resolution.\n\n#454 — the two things that make this case HERMETIC, both of which it previously only appeared to be. (1) Its own fixture, `fx-merged-extends-child`, rather than the differential sibling's `fx-tier1-extends-child`. That fixture declares `ghcr.io/devcontainers/features/node:1`, and `--include-merged-configuration` RESOLVES the feature set to fold each feature's metadata into the merged document — a ghcr.io fetch whose failure is fatal (correctly: a declared feature that cannot be fetched must fail fast). Watched to fail: with the network namespace removed, this case exited 1 with `Failed to fetch feature 'ghcr.io/devcontainers/features/node:1'` — the exact `chan-exit-code: Diverge; chan-structured-output: Diverge` signature the flake reported. The new fixture declares a LOCAL feature instead, which needs no registry and still exercises the feature-metadata contribution to `mergedConfiguration`. (2) `--docker-path` naming a binary that does not exist. A merged read on an image-shaped config inspects the base image's `devcontainer.metadata` LABEL and PULLS on a cache miss (#307) — so on any runner with a daemon this case downloaded `mcr.microsoft.com/devcontainers/base:bookworm` (1.2 GB) inside the lane that gates every pull request, and a registry that HANGS rather than fails would take the whole run to CASE_TIMEOUT. The flag removes that reach and turns it into an assertion: `--include-merged-configuration` must degrade cleanly when no container runtime exists, which nothing else pins. It also makes the case SUBSTRATE-INDEPENDENT — before, the merged document silently gained the base image's baked `customizations` on machines that happened to have the image cached and not on machines that did not. Neither the exit code nor the `image` signal depends on either reach: `mergedConfiguration.image` is echoed from the parent document, which is precisely what this case claims. Measured after the change: exit 0 in 165 ms with the network namespace removed, byte-identical to the run with network and a real daemon. The reaches are NOT gratuitous product behavior and are not being worked around — they stay covered by the Docker-lane and differential merged cases, whose jobs provision for them."
     },
     {
       "id": "case-merged-decl-feature-order",

--- a/parity/fixtures/fx-merged-extends-child/.devcontainer/base.json
+++ b/parity/fixtures/fx-merged-extends-child/.devcontainer/base.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "containerEnv": { "BASE": "yes", "CHILD": "no" },
+  "forwardPorts": [3000],
+  "postCreateCommand": "echo from base"
+}

--- a/parity/fixtures/fx-merged-extends-child/.devcontainer/devcontainer.json
+++ b/parity/fixtures/fx-merged-extends-child/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Child overrides base",
+  "extends": "./base.json",
+  "features": {
+    "./node-local": { "version": "20" }
+  },
+  "forwardPorts": [4000],
+  "containerEnv": { "CHILD": "yes" },
+  "remoteUser": "vscode"
+}

--- a/parity/fixtures/fx-merged-extends-child/.devcontainer/node-local/devcontainer-feature.json
+++ b/parity/fixtures/fx-merged-extends-child/.devcontainer/node-local/devcontainer-feature.json
@@ -1,0 +1,12 @@
+{
+  "id": "node-local",
+  "version": "1.0.0",
+  "name": "Node (local)",
+  "options": {
+    "version": {
+      "type": "string",
+      "default": "20",
+      "description": "Node major version the child document pins."
+    }
+  }
+}

--- a/parity/fixtures/fx-merged-extends-child/.devcontainer/node-local/install.sh
+++ b/parity/fixtures/fx-merged-extends-child/.devcontainer/node-local/install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+echo "node-local feature installed"


### PR DESCRIPTION
## The problem, measured

`case-merged-decl-extends-child` is the **only** `case-merged-decl-*` case in the hermetic lane (the other 23 are `live-differential`, so `driver::lane_of` puts them in `parity_differential`). It reached the network **twice** on every run, inside a lane whose contract is *"a Linux host, no daemon, no oracle, no network"* and which gates every pull request.

### Watched to fail

```
$ unshare -rn cargo nextest run -E 'binary(=parity_hermetic)' --no-fail-fast
    hermetic parity failure(s) in resource group `none`:
    case-merged-decl-extends-child: chan-exit-code: Diverge; chan-structured-output: Diverge
      deacon stderr (exit 1):
        | Error: Failed to fetch feature 'ghcr.io/devcontainers/features/node:1': …
        |   Connection failed for URL: https://ghcr.io/v2/devcontainers/features/node/manifests/1
```

That is byte-for-byte the signature the issue reports from run 30782631205 — so the flake was never transient noise, it was a standing dependency that happened to be satisfied most days.

### The two reaches

| # | Reach | Fatal? | Cost |
|---|---|---|---|
| 1 | `ghcr.io/devcontainers/features/node:1` — `--include-merged-configuration` resolves the feature set to fold each feature's metadata into the merged document | **Yes**, and correctly so: a declared feature that cannot be fetched must fail fast | the observed flake |
| 2 | `mcr.microsoft.com/devcontainers/base:bookworm` — the merged read inspects the base image's `devcontainer.metadata` LABEL and **pulls on a cache miss** (#307) | No (`parse_image_metadata_entries` is best-effort) | **1.2 GB download** on any runner with a daemon, and a registry that *hangs* rather than fails takes the run to `CASE_TIMEOUT` — the same shape as the 45-minute prepull stall recorded in the issue's second comment |

Reach 2 also made the case **substrate-dependent**: on a machine with the image cached the merged document gained the base image's baked `customizations`; on a machine without it, it did not. Same case, two different outputs.

## The decision: fix shape (b), and why not (a) or (c)

Both reaches are **incidental to what the case claims**. The recorded assertion is exit 0 plus `mergedConfiguration.image == "mcr.microsoft.com/devcontainers/base:bookworm"`, and that value is *echoed from the parent document* — it is the eager-`extends`-resolution signal, not anything the daemon or the registry produces. The fixture carried them only because it was authored for the **differential** sibling `case-tier1-decl-extends-child`, which runs `read-configuration` with no merged flag and therefore resolves neither.

**Not (a) — re-lane to a lane that establishes the precondition.** Two reasons. It would cost the PR gate its only merged-mode pin on `ext-extends-resolution`, and — decisively — *it would not fix the observed failure*: the fatal reach is a **registry**, not a daemon. `driver::lane_of` derives `Lane::Docker` from `resourceGroup` alone; `parity_docker`'s jobs prepull no features, and the nightly's own prepull step is exactly what stalled 45 minutes. Re-laning relocates the flake.

**Not (c) — make the metadata-label miss observably distinguishable.** The hard error *is* correct product behaviour (constitution IV), and softening it to satisfy a test would weaken a fail-fast path. On the other side there is nothing to distinguish: the image-metadata read is *already* best-effort — it warns and returns empty.

**(b), applied to both reaches:**

1. **New fixture `fx-merged-extends-child`** — the differential sibling's fixture with a **local** feature (`./node-local`) in place of the OCI one. This still exercises the feature-metadata contribution to `mergedConfiguration`, via `SourceInformation::FilePath` instead of a registry. `fx-tier1-extends-child` is untouched, so the differential case keeps its realistic pinned feature; it runs nightly, behind a prepull, and its realism is the point.
2. **`--docker-path /nonexistent/deacon-parity-no-container-runtime`** in the case's `argv` — a pure data edit that removes the daemon/registry image reach *and turns it into an assertion*: `--include-merged-configuration` must degrade cleanly when no container runtime exists, which nothing else in the suite pins. It also makes the case substrate-independent.

The recorded assertion is **unchanged**. This is a hermeticity fix, not a coverage change.

### Measured after

| | before | after |
|---|---|---|
| `unshare -rn` (no network, no daemon) | exit 1, empty stdout | **exit 0, 165 ms**, `mergedConfiguration.image` present |
| network + real daemon | exit 0, output varies with local image cache | exit 0, **byte-identical to the no-network run** |
| whole `parity_hermetic` lane | — | 1.8 s, 2/2 pass |

## What this PR does NOT fix — measured, and reported on the issue

The no-network run surfaced that the lane has **seven** network-reaching cases, not one. The other six are outside this issue's mandate and outside what I may decide alone — they need a coverage or lane-contract ruling, so they are **split out to #544** with the full measurement rather than folded in here:

- `case-readconfig-compose-lockfile-merged`, `case-readconfig-dockerfile-lockfile-extends`, `case-readconfig-extends-feature-version-override` — same mechanism (merged-config feature fetch), but their fixtures' *version-pinned OCI references* are part of what the behaviours pin. `bhv-extends-feature-version-override` is literally about `git:1.3.2` → `git:1.3.8` across an extends chain; a local feature has no version in its id, so that one cannot be expressed hermetically at all.
- `case-upgrade-compose-merge-config-adds-feature`, `case-upgrade-extends-chain-lockfile`, `case-upgrade-image-merge-config-contributes-only-feature` — `upgrade --dry-run` resolves feature digests to regenerate a lockfile. That is inherently a registry operation; these are genuinely mis-laned and there is no "needs a registry" lane today.

They pass in CI because CI has network, and they will flake the same way this one did. #544 also proposes the guard that would keep the contract true by construction once they are resolved.

## Gate

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo build --all-targets` ✅
- `make test-nextest-fast` ✅ — 3337 passed, 31 skipped
- `cargo nextest run -E 'binary(=parity_hermetic)'` ✅ — 2/2, 1.8 s
- `unshare -rn cargo nextest run -E 'binary(=parity_hermetic)'` ✅ for this case (the six above still fail; see the section directly above)
- `cargo nextest run --profile parity` (live, oracle 0.87.0) — 7/8 pass. `differential_group_none` reports four diverging cases, **all environment-pinned to this substrate, none touched by this change**: `case-merged-decl-{node-ts,python-features,ruby-node-feature,universal-jsonc}`, three diverging only at `mergedConfiguration.customizations.vscode` — the base image's baked metadata label. Their base images cannot be extracted on this host (`docker pull mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm` → `failed to register layer: RemoveAll root/.npm/_cacache: input/output error`, the same class as the recorded `universal:2-linux` pin), so the prepull left all four cold. The latest `main` nightly (run 31081838370) is green on these. This PR adds a new fixture directory and edits one hermetic-lane case record; the differential lane references neither.
- `.config/nextest.toml` untouched; all 8 profiles verified to still carry a `default-filter`
- No `SPEC_STATUS.md` row changes (the case id appears in no row), no `ALLOWLIST.json` reference

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a
