### PR TITLE
docs(CLAUDE.md): dockerComposeFile resolves against the config dir, not the workspace folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,14 @@ Pattern axes worth re-running periodically:
   `commands/shared/feature_resolver::resolve_features_ordered` rather than re-implementing
   the local/OCI + dependency-order loop; `read-configuration` keeps its own richer variant
   for `--additional-features`/auto-mapping/registry grouping).
-- Config-relative vs workspace-relative paths: `dockerComposeFile` resolves against the
-  **workspace folder**; local feature paths (`./…`) resolve against the **config dir**
-  (`config_path.parent()` or `<workspace>/.devcontainer`); a plain `devcontainer.json` at
-  the workspace root is NOT a discovery location.
+- Config-relative vs workspace-relative paths: BOTH `dockerComposeFile` and local feature
+  paths (`./…`) resolve against the **config dir** (`config_path.parent()` or
+  `<workspace>/.devcontainer`) — the spec says `dockerComposeFile` is "relative to the
+  `devcontainer.json` file" (`parity/spec/113500f4/devcontainerjson-reference.md:56`), so
+  for the standard layout it is the `.devcontainer` dir, NOT the workspace folder
+  (`ComposeManager::create_project`, which cites the spec). What IS workspace-relative on
+  that same path: the compose project name and working dir, both derived from `base_path`.
+  A plain `devcontainer.json` at the workspace root is NOT a discovery location.
 
 VERIFY agent claims empirically before filing — the workspace-folder audit produced two
 false positives this session (see "Verified Non-Bugs" below). Auditing also surfaces the


### PR DESCRIPTION
Fixes #555.

`CLAUDE.md`'s "Cross-Cutting Audits" pattern axis said `dockerComposeFile` resolves against the **workspace folder**. It resolves against the **config dir**.

**Spec** (`parity/spec/113500f4/devcontainerjson-reference.md:56`): "Path or an ordered list of paths to Docker Compose files relative to the `devcontainer.json` file."

**Code already agrees and cites it** — `ComposeManager::create_project` (`crates/core/src/compose.rs:832-843`) joins non-absolute paths onto `config_dir`, with a unit test pinning it (`test_create_project_resolves_compose_files_against_config_dir`).

Verified independently for this PR: read the spec line, read the resolution site, confirmed the pinning test. The guidance file is what was wrong — and it had already steered one fixture wrong, which is how #555 was filed.

**No product change.** deacon's behavior is correct and matches the reference.

The bullet exists to draw a config-dir vs workspace-folder contrast, so rather than deleting half of it, the contrast is preserved by naming what genuinely *is* workspace-relative on that same path: the compose project name and working dir, both derived from `base_path`. That is stated in `create_project`'s own comment.

`docs/DIFFERENTIATORS.md` carried a sibling error; it was fixed in #566. A sweep of `AGENTS.md` and `.github/copilot-instructions.md` found no other instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a