### PR TITLE
fix(up): correct --skip-non-blocking-commands help text

### DIFF
--- a/crates/deacon/src/cli.rs
+++ b/crates/deacon/src/cli.rs
@@ -276,7 +276,8 @@ pub enum Commands {
         /// Skip postAttach lifecycle phase
         #[arg(long)]
         skip_post_attach: bool,
-        /// Skip non-blocking commands (postStart & postAttach phases)
+        /// Stop after the lifecycle phase `waitFor` names (default:
+        /// updateContentCommand), skipping every phase after it (#604).
         #[arg(long)]
         skip_non_blocking_commands: bool,
         /// Default user environment probe mode when config omits userEnvProbe.
@@ -718,7 +719,8 @@ pub enum Commands {
         /// Skip postAttach lifecycle phase
         #[arg(long)]
         skip_post_attach: bool,
-        /// Skip non-blocking commands (postStart & postAttach phases)
+        /// Stop after the lifecycle phase `waitFor` names (default:
+        /// updateContentCommand), skipping every phase after it (#604).
         #[arg(long)]
         skip_non_blocking_commands: bool,
         /// Stop after updateContentCommand (prebuild mode)


### PR DESCRIPTION
Fixes #604.

`--skip-non-blocking-commands` stops the lifecycle after the phase `waitFor` names. Its
`--help` string said it *"skips non-blocking commands (postStart & postAttach phases)"* — a
different rule, which coincides with the real one **only** when `waitFor` is
`postCreateCommand`. Under the spec default (`updateContentCommand`) the two disagree about
`postCreateCommand`, and the documented one is wrong.

**Behaviour is correct and unchanged.** Two doc comments move; nothing else.

## Measured, at oracle 0.87.0

Five-phase fixtures, each hook appending its own phase name to one file. Both CLIs agree on
both:

```
waitFor omitted (spec default: updateContentCommand)
  deacon up --skip-non-blocking-commands → exit 0, "onCreate\nupdateContent\n"
  oracle up --skip-non-blocking-commands → exit 0, "onCreate\nupdateContent\n"

"waitFor": "onCreateCommand"
  deacon up --skip-non-blocking-commands → exit 0, "onCreate\n"
  oracle up --skip-non-blocking-commands → exit 0, "onCreate\n"
```

The first pair alone would not settle it — `"onCreate\nupdateContent\n"` is equally
consistent with an implementation that hardcodes the default. The second pair is the
discriminator, and **deacon reads the field.**

`run-user-commands` carries the same flag and the same correct behaviour (measured after an
`up --skip-post-create` so the marker file records only the pass under test), so the string
is corrected in **both** places it appears.

## Rendered result

```
--skip-non-blocking-commands
    Stop after the lifecycle phase `waitFor` names (default: updateContentCommand),
    skipping every phase after it (#604)
```

## Why it was filed before it was fixed

Right behaviour behind wrong documentation is the state in which a later "fix" aligning the
*code* to the *help text* would be a silent regression. That is the same failure mode as
[#476](https://github.com/get2knowio/deacon/issues/476) — `--skip-post-create` implemented
from what its **name** implied rather than what the flag means — one layer up, at the layer
where nothing fails a test. The behaviour is guarded from now on by two parity scenarios
landing in #602 (`case-up-skip-non-blocking-commands-wait-for-default` and
`…-wait-for-on-create`), which is what would catch such a regression.

## Verification

`cargo fmt --all -- --check` ✓ · `cargo clippy --all-targets --all-features -- -D warnings` ✓
· `make test-nextest-fast` ✓ (3434 passed) · both `--help` outputs inspected directly.

Independent of #602 and #603; branched from `main`.

> **Note:** this PR's `Lint (fmt + clippy)` job may be red for an unrelated, main-wide reason
> — GitHub's runners moved to Rust 1.98, which promotes `clippy::drain_collect`. That is
> fixed separately in #603 and is not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SFzA2sTh2EpX8MZU3TWNS
