### PR TITLE
ci(parity): guard that every open parity issue has a `SPEC_STATUS.md` row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,62 @@ jobs:
     - name: Run doctests
       run: cargo test --doc --workspace
 
+  # Every OPEN issue asserting a deacon-vs-reference difference must be cited by a behavior
+  # row in parity/SPEC_STATUS.md. This is the half `check_spec_status_census` cannot cover:
+  # that check compares the Summary header against the rows, which is arithmetic over what
+  # IS written and is silent about what is missing. #580 was filed on 2026-08-13 with no
+  # row, so the ledger read "0 open nonconformance" for two days with a measured, unfixed
+  # defect in the tracker, and nothing failed.
+  #
+  # A separate job rather than a step in `lint` on purpose: this is the one check here that
+  # needs the GitHub API, and folding it into an already-REQUIRED job would let an API
+  # outage block every pull request on something unrelated to the code.
+  #
+  # NOT a required check until branch protection says so — adding it there is the
+  # maintainer's call.
+  ledger-coverage:
+    name: Ledger (issue coverage)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo registry and target
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    # `--limit 1000` is a deliberate ceiling far above this repository's steady state
+    # (~15 open issues). `gh issue list` truncates SILENTLY at its limit, and a truncated
+    # list would drop obligations without saying so — the one failure mode this job cannot
+    # be allowed to have. Raise it before it can bind, never trim it to "what we need".
+    #
+    # `gh` owns the credentials and the pagination; the Rust side owns the decision. The
+    # binary exits 1 when an obligation is undischarged and 2 when it could not run at all
+    # (unreadable ledger, unparseable or EMPTY issue list) — an empty list is a failed
+    # query, never a vacuous pass.
+    - name: Check every open parity issue has a SPEC_STATUS.md row
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh issue list --state open --limit 1000 \
+          --json number,title,labels \
+          --jq '[.[] | {number, title, labels: [.labels[].name]}]' \
+          | cargo run -q -p parity-harness --bin ledger-issue-coverage
+
   msrv:
     name: MSRV (cargo check)
     if: github.event_name != 'schedule'

--- a/crates/parity-harness/src/bin/ledger-issue-coverage.rs
+++ b/crates/parity-harness/src/bin/ledger-issue-coverage.rs
@@ -1,0 +1,111 @@
+//! Fail when an open issue asserting a deacon-vs-reference difference has no
+//! `parity/SPEC_STATUS.md` row.
+//!
+//! The decision lives in [`parity_harness::registry::check_ledger_covers_issues`], which is
+//! a pure function with hermetic tests. This binary is only the plumbing that gets a live
+//! issue list to it — it is the one place in the parity harness that needs the network, and
+//! keeping it OUT of the library is what leaves the hermetic lane's no-network promise
+//! intact.
+//!
+//! Usage (see `.github/workflows/ci.yml`):
+//!
+//! ```text
+//! gh issue list --state open --limit 200 \
+//!   --json number,title,labels \
+//!   --jq '[.[] | {number, title, labels: [.labels[].name]}]' \
+//!   | cargo run -q -p parity-harness --bin ledger-issue-coverage
+//! ```
+//!
+//! stdin is the issue list because `gh` is the tool that already has the credentials and
+//! the pagination; re-implementing either against the REST API in Rust would add a token
+//! path and a dependency to restate what one shell line does.
+//!
+//! Exit 0 = every obligation discharged. Exit 1 = at least one is not, with each named on
+//! stderr. Exit 2 = the check could not run (unreadable ledger, unparseable input), which is
+//! deliberately NOT folded into exit 1: "the guard failed" and "the guard found something"
+//! are different facts and a CI log should not have to guess which one it is reading.
+
+use std::io::Read as _;
+use std::process::ExitCode;
+
+use parity_harness::parity_root;
+use parity_harness::registry::{LedgerIssue, check_ledger_covers_issues};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let allow_empty = args.iter().any(|a| a == "--allow-empty");
+
+    // The ledger path is an optional argument rather than a constant so the guard can be
+    // WATCHED FAILING, which the campaign requires of every check before it counts. The
+    // only honest demonstration is a historical replay — `git show <sha>:parity/SPEC_STATUS.md`
+    // from a day the ledger was known to be incomplete — and that is impossible against a
+    // hardcoded path. Defaults to this checkout's ledger, so CI passes no argument.
+    let ledger_path = match args.iter().find(|a| !a.starts_with("--")) {
+        Some(path) => std::path::PathBuf::from(path),
+        None => parity_root().join("SPEC_STATUS.md"),
+    };
+    let markdown = match std::fs::read_to_string(&ledger_path) {
+        Ok(text) => text,
+        Err(err) => {
+            eprintln!("could not read {}: {err}", ledger_path.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    let mut raw = String::new();
+    if let Err(err) = std::io::stdin().read_to_string(&mut raw) {
+        eprintln!("could not read the issue list from stdin: {err}");
+        return ExitCode::from(2);
+    }
+
+    // An EMPTY stdin is a failure, not a vacuous pass. `gh` returning nothing means the
+    // query broke, and a check that reports "no obligations" when it was handed no issues
+    // is the exact shape of the defect it exists to prevent.
+    let issues: Vec<LedgerIssue> = match serde_json::from_str(raw.trim()) {
+        Ok(issues) => issues,
+        Err(err) => {
+            eprintln!(
+                "could not parse the issue list as JSON ({err}). Expected the output of \
+                 `gh issue list --json number,title,labels --jq '[.[] | {{number, title, \
+                 labels: [.labels[].name]}}]'`; got {} byte(s).",
+                raw.trim().len()
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    // An EMPTY issue list is treated as a broken query, not as a clean repository. A guard
+    // that reports "every obligation discharged" after checking nothing is the precise
+    // shape of the defect this exists to prevent — and a `gh` invocation that loses its
+    // token, its repo or its `--jq` filter returns `[]` while exiting 0, so success here
+    // would be indistinguishable from having run. `--allow-empty` is the deliberate
+    // override for a repository that genuinely has no open issues.
+    if issues.is_empty() && !allow_empty {
+        eprintln!(
+            "the issue list is empty, which is treated as a FAILED QUERY rather than a clean \
+             repository: a check that passes without checking anything cannot be told apart \
+             from one that ran. Verify the `gh issue list` invocation (repo, auth, --jq), or \
+             pass --allow-empty if this repository really has no open issues."
+        );
+        return ExitCode::from(2);
+    }
+
+    let problems = check_ledger_covers_issues(&issues, &markdown);
+    if problems.is_empty() {
+        println!(
+            "ledger issue coverage: {} open issue(s) checked, every obligation discharged",
+            issues.len()
+        );
+        return ExitCode::SUCCESS;
+    }
+
+    eprintln!(
+        "ledger issue coverage: {} problem(s) across {} open issue(s)",
+        problems.len(),
+        issues.len()
+    );
+    for problem in &problems {
+        eprintln!("  - {problem}");
+    }
+    ExitCode::FAILURE
+}

--- a/crates/parity-harness/src/registry.rs
+++ b/crates/parity-harness/src/registry.rs
@@ -538,6 +538,145 @@ pub fn check_spec_status_census(markdown: &str) -> Vec<String> {
     problems
 }
 
+/// An open GitHub issue, reduced to the three fields the ledger-coverage check reads.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct LedgerIssue {
+    pub number: u64,
+    pub title: String,
+    /// Label names. `gh issue list --json labels` emits objects; the caller flattens.
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+/// The label whose stated meaning IS the ledger obligation: "Real divergence from the
+/// reference CLI."
+pub const LEDGER_ISSUE_LABEL: &str = "parity-drift";
+
+/// Conventional-commit scopes that describe tooling rather than deacon's observable
+/// behavior. A `fix(...)` in one of these owes no behavior row.
+///
+/// Deliberately SHORT and closed. Every scope added here is a hole in the check, so the
+/// bar is "this scope cannot name a deacon-vs-reference difference", not "this issue
+/// happened not to need a row".
+const NON_BEHAVIORAL_SCOPES: &[&str] = &[
+    "ci",
+    "build",
+    "docs",
+    "doc",
+    "test",
+    "tests",
+    "chore",
+    "deps",
+    "dependencies",
+    "examples",
+    "handoff",
+];
+
+/// Does this open issue owe `parity/SPEC_STATUS.md` a row?
+///
+/// **The label alone is not the selector, and that is the whole point.** The
+/// [`LEDGER_ISSUE_LABEL`] convention was applied through #557 and then quietly lapsed:
+/// #564, #569, #571, #572 and #580 all carry no label at all. A check keyed only on the
+/// label would therefore have passed on the very incident that motivated it. So the title
+/// is read too — this repository already writes issue titles as conventional commits, and
+/// a `fix(<scope>)` or `parity(<scope>)` title is a claim about deacon's behavior whether
+/// or not anybody remembered to click a label.
+fn owes_a_behavior_row(issue: &LedgerIssue) -> bool {
+    if issue.labels.iter().any(|label| label == LEDGER_ISSUE_LABEL) {
+        return true;
+    }
+
+    let title = issue.title.trim();
+    if title.starts_with("parity(") || title.starts_with("parity:") || title.starts_with("fix:") {
+        return true;
+    }
+    match title.strip_prefix("fix(").and_then(|r| r.split_once(')')) {
+        Some((scope, _)) => !NON_BEHAVIORAL_SCOPES.contains(&scope.trim()),
+        None => false,
+    }
+}
+
+/// Does `row` cite issue `number`, as `#580` or as an `…/issues/580` link?
+///
+/// The trailing-digit test is load-bearing: without it `#58` matches inside `#580` and a
+/// missing row is reported as covered by an unrelated one.
+fn row_cites_issue(row: &str, number: u64) -> bool {
+    let n = number.to_string();
+    [format!("#{n}"), format!("issues/{n}")]
+        .iter()
+        .any(|pattern| {
+            let mut from = 0;
+            while let Some(offset) = row[from..].find(pattern.as_str()) {
+                let end = from + offset + pattern.len();
+                if !row[end..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit())
+                {
+                    return true;
+                }
+                from = end;
+            }
+            false
+        })
+}
+
+/// Every open issue that asserts a deacon-vs-reference difference must be cited by a
+/// behavior ROW in `parity/SPEC_STATUS.md`. Returns human-readable problems (empty = OK).
+///
+/// **Why this exists, precisely.** "Ledger honesty" has been a campaign rule from the
+/// start: a measured difference gets an issue AND a row the day it is found. On
+/// 2026-08-13 [#580](https://github.com/get2knowio/deacon/issues/580) got the issue and no
+/// row, so for two days the Summary read "0 open nonconformance" while a measured,
+/// reproduced, unfixed defect sat in the tracker. Nothing caught it and nothing could:
+/// [`check_spec_status_census`] compares the header against the rows, which is arithmetic
+/// over what IS written and says nothing about what is missing. **The one number in that
+/// document with CI behind it was the one that cannot tell you whether the rows are
+/// complete.** This check supplies the other half by enumerating obligations from a source
+/// the ledger does not control.
+///
+/// It is therefore the only check in this module that needs the network, which is why the
+/// live issue list is a PARAMETER: the decision stays a pure function with hermetic tests,
+/// and a thin caller (`src/bin/ledger-issue-coverage.rs`) supplies the `gh` output. The
+/// hermetic lane's no-network promise is untouched.
+///
+/// Rows are matched exactly as the census matches them — a `|`-delimited line whose second
+/// cell prefix-matches a known status — so "cited in a row" cannot be satisfied by a
+/// passing mention in the Summary narrative. The obligation is a ROW; that is what was
+/// missing.
+pub fn check_ledger_covers_issues(open_issues: &[LedgerIssue], markdown: &str) -> Vec<String> {
+    let rows: Vec<&str> = markdown
+        .lines()
+        .filter(|line| {
+            line.trim_start()
+                .strip_prefix('|')
+                .and_then(|rest| rest.split('|').nth(1))
+                .is_some_and(|cell| {
+                    let cell = cell.trim().trim_matches('*').trim();
+                    SPEC_STATUS_LABELS
+                        .iter()
+                        .any(|(label, _)| cell.starts_with(label))
+                })
+        })
+        .collect();
+
+    open_issues
+        .iter()
+        .filter(|issue| owes_a_behavior_row(issue))
+        .filter(|issue| !rows.iter().any(|row| row_cites_issue(row, issue.number)))
+        .map(|issue| {
+            format!(
+                "SPEC_STATUS.md: open issue #{} (`{}`) asserts a deacon-vs-reference \
+                 difference but no behavior row cites it — add the row in the commit that \
+                 files the issue, or, if it owes none, say so on the issue and drop the \
+                 `{LEDGER_ISSUE_LABEL}` label / retitle it out of `fix(`",
+                issue.number,
+                issue.title.trim()
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -607,6 +746,113 @@ Of **3 recorded behaviors**:
                 .any(|p| p.contains("no `Of **N recorded behaviors**` line")),
             "a missing Summary must be flagged"
         );
+    }
+
+    fn issue(number: u64, title: &str, labels: &[&str]) -> LedgerIssue {
+        LedgerIssue {
+            number,
+            title: title.to_string(),
+            labels: labels.iter().map(|l| l.to_string()).collect(),
+        }
+    }
+
+    const LEDGER: &str = "\
+Of **2 recorded behaviors**:
+
+- **0** — open nonconformance
+- **0** — deacon extension
+- **2** — conformant and matching
+- **0** — deacon follows the spec where the CLI does not
+- **0** — documented choice
+
+Narrative prose mentioning #900 outside any row.
+
+| Behavior | Status | Evidence | Notes |
+|---|---|---|---|
+| something | matches the reference | 1 scenario | closes [#123](https://github.com/get2knowio/deacon/issues/123) |
+| something else | matches the reference | 1 scenario | see #58 for the sibling |
+";
+
+    /// The obligation is discharged by a ROW, whether the citation is a bare `#123` or a
+    /// full issue link.
+    #[test]
+    fn ledger_coverage_accepts_an_issue_cited_by_a_row() {
+        assert!(
+            check_ledger_covers_issues(
+                &[issue(123, "fix(compose): a real difference", &[])],
+                LEDGER
+            )
+            .is_empty()
+        );
+        assert!(
+            check_ledger_covers_issues(&[issue(58, "parity(up): a real difference", &[])], LEDGER)
+                .is_empty()
+        );
+    }
+
+    /// The #580 incident, replayed. An unlabelled `fix(<behavioral scope>)` issue with no
+    /// row is exactly what slipped through, so this is the case that must fail.
+    #[test]
+    fn ledger_coverage_catches_the_580_shape() {
+        let problems = check_ledger_covers_issues(
+            &[issue(
+                580,
+                "fix(compose): with no authored `name:`, deacon resolves COMPOSE_PROJECT_NAME \
+                 from only one of the sources Compose uses",
+                &[],
+            )],
+            LEDGER,
+        );
+        assert_eq!(problems.len(), 1, "{problems:#?}");
+        assert!(problems[0].contains("#580"), "{problems:#?}");
+    }
+
+    /// A mention in the Summary narrative does NOT discharge the obligation. The rule is a
+    /// row; anything looser would have been satisfied by prose while the ledger stayed
+    /// wrong.
+    #[test]
+    fn ledger_coverage_ignores_citations_outside_a_row() {
+        let problems =
+            check_ledger_covers_issues(&[issue(900, "fix(up): narrated but unrowed", &[])], LEDGER);
+        assert_eq!(problems.len(), 1, "{problems:#?}");
+    }
+
+    /// `#58` must not be read as covering `#580`, or a missing row is reported as covered
+    /// by an unrelated one.
+    #[test]
+    fn ledger_coverage_does_not_match_an_issue_number_prefix() {
+        let problems = check_ledger_covers_issues(&[issue(5, "fix(up): five", &[])], LEDGER);
+        assert_eq!(
+            problems.len(),
+            1,
+            "`#5` must not match `#58`: {problems:#?}"
+        );
+    }
+
+    /// The label selects on its own — that is its stated meaning — even when the title is
+    /// a `chore(` that would otherwise be exempt.
+    #[test]
+    fn ledger_coverage_selects_on_the_label_alone() {
+        let problems = check_ledger_covers_issues(
+            &[issue(777, "chore(parity): tooling", &[LEDGER_ISSUE_LABEL])],
+            LEDGER,
+        );
+        assert_eq!(problems.len(), 1, "{problems:#?}");
+    }
+
+    /// Issues that owe nothing are silent: feature work, tooling scopes, and a
+    /// `fix(<non-behavioral scope>)`. A check that demanded a row from every open issue
+    /// would be turned off within a week.
+    #[test]
+    fn ledger_coverage_exempts_issues_that_owe_no_row() {
+        let exempt = [
+            issue(1, "feat(up): add a flag", &["enhancement"]),
+            issue(2, "chore(parity): mine upstream fixtures", &[]),
+            issue(3, "fix(ci): the windows lane is flaky", &[]),
+            issue(4, "fix(docs): a typo", &[]),
+            issue(5, "Spike: feasibility of a Podman CI lane", &[]),
+        ];
+        assert!(check_ledger_covers_issues(&exempt, LEDGER).is_empty());
     }
 
     #[test]

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -31,6 +31,10 @@ changes, update this file in the same PR.
   worth naming: filing feels like recording, and it is the half that leaves a trace
   somewhere else. (#580 is closed and its row is `matches the reference`, so the
   column is legitimately 0 again — but it was not while the issue was open.)
+  **This is now guarded** — see "Ledger honesty" below — by a check that enumerates
+  obligations from the ISSUE side, which is the only side the ledger does not
+  control. The guard was watched failing against the real #580 state rather than a
+  synthetic one.
 - **Closing a defect can ADD rows, and that is not inflation.** #575 took the
   census 132 → 134 while closing an open nonconformance, because making deacon read
   the lockfile made two further behaviors observable that were previously vacuous:
@@ -256,7 +260,26 @@ each learned from a real failure:
   so a stale side-finding can poison a *different* issue's cause section too.
 - **Ledger honesty**: every measured deacon-vs-reference difference gets a GitHub
   issue and a `SPEC_STATUS.md` row the day it is found; rows and header census
-  move in the same commit.
+  move in the same commit. **Enforced since 2026-08-15, after the rule was broken
+  by #580.** `check_ledger_covers_issues` (registry.rs) requires every OPEN issue
+  that asserts a difference to be cited by a behavior ROW — a mention in the
+  Summary narrative does not discharge it, because the obligation is a row and a
+  row is what was missing. The selector deliberately does **not** rest on the
+  `parity-drift` label: that convention was applied through #557 and then lapsed,
+  and #564/#569/#571/#572/#580 all carry no label at all, so a label-only check
+  would have passed on the very incident that motivated it. It selects on the
+  label OR a `fix(<behavioral scope>)` / `parity(…)` title, with a short closed
+  list of non-behavioral scopes (`ci`, `docs`, `build`, `test`, …) as the only
+  exemption. The live issue list is a PARAMETER, so the decision stays a pure
+  function with hermetic tests and the hermetic lane keeps its no-network promise;
+  `src/bin/ledger-issue-coverage.rs` is the thin caller and the `Ledger (issue
+  coverage)` job in `ci.yml` supplies `gh` output. **Watched failing against the
+  real incident**, not a synthetic one: replayed with #580's actual title against
+  `git show f6b7c10:parity/SPEC_STATUS.md`, it exits 1 and names the issue; against
+  today's ledger it exits 0. An EMPTY issue list is exit 2, not a pass — a broken
+  `gh` query returns `[]` and exits 0, and a guard that reports success after
+  checking nothing is the defect it exists to prevent. It is **not a required check
+  until branch protection says so**; adding it there is a maintainer call.
 - **Merges are API-verified** (`gh pr view --json state,mergeCommit`), never
   trusted from an agent's report. If `--delete-branch` trips on a worktree-held
   ref, delete via `gh api -X DELETE repos/get2knowio/deacon/git/refs/heads/<branch>`.


### PR DESCRIPTION
## Why

"Ledger honesty" has been a campaign rule from the start: a measured deacon-vs-reference difference gets an issue **and** a `parity/SPEC_STATUS.md` row the day it is found. On 2026-08-13, #580 got the issue and no row — so for two days the Summary read **"0 open nonconformance"** while a measured, reproduced, unfixed defect sat in the tracker.

Nothing caught it, and nothing could. `check_spec_status_census` compares the header against the rows, which is arithmetic over what *is* written and says nothing about what is missing. **The one number in that document with CI behind it is the one that cannot tell you whether the rows are complete.** This supplies the other half by enumerating obligations from the *issue* side — the only side the ledger does not control.

## The selector is not the label, on purpose

The obvious implementation keys on the `parity-drift` label, whose stated meaning already *is* the obligation. It would not have worked. That convention was applied through #557 and then quietly lapsed:

| issue | label | owed a row |
|---|---|---|
| #556, #557 | `parity-drift` | ✅ |
| #564, #569, #571, #572, **#580** | *(none)* | ✅ |

A label-only check passes on every one of the unlabelled ones — including the incident that motivated it. So the title is read too: this repo already writes issue titles as conventional commits, and a `fix(<scope>)` or `parity(...)` title is a claim about behavior whether or not anyone clicked a label. A short, closed list of non-behavioral scopes (`ci`, `docs`, `build`, `test`, …) is the only exemption.

Citation must be by a **behavior row**. A mention in the Summary narrative does not discharge it — the obligation is a row, and a row is what was missing.

## Shape

Follows the module's existing checks. The decision is a pure function with hermetic tests; the live issue list is a **parameter**; a thin bin supplies `gh` output. This is the one check here that needs the network, and keeping it out of the library leaves the hermetic lane's no-network promise intact. It is a **separate CI job**, not a step in the already-required `lint` job, so a GitHub API outage cannot block every PR on something unrelated to the code.

## Watched failing — against the real incident, not a synthetic one

```
$ gh issue view 580 --json number,title --jq '[{number, title, labels: []}]' \
    | ledger-issue-coverage <(git show f6b7c10:parity/SPEC_STATUS.md)
ledger issue coverage: 1 problem(s) across 1 open issue(s)
  - SPEC_STATUS.md: open issue #580 (`fix(compose): with no authored `name:` …`)
    asserts a deacon-vs-reference difference but no behavior row cites it …
exit=1

$ … | ledger-issue-coverage          # today's ledger, row present
ledger issue coverage: 1 open issue(s) checked, every obligation discharged
exit=0
```

The ledger path is an argument precisely so this replay is possible — a guard whose path is hardcoded cannot be watched failing. Against the live open set (15 issues) it exits 0 with no special-casing: #480 is already cited by rows.

## Two vacuity holes closed in the plumbing

Both are the same shape as the defect being guarded — a check that looks like it ran when it didn't:

- **An empty issue list is exit 2, not a pass.** A `gh` invocation that loses its token, repo or `--jq` filter returns `[]` and exits 0; reporting "every obligation discharged" after checking nothing is exactly the failure mode this job exists to prevent. `--allow-empty` is the deliberate override.
- **`--limit` raised far above the steady state.** `gh issue list` truncates silently, and a truncated list drops obligations without saying so.

Exit codes are distinct on purpose: **1** = an obligation is undischarged, **2** = the guard could not run. A CI log should not have to guess which it is reading.

## Not required yet

This does not gate until branch protection lists it. Adding it there is your call — the check is designed to be safe to require (it fails closed on its own breakage rather than passing).

Verified: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `make test-nextest-fast` (3424 passed, +6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a