### PR TITLE
fix(build): restore `cargo run -- <subcommand>` at the workspace root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,14 @@ jobs:
     # list would drop obligations without saying so — the one failure mode this job cannot
     # be allowed to have. Raise it before it can bind, never trim it to "what we need".
     #
-    # `gh` owns the credentials and the pagination; the Rust side owns the decision. The
-    # binary exits 1 when an obligation is undischarged and 2 when it could not run at all
+    # `gh` owns the credentials and the pagination; the Rust side owns the decision. It
+    # exits 1 when an obligation is undischarged and 2 when it could not run at all
     # (unreadable ledger, unparseable or EMPTY issue list) — an empty list is a failed
     # query, never a vacuous pass.
+    #
+    # `--example`, not `--bin`: a second `[[bin]]` anywhere in the workspace makes a bare
+    # `cargo run -- <subcommand>` ambiguous, and that is the documented developer loop.
+    # See the guard's own module docs for why this target lives in `examples/`.
     - name: Check every open parity issue has a SPEC_STATUS.md row
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +127,7 @@ jobs:
         gh issue list --state open --limit 1000 \
           --json number,title,labels \
           --jq '[.[] | {number, title, labels: [.labels[].name]}]' \
-          | cargo run -q -p parity-harness --bin ledger-issue-coverage
+          | cargo run -q -p parity-harness --example ledger-issue-coverage
 
   msrv:
     name: MSRV (cargo check)

--- a/crates/parity-harness/examples/ledger-issue-coverage.rs
+++ b/crates/parity-harness/examples/ledger-issue-coverage.rs
@@ -10,11 +10,29 @@
 //! Usage (see `.github/workflows/ci.yml`):
 //!
 //! ```text
-//! gh issue list --state open --limit 200 \
+//! gh issue list --state open --limit 1000 \
 //!   --json number,title,labels \
 //!   --jq '[.[] | {number, title, labels: [.labels[].name]}]' \
-//!   | cargo run -q -p parity-harness --bin ledger-issue-coverage
+//!   | cargo run -q -p parity-harness --example ledger-issue-coverage
 //! ```
+//!
+//! # Why this is an `example` and not a `bin`
+//!
+//! A second `[[bin]]` anywhere in the workspace makes a bare `cargo run -- <subcommand>`
+//! ambiguous — cargo refuses and lists both binaries. That invocation is the documented
+//! developer loop (`cargo run -- up`, CLAUDE.md and AGENTS.md), and it broke the moment
+//! this guard first landed as `src/bin/`. An `examples/` target is runnable the same way
+//! (`--example` instead of `--bin`), stays covered by `cargo clippy --all-targets`
+//! (verified: a deliberate `unused_variable` here is reported), and does not join the
+//! `cargo run` namespace.
+//!
+//! The alternatives were worse. `default-members = ["crates/deacon"]` fixes `cargo run`
+//! and silently narrows `cargo clippy --all-targets` and every `cargo nextest run
+//! --profile …` to one package — the parity lanes would select NOTHING, which is the
+//! exact silent-scope-reduction failure `.config/nextest.toml` already has a rule about.
+//! `required-features` does not help: the target still counts for disambiguation
+//! (measured, not assumed). Rewriting eight documented `cargo run --` invocations to
+//! `-p deacon` fixes nothing for anyone typing from memory.
 //!
 //! stdin is the issue list because `gh` is the tool that already has the credentials and
 //! the pagination; re-implementing either against the REST API in Rust would add a token


### PR DESCRIPTION
My regression from #583, two commits old.

Adding the ledger-coverage guard as `crates/parity-harness/src/bin/` made it the workspace's second binary, and cargo then refuses a bare `cargo run`:

```
error: `cargo run` could not determine which binary to run.
available binaries: deacon, ledger-issue-coverage
```

That invocation is documented in **eight places** across `CLAUDE.md`, `AGENTS.md` and `README.md` — `cargo run -- up`, `cargo run -- --help`, the `RUST_LOG=debug cargo run -- <command>` examples — and it is what anyone types from memory.

## Fix

Moved the guard to `examples/`. It is runnable the same way (`--example` instead of `--bin`), stays covered by `cargo clippy --all-targets`, and does not join the `cargo run` namespace.

Lint coverage verified rather than assumed — planted a deliberate `unused_variable` in the moved file and watched clippy report it:

```
warning: unused variable: `unused_probe`
  --> crates/parity-harness/examples/ledger-issue-coverage.rs:113:23
```

## Alternatives measured and rejected

| Option | Why not |
|---|---|
| `default-members = ["crates/deacon"]` | Fixes `cargo run`, then silently narrows `cargo clippy --all-targets` (CI runs it without `--workspace`) and **every** `cargo nextest run --profile …` to one package. The parity lanes live in `parity-harness`, so they would select **nothing** — the exact silent-scope-reduction failure `.config/nextest.toml` already carries a rule about. |
| `required-features` on the bin | Does not remove the target from disambiguation. Tried it; cargo still lists both binaries. |
| Rewrite the docs to `-p deacon` | Fixes nothing for anyone typing from memory, and there are eight of them. |

The reasoning lives in the guard's own module docs, next to the code someone would have to move to undo it.

## Verified

- `cargo run -- --version` → `deacon 0.3.0`
- `gh issue list … | cargo run -q -p parity-harness --example ledger-issue-coverage` → `16 open issue(s) checked, every obligation discharged`
- `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvM19ZqL2AkpbSmdQYk79a