### PR TITLE
fix(core): replace a drain-collect to unblock clippy on Rust 1.98

### DIFF
--- a/crates/core/src/redaction.rs
+++ b/crates/core/src/redaction.rs
@@ -516,16 +516,21 @@ impl<W: Write> Write for RedactingWriter<W> {
     fn flush(&mut self) -> io::Result<()> {
         // Process any remaining buffered content as a final line
         if !self.buffer.is_empty() {
-            let remaining: Vec<u8> = self.buffer.drain(..).collect();
+            // `mem::take` rather than `drain(..).collect()`: both empty the buffer, but the
+            // drain form allocates a second Vec for bytes we already own (clippy::drain_collect,
+            // denied as of the 1.98 toolchain). Taking the buffer also lets the non-UTF-8 arm
+            // recover the original bytes from the error, so the `.clone()` this used to need in
+            // order to keep them alive across `String::from_utf8` is gone too.
+            let remaining = std::mem::take(&mut self.buffer);
 
-            match String::from_utf8(remaining.clone()) {
+            match String::from_utf8(remaining) {
                 Ok(remaining_str) => {
                     let redacted =
                         redact_with_registry(&remaining_str, &self.config, &self.registry);
                     self.inner.write_all(redacted.as_bytes())?;
                 }
-                Err(_) => {
-                    self.inner.write_all(&remaining)?;
+                Err(err) => {
+                    self.inner.write_all(err.as_bytes())?;
                 }
             }
         }


### PR DESCRIPTION
**`Lint (fmt + clippy)` is red on `main` and therefore on every open pull request.** This
unblocks it. Not anyone's change: GitHub's runners moved to **Rust 1.98**, which promotes
`clippy::drain_collect` into the set `-D warnings` denies, and `RedactingWriter::flush` has
carried a `drain(..).collect()` since it was written.

```
error: draining all elements of a collection into a new collection of the same type
   --> crates/core/src/redaction.rs:519
    |    let remaining: Vec<u8> = self.buffer.drain(..).collect();
    |    help: use `mem::take` to avoid creating a new allocation
    = note: `-D clippy::drain-collect` implied by `-D warnings`
```

Evidence it is main-wide rather than PR-specific: the scheduled `CI` run on `main`
(`32345549200`, 2026-08-20 07:46) fails in **14 seconds** — the lint job failing fast — and
the run before it, on 2026-08-19, is green. Nothing landed between them.

## The change

Both forms empty the buffer; the drain form allocates a second `Vec` for bytes we already
own. `mem::take` hands the buffer over directly.

Taking it also lets the `.clone()` beside it go. That clone existed only because
`String::from_utf8` consumes its argument while the non-UTF-8 arm still needed the original
bytes; `FromUtf8Error::as_bytes()` returns them. The flush path now allocates nothing on
either arm where it previously allocated twice on both.

**Behaviour is unchanged on both arms** — valid UTF-8 is redacted and written, invalid UTF-8
is passed through verbatim.

## Verification, with one caveat stated plainly

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p deacon-core --all-targets --all-features -- -D warnings` ✓
- redaction + parity-harness suites ✓ (266 tests)

**The local toolchain here is 1.97.1, which does not raise this lint at all.** So this was
reproduced from the CI job log, not from a local red-to-green, and the fix is verified
against the rule clippy quoted rather than against a local failure. The authoritative check
is this PR's own `Lint (fmt + clippy)` job on 1.98.

Found while running the batch-6 parity work (#602), whose lint job this was failing.
Per CLAUDE.md's standing rule — *"Fix All Failures — Even Unrelated Ones… a broken build
blocks everyone"* — it is fixed here rather than deferred, and kept in its own PR so it can
merge ahead of the parity work that is waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SFzA2sTh2EpX8MZU3TWNS
