### PR TITLE
chore(parity): add a registry axis and enforce the hermetic lane's no-network promise

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -51,11 +51,22 @@ parity-cli = { max-threads = 8 }
 # `normalize_consistency` and `runner_record_replay` do NOT match `binary(#parity_*)`,
 # so the live-parity exclusions never capture them.
 #
-# The three parity lanes split by what a case NEEDS, not by what it is about:
-#   `parity_hermetic`    — no Docker, no oracle → runs in EVERY profile, dev-fast included.
-#                          Gated to Linux in the source (`#![cfg(target_os = "linux")]`):
-#                          its case data pins Linux-measured output, so off-Linux the lane
-#                          is truthfully not selected rather than skipped (#441).
+# The four parity lanes split by what a case NEEDS, not by what it is about. Three
+# prerequisites, all independent: a registry, a daemon, the pinned oracle.
+#   `parity_hermetic`    — nothing at all → runs in EVERY profile, dev-fast included, on
+#                          every platform CI runs (#441 removed the Linux gate; the case
+#                          data now pins claims deacon can satisfy anywhere). Its own
+#                          `hermetic_lane_runs_without_a_network` test re-runs the lane
+#                          inside a network namespace, so "nothing at all" is enforced
+#                          rather than promised (#544).
+#   `parity_registry`    — a registry, no Docker, no oracle → must be selected only by
+#                          profiles whose JOB is provisioned for `ghcr.io`. That is
+#                          `mvp-integration` (a required PR check that acquires a
+#                          read-only GHCR bearer token) and NOT `dev-fast`, whose
+#                          `Test (MVP fast)` job has no token, no prepull and no Docker.
+#                          It is excluded from `dev-fast` by the `binary(#parity_*)` glob
+#                          in that profile's `default-filter`, which lists its exceptions
+#                          explicitly — do not add this binary to that exception list.
 #   `parity_docker`      — Docker, no oracle    → runs wherever a daemon is available
 #   `parity_differential`— needs the pinned oracle → `[profile.parity]` ONLY
 # The LIVE binary is `parity_differential`. It must be selected by `[profile.parity]` and
@@ -114,11 +125,11 @@ test-group = 'docker-exclusive'
 slow-timeout = { period = "5m", terminate-after = 1 }
 
 [[profile.default.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.default.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests + parity-harness integration tests (018 US5, T046):
@@ -252,11 +263,11 @@ filter = 'binary(=build_consistency)'
 test-group = 'docker-exclusive'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.dev-fast.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests + parity-harness integration tests (018 US5, T046):
@@ -398,11 +409,11 @@ filter = 'binary(=smoke_cli)'
 test-group = 'smoke-cli'
 
 [[profile.docker.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.docker.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests (018 US5, T046): fs-heavy where selected; the rest
@@ -497,11 +508,11 @@ filter = 'binary(=smoke_cli)'
 test-group = 'smoke-cli'
 
 [[profile.full.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.full.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests + parity-harness integration tests (018 US5, T046):
@@ -586,11 +597,11 @@ filter = 'binary(=smoke_cli)'
 test-group = 'smoke-cli'
 
 [[profile.ci.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.ci.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests + parity-harness integration tests (018 US5, T046):
@@ -676,11 +687,11 @@ test-group = 'smoke-cli'
 
 # Parity test grouping
 [[profile.mvp-integration.overrides]]
-filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic))'
+filter = 'binary(#parity_*) & not (binary(=parity_harness_faults) | binary(=parity_hermetic) | binary(=parity_registry))'
 test-group = 'parity'
 
 [[profile.mvp-integration.overrides]]
-filter = 'binary(=parity_hermetic)'
+filter = 'binary(=parity_hermetic) | binary(=parity_registry)'
 test-group = 'parity-cli'
 
 # Hermetic harness self-tests + parity-harness integration tests (018 US5, T046):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,16 @@ jobs:
       run: cargo nextest run --profile dev-fast --no-fail-fast
 
     # `parity_hermetic` is selected by `dev-fast` on every leg of this matrix (#441 removed
-    # its Linux gate), so this lane also owes its evidence on failure (#474). The name
+    # its Linux gate), so this lane also owes its evidence on failure (#474).
+    #
+    # `parity_registry` is NOT, and that is the point of it (#544): this job has no Docker
+    # setup, no prepull and no GHCR token, so a case that resolves an OCI Feature has no
+    # business gating on it. Six such cases sat in `parity_hermetic` and passed here only
+    # because the runner has network. They gate on `Test (MVP integration)` below instead,
+    # which acquires a read-only GHCR bearer token. Do NOT add `binary(=parity_registry)`
+    # to the `dev-fast` `default-filter`'s exception list.
+    #
+    # The name
     # carries the matrix leg because one run's artifacts share a namespace;
     # `if-no-files-found: ignore` guards the legs that fail before the parity binary runs
     # and therefore wrote no `target/parity/`.
@@ -264,6 +273,13 @@ jobs:
         fi
         echo "DEACON_REGISTRY_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
+    # This token is also what makes `parity_registry` gate a pull request HERE rather than
+    # on `Test (MVP fast)` (#544). The `mvp-integration` profile selects it through its
+    # `binary(#parity_*)` clause; the six registry-reaching cases split out of
+    # `parity_hermetic` therefore still gate every pull request, on the job actually
+    # provisioned for a registry. If that clause is ever narrowed, they stop gating
+    # anything — check `cargo nextest list -E 'binary(=parity_registry)' --profile
+    # mvp-integration` before touching it.
     - name: Run MVP integration tests
       run: make test-nextest-mvp-integration
 
@@ -371,8 +387,9 @@ jobs:
     # devcontainer.local_folder=…").
     #
     # The filterset INTERSECTS with the profile's `default-filter`, so this removes exactly
-    # the two `parity_docker` tests and leaves the other 381 — the same 381 that already
-    # pass here. `parity_hermetic` is unaffected: it is runtime-agnostic.
+    # the two `parity_docker` tests and leaves the rest — the same set that already passes
+    # here. `parity_hermetic` and `parity_registry` are unaffected: both are
+    # runtime-agnostic, and this job acquires the GHCR token the latter needs.
     - name: Run integration suite against Podman (full failure set)
       run: cargo nextest run --profile mvp-integration --no-fail-fast -E 'not binary(=parity_docker)'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,16 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
       # The PINNED scenario suite: every parity case whose expectation lives in its own
-      # record. `parity_hermetic` needs nothing; `parity_docker` needs the daemon this
-      # runner already has. Neither needs `@devcontainers/cli`, which is what makes them
-      # a release gate rather than a nightly.
+      # record. `parity_hermetic` needs nothing; `parity_registry` needs `ghcr.io`, which
+      # this runner reaches (it pre-pulls fixture images below); `parity_docker` needs the
+      # daemon this runner already has. None needs `@devcontainers/cli`, which is what
+      # makes them a release gate rather than a nightly.
+      #
+      # All three are named EXPLICITLY rather than by a `binary(#parity_*)` glob, so adding
+      # a lane is a deliberate decision about what gates a release. `parity_registry` was
+      # added with the lane (#544) precisely so the six cases split out of `parity_hermetic`
+      # keep gating a tag; dropping it here would have been a silent coverage regression
+      # disguised as a laning change.
       #
       # Differential-vs-oracle status is deliberately NOT gated here. It compares against
       # a third-party binary at a pin we do not control, so a republish upstream would
@@ -78,8 +85,8 @@ jobs:
           echo "engine exporter capability verified"
       - name: Build + pre-pull declarative-fixture images
         run: ./scripts/parity/prepull-fixture-images.sh
-      - name: Pinned parity scenarios (hermetic + Docker, no oracle)
-        run: cargo nextest run -E 'binary(=parity_hermetic) | binary(=parity_docker)'
+      - name: Pinned parity scenarios (hermetic + registry + Docker, no oracle)
+        run: cargo nextest run -E 'binary(=parity_hermetic) | binary(=parity_registry) | binary(=parity_docker)'
 
       # The evidence for the step above (#474). This is the RELEASE gate: a parity failure
       # here blocks a tag, and the raw capture behind it must outlive the runner rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,19 +377,39 @@ lets most of the suite gate every pull request:
 | Binary | Needs | Runs where |
 |---|---|---|
 | `parity_hermetic` | nothing | every profile, `dev-fast` included; Linux, macOS and Windows (#441) |
+| `parity_registry` | an OCI registry (no daemon, no oracle) | profiles whose JOB is provisioned for `ghcr.io`: `mvp-integration` (a required PR check with a GHCR token), `ci`, `docker`, `full`, `default`, the release gate — NOT `dev-fast` (#544) |
 | `parity_docker` | Docker | wherever a daemon exists; the release gate |
 | `parity_differential` | Docker + the pinned oracle | `--profile parity` ONLY (nightly) |
 | `parity_harness_faults` | nothing | `default`, `dev-fast` — the hermetic guard proving the comparison can fail (oracle mismatch, timeout, normalization failure, injected difference) |
 
-`driver::lane_of` derives a case's lane from its `oracleType` and `resourceGroup`, so a lane
+`driver::lane_of` derives a case's lane from THREE prerequisites — `oracleType` (the
+reference), `resourceGroup` (the daemon) and `needsRegistry` (a registry) — so a lane
 never *skips* a case it cannot run — a case it cannot run is in another lane, written down
 rather than discovered at run time. Live parity runs ONLY under `cargo nextest run --profile
 parity`; every other profile excludes it, so those lanes are truthful by non-selection — a
 green fast run never implies parity ran. There is no env-var opt-in and no silent skip: a
 missing oracle, absent Docker, or a normalization failure FAILS with a cause-specific
 `HarnessError`. The nightly runs `--no-fail-fast` (its job is to enumerate a work queue, not
-to stop at the first item) and gates nothing; the two no-oracle lanes DO gate — `release.yml`
-runs `binary(=parity_hermetic) | binary(=parity_docker)` in its verify job.
+to stop at the first item) and gates nothing; the three no-oracle lanes DO gate —
+`release.yml` runs `binary(=parity_hermetic) | binary(=parity_registry) |
+binary(=parity_docker)` in its verify job.
+
+**The registry axis is DERIVED from case data, never hand-listed** (#544). A case that
+reaches `ghcr.io` declares `"needsRegistry": true` in its own record, exactly as a
+Docker-backed case declares its `resourceGroup`; `driver::needs_registry` reads it and
+`lane_of` routes on it. Adding one stays a pure data edit. Two rules travel with it:
+re-laning is a **laning** change, so nothing a moved case asserts may be rewritten to fit
+the new lane (`bhv-extends-feature-version-override` keeps its `git:1.3.2` → `git:1.3.8`
+pin — that pin IS the behavior); and a Docker case that also reaches a registry stays in
+`parity_docker`, since every job with a daemon has network.
+
+**`parity_hermetic`'s "no network" is enforced, not promised.** Its own
+`hermetic_lane_runs_without_a_network` re-runs the lane's drivers inside a fresh user +
+network namespace (`unshare --map-root-user --net`). Reproduce a suspected leak with
+`unshare -rn cargo nextest run -E 'binary(=parity_hermetic)' --no-fail-fast --offline`. The
+guard is `#[cfg(target_os = "linux")]` — a visible non-selection off Linux, never a runtime
+skip — and FAILS with a cause-specific message when the host cannot create a namespace. If
+it goes red, move the case with `needsRegistry`; do NOT weaken what the case asserts.
 
 **`.config/nextest.toml` gotcha, learned the hard way.** Editing the profiles once silently
 dropped the `default-filter` from four of them, so `dev-fast` selected every Docker binary.

--- a/crates/deacon/tests/parity_hermetic.rs
+++ b/crates/deacon/tests/parity_hermetic.rs
@@ -126,7 +126,7 @@ async fn hermetic_group_fs_heavy() {
 
 /// The lane's "no network" promise, ENFORCED (#544).
 ///
-/// Re-runs this binary's own driver tests inside a fresh user + network namespace, so a
+/// Re-runs this binary's own driver tests inside a fresh network namespace, so a
 /// case that reaches out cannot resolve anything. Before this existed the promise lived in
 /// the docstring above and nowhere else, and six registry-reaching cases drifted into the
 /// lane and stayed — passing on every CI run that happened to have network, and waiting to
@@ -141,9 +141,19 @@ async fn hermetic_group_fs_heavy() {
 /// everywhere; what would not be acceptable is a platform silently believing it had been
 /// checked.
 ///
-/// **Never a silent skip at run time either.** If the host cannot create a user+network
+/// **Never a silent skip at run time either.** If the host cannot create a network
 /// namespace the guard FAILS with that cause named, exactly as every other prerequisite
 /// failure in this suite does (constitution IV). "Could not verify" is not "verified".
+///
+/// **It does NOT map root, and that is load-bearing.** `unshare --map-root-user` writes
+/// `/proc/self/uid_map`, which Ubuntu 24.04 denies to an unprivileged process: creating the
+/// user namespace succeeds and the map write returns `EPERM`
+/// (`kernel.apparmor_restrict_unprivileged_userns`). MEASURED on `ubuntu-latest`, the very
+/// runner where this lane gates — `unshare: write failed /proc/self/uid_map: Operation not
+/// permitted`. The namespace is what this guard needs; the mapping was only convenience, so
+/// the child runs as the unmapped overflow uid (`nobody`) instead. It is given a writable
+/// `HOME`, `TMPDIR` and report root under the world-writable temp dir for exactly that
+/// reason — every path it must write is one `nobody` can create.
 #[cfg(target_os = "linux")]
 #[test]
 fn hermetic_lane_runs_without_a_network() {
@@ -152,12 +162,17 @@ fn hermetic_lane_runs_without_a_network() {
     /// This test's own name — the child selects everything BUT this, which is what keeps
     /// the re-exec from recursing. Kept next to the `--skip` that consumes it.
     const SELF: &str = "hermetic_lane_runs_without_a_network";
+    /// The unprivileged way to get an empty network namespace: a user namespace supplies
+    /// `CAP_SYS_ADMIN` inside it, which is what `--net` then requires. Deliberately WITHOUT
+    /// `--map-root-user` — see the doc comment.
+    const NS_ARGS: [&str; 2] = ["--user", "--net"];
 
-    // Probe the facility separately from using it, so "this host has no unprivileged user
-    // namespaces" cannot be misread as "a hermetic case reached the network". The two
-    // failures have completely different remedies and must not share a message.
+    // Probe the facility separately from using it, so "this host cannot create a namespace"
+    // cannot be misread as "a hermetic case reached the network". The two failures have
+    // completely different remedies and must not share a message.
     let probe = Command::new("unshare")
-        .args(["--map-root-user", "--net", "--", "true"])
+        .args(NS_ARGS)
+        .args(["--", "true"])
         .output();
     match probe {
         Err(e) => panic!(
@@ -169,11 +184,11 @@ fn hermetic_lane_runs_without_a_network() {
         ),
         Ok(out) if !out.status.success() => panic!(
             "the hermetic guard could not create a user+network namespace \
-             (`unshare --map-root-user --net` exited {}): {}\nThis is a MACHINERY failure, \
-             not a parity divergence — unprivileged user namespaces must be enabled \
-             (`sysctl kernel.unprivileged_userns_clone=1` on some distributions, \
-             `/proc/sys/user/max_user_namespaces` non-zero). It is deliberately not a \
-             skip.",
+             (`unshare {} --` exited {}): {}\nThis is a MACHINERY failure, not a parity \
+             divergence — unprivileged user namespaces must be available \
+             (`/proc/sys/user/max_user_namespaces` non-zero; on some distributions \
+             `sysctl kernel.unprivileged_userns_clone=1`). It is deliberately not a skip.",
+            NS_ARGS.join(" "),
             out.status,
             String::from_utf8_lossy(&out.stderr).trim(),
         ),
@@ -182,20 +197,29 @@ fn hermetic_lane_runs_without_a_network() {
 
     // The child writes its own report fragments. Sharing `target/parity` with the outer
     // run would have two processes writing one path concurrently — nextest may schedule
-    // this test alongside the drivers it re-runs.
-    let evidence = tempfile::tempdir().expect("create a temp report root for the guard run");
+    // this test alongside the drivers it re-runs. It must also be a path the UNMAPPED child
+    // can create, so it is named under the world-writable temp dir and left to the child to
+    // make, rather than created here (owner-only) and handed over.
+    let scratch =
+        std::env::temp_dir().join(format!("deacon-hermetic-guard-{}", std::process::id()));
 
     let self_exe = std::env::current_exe().expect("locate this test binary to re-exec it");
     let output = Command::new("unshare")
-        .args(["--map-root-user", "--net", "--"])
+        .args(NS_ARGS)
+        .arg("--")
         .arg(&self_exe)
         // Everything in this binary EXCEPT this test: a selection, not a skip. Running the
         // drivers themselves is the point — the guard must exercise the same case set the
         // lane does, or it would only be checking a copy of it.
         .args(["--skip", SELF, "--test-threads=1"])
-        .env("DEACON_PARITY_REPORT_DIR", evidence.path())
+        .env("DEACON_PARITY_REPORT_DIR", scratch.join("report"))
+        .env("DEACON_CACHE_DIR", scratch.join("cache"))
+        .env("HOME", scratch.join("home"))
+        .env("TMPDIR", std::env::temp_dir())
         .output()
         .expect("re-exec this test binary inside the namespace");
+
+    let _ = std::fs::remove_dir_all(&scratch);
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -208,8 +232,12 @@ fn hermetic_lane_runs_without_a_network() {
          does not belong in it. Declare `\"needsRegistry\": true` on the case and it moves \
          to `parity_registry`, which runs on the jobs provisioned for a registry; do NOT \
          weaken what the case asserts to fit this lane.\n\
+         (The re-run is unprivileged — an unmapped `nobody` — so on the rare failure that \
+         names a permission rather than a registry, read it as machinery: every path the \
+         child writes is redirected under {}.)\n\
          --- namespaced re-run stdout ---\n{stdout}\n\
          --- namespaced re-run stderr ---\n{stderr}",
+        scratch.display(),
     );
 
     // A guard that selected nothing would pass forever. Assert it actually drove the

--- a/crates/deacon/tests/parity_hermetic.rs
+++ b/crates/deacon/tests/parity_hermetic.rs
@@ -1,9 +1,19 @@
 //! The HERMETIC parity lane: `spec-expectation` cases in the config-only resource
-//! groups. No Docker daemon, no pinned oracle, no network.
+//! groups. No Docker daemon, no pinned oracle, no network — and since #544 the last of
+//! those is ENFORCED by [`hermetic_lane_runs_without_a_network`], not merely promised
+//! here.
 //!
 //! These cases compare deacon against an assertion DECLARED in the record, so nothing
 //! external has to exist for them to mean something. That is what makes them the one
 //! parity lane that can gate every pull request, in every profile.
+//!
+//! **A registry is a prerequisite like any other.** `driver::lane_of` used to derive a
+//! lane from `oracleType` and `resourceGroup` alone — an axis encoding the reference and
+//! the daemon, on which "reaches `ghcr.io`" could not be said. Six cases that resolve OCI
+//! Features at case time therefore sat here, in the lane whose promise is no network,
+//! passing only because CI had some (#544). A case declares `needsRegistry` and lands in
+//! `parity_registry` instead; nothing about what such a case ASSERTS changed in the move,
+//! and nothing about it should — re-laning is a laning change, not a coverage change.
 //!
 //! **Every platform CI runs, and the case data is what earned that** (#441). The lane was
 //! gated to Linux because its records pinned LINUX-MEASURED output rather than deacon's
@@ -29,7 +39,8 @@
 //! rather than discovered at run time. A skip and a pass look identical in a report; a
 //! non-selection is written down.
 //!
-//! Its siblings: `parity_docker` (Docker-backed, still no oracle) and
+//! Its siblings: `parity_registry` (a registry, still no daemon and no oracle),
+//! `parity_docker` (Docker-backed, still no oracle) and
 //! `parity_differential` (live against the pinned reference).
 
 use std::path::PathBuf;
@@ -111,4 +122,102 @@ async fn hermetic_group_none() {
 #[tokio::test]
 async fn hermetic_group_fs_heavy() {
     drive(ResourceGroup::FsHeavy).await;
+}
+
+/// The lane's "no network" promise, ENFORCED (#544).
+///
+/// Re-runs this binary's own driver tests inside a fresh user + network namespace, so a
+/// case that reaches out cannot resolve anything. Before this existed the promise lived in
+/// the docstring above and nowhere else, and six registry-reaching cases drifted into the
+/// lane and stayed — passing on every CI run that happened to have network, and waiting to
+/// present as a transient with the signature of #454. A property asserted only in prose is
+/// a property nobody is checking.
+///
+/// **Linux-only, and deliberately so.** `unshare(2)` and unprivileged user namespaces are
+/// a Linux facility; this lane runs on macOS and Windows too since #441, where the guard
+/// is NOT SELECTED rather than skipped — the `#[cfg]` is visible in the source, whereas a
+/// runtime skip would report as a pass. The lane's hermeticity is a property of the CASE
+/// DATA, which is identical on every platform, so checking it on one platform checks it
+/// everywhere; what would not be acceptable is a platform silently believing it had been
+/// checked.
+///
+/// **Never a silent skip at run time either.** If the host cannot create a user+network
+/// namespace the guard FAILS with that cause named, exactly as every other prerequisite
+/// failure in this suite does (constitution IV). "Could not verify" is not "verified".
+#[cfg(target_os = "linux")]
+#[test]
+fn hermetic_lane_runs_without_a_network() {
+    use std::process::Command;
+
+    /// This test's own name — the child selects everything BUT this, which is what keeps
+    /// the re-exec from recursing. Kept next to the `--skip` that consumes it.
+    const SELF: &str = "hermetic_lane_runs_without_a_network";
+
+    // Probe the facility separately from using it, so "this host has no unprivileged user
+    // namespaces" cannot be misread as "a hermetic case reached the network". The two
+    // failures have completely different remedies and must not share a message.
+    let probe = Command::new("unshare")
+        .args(["--map-root-user", "--net", "--", "true"])
+        .output();
+    match probe {
+        Err(e) => panic!(
+            "the hermetic guard needs `unshare` (util-linux) to remove the network \
+             namespace, and it could not be run: {e}. This is a MACHINERY failure, not a \
+             parity divergence — install util-linux, or run this lane on a host that can \
+             create namespaces. It is deliberately not a skip: a skip and a pass are \
+             indistinguishable in a report."
+        ),
+        Ok(out) if !out.status.success() => panic!(
+            "the hermetic guard could not create a user+network namespace \
+             (`unshare --map-root-user --net` exited {}): {}\nThis is a MACHINERY failure, \
+             not a parity divergence — unprivileged user namespaces must be enabled \
+             (`sysctl kernel.unprivileged_userns_clone=1` on some distributions, \
+             `/proc/sys/user/max_user_namespaces` non-zero). It is deliberately not a \
+             skip.",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim(),
+        ),
+        Ok(_) => {}
+    }
+
+    // The child writes its own report fragments. Sharing `target/parity` with the outer
+    // run would have two processes writing one path concurrently — nextest may schedule
+    // this test alongside the drivers it re-runs.
+    let evidence = tempfile::tempdir().expect("create a temp report root for the guard run");
+
+    let self_exe = std::env::current_exe().expect("locate this test binary to re-exec it");
+    let output = Command::new("unshare")
+        .args(["--map-root-user", "--net", "--"])
+        .arg(&self_exe)
+        // Everything in this binary EXCEPT this test: a selection, not a skip. Running the
+        // drivers themselves is the point — the guard must exercise the same case set the
+        // lane does, or it would only be checking a copy of it.
+        .args(["--skip", SELF, "--test-threads=1"])
+        .env("DEACON_PARITY_REPORT_DIR", evidence.path())
+        .output()
+        .expect("re-exec this test binary inside the namespace");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "a `{BINARY}` case REACHED THE NETWORK. This lane promises none, gates every pull \
+         request on a job with no registry token, and every case here compares deacon \
+         against an assertion declared in its own record — so a case that needs `ghcr.io` \
+         does not belong in it. Declare `\"needsRegistry\": true` on the case and it moves \
+         to `parity_registry`, which runs on the jobs provisioned for a registry; do NOT \
+         weaken what the case asserts to fit this lane.\n\
+         --- namespaced re-run stdout ---\n{stdout}\n\
+         --- namespaced re-run stderr ---\n{stderr}",
+    );
+
+    // A guard that selected nothing would pass forever. Assert it actually drove the
+    // drivers rather than trusting an exit code that an empty selection also produces.
+    assert!(
+        stdout.contains("2 passed"),
+        "the namespaced re-run reported no driver tests, so this guard checked nothing — \
+         the `--skip {SELF}` selection is wrong or the lane's driver functions were \
+         renamed.\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+    );
 }

--- a/crates/deacon/tests/parity_registry.rs
+++ b/crates/deacon/tests/parity_registry.rs
@@ -1,0 +1,123 @@
+//! The REGISTRY parity lane: `spec-expectation` cases in the config-only resource groups
+//! that REACH AN OCI REGISTRY. No Docker daemon, no pinned oracle — but network, and
+//! `ghcr.io` specifically.
+//!
+//! **Why it exists** (#544). `driver::lane_of` used to derive a lane from `oracleType` and
+//! `resourceGroup` only, an axis that encodes the reference and the daemon. "Needs a
+//! registry" was not on it, so six cases that fetch `ghcr.io/devcontainers/features/git`
+//! at case time sat in `parity_hermetic` — the lane whose docstring promises "no network"
+//! and which gates every pull request on `Test (MVP fast)`, a job with no Docker setup, no
+//! prepull and no GHCR token. They passed only because CI happened to have network. Each
+//! was a standing dependency waiting to present as a transient, with a failure signature
+//! byte-identical to the one that produced #454.
+//!
+//! **Why the reach is not removable.** These are not incidental registry touches a fixture
+//! edit could swap for a local Feature:
+//!
+//! - `read-configuration --include-merged-configuration` resolves the effective Feature
+//!   set to fold each Feature's metadata into the merged document, and the case data
+//!   asserts VERSION-PINNED OCI keys. For `bhv-extends-feature-version-override` (#411)
+//!   the pin *is* the behavior — `git:1.3.2` overridden to `git:1.3.8` across an extends
+//!   chain — and a local Feature has no version in its id, so the claim cannot be
+//!   expressed hermetically at all.
+//! - `upgrade --dry-run` resolves Feature digests against the registry in order to
+//!   regenerate the lockfile. That *is* the subcommand.
+//!
+//! So the cases moved lanes and NOTHING about what they claim changed. Re-laning is a
+//! laning change, not a coverage change.
+//!
+//! **Where it runs, and why the six still gate every pull request.** `Test (MVP
+//! integration)` is a required PR check and already acquires a read-only GHCR bearer token
+//! (`.github/workflows/ci.yml`), so the `mvp-integration` profile selects this binary and
+//! `dev-fast` excludes it. The release gate runs it too, alongside its two sibling
+//! no-oracle lanes.
+//!
+//! **No skips.** Absent network the cases FAIL, loudly, naming the registry they could not
+//! reach — the same discipline as every other lane (constitution IV). A lane that skipped
+//! when the registry was unreachable would be the original defect wearing a different hat.
+//!
+//! Its siblings: `parity_hermetic` (nothing at all), `parity_docker` (Docker-backed, still
+//! no oracle) and `parity_differential` (live against the pinned reference).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use parity_harness::driver::{self, DriverConfig, Lane};
+use parity_harness::load::Registry;
+use parity_harness::model::ResourceGroup;
+use parity_harness::{HarnessError, parity_root, report_root, workspace_root};
+
+/// This binary's name — the report-fragment key.
+const BINARY: &str = "parity_registry";
+
+/// Fail with the error's cause-specific `Display` message (never `Debug`) so a
+/// prereq/normalization failure reads as its remedy.
+fn ff<T>(r: Result<T, HarnessError>) -> T {
+    r.unwrap_or_else(|e| panic!("{e}"))
+}
+
+/// Drive one config-only resource group's registry-reaching cases end to end.
+///
+/// A group with no cases is NOT a silent skip: it still writes its fragment (which is what
+/// proves the binary ran) and says so on stderr. The case set as a whole is still asserted
+/// non-empty, so a loader that stopped finding cases fails loudly instead of passing by
+/// driving nothing.
+async fn drive(group: ResourceGroup) {
+    assert!(
+        !driver::needs_docker(group),
+        "`{BINARY}` needs a registry, not a daemon; `{}` is Docker-backed and belongs to \
+         parity_docker",
+        driver::group_slug(group)
+    );
+
+    let registry = Registry::load(&parity_root())
+        .unwrap_or_else(|e| panic!("the parity case set must load: {e}"));
+    assert!(
+        !registry.cases.is_empty(),
+        "expected the parity case set to hold cases to drive"
+    );
+    let cases = driver::cases_in_lane_and_group(&registry.cases, Lane::Registry, group);
+    if cases.is_empty() {
+        eprintln!(
+            "note: no registry case declares resourceGroup `{}` yet",
+            driver::group_slug(group)
+        );
+    }
+
+    let cfg = Arc::new(DriverConfig {
+        binary: BINARY.to_string(),
+        deacon_path: PathBuf::from(env!("CARGO_BIN_EXE_deacon")),
+        // No oracle: like its hermetic sibling, every case here compares deacon against an
+        // assertion declared in its own record. The registry is a prerequisite of the
+        // SUBJECT, not of the comparison.
+        oracle: None,
+        fixtures_root: workspace_root().join("parity").join("fixtures"),
+        report_root: report_root(),
+    });
+
+    let run = ff(driver::drive_group(Arc::clone(&cfg), cases, group).await);
+    ff(driver::emit(&run));
+    assert!(
+        run.failures.is_empty(),
+        "registry parity failure(s) in resource group `{}`:\n{}",
+        driver::group_slug(group),
+        run.failures.join("\n"),
+    );
+}
+
+/// Resource group `none` — the config-only cases (`read-configuration`, `upgrade`) that
+/// need no special local resource, only the registry. This is the whole registry set
+/// today.
+#[tokio::test]
+async fn registry_group_none() {
+    drive(ResourceGroup::None).await;
+}
+
+/// Resource group `fs-heavy` — significant filesystem work AND a registry reach, still no
+/// Docker. Empty today; it exists so that a case declaring both stays a pure data edit,
+/// and so `fs-heavy`'s nextest group can throttle it independently of the `none` cases
+/// (FR-077).
+#[tokio::test]
+async fn registry_group_fs_heavy() {
+    drive(ResourceGroup::FsHeavy).await;
+}

--- a/crates/parity-harness/src/driver.rs
+++ b/crates/parity-harness/src/driver.rs
@@ -15,10 +15,15 @@
 //!
 //! So the case set is partitioned by [`ResourceGroup`] and each group gets its own driver
 //! function. A second, independent axis — [`Lane`] — partitions by what a case NEEDS
-//! (Docker? the pinned oracle?), which is what lets the hermetic and pinned-Docker
-//! majorities gate every pull request while only the oracle-dependent cases stay nightly.
-//! The two axes cross into the three test binaries `parity_hermetic`, `parity_docker` and
-//! `parity_differential`.
+//! (a registry? Docker? the pinned oracle?), which is what lets the hermetic, registry and
+//! pinned-Docker majorities gate every pull request while only the oracle-dependent cases
+//! stay nightly. The two axes cross into the four test binaries `parity_hermetic`,
+//! `parity_registry`, `parity_docker` and `parity_differential`.
+//!
+//! The registry prerequisite joined the `Lane` axis rather than [`ResourceGroup`] because
+//! the two answer different questions (#544): a group says what a case CONTENDS for, which
+//! is why `needs_docker` can be read off it; nothing about contention can say "reaches
+//! `ghcr.io`". Keeping them separate is also what lets a case declare both.
 //!
 //! **SC-013 is preserved.** `ResourceGroup` is a CLOSED set and every variant already has a
 //! driver, so adding a case with an existing group stays a pure data edit. Only introducing
@@ -118,11 +123,17 @@ pub fn default_concurrency(group: ResourceGroup) -> usize {
 /// where 72 sub-second cases taken one at a time is over a minute of pure latency in the
 /// loop developers run most.
 ///
+/// The registry lane's config-only groups run four at a time: its cases are dominated by
+/// network round-trips rather than by CPU, so serializing them is pure latency, but a
+/// third party's rate limiter is a shared resource in a way a temp directory is not — so
+/// it gets the fs-heavy number rather than the hermetic one.
+///
 /// The Docker groups keep their existing numbers, which encode real daemon contention:
 /// raising those would trade a correctness property for wall clock.
 pub fn concurrency_for(lane: Lane, group: ResourceGroup) -> usize {
     match (lane, group) {
         (Lane::Hermetic, ResourceGroup::None | ResourceGroup::FsHeavy) => 8,
+        (Lane::Registry, ResourceGroup::None | ResourceGroup::FsHeavy) => 4,
         _ => default_concurrency(group),
     }
 }
@@ -130,20 +141,33 @@ pub fn concurrency_for(lane: Lane, group: ResourceGroup) -> usize {
 /// Which lane a case can run in, decided by what it NEEDS rather than by what it is
 /// about.
 ///
-/// The two axes are independent and both are prerequisites, not preferences: a case that
-/// runs the reference cannot run without the pinned oracle installed, and a case that
-/// creates a container cannot run without a daemon. Splitting on them is what lets the
-/// hermetic majority gate every pull request while the oracle-dependent majority stays
-/// nightly — and, crucially, it is why a fast lane never has to *skip* anything. A skip is
-/// indistinguishable from a pass; non-selection is visible in the lane's own definition.
+/// The three axes are independent and all are prerequisites, not preferences: a case that
+/// runs the reference cannot run without the pinned oracle installed, a case that creates
+/// a container cannot run without a daemon, and a case that resolves an OCI Feature cannot
+/// run without a registry. Splitting on them is what lets the hermetic majority gate every
+/// pull request while the oracle-dependent majority stays nightly — and, crucially, it is
+/// why a fast lane never has to *skip* anything. A skip is indistinguishable from a pass;
+/// non-selection is visible in the lane's own definition.
+///
+/// The registry axis is the newest and was the one a case could sit on undeclared (#544):
+/// `resourceGroup` encodes the daemon and the contention, `oracleType` encodes the
+/// reference, and neither could say "reaches `ghcr.io`". Six cases were therefore in a lane
+/// promising "no network" and passing only because CI had some.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Lane {
-    /// No Docker and no oracle: a `spec-expectation` case in a config-only group. It
-    /// compares deacon against a DECLARED assertion, so it can run anywhere.
+    /// No Docker, no oracle and no network: a `spec-expectation` case in a config-only
+    /// group. It compares deacon against a DECLARED assertion, so it can run anywhere —
+    /// and `parity_hermetic`'s namespace guard proves that by running this selection with
+    /// the network removed.
     Hermetic,
+    /// No Docker and no oracle, but reaches an OCI registry: a `spec-expectation` case in
+    /// a config-only group that declares `needsRegistry`. Runs on the jobs provisioned for
+    /// a registry, which on a pull request is `Test (MVP integration)`.
+    Registry,
     /// Docker but no oracle: a `spec-expectation` or `invariant-metamorphic` case in a
     /// Docker group. Its expectation is pinned in the record, so it needs a daemon but
-    /// not the reference.
+    /// not the reference. A Docker case may ALSO reach a registry; every job with a
+    /// daemon has network, so the daemon is the binding prerequisite and it stays here.
     Docker,
     /// Needs the pinned oracle, with or without Docker: every `live-differential` case.
     Differential,
@@ -154,6 +178,7 @@ impl Lane {
     pub fn slug(self) -> &'static str {
         match self {
             Lane::Hermetic => "hermetic",
+            Lane::Registry => "registry",
             Lane::Docker => "docker",
             Lane::Differential => "differential",
         }
@@ -169,13 +194,31 @@ impl Lane {
     }
 }
 
-/// The lane a case belongs to. `live-differential` always needs the reference; anything
-/// else is decided by its resource group.
+/// Whether a case reaches an OCI registry at run time — the third prerequisite axis,
+/// DERIVED from the case's own record exactly as Docker-ness is derived from its
+/// `resourceGroup`, never from a list of case ids kept in this file (#544).
+///
+/// A hand-maintained list here would be the same defect one level up: it would live apart
+/// from the case it describes, and adding a case would stop being a pure data edit. The
+/// declaration travels with the record; `parity_hermetic`'s namespace guard is what
+/// catches a record that forgot to make it.
+pub fn needs_registry(case: &TestCase) -> bool {
+    case.needs_registry
+}
+
+/// The lane a case belongs to, in prerequisite order: the oracle is the scarcest resource,
+/// then the daemon, then the registry.
+///
+/// A Docker case that also reaches a registry stays in [`Lane::Docker`] — every job that
+/// provides a daemon also has network, so the daemon is the binding constraint and
+/// splitting further would buy nothing.
 pub fn lane_of(case: &TestCase) -> Lane {
     if case.oracle_type == Some(OracleType::LiveDifferential) {
         Lane::Differential
     } else if needs_docker(group_of(case)) {
         Lane::Docker
+    } else if needs_registry(case) {
+        Lane::Registry
     } else {
         Lane::Hermetic
     }
@@ -938,6 +981,116 @@ mod tests {
         assert_eq!(
             concurrency_for(Lane::Docker, ResourceGroup::DockerExclusive),
             1
+        );
+        // The registry lane is network-bound, so serializing it is pure latency — but a
+        // third party's rate limiter is a shared resource, so it gets four rather than
+        // eight.
+        assert_eq!(concurrency_for(Lane::Registry, ResourceGroup::None), 4);
+        assert_eq!(concurrency_for(Lane::Registry, ResourceGroup::FsHeavy), 4);
+    }
+
+    /// The registry axis is DERIVED from the case's own record, exactly as Docker-ness is
+    /// derived from its `resourceGroup` — never from a list of ids kept in this file
+    /// (#544). Declaring it is what routes a case out of the hermetic lane, and a case
+    /// that declares nothing stays hermetic, which is why the namespace guard has to
+    /// exist.
+    #[test]
+    fn the_registry_axis_is_declared_by_the_case_not_listed_in_the_driver() {
+        let plain = declarative("case-plain", None);
+        assert!(!needs_registry(&plain));
+        assert_eq!(lane_of(&plain), Lane::Hermetic);
+
+        let mut reaches = declarative("case-reaches", None);
+        reaches.needs_registry = true;
+        assert!(needs_registry(&reaches));
+        assert_eq!(lane_of(&reaches), Lane::Registry);
+    }
+
+    /// The three prerequisites resolve in scarcity order: the oracle, then the daemon,
+    /// then the registry. A Docker case that also reaches a registry stays in the Docker
+    /// lane — every job with a daemon has network — and a `live-differential` case stays
+    /// differential whatever else it declares.
+    #[test]
+    fn registry_never_outranks_the_daemon_or_the_oracle() {
+        let mut docker_and_registry = declarative("case-both", Some(ResourceGroup::DockerShared));
+        docker_and_registry.needs_registry = true;
+        assert_eq!(lane_of(&docker_and_registry), Lane::Docker);
+
+        let mut live = declarative("case-live", None);
+        live.needs_registry = true;
+        live.oracle_type = Some(OracleType::LiveDifferential);
+        assert_eq!(lane_of(&live), Lane::Differential);
+    }
+
+    /// The four lanes PARTITION the declarative set within a group: every case is driven by
+    /// exactly one binary. A case driven by nobody is the inert-declaration defect the lane
+    /// split exists to prevent, and a case driven twice would double-count evidence.
+    #[test]
+    fn the_lanes_partition_every_group() {
+        let mut registry_case = declarative("case-registry", Some(ResourceGroup::None));
+        registry_case.needs_registry = true;
+        let mut live = declarative("case-live", Some(ResourceGroup::None));
+        live.oracle_type = Some(OracleType::LiveDifferential);
+        let cases = vec![
+            declarative("case-hermetic", Some(ResourceGroup::None)),
+            registry_case,
+            live,
+            declarative("case-docker", Some(ResourceGroup::DockerShared)),
+        ];
+
+        for group in [
+            ResourceGroup::None,
+            ResourceGroup::FsHeavy,
+            ResourceGroup::DockerShared,
+            ResourceGroup::DockerExclusive,
+        ] {
+            let per_lane: usize = [
+                Lane::Hermetic,
+                Lane::Registry,
+                Lane::Docker,
+                Lane::Differential,
+            ]
+            .iter()
+            .map(|l| cases_in_lane_and_group(&cases, *l, group).len())
+            .sum();
+            assert_eq!(
+                per_lane,
+                cases_in_group(&cases, group).len(),
+                "the lanes must partition group `{}`",
+                group_slug(group)
+            );
+        }
+
+        assert_eq!(
+            cases_in_lane_and_group(&cases, Lane::Hermetic, ResourceGroup::None)
+                .iter()
+                .map(|c| c.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["case-hermetic"],
+            "the registry case must have LEFT the hermetic selection, not joined a second one"
+        );
+    }
+
+    /// Each lane's slug is distinct — they name report fragments and diagnostics, and two
+    /// lanes sharing one would silently merge two lanes' evidence.
+    #[test]
+    fn every_lane_has_a_distinct_slug() {
+        let slugs: Vec<&str> = [
+            Lane::Hermetic,
+            Lane::Registry,
+            Lane::Docker,
+            Lane::Differential,
+        ]
+        .iter()
+        .map(|l| l.slug())
+        .collect();
+        let mut sorted = slugs.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), slugs.len(), "lane slugs must be distinct");
+        assert!(
+            !Lane::Registry.needs_oracle(),
+            "the registry lane compares against a declared assertion, so it needs no oracle"
         );
     }
 

--- a/crates/parity-harness/src/model.rs
+++ b/crates/parity-harness/src/model.rs
@@ -495,6 +495,27 @@ pub struct TestCase {
     /// The nextest resource group for a Docker-backed case (default `none`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_group: Option<ResourceGroup>,
+    /// Whether running this case REACHES AN OCI REGISTRY (default `false`) — the third
+    /// prerequisite axis, alongside the daemon and the oracle (#544).
+    ///
+    /// `resourceGroup` answers "what does this case contend for?" and, incidentally,
+    /// "does it need a daemon?". It cannot answer "does it need the network?": a
+    /// `read-configuration --include-merged-configuration` over an OCI Feature, or an
+    /// `upgrade --dry-run` regenerating a lockfile, contends for nothing and creates no
+    /// container, yet cannot run without `ghcr.io`. Six such cases sat in the lane whose
+    /// docstring promised "no network" and passed only because CI happened to have some;
+    /// each was a standing dependency waiting to present as a transient (#454, #544).
+    ///
+    /// Declaring it is what routes the case to [`crate::driver::Lane::Registry`] and the
+    /// jobs provisioned for a registry. Forgetting to declare it on a new case is caught
+    /// by `parity_hermetic`'s own namespace guard, which runs the hermetic selection with
+    /// the network removed — the contract is enforced, not merely documented.
+    ///
+    /// **Excluded from `caseHash`** by construction (`case_hash.rs` builds an explicit
+    /// allow-list): it classifies the case, it does not change a byte the runner feeds the
+    /// CLI, so re-laning a case must never mark its snapshot stale.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub needs_registry: bool,
     /// Human prose; **excluded from `caseHash`** so annotating never re-records (D3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,

--- a/crates/parity-harness/src/registry.rs
+++ b/crates/parity-harness/src/registry.rs
@@ -33,12 +33,20 @@ pub const LIVE_BINARIES: &[&str] = &["parity_differential"];
 /// they must never be treated as live and MUST run in the ordinary lanes.
 ///
 /// Two kinds, both non-live for the same reason — they need no reference CLI:
-/// `parity_hermetic` and `parity_docker` run cases whose expectation is pinned in the
-/// record, and `parity_harness_faults` is the hermetic proof that the comparison can
-/// fail at all. Recognized by [`check_test_files`] so the file↔name match does not flag
-/// them as undeclared live binaries.
-pub const META_TEST_BINARIES: &[&str] =
-    &["parity_harness_faults", "parity_hermetic", "parity_docker"];
+/// `parity_hermetic`, `parity_registry` and `parity_docker` run cases whose expectation is
+/// pinned in the record, and `parity_harness_faults` is the hermetic proof that the
+/// comparison can fail at all. Recognized by [`check_test_files`] so the file↔name match
+/// does not flag them as undeclared live binaries.
+///
+/// They differ only in what they NEED — nothing, a registry, a daemon — which is the same
+/// axis [`crate::driver::Lane`] splits on, and the reason each can gate a pull request on
+/// the job provisioned for it.
+pub const META_TEST_BINARIES: &[&str] = &[
+    "parity_harness_faults",
+    "parity_hermetic",
+    "parity_registry",
+    "parity_docker",
+];
 
 /// Bidirectional file↔name match for `parity_*` sources under `tests_dir`. Returns
 /// human-readable problems (empty = OK).

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -159,12 +159,46 @@ two are now failures. **After writing any assertion, perturb it once and confirm
 
 ## The lanes
 
-Three lane binaries, split by what a case NEEDS rather than by what it is about, which is
+Four lane binaries, split by what a case NEEDS rather than by what it is about, which is
 what lets most of the suite gate every pull request. `driver::lane_of` derives a case's lane
-from its `oracleType` and `resourceGroup`, so a lane never *skips* a case it cannot run — a
-case it cannot run is in another lane. A skip and a pass look identical in a report; a
+from **three** prerequisites — `oracleType` (the pinned reference), `resourceGroup` (the
+daemon) and `needsRegistry` (an OCI registry) — so a lane never *skips* a case it cannot run
+— a case it cannot run is in another lane. A skip and a pass look identical in a report; a
 non-selection does not. The table of binaries and how to run them is in
 [`CLAUDE.md`](../CLAUDE.md) § Differential Parity Suite.
+
+**The registry axis, and why it exists** (#544). For a long time `lane_of` derived from
+`oracleType` and `resourceGroup` alone. That axis encodes the reference and the daemon, and
+"reaches `ghcr.io`" cannot be said on it — so six cases that resolve OCI Features at case
+time (`read-configuration --include-merged-configuration` folding Feature metadata into the
+merged document; `upgrade --dry-run` resolving digests to regenerate a lockfile) sat in
+`parity_hermetic`, the lane whose promise is *no network*, gating every pull request on a job
+with no registry token. They passed only because CI happened to have network; each was a
+standing dependency waiting to present as a transient, with the signature of #454.
+
+A case now declares `"needsRegistry": true` and lands in `parity_registry`, which the
+`mvp-integration` profile selects and `dev-fast` excludes — so those six still gate every
+pull request, on `Test (MVP integration)`, the required check that already acquires a
+read-only GHCR bearer token. Two rules travel with the axis:
+
+- **The dependency is DERIVED from the case's own record**, exactly as Docker-ness is
+  derived from its `resourceGroup`. A list of case ids in the driver would be the same
+  defect one level up — it would live apart from the case it describes, and adding a case
+  would stop being a pure data edit.
+- **Re-laning is a laning change, not a coverage change.** Nothing a moved case asserts may
+  be rewritten to fit its new lane. `bhv-extends-feature-version-override` (#411) keeps its
+  `git:1.3.2` → `git:1.3.8` pin exactly as authored: that pin *is* the behavior, and a local
+  Feature has no version in its id, so the claim cannot be expressed hermetically at all.
+
+**Hermeticity is enforced, not promised.** `parity_hermetic`'s own
+`hermetic_lane_runs_without_a_network` re-runs the lane's drivers inside a fresh user +
+network namespace, so a case that reaches out cannot resolve anything and the contract is
+true by construction. Before it existed, the promise lived in a docstring and nowhere else,
+which is exactly how six cases drifted out of it unnoticed. It is Linux-only (`unshare(2)`
+is a Linux facility) while the lane itself runs on macOS and Windows since #441: the `#[cfg]`
+is a visible non-selection, and the property it checks belongs to the case DATA, which is
+identical on every platform. At run time it never skips — a host that cannot create a
+namespace FAILS with that cause named, because "could not verify" is not "verified".
 
 **Selection is profile-based. There is no env-var opt-in and no silent skip.** Live parity
 runs ONLY under `cargo nextest run --profile parity`; every other profile excludes it, so
@@ -185,7 +219,9 @@ Neither belongs in this file — status snapshots in prose go stale within the d
 **What a failing run leaves behind.** Every lane writes its raw capture and report fragments
 under `target/parity/`, and every job that runs a parity binary uploads that tree as a
 `parity-evidence-*` artifact — the nightly on any outcome, the gating lanes (`ci.yml`'s fast,
-MVP-integration and Podman jobs; `release.yml`'s verify job) on failure only. Download it
+MVP-integration and Podman jobs; `release.yml`'s verify job) on failure only. The hermetic
+guard's namespaced re-run writes to a temp root of its own rather than to `target/parity`,
+so its evidence cannot be confused with the lane's; what it reports is in the failure text. Download it
 before re-running: a re-run that goes green destroys the only copy of what happened (#474).
 The failure text itself carries the diverging observable paths, and — for a `chan-exit-code`
 divergence specifically — a tail-bounded excerpt of the stderr of whichever side exited

--- a/docs/testing/nextest.md
+++ b/docs/testing/nextest.md
@@ -195,13 +195,16 @@ default-filter = 'binary(=parity_differential)'
 ```
 
 ONE binary, because only `live-differential` cases need the reference CLI. The
-other two parity lanes carry their expectation in the record and therefore need
-no oracle, so they run in the ordinary lanes: `parity_hermetic` (no Docker
-either — it runs in `dev-fast` on every platform CI covers, Linux, macOS and
-Windows alike, since #441 removed the last host-measured pins from its case
-data) and `parity_docker` (needs a daemon). The split
+other three parity lanes carry their expectation in the record and therefore need
+no oracle, so they run in the ordinary lanes: `parity_hermetic` (nothing at all —
+it runs in `dev-fast` on every platform CI covers, Linux, macOS and Windows
+alike, since #441 removed the last host-measured pins from its case data),
+`parity_registry` (an OCI registry but no daemon — selected by `mvp-integration`,
+which has a GHCR token, and EXCLUDED from `dev-fast`, which does not; #544) and
+`parity_docker` (needs a daemon). The split
 is by what a case NEEDS, not by subject; adding a scenario is a JSON edit and no
-binary changes.
+binary changes — including moving one onto the registry axis, which is a
+`"needsRegistry": true` in the case's own record.
 
 The explicit list is deliberate. A `binary(#parity_*)` glob would also match
 `parity_harness_faults`, the **hermetic guard** that proves the comparison can

--- a/parity/cases/read-configuration.json
+++ b/parity/cases/read-configuration.json
@@ -1406,6 +1406,7 @@
         "bhv-readconfig-merged-configuration"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {
@@ -1878,6 +1879,7 @@
         "bhv-readconfig-extends-merged"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {
@@ -2173,6 +2175,7 @@
         "bhv-extends-feature-version-override"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {

--- a/parity/cases/upgrade.json
+++ b/parity/cases/upgrade.json
@@ -7,6 +7,7 @@
         "bhv-upgrade-cli-config-overlay-honored"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {
@@ -186,6 +187,7 @@
         "bhv-upgrade-regenerates-lockfile"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {
@@ -234,6 +236,7 @@
         "bhv-upgrade-cli-config-overlay-honored"
       ],
       "context": [],
+      "needsRegistry": true,
       "oracleType": "spec-expectation",
       "operations": [
         {


### PR DESCRIPTION
Implements the maintainer ruling on #544: **option 2 — add a registry axis**. Options 1 (widen the lane's promise) and 3 (pre-seed the feature cache) are not attempted.

## Before / after, measured

`unshare -rn cargo nextest run -E 'binary(=parity_hermetic)' --no-fail-fast --offline`

**Before** (at `b745a47`) — the issue's premise reproduces exactly, six cases, all `resourceGroup: none`, all `chan-exit-code: Diverge; chan-structured-output: Diverge`, all an OCI manifest fetch:

```
Summary [ 9.882s] 2 tests run: 1 passed, 1 failed, 0 skipped
   FAIL (2/2) deacon::parity_hermetic hermetic_group_none

hermetic parity failure(s) in resource group `none`:
case-readconfig-compose-lockfile-merged              -> ghcr.io/.../git/manifests/1.3.2
case-readconfig-dockerfile-lockfile-extends          -> ghcr.io/.../git/manifests/1.3.2
case-readconfig-extends-feature-version-override     -> ghcr.io/.../git/manifests/1.3.8
case-upgrade-compose-merge-config-adds-feature       -> ghcr.io/.../git/manifests/1.3.2
case-upgrade-extends-chain-lockfile                  -> ghcr.io/.../git/manifests/1.3.2
case-upgrade-image-merge-config-contributes-only-feature -> ghcr.io/.../git/manifests/1.3.2
```

The set is exactly the six the issue names — verified by measurement, not taken on trust.

**After** — including the new guard, which itself re-enters a namespace:

```
Summary [ 12.014s] 3 tests run: 3 passed, 0 skipped
   PASS deacon::parity_hermetic hermetic_group_fs_heavy
   PASS deacon::parity_hermetic hermetic_group_none
   PASS deacon::parity_hermetic hermetic_lane_runs_without_a_network
```

## The axis, and why it derives

`driver::lane_of` derived from `oracleType` + `resourceGroup` — an axis encoding the pinned oracle and the daemon. "Reaches a registry" cannot be said on it, which is why a registry-dependent case could sit in the lane promising no network with nothing catching it.

- **`TestCase::needs_registry`** (`"needsRegistry": true`), declared in the case's own record — DERIVED the same way `needs_docker` is derived from `resourceGroup`, never a list of case ids in the driver. A list in `driver.rs` would be the same defect one level up: it would live apart from the case it describes, and adding a case would stop being a pure data edit. Excluded from `caseHash` by construction (the hash is an explicit allow-list), so re-laning never marks a snapshot stale.
- **`Lane::Registry`**, resolved in **scarcity order** — oracle, then daemon, then registry. A Docker case that also reaches a registry stays in `parity_docker`: every job with a daemon has network, so the daemon is the binding prerequisite.
- **Not a new `ResourceGroup` variant.** A group answers "what does this case contend for?"; nothing about contention can say "reaches `ghcr.io`", and folding them would make "fs-heavy *and* needs a registry" inexpressible.
- **`parity_registry`** drives it, mirroring `parity_hermetic`: no oracle, no daemon, no skips.

**No behavior claim was rewritten.** The six moved lanes and their assertions are byte-identical. `bhv-extends-feature-version-override` (#411) keeps its `git:1.3.2` → `git:1.3.8` pin exactly as authored — that pin IS the behavior. The whole diff to case data is six `"needsRegistry": true` lines.

## Per-profile selection proof

`cargo nextest list --profile <p>`, test counts:

| profile | `parity_registry` | `parity_hermetic` |
|---|---|---|
| `dev-fast` (**`Test (MVP fast)`** — no token) | **0** | 3 |
| `mvp-integration` (**`Test (MVP integration)`** — required check, GHCR token) | **2** | 3 |
| `ci` | 2 | 3 |
| `docker` | 2 | 3 |
| `full` | 2 | 3 |
| `default` | 2 | 3 |
| `parity` (nightly, oracle only) | 0 | 0 |
| `long-running` | 0 | 0 |

So the six keep gating **every** pull request, on the job actually provisioned for them. `dev-fast` excludes the binary through its existing `binary(#parity_*)` glob whose exceptions are listed explicitly — no new exclusion clause was needed, and a comment in `.config/nextest.toml` says not to add one. `release.yml`'s verify job names the lane explicitly (`parity_hermetic | parity_registry | parity_docker`) so the six keep gating a tag as well; dropping it there would have been a silent coverage regression disguised as a laning change.

`.config/nextest.toml` edits touched 6 profiles × 2 override blocks (the `parity` exclusion and the `parity-cli` grouping). Every profile still carries a `default-filter` — asserted by `registry::tests::parses_and_checks_the_real_nextest_toml` / `a_profile_without_a_default_filter_is_a_problem`, both green. While there, a stale comment claiming `parity_hermetic` is `#![cfg(target_os = "linux")]`-gated was corrected (#441 removed that).

## The guard

`hermetic_lane_runs_without_a_network` re-execs this test binary under `unshare --map-root-user --net`, selecting every test in it *but itself* (`--skip`, a selection rather than a recursion guard flag), with its own temp `DEACON_PARITY_REPORT_DIR` so it cannot race the outer run's fragments.

- **Linux-only, deliberately**: `#[cfg(target_os = "linux")]` with the reason stated in the docstring — `unshare(2)` is a Linux facility and the lane runs on macOS and Windows since #441. A `cfg` is a visible non-selection; a runtime skip reports as a pass.
- **Never a silent skip at run time**: the namespace facility is probed *separately* from being used, so "this host has no unprivileged user namespaces" fails with its own remedy and cannot be misread as "a case reached the network". Both paths `panic!` with a cause-specific message.
- **Cannot pass vacuously**: it asserts the namespaced re-run actually reported its driver tests.

## Broken to verify (all observed red)

1. **The guard itself — the one that matters.** Removed `"needsRegistry": true` from `case-upgrade-extends-chain-lockfile`, putting a registry-reaching case back in the hermetic lane, and ran **with full network**. `hermetic_group_none` PASSED (that is exactly how the six hid for so long); `hermetic_lane_runs_without_a_network` FAILED, naming the case, the URL it could not reach, and the remedy:
   > a `parity_hermetic` case REACHED THE NETWORK. […] Declare `"needsRegistry": true` on the case and it moves to `parity_registry` […] do NOT weaken what the case asserts to fit this lane.
2. **The guard's vacuity check.** Widened `--skip` to match every test: the re-run reported `running 0 tests` and exited 0, and the `2 passed` assertion fired — "this guard checked nothing".
3. **`registry_never_outranks_the_daemon_or_the_oracle`** — reordered `lane_of` to test the registry before the daemon. Red.
4. **`every_lane_has_a_distinct_slug`** — made `Lane::Registry.slug()` return `"hermetic"`. Red.
5. **`only_the_hermetic_lane_raises_config_only_concurrency`** — set the registry lane's concurrency to 8. Red.
6. **`the_registry_axis_is_declared_by_the_case_not_listed_in_the_driver`** and **`the_lanes_partition_every_group`** — made `needs_registry` always return `false`. Both red.

All restored; the suite is green.


## The guard's namespace: measured twice

The first push used `unshare --map-root-user --net`. **It could not run on `ubuntu-latest`** — the very runner where this lane gates:

```
unshare: write failed /proc/self/uid_map: Operation not permitted
```

`unshare(2)` succeeded; the *uid_map write* was denied (Ubuntu 24.04's `kernel.apparmor_restrict_unprivileged_userns`). The guard reported it exactly as designed — as MACHINERY, not as a parity divergence — and `hermetic_group_none` passed alongside it, so the re-laning itself was already green on that run.

The namespace is what the guard needs; the root mapping was only convenience. `unshare --user --net` (second commit) is permitted there, since the failure was *after* the namespace existed. The child then runs as the unmapped overflow uid, so `DEACON_PARITY_REPORT_DIR`, `DEACON_CACHE_DIR`, `HOME` and `TMPDIR` are redirected under a world-writable scratch dir it can create itself. Re-verified after the change: the lane still passes under it, **and it still goes RED** when a registry-reaching case is put back in the hermetic lane with the network fully available. `Test (MVP fast) (ubuntu)` is green on the second push.

## Gates

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo build --all-targets` | pass |
| `make test-nextest-fast` | 3352 passed, 31 skipped, 0 failed |
| `-E 'binary(=parity_hermetic) \| binary(=parity_registry)'` | 5 passed |
| `unshare -rn … -E 'binary(=parity_hermetic)' --offline` | 3 passed (was 1 failed / 6 cases) |
| CI: all 10 required checks | pass (two consecutive all-green polls) |
| `-E 'binary(=parity_docker)'` | 2 pre-existing env-pinned failures, unchanged |
| `cargo nextest run --profile parity` (oracle 0.87.0) | pre-existing env-pinned failures, unchanged |

**Failure-set diffs.** `parity_docker` fails on `case-build-output-export-tar` and `case-build-output-metadata-label` — both the documented local `/etc/docker/daemon.json` `containerd-snapshotter: false` pin ("Docker exporter is not supported for the docker driver"), which the maintainer ruled keep-as-is; identical to `main`. The `--profile parity` diverging set is the documented `universal:2-linux` local pins. Neither lane's case selection can have changed: no `live-differential` or Docker-group case declares `needsRegistry`, and `lane_of`'s ordering keeps the daemon and the oracle ahead of it — which `the_lanes_partition_every_group` asserts.

## Docs

`docs/PARITY.md`'s lane section now names the third prerequisite and the guard; `CLAUDE.md`'s lane table gains the row and the derive-don't-list rule; `docs/testing/nextest.md`, `.config/nextest.toml`, `ci.yml` and `release.yml` carry the reasoning at the point of edit. No `parity/SPEC_STATUS.md` row's evidence claim changed — the six cases still exist and assert the same things — so no row moved and the header census is untouched. `docs/HANDOFF.md` deliberately not edited.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a
