### PR TITLE
chore(parity): make the hermetic lane's case data portable and ungate it from Linux (#441)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -74,3 +74,13 @@ conformance/obligations/** -text
 # canonical-rendering comparison fails on bytes git introduced — pointing the reader at a
 # renderer that is working correctly. Same discipline, same pin.
 conformance/discovery/** -text
+
+# The differential parity suite's fixtures ARE the expected bytes. A `templates apply`
+# case materializes `parity/fixtures/fx-templates-*/` into a temp workspace, runs deacon,
+# and compares the scaffolded file's content to a literal in `parity/cases/templates.json`
+# — so the fixture's line endings are the subject of the assertion, not incidental to it.
+# On a Windows checkout git's autocrlf rewrote LF to CRLF and all six `chan-file-content`
+# cases diverged on bytes git introduced, which is what gated the hermetic lane to Linux
+# (#441). `-text` (not `eol=lf`) matches every other byte-exact pin in this file and keeps
+# a future binary fixture safe from translation in both directions.
+parity/fixtures/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,11 @@ jobs:
       # cross-platform failure set, not just the earliest).
       run: cargo nextest run --profile dev-fast --no-fail-fast
 
-    # `parity_hermetic` is selected by `dev-fast` too, so this lane also owes its evidence
-    # on failure (#474). The name carries the matrix leg because one run's artifacts share a
-    # namespace; `if-no-files-found: ignore` is doing real work here rather than guarding a
-    # hypothetical — the macOS and Windows legs run no parity binary at all (#441), so they
-    # have no `target/parity/` to upload even when they fail.
+    # `parity_hermetic` is selected by `dev-fast` on every leg of this matrix (#441 removed
+    # its Linux gate), so this lane also owes its evidence on failure (#474). The name
+    # carries the matrix leg because one run's artifacts share a namespace;
+    # `if-no-files-found: ignore` guards the legs that fail before the parity binary runs
+    # and therefore wrote no `target/parity/`.
     - name: Upload parity evidence
       if: failure()
       uses: actions/upload-artifact@v7
@@ -360,7 +360,8 @@ jobs:
         echo "DEACON_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
     # `parity_docker` is excluded here, and that is a SELECTION rather than a skip — the
-    # mirror of the platform gate on `parity_hermetic` (#441). The parity harness probes the
+    # same truthful-by-non-selection principle that keeps `parity_differential` off every
+    # machine without the pinned oracle. The parity harness probes the
     # container runtime through the literal `docker` CLI (`workspace.rs` discovery and
     # reclamation, `observe/mod.rs` container probe) and its case data is Docker-MEASURED.
     # Under `DEACON_CONTAINER_RUNTIME=podman` deacon creates a podman container that a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,7 @@ lets most of the suite gate every pull request:
 
 | Binary | Needs | Runs where |
 |---|---|---|
-| `parity_hermetic` | a Linux host | every profile, `dev-fast` included; Linux only (#441) |
+| `parity_hermetic` | nothing | every profile, `dev-fast` included; Linux, macOS and Windows (#441) |
 | `parity_docker` | Docker | wherever a daemon exists; the release gate |
 | `parity_differential` | Docker + the pinned oracle | `--profile parity` ONLY (nightly) |
 | `parity_harness_faults` | nothing | `default`, `dev-fast` — the hermetic guard proving the comparison can fail (oracle mismatch, timeout, normalization failure, injected difference) |
@@ -772,6 +772,19 @@ We ship Windows binaries, so keep this lane green. Hard-won lessons:
   (`.replace('\\', "/")`) for relative fragments; for substituted absolute paths compare
   the **leaf component** (`dest_dir.file_name()`), which survives canonicalization, rather
   than the full path string.
+- **A fixture whose BYTES are the expectation must be pinned `-text` in `.gitattributes`.**
+  Git's autocrlf rewrites LF to CRLF on a Windows checkout, so a test comparing a file's
+  content to a `"…\n"` literal fails on bytes git introduced, not on anything the code did
+  — that is what kept `parity_hermetic` off Windows (#441), fixed by
+  `parity/fixtures/** -text`. Prefer `-text` over `eol=lf` (it matches the other pins here
+  and cannot corrupt a binary fixture), and run `git add --renormalize <path>` after adding
+  the rule: it must produce NO diff, or every contributor sees the tree as modified.
+- **A test that holds a path and compares it against a path the CLI printed must expect
+  every SPELLING of it.** deacon canonicalizes `--workspace-folder`, and canonicalization
+  renames: Windows returns the `\\?\` verbatim form with 8.3 short names expanded
+  (`RUNNER~1` → `runneradmin`), macOS resolves `/var` → `/private/var`. The string the test
+  passed in is then not a substring of the string it gets back. The parity normalizer's
+  `TokenMap::workspace` registers all three spellings for this reason.
 - **`--no-fail-fast`** is set on the test step so one run reports the full failure set
   (a single failure otherwise cancels the run and hides the rest — `nextest` shows
   `N/Total tests run` when cancelled vs `Total tests run` when complete).

--- a/crates/deacon/tests/parity_hermetic.rs
+++ b/crates/deacon/tests/parity_hermetic.rs
@@ -5,19 +5,22 @@
 //! external has to exist for them to mean something. That is what makes them the one
 //! parity lane that can gate every pull request, in every profile.
 //!
-//! **Linux only, and that is a selection rather than a skip.** The hermetic case data pins
-//! LINUX-MEASURED output: `case-doctor-structured-*` assert `host_os.name: "linux"`, and the
-//! `templates apply` / substitution cases pin path separators and line endings. Those are
-//! assertions about the runner, so the lane runs only where its pins are valid — the same
-//! reasoning that keeps `parity_differential` out of every profile that has no oracle. On
-//! macOS and Windows the lane is truthfully NOT SELECTED rather than skipped or excused, and
-//! deacon's own cross-platform coverage stays with the rest of `dev-fast`. Making the data
-//! platform-conditional instead would rebuild the case machinery this suite deleted; the
-//! four measured portability gaps are inventoried on #441.
+//! **Every platform CI runs, and the case data is what earned that** (#441). The lane was
+//! gated to Linux because its records pinned LINUX-MEASURED output rather than deacon's
+//! behavior: `case-doctor-structured-*` asserted `host_os.name: "linux"` — the RUNNER's
+//! operating system, which deacon does not choose — and a `templates apply` case pinned a
+//! POSIX file mode, an observable that does not exist off Unix. Both are now claims deacon
+//! can actually satisfy anywhere (a present `host_os` OBJECT; presence and bytes, not
+//! permissions). The remaining two were never case-data problems at all: git's autocrlf
+//! rewrote the `templates apply` fixture bytes on a Windows checkout, fixed by pinning
+//! `parity/fixtures/** -text` in `.gitattributes`, and `TokenMap::workspace` registered
+//! ONE spelling of the workspace path while deacon reports the canonicalized one
+//! (`\\?\` + 8.3 expansion on Windows, `/private/var` on macOS), fixed in the normalizer.
 //!
-//! The inner `cfg` leaves an EMPTY test binary off Linux rather than an uncompiled one,
-//! which is required: nextest compiles every test target before filtering, so this file
-//! must still build on Windows.
+//! Nothing here is platform-conditional: there is no per-platform expected value, no
+//! `cfg`-gated case and no skip. That was the constraint — making the DATA name the host
+//! would have rebuilt the case machinery this suite deleted, and keeping the gate would
+//! have been better than that.
 //!
 //! **No skips.** A missing fixture, a CLI failure or a normalization failure FAILS with a
 //! cause-specific message (constitution IV). The lane never has to *skip* a case it cannot
@@ -28,8 +31,6 @@
 //!
 //! Its siblings: `parity_docker` (Docker-backed, still no oracle) and
 //! `parity_differential` (live against the pinned reference).
-
-#![cfg(target_os = "linux")]
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/parity-harness/src/compare.rs
+++ b/crates/parity-harness/src/compare.rs
@@ -687,6 +687,49 @@ mod tests {
         assert_eq!(v.outcome, Outcome::Diverge);
     }
 
+    /// The `mode` predicate has no case in the committed set: its only expectation lived on
+    /// `case-templates-apply-multifile-tree` and was dropped with #441, because a POSIX file
+    /// mode is not an observable off Unix (`FilesystemObserver::mode_string` reports `null`
+    /// there) and an octal pin was therefore an assertion about the runner. The predicate is
+    /// still reachable from the case schema, so it is exercised HERE rather than left to rot
+    /// — an arm nothing evaluates is an arm nobody notices breaking.
+    #[test]
+    fn filesystem_mode_predicate() {
+        let ev = norm(
+            CHAN_FILESYSTEM,
+            json!({ "a.json": { "exists": true, "mode": "0644" } }),
+        );
+        assert_eq!(
+            verdict_spec_expectation(CHAN_FILESYSTEM, &ev, &json!({"mode": {"a.json": "0644"}}))
+                .unwrap()
+                .outcome,
+            Outcome::Agree
+        );
+        assert_eq!(
+            verdict_spec_expectation(CHAN_FILESYSTEM, &ev, &json!({"mode": {"a.json": "0755"}}))
+                .unwrap()
+                .outcome,
+            Outcome::Diverge
+        );
+
+        // The off-Unix observation: the concept does not exist, so the observer reports
+        // `null` and no octal expectation can hold. This is the shape that gated the lane.
+        let unix_less = norm(
+            CHAN_FILESYSTEM,
+            json!({ "a.json": { "exists": true, "mode": Value::Null } }),
+        );
+        assert_eq!(
+            verdict_spec_expectation(
+                CHAN_FILESYSTEM,
+                &unix_less,
+                &json!({"mode": {"a.json": "0644"}})
+            )
+            .unwrap()
+            .outcome,
+            Outcome::Diverge
+        );
+    }
+
     #[test]
     fn malformed_assertion_is_fail_loud() {
         let ev = norm(CHAN_EXIT_CODE, json!(0));

--- a/crates/parity-harness/src/normalize.rs
+++ b/crates/parity-harness/src/normalize.rs
@@ -161,10 +161,37 @@ impl TokenMap {
         TokenMap::default()
     }
 
-    /// A token map that rewrites the workspace path to `<WORKSPACE>`.
+    /// A token map that rewrites the workspace path to `<WORKSPACE>` — in EVERY spelling
+    /// the operating system admits for it, not only the one the harness happens to hold.
+    ///
+    /// A CLI does not have to echo back the path string it was handed. deacon's
+    /// `SubstitutionContext::new` canonicalizes `--workspace-folder` before
+    /// `${localWorkspaceFolder}` resolves, so the path in its output can be a DIFFERENT
+    /// STRING naming the same directory:
+    ///
+    /// - Windows canonicalization returns the `\\?\` verbatim form and expands 8.3 short
+    ///   names, so a workspace under the runner's `C:\Users\RUNNER~1\AppData\Local\Temp`
+    ///   comes back as `\\?\C:\Users\runneradmin\AppData\Local\Temp\…` — which does not
+    ///   contain the harness's spelling as a substring at all, so the single-spelling map
+    ///   tokenized nothing and `case-readconfig-substitution-object-fields` diverged at
+    ///   `configuration.build.args.WS` (#441).
+    /// - macOS `$TMPDIR` lives under `/var/folders/…`, and `/var` is a symlink, so the
+    ///   canonical form is `/private/var/folders/…`. Same failure mode, latent.
+    ///
+    /// So the map registers the path as given, its canonical form, and (on Windows) that
+    /// canonical form with the verbatim prefix stripped, since deacon is free to present
+    /// either. This is [`path_token`] doing what it already claims — rewriting the temp
+    /// workspace path to a stable token — over the full set of names for one directory.
+    /// It is NOT a separator munge: nothing rewrites `\` to `/`, and a path that is not
+    /// this workspace is untouched.
+    ///
+    /// Every spelling maps to the SAME token, so the map cannot hide a difference between
+    /// two distinct directories; it can only stop reporting one directory under two names.
     pub fn workspace(workspace: &Path) -> TokenMap {
         let mut m = TokenMap::new();
-        m.insert(workspace.to_string_lossy(), "<WORKSPACE>");
+        for spelling in path_spellings(workspace) {
+            m.insert(spelling, "<WORKSPACE>");
+        }
         m
     }
 
@@ -215,6 +242,31 @@ impl TokenMap {
         }
         out
     }
+}
+
+/// The Windows verbatim path prefix `std::fs::canonicalize` returns. Stripping it from a
+/// string is a no-op on every other platform, so this needs no `cfg`.
+const WINDOWS_VERBATIM_PREFIX: &str = r"\\?\";
+
+/// Every string spelling of `path` a CLI might present: as given, canonicalized, and the
+/// canonical form without the Windows verbatim prefix. Deduplicated, so the common case
+/// (an already-canonical Linux temp path) yields exactly one entry. An uncanonicalizable
+/// path — deleted, or never created — contributes only its literal spelling rather than
+/// failing: the caller is building a normalization map, not validating the filesystem.
+///
+/// See [`TokenMap::workspace`] for why the alternates matter.
+fn path_spellings(path: &Path) -> Vec<String> {
+    let mut out = vec![path.to_string_lossy().into_owned()];
+    if let Ok(canonical) = path.canonicalize() {
+        let canonical = canonical.to_string_lossy().into_owned();
+        if let Some(stripped) = canonical.strip_prefix(WINDOWS_VERBATIM_PREFIX) {
+            out.push(stripped.to_string());
+        }
+        out.push(canonical);
+    }
+    out.sort();
+    out.dedup();
+    out
 }
 
 /// **Rule `path_token`** (FR-024): rewrite temp workspace/project paths to stable tokens
@@ -1258,6 +1310,66 @@ mod tests {
         let obj = out.as_object().unwrap();
         for k in ["null_val", "empty_str", "empty_arr", "empty_obj"] {
             assert!(obj.contains_key(k), "field {k} must not be dropped");
+        }
+    }
+
+    /// #441: the CLI may present the workspace under a name the harness never typed —
+    /// deacon canonicalizes `--workspace-folder` before `${localWorkspaceFolder}` resolves.
+    /// A symlinked spelling is the portable stand-in for Windows' `\\?\` + 8.3 expansion:
+    /// same mechanism (canonicalization returns a different string for one directory), and
+    /// creatable on any Unix. Both spellings must reach `<WORKSPACE>`.
+    #[cfg(unix)]
+    #[test]
+    fn workspace_tokenizes_the_canonical_spelling_too() {
+        let real = tempfile::tempdir().expect("tempdir");
+        let link_parent = tempfile::tempdir().expect("tempdir");
+        let link = link_parent.path().join("ws-link");
+        std::os::unix::fs::symlink(real.path(), &link).expect("symlink");
+
+        // The harness holds the SYMLINKED spelling; deacon would report the canonical one.
+        let tokens = TokenMap::workspace(&link);
+        let canonical = real.path().canonicalize().expect("canonicalize");
+        let value = json!({
+            "asGiven": link.to_string_lossy(),
+            "asCanonicalized": format!("{}/x", canonical.display()),
+        });
+        let out = path_token(&value, &tokens);
+        assert_eq!(out["asGiven"], json!("<WORKSPACE>"));
+        assert_eq!(
+            out["asCanonicalized"],
+            json!("<WORKSPACE>/x"),
+            "the canonical spelling names the same directory and must tokenize"
+        );
+    }
+
+    /// The verbatim-prefix handling is Windows-shaped but the code path is unconditional,
+    /// so assert the two invariants that hold everywhere. (1) The literal spelling the
+    /// caller passed always survives, including for a path that does not exist, where
+    /// canonicalization can contribute nothing — a normalization map is not a filesystem
+    /// validator. (2) A verbatim spelling is never registered ALONE: deacon may present
+    /// either form, so `\\?\C:\…` and `C:\…` are both registered or neither is. On Unix
+    /// (2) is vacuous; on Windows it is the whole fix.
+    #[test]
+    fn path_spellings_keep_the_literal_and_pair_the_verbatim_form() {
+        let missing = std::path::Path::new("/definitely/not/a/real/path-441");
+        assert_eq!(
+            path_spellings(missing),
+            vec!["/definitely/not/a/real/path-441".to_string()]
+        );
+
+        let real = tempfile::tempdir().expect("tempdir");
+        let spellings = path_spellings(real.path());
+        assert!(
+            spellings.contains(&real.path().to_string_lossy().into_owned()),
+            "the spelling the caller passed must survive: {spellings:?}"
+        );
+        for s in &spellings {
+            if let Some(stripped) = s.strip_prefix(WINDOWS_VERBATIM_PREFIX) {
+                assert!(
+                    spellings.iter().any(|o| o == stripped),
+                    "a verbatim spelling must be paired with its plain twin: {spellings:?}"
+                );
+            }
         }
     }
 

--- a/docs/testing/nextest.md
+++ b/docs/testing/nextest.md
@@ -197,9 +197,9 @@ default-filter = 'binary(=parity_differential)'
 ONE binary, because only `live-differential` cases need the reference CLI. The
 other two parity lanes carry their expectation in the record and therefore need
 no oracle, so they run in the ordinary lanes: `parity_hermetic` (no Docker
-either — it runs in `dev-fast`, on Linux hosts; its case data pins
-Linux-measured output, so it is `#![cfg(target_os = "linux")]`-gated and simply
-not selected elsewhere — #441) and `parity_docker` (needs a daemon). The split
+either — it runs in `dev-fast` on every platform CI covers, Linux, macOS and
+Windows alike, since #441 removed the last host-measured pins from its case
+data) and `parity_docker` (needs a daemon). The split
 is by what a case NEEDS, not by subject; adding a scenario is a JSON edit and no
 binary changes.
 

--- a/parity/cases/doctor.json
+++ b/parity/cases/doctor.json
@@ -240,9 +240,7 @@
           "operation": "op-doctor",
           "assertion": {
             "jsonSubset": {
-              "host_os": {
-                "name": "linux"
-              },
+              "host_os": {},
               "config_discovery": {
                 "primary_config": ".devcontainer/devcontainer.json"
               }
@@ -253,7 +251,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Closes the `config-source=compose` x `output-mode=structured` pair, the companion to the Dockerfile case above and the structured counterpart of `case-doctor-compose-workspace`. A Compose workspace carries `docker-compose.yml` and an override beside its `devcontainer.json`, and the diagnosis still reports the devcontainer configuration as primary rather than being drawn into resolving the Compose project. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved — the `jsonSubset: {}` failure mode 024 found in committed cases. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
+      "notes": "Closes the `config-source=compose` x `output-mode=structured` pair, the companion to the Dockerfile case above and the structured counterpart of `case-doctor-compose-workspace`. A Compose workspace carries `docker-compose.yml` and an override beside its `devcontainer.json`, and the diagnosis still reports the devcontainer configuration as primary rather than being drawn into resolving the Compose project. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved — the `jsonSubset: {}` failure mode 024 found in committed cases. `host_os` is asserted as a PRESENT OBJECT and not by value (#441): a nested `{}` still requires the key to exist and to be an object, while `host_os.name: \"linux\"` asserted the RUNNER's operating system, which deacon does not choose — the pin was the only thing keeping this lane off macOS and Windows. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
     },
     {
       "id": "case-doctor-structured-diagnostics",
@@ -289,8 +287,9 @@
           "operation": "op-doctor",
           "assertion": {
             "jsonSubset": {
-              "host_os": {
-                "name": "linux"
+              "host_os": {},
+              "config_discovery": {
+                "primary_config": ".devcontainer/devcontainer.json"
               }
             }
           }
@@ -299,7 +298,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The structured rendering of the same diagnosis. The assertion deliberately avoids `cli_version` and every probed path: those change with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
+      "notes": "The structured rendering of the same diagnosis, over an IMAGE-based workspace (its two siblings cover `compose` and `dockerfile`). `host_os` is asserted as a PRESENT OBJECT and not by value (#441): a nested `{}` still requires the key to exist and to be an object, while `host_os.name: \"linux\"` asserted the RUNNER's operating system, which deacon does not choose — the pin was the only thing keeping this lane off macOS and Windows. Because that left `host_os` as the only claim here, `config_discovery.primary_config` was added so the case still names something deacon DECIDES; the value is a portable literal (`collect_config_discovery_info` reports the discovery location it matched, not a host path, so it carries no separator). The assertion deliberately avoids `cli_version` and every probed path: those change with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
     },
     {
       "id": "case-doctor-structured-dockerfile-workspace",
@@ -335,9 +334,7 @@
           "operation": "op-doctor",
           "assertion": {
             "jsonSubset": {
-              "host_os": {
-                "name": "linux"
-              },
+              "host_os": {},
               "config_discovery": {
                 "primary_config": ".devcontainer/devcontainer.json"
               }
@@ -348,7 +345,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "Closes the `config-source=dockerfile` x `output-mode=structured` pair. `case-doctor-dockerfile-workspace` already shows the human rendering over a Dockerfile-based workspace and `case-doctor-structured-diagnostics` shows the structured rendering over an image-based one; neither shows that the two dimensions are independent, which is exactly what a pairwise obligation asks. `doctor` diagnoses the HOST and the runtime, so the structured document reports the configuration it FOUND without resolving the build — an implementation that resolved it would be slower and would fail where the diagnosis is most needed. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved — the `jsonSubset: {}` failure mode 024 found in committed cases. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
+      "notes": "Closes the `config-source=dockerfile` x `output-mode=structured` pair. `case-doctor-dockerfile-workspace` already shows the human rendering over a Dockerfile-based workspace and `case-doctor-structured-diagnostics` shows the structured rendering over an image-based one; neither shows that the two dimensions are independent, which is exactly what a pairwise obligation asks. `doctor` diagnoses the HOST and the runtime, so the structured document reports the configuration it FOUND without resolving the build — an implementation that resolved it would be slower and would fail where the diagnosis is most needed. The assertion names `config_discovery.primary_config` rather than only `host_os`, which is the whole point of the pair: `host_os` would hold for any workspace and would leave the configuration-source dimension declared but unobserved — the `jsonSubset: {}` failure mode 024 found in committed cases. `host_os` is asserted as a PRESENT OBJECT and not by value (#441): a nested `{}` still requires the key to exist and to be an object, while `host_os.name: \"linux\"` asserted the RUNNER's operating system, which deacon does not choose — the pin was the only thing keeping this lane off macOS and Windows. `cli_version` and every probed path are deliberately excluded: they move with the release and with the machine, and a case whose verdict moved with either would be measuring the environment rather than the behavior."
     },
     {
       "id": "case-doctor-unsupported-values-still-diagnoses",

--- a/parity/cases/templates.json
+++ b/parity/cases/templates.json
@@ -279,15 +279,6 @@
           }
         },
         {
-          "channel": "chan-filesystem",
-          "operation": "op-apply",
-          "assertion": {
-            "mode": {
-              "applied/.devcontainer/devcontainer.json": "0644"
-            }
-          }
-        },
-        {
           "channel": "chan-file-content",
           "operation": "op-apply",
           "assertion": {
@@ -306,7 +297,7 @@
       "cleanup": {
         "tempdir": true
       },
-      "notes": "The third covering case for `chan-filesystem` (SC-005's floor), and the one that asserts scaffolding as a TREE rather than as a single document. Three separate claims, each its own predicate. `exists`: a file outside `.devcontainer/` is scaffolded too — a template is a directory, not a configuration file. `absent`: `devcontainer-template.json` is template METADATA and must not land in the user's project; a naive whole-tree copy leaves it behind and every other assertion still passes. `mode`: the scaffolded configuration's permissions are observed, not just its bytes. The `chan-file-content` assertion pins the option substituted into the DOCKERFILE, not the configuration — substitution that only walks `devcontainer.json` produces a scaffolded tree with a raw `${templateOption:...}` in it. Also closes the `dockerfile` x `cli-overlay` pair. NOT asserted, deliberately: the template's script is committed executable and is scaffolded `0644`, so deacon drops the executable bit. That is a real observation with no reference side (the pinned reference cannot apply a LOCAL template directory at all, so there is nothing to differentiate against); pinning either mode here would record an unreviewed judgement as an expectation."
+      "notes": "The third covering case for `chan-filesystem` (SC-005's floor), and the one that asserts scaffolding as a TREE rather than as a single document. Two separate claims, each its own predicate. `exists`: a file outside `.devcontainer/` is scaffolded too — a template is a directory, not a configuration file. `absent`: `devcontainer-template.json` is template METADATA and must not land in the user's project; a naive whole-tree copy leaves it behind and every other assertion still passes. The `chan-file-content` assertion pins the option substituted into the DOCKERFILE, not the configuration — substitution that only walks `devcontainer.json` produces a scaffolded tree with a raw `${templateOption:...}` in it. Also closes the `dockerfile` x `cli-overlay` pair. NOT asserted, deliberately: the template's script is committed executable and is scaffolded `0644`, so deacon drops the executable bit. That is a real observation with no reference side (the pinned reference cannot apply a LOCAL template directory at all, so there is nothing to differentiate against); pinning either mode here would record an unreviewed judgement as an expectation. A third `mode: {\"applied/.devcontainer/devcontainer.json\": \"0644\"}` claim was DROPPED with #441 and the reason is the same defect the doctor `host_os.name` pin had: a POSIX file mode is not an observable off Unix — `FilesystemObserver::mode_string` reports `null` there BY DESIGN — so `\"0644\"` asserted the runner's operating system, not what deacon did. It was the case set's only `mode` expectation; the predicate itself stays exercised by `compare::tests::filesystem_mode_predicate`, and the coverage that was lost (one octal string, on a file whose bytes and presence are both still asserted) is the price of this lane running on three platforms instead of one."
     },
     {
       "id": "case-templates-apply-option-substituted",


### PR DESCRIPTION
## What

`parity_hermetic` is selected by every nextest profile including `dev-fast`, and CI runs
`dev-fast` on Linux, macOS and Windows — but the lane was `#![cfg(target_os = "linux")]`-gated,
so two of the three legs ran no parity binary at all. This makes the case data portable and
removes the gate.

The gate was honest: the records pinned host-measured output. The pins were the bug. Measured
on PR #435's first CI (the run that produced the gate): **3 cases fail on macOS, 10 on Windows**.

## Per case class, smallest instrument first

**1. Doctor `host_os` — 3 cases, macOS + Windows.** `"host_os": {"name": "linux"}` asserted the
RUNNER's operating system, which deacon does not choose. Replaced with `"host_os": {}`. A nested
empty object is explicitly NOT vacuous (`model::is_vacuous_assertion` documents the distinction;
`compare::is_json_subset` iterates the subset's keys, so the key must still exist and still be an
object) — the case keeps its shape claim and loses only the runner claim.
`case-doctor-structured-diagnostics` had `host_os` as its ONLY claim, so it gains
`config_discovery.primary_config`, which `collect_config_discovery_info` reports as a portable
literal (`".devcontainer/devcontainer.json"`) rather than a host path — no separator, nothing
machine-dependent.

**2. Templates line endings — 6 cases, Windows.** Checked first, exactly as the issue prescribed,
and it was the entire fix for these: the expected content is pure ASCII JSON containing no paths,
so autocrlf was the only thing that could move it. Pinned `parity/fixtures/** -text`, matching
every other byte-exact pin already in `.gitattributes` (`-text`, not `eol=lf`: it is the file's
existing idiom and cannot corrupt a future binary fixture). `git add --renormalize parity/fixtures`
produces **no diff** — all 477 fixture files are already `i/lf w/lf` — so no contributor sees a
modified tree.

**3. Templates file mode — 1 case, Windows.** `case-templates-apply-multifile-tree` also asserted
`mode: {"applied/.devcontainer/devcontainer.json": "0644"}`. A POSIX file mode is not an observable
off Unix — `FilesystemObserver::mode_string` reports `null` there BY DESIGN — so the octal was an
assertion about the runner, the same defect class as `host_os.name`. Dropped. It was the case set's
only `mode` expectation, so rather than leave the predicate unevaluated the arm is now exercised by
`compare::tests::filesystem_mode_predicate` (agree, diverge, and the off-Unix `null` shape that
gated the lane). Net coverage change: one octal string on a file whose presence and bytes are both
still asserted.

**4. Path spellings — 1 case, Windows.** Not case data. `TokenMap::workspace` registered ONE
spelling of the workspace path, but deacon canonicalizes `--workspace-folder` in
`SubstitutionContext::new` before `${localWorkspaceFolder}` resolves. Windows canonicalization
returns the `\\?\` verbatim form with 8.3 short names expanded (`RUNNER~1` → `runneradmin`), so the
harness's spelling was not even a *substring* of deacon's output and `path_token` tokenized nothing
— `case-readconfig-substitution-object-fields` diverged at `configuration.build.args.WS`. The map
now registers every spelling of the one directory (as given, canonical, verbatim-stripped), all
mapping to the SAME token. This is the existing named `path_token` rule doing what it already
claims; it does **not** rewrite separators, and it cannot hide a difference between two distinct
directories — only stop reporting one directory under two names. It also closes the latent macOS
`/var` → `/private/var` case.

**5.** Then `#![cfg(target_os = "linux")]` came off.

## The guardrail held

Nothing added is platform-conditional: no per-platform expected value, no `cfg`-gated case, no
skip, no new field on the case model. That was the stated stop condition — per-platform expectation
machinery is the deleted conformance-layer pattern, and keeping the gate would have been the better
outcome than rebuilding it.

## Verification

- **Watched-to-fail on Linux**: renaming doctor's `host_os` serde key turns all three doctor cases
  red under the weakened assertion (`case-doctor-structured-{compose-workspace,diagnostics,dockerfile-workspace}:
  chan-structured-output: Diverge`), green again on restore. The presence claim is load-bearing.
- `cargo nextest run -E 'binary(=parity_hermetic)'` — 2/2 pass.
- `cargo nextest run -p parity-harness` — 244/244 pass.
- `make test-nextest-fast` — 3340 pass.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
  `cargo build --all-targets` — clean.
- Live `cargo nextest run --profile parity` against the pinned oracle 0.87.0.
- **The macOS and Windows legs of this PR's own CI are the measurement** for the off-Linux claim.

## Notes

`.gitattributes` still carries ~60 lines of `-text` rules for `conformance/**` and
`fixtures/conformance/**`, directories deleted with the conformance crate. Left alone here to keep
this diff scoped; worth a separate cleanup.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a
