### PR TITLE
chore(examples): make up/build exec.sh scripts self-clean workspace artifacts (#179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,12 @@ artifacts/nextest/full-timing.json
 # runs. The intentionally-committed lockfile-demo lives at an example root (not
 # in a .devcontainer/ dir), so this scoped rule leaves it tracked.
 **/.devcontainer/devcontainer-lock.json
+# The lockfile takes the config's leading dot: a workspace-root `.devcontainer.json`
+# yields a workspace-root `.devcontainer-lock.json` (see `lockfile_path_for_config`),
+# which the scoped rule above does not match. That spelling is ALWAYS generated —
+# nothing under examples/ commits one — so it is ignored unscoped, with the parity
+# fixture exemption below covering the one place it is version-controlled INPUT.
+**/.devcontainer-lock.json
 # ...but a parity fixture's lockfile is test INPUT, not a generated artifact:
 # a case asserts what the lockfile makes the CLI report. Without this exemption
 # `git add -A` skips it silently, the fixture works locally (the file is in the
@@ -77,6 +83,7 @@ artifacts/nextest/full-timing.json
 # so the rule looked like it was working right up until the next NEW fixture
 # lockfile was silently skipped. Keep this glob in step with the data root.
 !parity/fixtures/**/devcontainer-lock.json
+!parity/fixtures/**/.devcontainer-lock.json
 
 # Beads / Dolt files (added by bd init)
 .dolt/

--- a/examples/CANARY_STATUS.md
+++ b/examples/CANARY_STATUS.md
@@ -22,6 +22,29 @@ pass, so they don't have to be re-evaluated from scratch every session.
 - `🚫 deferred` — exercises a deacon capability that isn't implemented yet.
 - `❓ unverified` — not evaluated this cycle.
 
+Targeted sweep: **2026-08-20** against `main` @ `f716920`, verifying the #179
+self-cleaning change (every `up`/`build` `exec.sh` now removes its own workspace
+artifacts from an `EXIT` trap). Nine canaries run end to end with the release
+binary — `build/basic-dockerfile`, `build/compose-missing-service`,
+`build/dockerfile-with-features`, `features/local-feature`, `up/basic-image`,
+`up/compose-basic`, `up/dockerfile-build`, `up/host-ca`, `up/up-exec-down` — all
+`✅ pass`, each leaving `git status` clean **and** no `.devcontainer-state/`,
+`.devcontainer/build-cache/`, `.deacon/` or lockfile on disk. What the baseline
+measured, before the change:
+
+- The three directories #179 named no longer appear at all: #280 moved lifecycle
+  markers, the build cache and the transient build context to `~/.deacon/`. The
+  traps are a durable guard against a regression there, not a live cleanup.
+- The one artifact still landing in the workspace is the **feature lockfile**.
+  It is written beside the config and takes the config's leading dot, so a
+  workspace-root `.devcontainer.json` yields a workspace-root
+  `.devcontainer-lock.json` — a spelling #178's `.gitignore` did not match, so a
+  bare `deacon build` on `build/dockerfile-with-features` dirtied `git status`.
+  Both the traps and the `.gitignore` now cover all four spellings.
+- Unrelated pre-existing gap, NOT fixed here: `up/up-exec-down` finishes with a
+  plain `deacon down`, which per `shutdownAction: stopContainer` *stops* rather
+  than removes, so it leaves one exited container behind. Removed by hand.
+
 Targeted sweep: **2026-08-05** against `main` @ `a496609` + the #493 example
 migration. The 13 rows that #488 had turned `⚠️ fixture` are `✅ pass` again. #493
 moved each example's local Feature folders under `.devcontainer/` and re-spelled the
@@ -108,6 +131,8 @@ two were unclassified and have since been decided (both fixture-side):
 Sweep hygiene note: canaries left 9 stray `*devcontainer-lock.json` files and
 (via the missing `nginx.conf`) one root-owned directory in the working tree.
 Removed by hand; `exec.sh` cleanup is incomplete for those examples.
+(The lockfile half of this is resolved as of the 2026-08-20 sweep above — every
+`up`/`build` `exec.sh` now removes its own lockfile from its `EXIT` trap, #179.)
 
 Prior sweep: 2026-05-29 (against `main` including PRs #129/#131/#132/#134/#139/
 #143/#144/#145 and #147/#148/#149/#150/#151), when every row was ✅. A later
@@ -120,13 +145,13 @@ and aren't listed.
 
 | Canary | Status | Verified | Notes |
 |---|---|---|---|
-| build/basic-dockerfile | ✅ pass | 2026-07-20 `de5b045` |  |
+| build/basic-dockerfile | ✅ pass | 2026-08-20 `f716920` | #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | build/buildkit-gated-feature | ✅ pass | 2026-08-05 `a496609` | needs debian base + `build.dockerfile` (#129) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
-| build/compose-missing-service | ✅ pass | 2026-07-20 `de5b045` | asserts error |
+| build/compose-missing-service | ✅ pass | 2026-08-20 `f716920` | asserts error #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | build/compose-service-target | ✅ pass | 2026-07-20 `de5b045` |  |
 | build/compose-unsupported-flags | ✅ pass | 2026-07-20 `de5b045` | asserts errors (`--push`/`--output`) |
 | build/compose-with-features | ✅ pass | 2026-08-05 `a496609` | compose+features build (#139) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
-| build/dockerfile-with-features | ✅ pass | 2026-08-05 `a496609` | feature layering (#129) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
+| build/dockerfile-with-features | ✅ pass | 2026-08-20 `f716920` | feature layering (#129) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | build/duplicate-tags | ✅ pass | 2026-07-22 `3db4306` | tag de-dup (#129); exec.sh updated to assert `imageName` array form (#330) |
 | build/image-reference | ✅ pass | 2026-07-20 `de5b045` |  |
 | build/image-reference-with-features | ✅ pass | 2026-08-05 `a496609` | image-ref+features (#134) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
@@ -162,7 +187,7 @@ and aren't listed.
 | features/dependency-ordering | ✅ pass | 2026-08-05 `a496609` | auto install order via `installsAfter`+`dependsOn` (no override); now uses local-path `dependsOn` form `./feature-lib` (#155, PR #158) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
 | features/feature-contributed-lifecycle | ✅ pass | 2026-08-05 `a496609` | #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
 | features/feature-env-injection | ✅ pass | 2026-08-05 `a496609` | #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
-| features/local-feature | ✅ pass | 2026-08-05 `a496609` | local `./` feature install + option override (new) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
+| features/local-feature | ✅ pass | 2026-08-20 `f716920` | local `./` feature install + option override (new) #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | features/lockfile | ✅ pass | 2026-07-20 `de5b045` | lockfile generate / `--frozen-lockfile` pass + mismatch fail; needs ghcr (new) |
 | features/oci-digest-pin | ✅ pass | 2026-07-20 `8179744` | digest ref round-trip regression of #131, fixed in PR #321 (`reference()` now joins a digest with `@`); re-verified green post-merge. |
 | features/option-sanitization | ✅ pass | 2026-08-05 `a496609` | #493 moved the local Features under `.devcontainer/` and re-spelled the ids config-relative; deacon **and** the reference CLI 0.87.0 both accept the new layout (both exited 1 before). |
@@ -184,15 +209,15 @@ and aren't listed.
 | template-management/optional-paths | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/additional-mounts | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/auto-forward | ✅ pass | 2026-07-20 `de5b045` | `--auto-forward` loopback reach + multi-container collision-free (015) |
-| up/basic-image | ✅ pass | 2026-07-20 `de5b045` |  |
-| up/compose-basic | ✅ pass | 2026-07-20 `de5b045` |  |
+| up/basic-image | ✅ pass | 2026-08-20 `f716920` | #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
+| up/compose-basic | ✅ pass | 2026-08-20 `f716920` | #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | up/compose-profiles | ⚠️ fixture | 2026-07-20 `de5b045` | `nginx.conf` referenced by docker-compose.yml but never committed → docker makes a dir, bind mount fails. Not a deacon bug. |
 | up/configuration-output | ✅ pass | 2026-07-20 `de5b045` | base switched alpine→debian:bookworm-slim (git feature needs bash) (#151) |
 | up/container-user-vs-remote-user | ✅ pass | 2026-07-20 `de5b045` |  |
-| up/dockerfile-build | ✅ pass | 2026-07-20 `de5b045` |  |
+| up/dockerfile-build | ✅ pass | 2026-08-20 `f716920` | #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | up/dotfiles-integration | ✅ pass | 2026-07-20 `de5b045` | repo URL `codespaces/dotfiles` (404)→`holman/dotfiles` (#151); `~` target-path expansion (#150) |
 | up/gpu-modes | ✅ pass | 2026-07-20 `de5b045` | GPU `all` failure expected on non-GPU hosts (tolerated) |
-| up/host-ca | ✅ pass | 2026-07-20 `de5b045` | `--inject-host-ca` explicit bundle; debian-slim → env-var-only fallback (no `ca-certificates`), canonical bundle + CA env vars present (016) |
+| up/host-ca | ✅ pass | 2026-08-20 `f716920` | `--inject-host-ca` explicit bundle; debian-slim → env-var-only fallback (no `ca-certificates`), canonical bundle + CA env vars present (016) #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | up/id-labels-reconnect | ✅ pass | 2026-07-20 `de5b045` | full-ID on reconnect (#143) |
 | up/image-metadata-merge | ✅ pass | 2026-07-22 `3db4306` | scenario 4 (warm read-config) regressed by #339, fixed in PR #342 (container-first metadata resolution) |
 | up/initialize-command | ✅ pass | 2026-07-20 `de5b045` |  |
@@ -204,7 +229,7 @@ and aren't listed.
 | up/remove-existing | ✅ pass | 2026-07-20 `de5b045` | full-ID reuse (#143) |
 | up/security-options | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/skip-lifecycle | ✅ pass | 2026-07-20 `de5b045` |  |
-| up/up-exec-down | ✅ pass | 2026-07-22 `3db4306` | compound-flow up→exec→run-user-commands→down by --workspace-folder (#187 configHash fix); exec.sh drops `--mount-workspace-git-root false` so all four subcommands anchor consistently (run-user-commands/down lack the flag) |
+| up/up-exec-down | ✅ pass | 2026-08-20 `f716920` | compound-flow up→exec→run-user-commands→down by --workspace-folder (#187 configHash fix); exec.sh drops `--mount-workspace-git-root false` so all four subcommands anchor consistently (run-user-commands/down lack the flag) #179 self-clean verified: no `.devcontainer-state/` / `.devcontainer/build-cache/` / `.deacon/` / lockfile residue after the run. |
 | up/update-remote-user-uid | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/user-env-probe-modes | ✅ pass | 2026-07-20 `de5b045` |  |
 | up/wait-for | ✅ pass | 2026-07-20 `de5b045` |  |

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,22 @@
 
 Each subdirectory under `examples/` is fully self‑contained: copy or `cd` into it and run the shown commands without referencing assets elsewhere in the repo.
 
+### Self-cleaning contract
+
+Every `exec.sh` leaves its directory exactly as committed. Container-backed
+examples clean up their containers, images and volumes, and every `up`/`build`
+script additionally arms an `EXIT` trap (`clean_workspace_artifacts`) that removes
+the runtime artifacts deacon can write into the workspace — `.devcontainer-state/`,
+`.devcontainer/build-cache/`, `.deacon/`, `.deacon-temp-build/`, and the generated
+`devcontainer-lock.json` (which takes the config's leading dot, so a workspace-root
+`.devcontainer.json` yields `.devcontainer-lock.json`). Because it runs from a trap,
+a failing scenario cleans up too.
+
+The trap removes only those generated paths — never the committed
+`.devcontainer/` config or fixtures. Each script carries its own copy of the
+function on purpose: there is deliberately **no** shared sourced helper library,
+so a directory stays copy-and-run self-contained.
+
 ### Status: which examples pass today
 
 Several of the newer examples are intentionally designed as **canaries** — they exercise spec-mandated behavior that deacon doesn't fully implement yet. If you run them today and they fail, it's by design.

--- a/examples/build/basic-dockerfile/exec.sh
+++ b/examples/build/basic-dockerfile/exec.sh
@@ -13,7 +13,24 @@ cleanup_images() {
 	docker images --filter "label=example.type=basic-dockerfile" -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 
-trap cleanup_images EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup_images; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/buildkit-gated-feature/exec.sh
+++ b/examples/build/buildkit-gated-feature/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/compose-missing-service/exec.sh
+++ b/examples/build/compose-missing-service/exec.sh
@@ -17,6 +17,25 @@ run_expect_fail() {
 	echo "Received expected failure (exit $code)" >&2
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Compose missing service (README: expect error) ==" >&2

--- a/examples/build/compose-service-target/exec.sh
+++ b/examples/build/compose-service-target/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f myapp:latest >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/compose-unsupported-flags/exec.sh
+++ b/examples/build/compose-unsupported-flags/exec.sh
@@ -17,6 +17,25 @@ run_expect_fail() {
 	echo "Received expected failure (exit $code)" >&2
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Unsupported --push in compose mode (README) ==" >&2

--- a/examples/build/compose-with-features/exec.sh
+++ b/examples/build/compose-with-features/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/dockerfile-with-features/exec.sh
+++ b/examples/build/dockerfile-with-features/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/duplicate-tags/exec.sh
+++ b/examples/build/duplicate-tags/exec.sh
@@ -15,7 +15,24 @@ cleanup() {
 	docker images --filter "reference=deacon-build:*" -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/image-reference-with-features/exec.sh
+++ b/examples/build/image-reference-with-features/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/image-reference/exec.sh
+++ b/examples/build/image-reference/exec.sh
@@ -14,7 +14,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/invalid-config-name/exec.sh
+++ b/examples/build/invalid-config-name/exec.sh
@@ -17,6 +17,25 @@ run_expect_fail() {
 	echo "Received expected failure (exit $code)" >&2
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Invalid config filename (README: expect error) ==" >&2

--- a/examples/build/multi-tags-and-labels/exec.sh
+++ b/examples/build/multi-tags-and-labels/exec.sh
@@ -15,7 +15,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG1" "$IMAGE_TAG2" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/output-archive/exec.sh
+++ b/examples/build/output-archive/exec.sh
@@ -16,7 +16,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/platform-and-cache/exec.sh
+++ b/examples/build/platform-and-cache/exec.sh
@@ -13,7 +13,24 @@ cleanup() {
 	docker images --filter "label=example.type=platform-and-cache" -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/push-output-conflict/exec.sh
+++ b/examples/build/push-output-conflict/exec.sh
@@ -17,6 +17,25 @@ run_expect_fail() {
 	echo "Received expected failure (exit $code)" >&2
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== --push and --output conflict (README: expect error) ==" >&2

--- a/examples/build/push/exec.sh
+++ b/examples/build/push/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	docker rmi -f "$IMAGE_TAG1" "$IMAGE_TAG2" >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/secrets-and-ssh/exec.sh
+++ b/examples/build/secrets-and-ssh/exec.sh
@@ -22,7 +22,24 @@ cleanup() {
 	docker images --filter "label=example.type=secrets-and-ssh" -q | xargs -r docker rmi -f >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/build/unwritable-output/exec.sh
+++ b/examples/build/unwritable-output/exec.sh
@@ -23,7 +23,24 @@ cleanup() {
 	docker rmi -f myorg/unwritable:latest >/dev/null 2>&1 || true
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/compose/multiple-compose-files/exec.sh
+++ b/examples/compose/multiple-compose-files/exec.sh
@@ -26,7 +26,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/compose/multiservice-down/exec.sh
+++ b/examples/compose/multiservice-down/exec.sh
@@ -26,7 +26,25 @@ cleanup() {
 	service_ids | xargs -r docker rm -f >/dev/null 2>&1 || true
 	docker volume ls -q | grep -i msdown-data | xargs -r docker volume rm >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/compose/run-services/exec.sh
+++ b/examples/compose/run-services/exec.sh
@@ -17,7 +17,25 @@ svc_running() {
 cleanup() {
 	docker ps -a --filter "label=canary.group=runsvc" -q | xargs -r docker rm -f >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/configuration/secrets-declarative/exec.sh
+++ b/examples/configuration/secrets-declarative/exec.sh
@@ -24,7 +24,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 # Reproducible fake secrets — never use real values in an example.
 export GITHUB_TOKEN="demo-fake-token-1234"

--- a/examples/configuration/workspace-trust/exec.sh
+++ b/examples/configuration/workspace-trust/exec.sh
@@ -22,7 +22,25 @@ cleanup() {
 	fi
 	rm -f "$MARKER"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 rm -f "$MARKER"

--- a/examples/down/basic/exec.sh
+++ b/examples/down/basic/exec.sh
@@ -22,7 +22,25 @@ cleanup() {
 	fi
 	docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/container-id-targeting/exec.sh
+++ b/examples/exec/container-id-targeting/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/exit-code-handling/exec.sh
+++ b/examples/exec/exit-code-handling/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/id-label-targeting/exec.sh
+++ b/examples/exec/id-label-targeting/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/interactive-pty/exec.sh
+++ b/examples/exec/interactive-pty/exec.sh
@@ -26,7 +26,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/non-interactive-streaming/exec.sh
+++ b/examples/exec/non-interactive-streaming/exec.sh
@@ -22,7 +22,24 @@ cleanup() {
 	rm -f "${SCRIPT_DIR}/output.txt" "${SCRIPT_DIR}/errors.txt" "${SCRIPT_DIR}/build.log"
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/remote-env-variables/exec.sh
+++ b/examples/exec/remote-env-variables/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/remote-user-execution/exec.sh
+++ b/examples/exec/remote-user-execution/exec.sh
@@ -22,7 +22,24 @@ cleanup() {
 	rm -f "${SCRIPT_DIR}/shared-workspace/created-by-exec.txt" "${SCRIPT_DIR}/shared-workspace/test.txt"
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/user-env-probe-modes/exec.sh
+++ b/examples/exec/user-env-probe-modes/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/exec/workspace-folder-discovery/exec.sh
+++ b/examples/exec/workspace-folder-discovery/exec.sh
@@ -21,7 +21,24 @@ cleanup() {
 	fi
 }
 
-trap cleanup EXIT
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/features/contributed-options/exec.sh
+++ b/examples/features/contributed-options/exec.sh
@@ -23,7 +23,25 @@ cleanup() {
 	docker volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
 	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/probe-feature/install.sh
 

--- a/examples/features/dependency-ordering/exec.sh
+++ b/examples/features/dependency-ordering/exec.sh
@@ -21,7 +21,25 @@ cleanup() {
 	fi
 	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/feature-*/install.sh
 

--- a/examples/features/feature-contributed-lifecycle/exec.sh
+++ b/examples/features/feature-contributed-lifecycle/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/monitor/install.sh "$SCRIPT_DIR"/.devcontainer/tooling/install.sh
 

--- a/examples/features/feature-env-injection/exec.sh
+++ b/examples/features/feature-env-injection/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/capture-env/install.sh
 

--- a/examples/features/local-feature/exec.sh
+++ b/examples/features/local-feature/exec.sh
@@ -21,7 +21,25 @@ cleanup() {
 	fi
 	rm -f "$SCRIPT_DIR/devcontainer-lock.json"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/hello-feature/install.sh
 

--- a/examples/features/lockfile/exec.sh
+++ b/examples/features/lockfile/exec.sh
@@ -22,7 +22,25 @@ cleanup() {
 	fi
 	rm -f "$LOCKFILE"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 rm -f "$LOCKFILE"

--- a/examples/features/oci-digest-pin/exec.sh
+++ b/examples/features/oci-digest-pin/exec.sh
@@ -24,7 +24,25 @@ cleanup() {
 		mv "$SCRIPT_DIR/devcontainer.json.bak" "$SCRIPT_DIR/devcontainer.json"
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/features/option-sanitization/exec.sh
+++ b/examples/features/option-sanitization/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/report/install.sh
 

--- a/examples/features/override-install-order/exec.sh
+++ b/examples/features/override-install-order/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 chmod +x "$SCRIPT_DIR"/.devcontainer/feature-*/install.sh
 

--- a/examples/run-user-commands/basic/exec.sh
+++ b/examples/run-user-commands/basic/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 assert_marker() {
 	local marker="$1" expected_present="$2" cid

--- a/examples/up/additional-mounts/exec.sh
+++ b/examples/up/additional-mounts/exec.sh
@@ -30,6 +30,25 @@ cleanup_container() {
 	fi
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Basic (Config File Mounts) from devcontainer.json ==" >&2

--- a/examples/up/auto-forward/exec.sh
+++ b/examples/up/auto-forward/exec.sh
@@ -40,7 +40,25 @@ cleanup() {
 	docker ps -aq --filter "label=devcontainer.name=auto-forward" | xargs -r docker rm -f >/dev/null 2>&1 || true
 	rm -rf "$UDF" "$WS2" "$SCRIPT_DIR/.devcontainer-state"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 # Fetch from a loopback host port via bash /dev/tcp (no curl/nc needed on host).
 fetch() {

--- a/examples/up/basic-image/exec.sh
+++ b/examples/up/basic-image/exec.sh
@@ -24,6 +24,25 @@ extract_container_id() {
 	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 echo "== Basic Image: create container and run postCreateCommand (README: Basic Up Command) ==" >&2
 output="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove-existing-container "$@")"

--- a/examples/up/compose-basic/exec.sh
+++ b/examples/up/compose-basic/exec.sh
@@ -10,6 +10,25 @@ run() {
 	"$@"
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 # Run against docker-compose.yml targeting service=app as described in the README.
 echo "== Compose Basic: app + db services (README: Basic Compose Up) ==" >&2

--- a/examples/up/compose-profiles/exec.sh
+++ b/examples/up/compose-profiles/exec.sh
@@ -10,6 +10,25 @@ run() {
 	"$@"
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 EXTRA_ARGS=("$@")
 

--- a/examples/up/configuration-output/exec.sh
+++ b/examples/up/configuration-output/exec.sh
@@ -30,6 +30,25 @@ cleanup_container() {
 	fi
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Default Output (no configuration flags) ==" >&2

--- a/examples/up/container-user-vs-remote-user/exec.sh
+++ b/examples/up/container-user-vs-remote-user/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 assert_eq() {
 	local label="$1" expected="$2" actual="$3"

--- a/examples/up/dockerfile-build/exec.sh
+++ b/examples/up/dockerfile-build/exec.sh
@@ -34,6 +34,33 @@ cleanup_container() {
 	fi
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+
+# CACHE_DIR is created further down; clearing it from the trap (rather than at the
+# end of the script) means a failed scenario still removes it.
+cleanup_cache_dir() {
+	if [ -n "${CACHE_DIR:-}" ]; then
+		rm -rf "$CACHE_DIR"
+	fi
+}
+trap 'cleanup_cache_dir; clean_workspace_artifacts' EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Basic Build and Up ==" >&2
@@ -67,5 +94,3 @@ out_cache_from="$(run "$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" --remove
 	--cache-from "type=local,src=${CACHE_DIR}" \
 	"$@")"
 cleanup_container "$(extract_container_id "$out_cache_from")"
-
-rm -rf "$CACHE_DIR"

--- a/examples/up/dotfiles-integration/exec.sh
+++ b/examples/up/dotfiles-integration/exec.sh
@@ -34,6 +34,25 @@ cleanup_container() {
 	fi
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Basic Dotfiles Integration (default repository) ==" >&2

--- a/examples/up/gpu-modes/exec.sh
+++ b/examples/up/gpu-modes/exec.sh
@@ -24,6 +24,25 @@ extract_container_id() {
 	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 # README: "Explicit CPU-Only Runs (Mode: none)" — default behavior, no GPU requests

--- a/examples/up/host-ca/exec.sh
+++ b/examples/up/host-ca/exec.sh
@@ -38,7 +38,25 @@ MOUNT_FLAG=(--mount-workspace-git-root false)
 # 1. Generate a throwaway "corporate" root CA to inject (an explicit bundle, so
 #    the demo doesn't depend on the host machine's trust store).
 CA_DIR="$(mktemp -d)"
-trap 'rm -rf "$CA_DIR"' EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'rm -rf "$CA_DIR"; clean_workspace_artifacts' EXIT
 run openssl req -x509 -newkey rsa:2048 -nodes \
 	-keyout "$CA_DIR/corp.key" -out "$CA_DIR/corp-root.pem" -days 3650 \
 	-subj "/CN=Example Corp Root CA/O=Example Corp/C=US" \

--- a/examples/up/id-labels-reconnect/exec.sh
+++ b/examples/up/id-labels-reconnect/exec.sh
@@ -44,6 +44,25 @@ deacon_with_labels() {
 	run "${args[@]}"
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 # Create a labeled container (README: "Create Container with ID Labels").

--- a/examples/up/image-metadata-merge/exec.sh
+++ b/examples/up/image-metadata-merge/exec.sh
@@ -24,7 +24,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/up/initialize-command/exec.sh
+++ b/examples/up/initialize-command/exec.sh
@@ -26,7 +26,25 @@ cleanup() {
 	rm -rf "$TMP_ROOT"
 	rm -f "$SCRIPT_DIR/.initialize-marker"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 clear_marker() { rm -f "$SCRIPT_DIR/.initialize-marker"; }
 marker_exists() { [ -f "$SCRIPT_DIR/.initialize-marker" ]; }

--- a/examples/up/lifecycle-hooks/exec.sh
+++ b/examples/up/lifecycle-hooks/exec.sh
@@ -24,6 +24,25 @@ extract_container_id() {
 	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 # Execute the full lifecycle path described in the README.
 echo "== Lifecycle Hooks: full sequence onCreate -> postAttach ==" >&2

--- a/examples/up/override-command/exec.sh
+++ b/examples/up/override-command/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/up/ports-config/exec.sh
+++ b/examples/up/ports-config/exec.sh
@@ -29,7 +29,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/up/prebuild-mode/exec.sh
+++ b/examples/up/prebuild-mode/exec.sh
@@ -28,6 +28,25 @@ extract_container_id() {
 	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 # Step 1: prebuild (README).

--- a/examples/up/remote-env-secrets/exec.sh
+++ b/examples/up/remote-env-secrets/exec.sh
@@ -34,6 +34,25 @@ cleanup_container() {
 	fi
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 # Basic devcontainer remoteEnv only.

--- a/examples/up/remove-existing/exec.sh
+++ b/examples/up/remove-existing/exec.sh
@@ -31,6 +31,25 @@ deacon_up() {
 	"$DEACON_BIN" up --workspace-folder "$SCRIPT_DIR" "$@"
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "Creating container (first run)..." >&2

--- a/examples/up/security-options/exec.sh
+++ b/examples/up/security-options/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/up/skip-lifecycle/exec.sh
+++ b/examples/up/skip-lifecycle/exec.sh
@@ -27,6 +27,25 @@ extract_container_id() {
 	printf '%s' "$1" | "$PYTHON_BIN" -c 'import json, sys; data = json.load(sys.stdin); print(data.get("containerId", ""))'
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "Running with full lifecycle..." >&2

--- a/examples/up/up-exec-down/exec.sh
+++ b/examples/up/up-exec-down/exec.sh
@@ -42,7 +42,25 @@ run() {
 cleanup() {
 	"$DEACON_BIN" down "${WS_ARGS[@]}" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 
@@ -66,5 +84,5 @@ echo "== down: resolve and remove by --workspace-folder ==" >&2
 run "$DEACON_BIN" down "${WS_ARGS[@]}" >/dev/null
 echo "down removed the container ✓" >&2
 
-trap - EXIT
+trap clean_workspace_artifacts EXIT
 echo "up-exec-down canary passed ✓" >&2

--- a/examples/up/update-remote-user-uid/exec.sh
+++ b/examples/up/update-remote-user-uid/exec.sh
@@ -25,7 +25,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 host_uid="$(id -u)"
 host_gid="$(id -g)"

--- a/examples/up/user-env-probe-modes/exec.sh
+++ b/examples/up/user-env-probe-modes/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/up/wait-for/exec.sh
+++ b/examples/up/wait-for/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 read_log() {
 	local cid

--- a/examples/up/with-features/exec.sh
+++ b/examples/up/with-features/exec.sh
@@ -30,6 +30,25 @@ extract_container_id() {
 	printf '%s' "$fallback" | head -n1
 }
 
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap clean_workspace_artifacts EXIT
+
 cd "$SCRIPT_DIR"
 
 echo "== Basic Up with Features ==" >&2

--- a/examples/up/workspace-mount/exec.sh
+++ b/examples/up/workspace-mount/exec.sh
@@ -20,7 +20,25 @@ cleanup() {
 		docker rm -f "$cid" >/dev/null 2>&1 || true
 	fi
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 

--- a/examples/upgrade/basic/exec.sh
+++ b/examples/upgrade/basic/exec.sh
@@ -14,7 +14,25 @@ run() {
 cleanup() {
 	rm -f "$LOCKFILE"
 }
-trap cleanup EXIT
+
+# Runtime artifacts `deacon up` / `deacon build` may write into this example's
+# workspace. Removing only these generated paths leaves the directory exactly as
+# committed (#179); the committed `.devcontainer/` config is never touched.
+clean_workspace_artifacts() {
+	rm -rf \
+		"${SCRIPT_DIR}/.devcontainer-state" \
+		"${SCRIPT_DIR}/.devcontainer/build-cache" \
+		"${SCRIPT_DIR}/.deacon" \
+		"${SCRIPT_DIR}/.deacon-temp-build"
+	# The lockfile sits beside the config and gains a leading dot when the
+	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
+	rm -f \
+		"${SCRIPT_DIR}/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
+		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
+}
+trap 'cleanup; clean_workspace_artifacts' EXIT
 
 cd "$SCRIPT_DIR"
 rm -f "$LOCKFILE"


### PR DESCRIPTION
## The pattern

Every `up`/`build` `exec.sh` gains the same self-contained cleanup function, armed from an `EXIT` trap:

```bash
clean_workspace_artifacts() {
	rm -rf \
		"${SCRIPT_DIR}/.devcontainer-state" \
		"${SCRIPT_DIR}/.devcontainer/build-cache" \
		"${SCRIPT_DIR}/.deacon" \
		"${SCRIPT_DIR}/.deacon-temp-build"
	# The lockfile sits beside the config and gains a leading dot when the
	# config basename has one (`.devcontainer.json` -> `.devcontainer-lock.json`).
	rm -f \
		"${SCRIPT_DIR}/devcontainer-lock.json" \
		"${SCRIPT_DIR}/.devcontainer-lock.json" \
		"${SCRIPT_DIR}/.devcontainer/devcontainer-lock.json" \
		"${SCRIPT_DIR}/.devcontainer/.devcontainer-lock.json"
}
```

Scripts that already had a trap chain it (`trap 'cleanup; clean_workspace_artifacts' EXIT`); scripts that had none get `trap clean_workspace_artifacts EXIT` before `cd "$SCRIPT_DIR"`. `up/up-exec-down` disarms its trap on success (`trap - EXIT`) and now re-arms the artifact cleanup instead of dropping it.

Putting the removal in a **trap** rather than at the end of the script is the point: a failing scenario cleans up too.

The function is copied into all 72 scripts on purpose — each example directory stays copy-and-run self-contained, with deliberately **no** shared sourced helper library. It removes only paths deacon generates; the committed `.devcontainer/` config and fixtures are never touched (verified: nothing under `examples/` commits any of these paths, and `.devcontainer/` itself is never an `rm -rf` target).

## What the baseline actually measured

Before changing anything, a bare `deacon build` was run against a committed example to see what residue exists today:

- **The three directories #179 named no longer appear at all.** #280 relocated lifecycle markers, the build cache and the transient build context to the host user-data folder (`~/.deacon/`). The traps are a durable guard against a regression there, not a live cleanup.
- **The one artifact still landing in the workspace is the feature lockfile** — and it exposed a gap in #178's `.gitignore`. `lockfile_path_for_config` writes the lockfile beside the config and gives it the config's leading dot, so a workspace-root `.devcontainer.json` yields a workspace-root **`.devcontainer-lock.json`**, which `**/.devcontainer/devcontainer-lock.json` does not match. A plain `deacon build --workspace-folder .` on `examples/build/dockerfile-with-features` left an untracked `.devcontainer-lock.json` and dirtied `git status`.

So this PR also adds `**/.devcontainer-lock.json` to `.gitignore`, with the matching `!parity/fixtures/**/.devcontainer-lock.json` exemption — three parity fixtures commit that exact filename as version-controlled test INPUT, and the existing exemption's literal `devcontainer-lock.json` pattern does not cover the dotted spelling. Verified with `git check-ignore`: all three fixtures stay un-ignored, the example residue is ignored.

## Should the #178 `.gitignore` entries stay?

**Yes — keep them.** The traps close the on-disk accumulation, but they cannot cover every path: an interrupted run (`SIGKILL`, a killed CI job) never fires an `EXIT` trap, and a developer running `deacon up` by hand in an example directory (exactly what the READMEs invite) bypasses `exec.sh` entirely. The traps are the primary fix; the ignore rules stay as the outer guard.

## Scripts changed

**72** `exec.sh` files (all `up`/`build`-invoking scripts under `examples/`), plus `.gitignore`, `examples/README.md` (documents the self-cleaning contract, keeping README and scripts in lockstep) and `examples/CANARY_STATUS.md`.

`up/dockerfile-build` gets one extra change: its build-cache `mktemp -d` removal moves from the last line of the script into the trap, so a failing scenario removes it too.

## Executed vs. reviewed

**Executed** (9, release binary at `f716920`, Docker, `--mount-workspace-git-root false` where the monorepo rule requires it) — chosen to cover each structural variant:

| Canary | Covers |
|---|---|
| `up/basic-image` | plain `up`, no pre-existing trap |
| `up/dockerfile-build` | Dockerfile `up` + the relocated cache-dir cleanup |
| `up/compose-basic` | Compose `up` |
| `up/with-features` | OCI features `up` |
| `features/local-feature` | local-feature `up` |
| `build/basic-dockerfile` | plain `build`, non-`cleanup` trap name (`cleanup_images`) |
| `build/dockerfile-with-features` | features `build` — the case that produced the baseline residue |
| `build/compose-missing-service` | error-asserting `build`, no pre-existing trap |
| `up/up-exec-down` | the `trap - EXIT` disarm re-arm |
| `up/host-ca` | inline-command trap (`trap 'rm -rf "$CA_DIR"' EXIT`) |

All exited 0, and each was checked for **both** `git status --porcelain` clean **and** `find <dir> -name '.devcontainer-state' -o -name 'build-cache' -o -name '.deacon' -o -name '*devcontainer-lock.json'` empty. Failure-path behavior was verified directly: planted a `.devcontainer-state/` and a `.devcontainer-lock.json` in `up/basic-image`, ran `exec.sh` so it aborted (rc 127), and confirmed both were removed while the committed `.devcontainer/` survived.

**Reviewed** (the remaining 63): the edit is mechanically identical — applied by script, then verified for all 72 with `bash -n` (syntax), presence of the function, a `^trap …clean_workspace_artifacts… EXIT` arming line, and that the trap is armed before the first executed deacon invocation.

## Verification

```
72/72  bash -n clean, function present, trap armed, ordering correct
9/9    canaries pass; git status clean and zero on-disk residue each
3/3    parity fixture .devcontainer-lock.json files remain un-ignored
       cargo fmt --all -- --check                                  OK
       cargo clippy --all-targets --all-features -- -D warnings    OK
```

No Rust or test files were touched, so `make test-nextest-fast` was not required. `CANARY_STATUS.md` records the sweep and refreshes the nine rows (status + `2026-08-20 f716920` + note); the stale "exec.sh cleanup is incomplete" hygiene note from the 2026-07-20 sweep is marked resolved for the lockfile half.

## Out of scope, noted while verifying

`up/up-exec-down` finishes with a plain `deacon down`, which per `shutdownAction: stopContainer` **stops** rather than removes, so it leaves one exited container behind. That is a container-resource gap, pre-existing and orthogonal to this issue's workspace-artifact scope; it is recorded in `CANARY_STATUS.md` rather than fixed here, to keep this PR a single uniform mechanical pattern. The container was removed by hand, along with the Compose sidecar/network/volume from `up/compose-basic`.

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SFzA2sTh2EpX8MZU3TWNS
